### PR TITLE
fix: Docker build fails due to missing perplexity-ask

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,11 @@ RUN pip install --no-cache-dir --upgrade pip setuptools && \
 # Playwright 브라우저 설치 (Chromium만)
 RUN playwright install --with-deps chromium
 
-# perplexity-ask MCP 서버 설치
+# perplexity-ask MCP 서버 설치 (gitignore 대상이므로 MCP 공식 저장소에서 가져옴)
+RUN git clone --depth 1 https://github.com/modelcontextprotocol/servers.git /tmp/mcp-servers && \
+    cp -r /tmp/mcp-servers/src/perplexity-ask /app/prism-insight/perplexity-ask && \
+    rm -rf /tmp/mcp-servers
+
 WORKDIR /app/prism-insight/perplexity-ask
 RUN npm install && \
     npm run build


### PR DESCRIPTION
## Summary
- `perplexity-ask/` 디렉토리가 `.gitignore`에 포함되어 있어 Docker 빌드 시 `git clone`으로 받아지지 않음
- `npm install` 단계에서 `package.json`을 찾지 못해 빌드 실패 (exit code 254)
- MCP 공식 저장소(modelcontextprotocol/servers)에서 `perplexity-ask`를 가져오도록 Dockerfile 수정

## Test plan
- [ ] `docker-compose up -d --build`로 이미지 빌드 성공 확인
- [ ] `docker exec prism-insight-container node perplexity-ask/dist/index.js --help` 동작 확인
- [ ] 기존 분석 실행에 영향 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)