### PR TITLE
fix: Use official Perplexity MCP server npm package in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,17 +76,8 @@ RUN pip install --no-cache-dir --upgrade pip setuptools && \
 # Playwright 브라우저 설치 (Chromium만)
 RUN playwright install --with-deps chromium
 
-# perplexity-ask MCP 서버 설치 (gitignore 대상이므로 MCP 공식 저장소에서 가져옴)
-RUN git clone --depth 1 https://github.com/modelcontextprotocol/servers.git /tmp/mcp-servers && \
-    cp -r /tmp/mcp-servers/src/perplexity-ask /app/prism-insight/perplexity-ask && \
-    rm -rf /tmp/mcp-servers
-
-WORKDIR /app/prism-insight/perplexity-ask
-RUN npm install && \
-    npm run build
-
-# 다시 메인 디렉토리로 이동
-WORKDIR /app/prism-insight
+# Perplexity MCP 서버 설치 (공식 npm 패키지)
+RUN npm install -g @perplexity-ai/mcp-server
 
 # 한글 폰트 설치 (Ubuntu용)
 RUN python3 ./cores/ubuntu_font_installer.py || true

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -79,8 +79,8 @@ services:
               read_timeout_seconds: 120
 
             perplexity:
-              command: "node"
-              args: ["perplexity-ask/dist/index.js"]
+              command: "npx"
+              args: ["-y", "@perplexity-ai/mcp-server"]
               env:
                 PERPLEXITY_API_KEY: "${PERPLEXITY_API_KEY:-optional}"
 

--- a/mcp_agent.config.yaml.example
+++ b/mcp_agent.config.yaml.example
@@ -42,10 +42,11 @@ mcp:
         # KRX_LOGIN_METHOD: "kakao"
 
     perplexity:
-      command: "node"
+      command: "npx"
       args:
         [
-          "perplexity-ask/dist/index.js"
+          "-y",
+          "@perplexity-ai/mcp-server"
         ]
       env:
         PERPLEXITY_API_KEY: "example key"


### PR DESCRIPTION
## Summary
- 이전 수정(#155)에서 `modelcontextprotocol/servers` 저장소를 clone 했으나, 해당 저장소에 `perplexity-ask`가 없어서 여전히 빌드 실패
- Perplexity 공식 npm 패키지 `@perplexity-ai/mcp-server`로 교체
- `mcp_agent.config.yaml.example`과 `docker-compose.quickstart.yml`도 `npx -y @perplexity-ai/mcp-server` 방식으로 통일

## Changes
- **Dockerfile**: `git clone` + `npm install/build` → `npm install -g @perplexity-ai/mcp-server`
- **mcp_agent.config.yaml.example**: `node perplexity-ask/dist/index.js` → `npx -y @perplexity-ai/mcp-server`
- **docker-compose.quickstart.yml**: 동일 변경

## Test plan
- [ ] `docker-compose up -d --build`로 이미지 빌드 성공 확인
- [ ] `docker exec prism-insight-container npx -y @perplexity-ai/mcp-server` 실행 확인
- [ ] 기존 분석 실행에 영향 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)