### PR TITLE
fix: AI 보유 분석 탭에서 오늘 날짜 데이터만 표시하도록 수정

### DIFF
--- a/examples/dashboard/components/ai-decisions-page.tsx
+++ b/examples/dashboard/components/ai-decisions-page.tsx
@@ -140,6 +140,8 @@ export function AIDecisionsPage({ data }: AIDecisionsPageProps) {
               <div className="space-y-4">
                 {decisionsByDate[date].map((decision) => {
                   const stock = getStockInfo(decision.ticker)
+                  // company_name은 decision에서 먼저 가져오고, 없으면 stock에서 가져오고, 둘 다 없으면 ticker 표시
+                  const companyName = decision.company_name || stock?.company_name || decision.ticker
                   return (
                     <Card key={decision.id} className="border-border/30 bg-muted/20">
                       <CardContent className="p-6">
@@ -149,7 +151,7 @@ export function AIDecisionsPage({ data }: AIDecisionsPageProps) {
                             <div className="flex-1">
                               <div className="flex items-center gap-3 mb-2">
                                 <h3 className="text-lg font-bold text-foreground">
-                                  {stock?.company_name || decision.ticker}
+                                  {companyName}
                                 </h3>
                                 <Badge variant="outline" className="text-xs">
                                   {decision.ticker}

--- a/examples/dashboard/types/dashboard.ts
+++ b/examples/dashboard/types/dashboard.ts
@@ -251,6 +251,7 @@ export interface JeoninguLabData {
 export interface HoldingDecision {
   id: number
   ticker: string
+  company_name?: string
   decision_date: string
   decision_time: string
   current_price: number

--- a/examples/generate_dashboard_json.py
+++ b/examples/generate_dashboard_json.py
@@ -325,29 +325,35 @@ class DashboardDataGenerator:
         return market_data
     
     def get_holding_decisions(self, conn) -> List[Dict]:
-        """보유 종목 매도 판단 데이터 가져오기"""
+        """보유 종목 매도 판단 데이터 가져오기 (오늘 날짜만, 종목명 포함)"""
         try:
             cursor = conn.cursor()
+            today = datetime.now().strftime("%Y-%m-%d")
+
+            # stock_holdings와 LEFT JOIN하여 company_name도 함께 가져옴
             cursor.execute("""
-                SELECT id, ticker, decision_date, decision_time, current_price, 
-                       should_sell, sell_reason, confidence, technical_trend, 
-                       volume_analysis, market_condition_impact, time_factor, 
-                       portfolio_adjustment_needed, adjustment_reason, 
-                       new_target_price, new_stop_loss, adjustment_urgency, 
-                       full_json_data, created_at
-                FROM holding_decisions
-                ORDER BY created_at DESC
-            """)
-            
+                SELECT hd.id, hd.ticker, hd.decision_date, hd.decision_time, hd.current_price,
+                       hd.should_sell, hd.sell_reason, hd.confidence, hd.technical_trend,
+                       hd.volume_analysis, hd.market_condition_impact, hd.time_factor,
+                       hd.portfolio_adjustment_needed, hd.adjustment_reason,
+                       hd.new_target_price, hd.new_stop_loss, hd.adjustment_urgency,
+                       hd.full_json_data, hd.created_at,
+                       sh.company_name
+                FROM holding_decisions hd
+                LEFT JOIN stock_holdings sh ON hd.ticker = sh.ticker
+                WHERE hd.decision_date = ?
+                ORDER BY hd.created_at DESC
+            """, (today,))
+
             decisions = []
             for row in cursor.fetchall():
                 decision = self.dict_from_row(row, cursor)
-                
+
                 # full_json_data 파싱
                 decision['full_json_data'] = self.parse_json_field(decision.get('full_json_data', ''))
-                
+
                 decisions.append(decision)
-            
+
             return decisions
         except Exception as e:
             logger.warning(f"holding_decisions 테이블 조회 실패 (테이블이 없을 수 있음): {str(e)}")


### PR DESCRIPTION
- generate_dashboard_json.py: holding_decisions 조회 시 오늘 날짜만 필터링
- stock_holdings와 LEFT JOIN하여 company_name 포함
- dashboard.ts: HoldingDecision 타입에 company_name 추가
- ai-decisions-page.tsx: company_name fallback 로직 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)