### PR TITLE
Update stock_tracking_agent.py (Fix buying message)

### DIFF
--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -730,7 +730,7 @@ class StockTrackingAgent:
             self.conn.commit()
 
             # 매수 내역 메시지 추가
-            message = f"📈 매수: {company_name}({ticker})\n" \
+            message = f"📈 신규 매수: {company_name}({ticker})\n" \
                       f"매수가: {current_price:,.0f}원\n" \
                       f"목표가: {scenario.get('target_price', 0):,.0f}원\n" \
                       f"손절가: {scenario.get('stop_loss', 0):,.0f}원\n" \


### PR DESCRIPTION
안녕하세요.
프리즘 인사이트에서 인사이트 많이 얻고 있습니다. 
먼저 감사드립니다.

오픈소스 공개에도 너무 감사드립니다.
다름이 아니고, 다음 소소한 사항에 대한 수정을 해도 될지 PR올려봅니다. 
작은 기여라도 할 수 있음에 기쁨니다!!

## 작업 개요

- 텔레그램 종토방에서 `신규 매수` 알림을 놓치는 경우가 있습니다.
- 지난 매수 시그널을 찾아보고 싶은데 `매수` 라는 단어가 거의 모든 알림에 많이 있어 선별해서 찾기가 쉽지 않습니다.
- 그래서 `📈 매수:` -> `📈 신규 매수:` 로 변경해봅니다.

## 테스트 케이스

단순 워딩 수정이라 없음.

## 리뷰 포인트

해당 매수의 의미가 신규 매수가 아니라 
`물타기 매수, 추격 매수, 돌파 매수, N차 매수` 등등의 여러 의미를 가진다면
제 수정사항이 적절치 않을 수 있습니다. 

제가 이 알림의 의도는 정확히 알지 못하기에 이 부분 감안하여 리뷰 부탁드리겠습니다. 🙏