### PR TITLE
fix: update dashboard to use total_cash (D+2) and fix translation import

### DIFF
--- a/examples/dashboard/components/metrics-cards.tsx
+++ b/examples/dashboard/components/metrics-cards.tsx
@@ -59,9 +59,9 @@ export function MetricsCards({
   const season2StartAmount = 9969801
   const totalAssetsReturn = totalAssets > 0 ? ((totalAssets - season2StartAmount) / season2StartAmount) * 100 : 0
 
-  // 현금 비율 계산 (deposit 사용, KIS API의 tot_evlu_amt가 이미 예수금 포함)
-  const deposit = summary.real_trading.deposit || 0
-  const cashRatio = totalAssets > 0 ? (deposit / totalAssets) * 100 : 0
+  // 현금 비율 계산 (total_cash 사용: D+2 포함 총 현금, fallback으로 deposit)
+  const totalCash = summary.real_trading.total_cash || summary.real_trading.deposit || 0
+  const cashRatio = totalAssets > 0 ? (totalCash / totalAssets) * 100 : 0
   const investmentRatio = 100 - cashRatio
 
   const realMetrics = [
@@ -92,7 +92,7 @@ export function MetricsCards({
     },
     {
       label: t("metrics.cashAndStability"),
-      value: formatCurrency(deposit),
+      value: formatCurrency(totalCash),
       change: `${t("metrics.cashRatio")} ${cashRatio.toFixed(1)}%`,
       changeValue: `${t("metrics.investmentRatio")} ${investmentRatio.toFixed(1)}% | ${summary.real_trading.total_stocks || 0}${t("metrics.stocks")}`,
       description: t("metrics.cashStabilityDesc"),

--- a/examples/dashboard/types/dashboard.ts
+++ b/examples/dashboard/types/dashboard.ts
@@ -31,6 +31,7 @@ export interface RealTradingSummary {
   total_profit_amount: number
   total_profit_rate: number
   deposit: number
+  total_cash: number  // D+2 포함 총 현금
   available_amount: number
 }
 

--- a/examples/generate_dashboard_json.py
+++ b/examples/generate_dashboard_json.py
@@ -27,6 +27,14 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+# 경로 설정 (다른 모듈 import 전에 먼저 설정)
+SCRIPT_DIR = Path(__file__).parent
+PROJECT_ROOT = SCRIPT_DIR.parent
+TRADING_DIR = PROJECT_ROOT / "trading"
+sys.path.insert(0, str(SCRIPT_DIR))  # examples/ 폴더 추가 (translation_utils용)
+sys.path.insert(0, str(PROJECT_ROOT))
+sys.path.insert(0, str(TRADING_DIR))
+
 # pykrx import for market index data
 try:
     from pykrx import stock
@@ -35,20 +43,13 @@ except ImportError:
     PYKRX_AVAILABLE = False
     logger.warning("pykrx 패키지가 설치되어 있지 않습니다. 시장 지수 데이터를 가져올 수 없습니다.")
 
-# 번역 유틸리티 import
+# 번역 유틸리티 import (경로 설정 후에 import)
 try:
     from translation_utils import DashboardTranslator
     TRANSLATION_AVAILABLE = True
 except ImportError:
     TRANSLATION_AVAILABLE = False
     logger.warning("번역 유틸리티를 찾을 수 없습니다. 영어 번역이 비활성화됩니다.")
-
-# 경로 설정
-SCRIPT_DIR = Path(__file__).parent
-PROJECT_ROOT = SCRIPT_DIR.parent
-TRADING_DIR = PROJECT_ROOT / "trading"
-sys.path.insert(0, str(PROJECT_ROOT))
-sys.path.insert(0, str(TRADING_DIR))
 
 # 설정파일 로딩
 CONFIG_FILE = TRADING_DIR / "config" / "kis_devlp.yaml"


### PR DESCRIPTION
- Add total_cash field to RealTradingSummary TypeScript type
- Update metrics-cards.tsx to use total_cash instead of deposit for accurate cash ratio calculation
- Fix translation_utils import by moving sys.path setup before import

🤖 Generated with [Claude Code](https://claude.com/claude-code)