### PR TITLE
feat: GPT 모델 gpt-4.1 → gpt-5.2 업그레이드

### DIFF
--- a/cores/report_generation.py
+++ b/cores/report_generation.py
@@ -91,7 +91,8 @@ async def generate_report(agent, section, company_name, company_code, reference_
     report = await llm.generate_str(
         message=message,
         request_params=RequestParams(
-            model="gpt-4.1",
+            model="gpt-5.2",
+            reasoning_effort="none",
             maxTokens=16000,
             parallel_tool_calls=True,
             use_history=True
@@ -168,7 +169,8 @@ async def generate_market_report(agent, section, reference_date, logger, languag
     report = await llm.generate_str(
         message=message,
         request_params=RequestParams(
-            model="gpt-4.1",
+            model="gpt-5.2",
+            reasoning_effort="none",
             maxTokens=16000,
             max_iterations=3,
             parallel_tool_calls=True,
@@ -277,7 +279,8 @@ Comprehensive Analysis Report:
         executive_summary = await llm.generate_str(
             message=message,
             request_params=RequestParams(
-                model="gpt-4.1",
+                model="gpt-5.2",
+                reasoning_effort="none",
                 maxTokens=6000,
                 max_iterations=2,
                 parallel_tool_calls=True,
@@ -506,7 +509,8 @@ Please present a consistent and executable investment strategy that investors ca
         investment_strategy = await llm.generate_str(
             message=message,
             request_params=RequestParams(
-                model="gpt-4.1",
+                model="gpt-5.2",
+                reasoning_effort="none",
                 maxTokens=16000,
                 max_iterations=3,
                 parallel_tool_calls=True,


### PR DESCRIPTION
### 변경 사항
- cores/report_generation.py의 모든 GPT 모델을 gpt-5.2로 업그레이드
- reasoning_effort="none" 파라미터 추가 (추론 오버헤드 제거)

### 수정 위치 (4개)
1. generate_detailed_report 함수
2. generate_comprehensive_report 함수
3. generate_executive_summary 함수
4. generate_investment_strategy 함수

🤖 Generated with [Claude Code](https://claude.ai/claude-code)