### PR TITLE
feat: improve telegram messages for portfolio and holding stocks

### DIFF
--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -632,7 +632,15 @@ class StockTrackingAgent:
             is_holding = await self._is_ticker_in_holdings(ticker)
             if is_holding:
                 logger.info(f"{ticker}({company_name}) already in holdings")
-                return {"success": True, "decision": "보유 중", "ticker": ticker, "company_name": company_name}
+                # Get current price for the stock even when already holding
+                holding_current_price = await self._get_current_stock_price(ticker)
+                return {
+                    "success": True,
+                    "decision": "보유 중",
+                    "ticker": ticker,
+                    "company_name": company_name,
+                    "current_price": holding_current_price
+                }
 
             # Get current stock price
             current_price = await self._get_current_stock_price(ticker)

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -354,8 +354,8 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                     logger.error(f"Report analysis failed: {pdf_report_path} - {analysis_result.get('error', 'Unknown error')}")
                     continue
 
-                # Skip if already holding this stock
-                if analysis_result.get("decision") == "Hold 중":
+                # Skip if already holding this stock (no telegram message for already held stocks)
+                if analysis_result.get("decision") == "보유 중":
                     logger.info(f"Skipping stock already in holdings: {analysis_result.get('ticker')} - {analysis_result.get('company_name')}")
                     continue
 


### PR DESCRIPTION
## Summary
- Fix confusing "매수 보류" message for already-held stocks by skipping telegram message entirely
- Enhance portfolio telegram reporter with Season 2 tracking info (start date, start amount, season profit rate, cash ratio)

## Changes
### stock_tracking_agent.py
- Return `current_price` in `analyze_report()` for already-held stocks

### stock_tracking_enhanced_agent.py
- Skip telegram message for stocks already in holdings (no more confusing "매수 보류" messages)
- Fix typo: "Hold 중" -> "보유 중"

### trading/portfolio_telegram_reporter.py
- Add Season 2 constants (start date: 2025.09.29, start amount: 9,969,801원)
- Display total assets (evaluation + cash) instead of just evaluation
- Show season profit (total assets vs start amount) with percentage
- Separate "보유종목 평가손익" from season profit for clarity
- Add cash ratio display for portfolio stability assessment