### PR TITLE
feat: fetch market index data from pykrx since Season2 start (2025-09…

### DIFF
--- a/examples/dashboard/app/page.tsx
+++ b/examples/dashboard/app/page.tsx
@@ -118,7 +118,7 @@ export default function Page() {
             {/* 시장 지수 차트 - 하단 배치 */}
             <PerformanceChart
               data={data.market_condition}
-              tradingHistory={data.trading_history}
+              prismPerformance={data.prism_performance}
               holdings={data.holdings}
               summary={data.summary}
             />

--- a/examples/dashboard/types/dashboard.ts
+++ b/examples/dashboard/types/dashboard.ts
@@ -159,6 +159,14 @@ export interface MarketCondition {
   volatility: number
 }
 
+export interface PrismPerformance {
+  date: string
+  cumulative_realized_profit: number
+  prism_simulator_return: number
+  holdings_unrealized_profit: number
+  holdings_return: number
+}
+
 export interface AccountSummary {
   total_eval_amount: number
   total_profit_amount: number
@@ -186,6 +194,7 @@ export interface DashboardData {
   trading_history: Trade[]
   watchlist: WatchlistStock[]
   market_condition: MarketCondition[]
+  prism_performance?: PrismPerformance[]
   holding_decisions?: HoldingDecision[]
   jeoningu_lab?: JeoninguLabData
 }


### PR DESCRIPTION
…-29)

- Update get_market_condition() to use pykrx for KOSPI/KOSDAQ index data
- Add calculate_cumulative_realized_profit() for daily prism simulator returns
- Add PrismPerformance interface and prism_performance field to dashboard data
- Update performance charts to display date-based cumulative returns
- Add fallback to DB when pykrx is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)