### PR TITLE
fix: Remove holdings from prism_performance and use only realized pro…

### DIFF
--- a/examples/dashboard/components/performance-chart-new.tsx
+++ b/examples/dashboard/components/performance-chart-new.tsx
@@ -59,10 +59,6 @@ export function PerformanceChart({ data, prismPerformance = [], holdings = [], s
     prismPerformanceMap.set(p.date, p)
   })
 
-  // 보유종목 평가수익률 계산 (현재 보유종목의 미실현 수익)
-  const holdingsTotalProfit = summary?.portfolio?.total_profit || 0
-  const holdingsReturn = holdingsTotalProfit / 10
-
   // 실전 투자 수익률
   const realTotalAssets = (summary?.real_trading?.total_eval_amount || 0) +
                           (summary?.real_trading?.available_amount || 0)
@@ -70,24 +66,24 @@ export function PerformanceChart({ data, prismPerformance = [], holdings = [], s
     ? ((realTotalAssets - season2StartAmount) / season2StartAmount) * 100
     : 0
 
-  // 최신 프리즘 시뮬레이터 수익률 (실현 + 미실현)
+  // 최신 프리즘 시뮬레이터 수익률 (누적 실현 수익률만)
   const latestPrismPerformance = prismPerformance.length > 0
     ? prismPerformance[prismPerformance.length - 1]
     : null
   const latestPrismReturn = latestPrismPerformance
-    ? latestPrismPerformance.prism_simulator_return + holdingsReturn
-    : holdingsReturn
+    ? latestPrismPerformance.prism_simulator_return
+    : 0
 
-  // KOSPI 기준 차트 데이터 - 날짜별 프리즘 수익률 사용
+  // KOSPI 기준 차트 데이터 - 누적 실현 수익률만 사용
   const kospiChartData = filteredData.map((item) => {
     const kospiReturn = startKospi > 0 ? ((item.kospi_index - startKospi) / startKospi) * 100 : 0
 
     // 해당 날짜의 프리즘 퍼포먼스 찾기
     const prismData = prismPerformanceMap.get(item.date)
-    // 실현 수익률 + 현재 미실현 수익률 (보유종목)
+    // 누적 실현 수익률만 사용 (cumulative_realized_profit / 10)
     const prismReturn = prismData
-      ? prismData.prism_simulator_return + holdingsReturn
-      : holdingsReturn
+      ? prismData.prism_simulator_return
+      : 0
 
     return {
       date: item.date,
@@ -103,9 +99,10 @@ export function PerformanceChart({ data, prismPerformance = [], holdings = [], s
 
     // 해당 날짜의 프리즘 퍼포먼스 찾기
     const prismData = prismPerformanceMap.get(item.date)
+    // 누적 실현 수익률만 사용
     const prismReturn = prismData
-      ? prismData.prism_simulator_return + holdingsReturn
-      : holdingsReturn
+      ? prismData.prism_simulator_return
+      : 0
 
     return {
       date: item.date,

--- a/examples/generate_dashboard_json.py
+++ b/examples/generate_dashboard_json.py
@@ -462,7 +462,7 @@ class DashboardDataGenerator:
             'available_amount': account_summary.get('available_amount', 0)
         }
 
-    def calculate_cumulative_realized_profit(self, trading_history: List[Dict], holdings: List[Dict], market_data: List[Dict]) -> List[Dict]:
+    def calculate_cumulative_realized_profit(self, trading_history: List[Dict], market_data: List[Dict]) -> List[Dict]:
         """
         날짜별 프리즘 시뮬레이터 누적 실현 수익률 계산
 
@@ -492,9 +492,6 @@ class DashboardDataGenerator:
                 cumulative_profit += profit_rate
                 cumulative_by_date[sell_date] = cumulative_profit
 
-        # 현재 보유종목의 미실현 수익률 계산
-        holdings_profit = sum(h.get('profit_rate', 0) for h in holdings)
-
         # 시장 데이터의 각 날짜에 맞춰 프리즘 수익률 데이터 생성
         result = []
         last_cumulative = 0.0
@@ -516,9 +513,7 @@ class DashboardDataGenerator:
             result.append({
                 'date': date,
                 'cumulative_realized_profit': last_cumulative,
-                'prism_simulator_return': prism_return,
-                'holdings_unrealized_profit': holdings_profit,
-                'holdings_return': holdings_profit / 10
+                'prism_simulator_return': prism_return
             })
 
         return result
@@ -756,7 +751,7 @@ class DashboardDataGenerator:
 
             # 날짜별 프리즘 시뮬레이터 누적 수익률 계산
             prism_performance = self.calculate_cumulative_realized_profit(
-                trading_history, holdings, market_condition
+                trading_history, market_condition
             )
 
             # 전체 데이터 구성


### PR DESCRIPTION
…fits in chart

- Remove holdings_unrealized_profit and holdings_return fields from prism_performance
- Update performance chart to display only cumulative realized profits
- Fix issue where holdings values were static across all dates