### PR TITLE
fix: correct sector distribution bug in sell decision and add D+2 cas…

### DIFF
--- a/examples/generate_dashboard_json.py
+++ b/examples/generate_dashboard_json.py
@@ -453,15 +453,20 @@ class DashboardDataGenerator:
                 'total_profit_amount': 0,
                 'total_profit_rate': 0,
                 'deposit': 0,
+                'total_cash': 0,
                 'available_amount': 0
             }
+
+        # total_cash (D+2 포함)를 사용하고, 없으면 deposit으로 fallback
+        total_cash = account_summary.get('total_cash', account_summary.get('deposit', 0))
 
         return {
             'total_stocks': len(real_portfolio),
             'total_eval_amount': account_summary.get('total_eval_amount', 0),
             'total_profit_amount': account_summary.get('total_profit_amount', 0),
             'total_profit_rate': account_summary.get('total_profit_rate', 0),
-            'deposit': account_summary.get('deposit', 0),
+            'deposit': account_summary.get('deposit', 0),  # 예수금 (D+0)
+            'total_cash': total_cash,  # 총 현금 (D+2 포함)
             'available_amount': account_summary.get('available_amount', 0)
         }
 

--- a/trading/domestic_stock_trading.py
+++ b/trading/domestic_stock_trading.py
@@ -1365,17 +1365,28 @@ class DomesticStockTrading:
                 if output2:
                     pchs_amt = float(output2.get('pchs_amt_smtl_amt', 0)) or 1  # 0이면 1로 대체
 
+                    # 총평가금액과 유가증권평가금액
+                    tot_evlu_amt = float(output2.get('tot_evlu_amt', 0))
+                    scts_evlu_amt = float(output2.get('scts_evlu_amt', 0))
+                    dnca_tot_amt = float(output2.get('dnca_tot_amt', 0))
+
+                    # 총 현금 (D+2 포함) = 총평가금액 - 유가증권평가금액
+                    # 이는 예수금(D+0) + D+1 + D+2 미수금을 모두 포함
+                    total_cash = tot_evlu_amt - scts_evlu_amt
+
                     account_summary = {
-                        'total_eval_amount': float(output2.get('tot_evlu_amt', 0)),
+                        'total_eval_amount': tot_evlu_amt,
                         'total_profit_amount': float(output2.get('evlu_pfls_smtl_amt', 0)),
                         'total_profit_rate': round(float(output2.get('evlu_pfls_smtl_amt', 0)) / pchs_amt * 100, 2),
-                        'deposit': float(output2.get('dnca_tot_amt', 0)),
+                        'deposit': dnca_tot_amt,  # 예수금 (D+0, 당일 출금가능)
+                        'total_cash': total_cash,  # 총 현금 (D+2 포함)
                         'available_amount': float(output2.get('ord_psbl_cash', 0))
                     }
 
                     logger.info(f"계좌 요약: 총평가 {account_summary['total_eval_amount']:,.0f}원, "
                                 f"손익 {account_summary['total_profit_amount']:+,.0f}원 "
-                                f"({account_summary['total_profit_rate']:+.2f}%)")
+                                f"({account_summary['total_profit_rate']:+.2f}%), "
+                                f"총현금(D+2포함) {account_summary['total_cash']:,.0f}원")
 
                     return account_summary
 

--- a/trading/portfolio_telegram_reporter.py
+++ b/trading/portfolio_telegram_reporter.py
@@ -140,7 +140,9 @@ class PortfolioTelegramReporter:
             total_eval = account_summary.get('total_eval_amount', 0)
             total_profit = account_summary.get('total_profit_amount', 0)
             total_profit_rate = account_summary.get('total_profit_rate', 0)
-            deposit = account_summary.get('deposit', 0)  # 예수금 (현금)
+            deposit = account_summary.get('deposit', 0)  # 예수금 (D+0, 당일 출금가능)
+            # total_cash (D+2 포함)를 사용하고, 없으면 deposit으로 fallback
+            total_cash = account_summary.get('total_cash', deposit)
             available = account_summary.get('available_amount', 0)  # 주문가능금액
 
             # Note: total_eval (tot_evlu_amt) already includes deposit in KIS API
@@ -151,8 +153,8 @@ class PortfolioTelegramReporter:
             season_profit = total_assets - self.SEASON2_START_AMOUNT
             season_profit_rate = (season_profit / self.SEASON2_START_AMOUNT) * 100 if self.SEASON2_START_AMOUNT > 0 else 0
 
-            # Calculate cash ratio (using deposit as cash)
-            cash_ratio = (deposit / total_assets * 100) if total_assets > 0 else 0
+            # Calculate cash ratio (using total_cash which includes D+2)
+            cash_ratio = (total_cash / total_assets * 100) if total_assets > 0 else 0
 
             # Total assets and season profit
             season_profit_emoji = "📈" if season_profit >= 0 else "📉"
@@ -169,8 +171,8 @@ class PortfolioTelegramReporter:
             message += f"📊 *보유종목 평가손익*: `{holdings_profit_sign}{self.format_currency(total_profit)}` "
             message += f"({self.format_percentage(total_profit_rate)})\n"
 
-            # Cash info (deposit = 예수금, available = 주문가능금액)
-            message += f"💳 현금(예수금): `{self.format_currency(deposit)}` (현금비율: {cash_ratio:.1f}%)\n"
+            # Cash info (total_cash = D+2 포함 총 현금, deposit = 예수금)
+            message += f"💳 현금(D+2포함): `{self.format_currency(total_cash)}` (현금비율: {cash_ratio:.1f}%)\n"
             message += "\n"
         else:
             message += "❌ 계좌 정보를 가져올 수 없습니다\n\n"


### PR DESCRIPTION
…h calculation

- Fix _analyze_sell_decision sector distribution bug: was using same sector for all holdings instead of parsing each holding's scenario JSON
- Add portfolio_info logging for debugging sell decision agent
- Add total_cash field (D+2 included) to get_account_summary
- Update generate_dashboard_json and portfolio_telegram_reporter to use total_cash instead of deposit for accurate cash ratio calculation

🤖 Generated with [Claude Code](https://claude.com/claude-code)