### PR TITLE
fix: Overhaul US entry strategy to resolve 0% entry rate

### DIFF
--- a/prism-us/cores/agents/trading_agents.py
+++ b/prism-us/cores/agents/trading_agents.py
@@ -361,7 +361,7 @@ You need to read stock analysis reports and generate trading scenarios in JSON f
 
 **Step 0: Market Environment Assessment**
 Check S&P 500 (^GSPC) last 20 days with yahoo_finance-get_historical_stock_prices:
-- Bull Market: S&P 500 above 20-day MA + rose 5%+ in last 2 weeks
+- Bull Market: S&P 500 above 20-day MA + (rose 2%+ in last 4 weeks OR rose 3%+ in last 2 weeks)
 - Bear/Sideways Market: Above conditions not met
 
 **Bear/Sideways Criteria (Strict - No Change):**
@@ -421,8 +421,8 @@ Check from us_stock_holdings table:
 
 ### 2. Stock Evaluation (1~10 points)
 - **8~10 points**: Active entry (undervalued vs peers + strong momentum)
-- **7 points**: Entry (basic conditions met)
-- **6 points**: Conditional entry (bull market + momentum confirmed)
+- **7 points**: Entry (solid risk/reward with acceptable fundamentals)
+- **6 points**: Entry with caution (momentum present, manageable risk factors)
 - **5 points or less**: No entry (clear negative factors exist)
 
 ### 3. Entry Decision Required Checks
@@ -523,10 +523,10 @@ Add buy score when these signals confirmed:
 - If stop loss within -7% possible, R/R 1.2+ is OK
 - **For No Entry: Must specify 1+ "negative factor" below**
 
-**Bear/Sideways Market (Stay Conservative):**
-- 7 points + strong momentum + undervalued → Consider entry
-- 8 points + normal conditions + positive outlook → Consider entry
-- 9+ points + valuation attractive → Active entry
+**Bear/Sideways Market (Selective but Active):**
+- 6 points + strong momentum + R/R 2.0+ → Entry with tight stop (-5%)
+- 7 points + acceptable risk/reward → Entry
+- 8+ points → Active entry
 - Conservative approach when explicit warnings or negative outlook
 
 ### 6. No Entry Justification Requirements (Bull Market)
@@ -577,7 +577,7 @@ Wrong (may fail parsing):
     "valuation_analysis": "Peer valuation comparison results",
     "sector_outlook": "Industry outlook and trends",
     "buy_score": Score between 1~10,
-    "min_score": Market-adaptive minimum entry score (Bull: 6, Bear/Sideways: 7),
+    "min_score": Market-adaptive minimum entry score (Bull: 5, Bear/Sideways: 6),
     "decision": "Enter" or "No Entry",
     "entry_checklist_passed": Number of checks passed (out of 6),
     "rejection_reason": "For No Entry: specific negative factor (null or empty for Enter)",

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -1718,6 +1718,15 @@ class USStockTrackingAgent:
                 if raw_decision and raw_decision.lower() != normalized_decision:
                     logger.debug(f"Decision normalized: '{raw_decision}' -> '{normalized_decision}'")
 
+                # Score-decision consistency enforcement:
+                # If adjusted score meets threshold, override LLM decision to entry
+                if adjusted_score >= min_score and normalized_decision != "entry":
+                    logger.info(
+                        f"Score-decision override: {company_name}({ticker}) - "
+                        f"Score {adjusted_score} >= {min_score} but decision='{normalized_decision}', forcing entry"
+                    )
+                    normalized_decision = "entry"
+
                 if normalized_decision == "entry":
                     buy_success = await self.buy_stock(ticker, company_name, current_price, scenario, rank_change_msg)
 

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -412,6 +412,15 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                 decision = analysis_result.get("decision")
                 logger.info(f"Buy score check: {company_name}({ticker}) - Score: {buy_score}, Min required score: {min_score}")
 
+                # Score-decision consistency enforcement:
+                # If score meets threshold and sector is diverse, override LLM decision to Enter
+                if buy_score >= min_score and sector_diverse and decision != "Enter":
+                    logger.info(
+                        f"Score-decision override: {company_name}({ticker}) - "
+                        f"Score {buy_score} >= {min_score} but decision='{decision}', forcing Enter"
+                    )
+                    decision = "Enter"
+
                 # Generate message if not buying (watch/insufficient score/sector constraints)
                 if decision != "Enter" or buy_score < min_score or not sector_diverse:
                     # Determine reason for not buying


### PR DESCRIPTION
## Summary
- **US 71건 전부 미진입 (0% 진입률)** 문제의 근본 원인 3개를 동시 수정
- KR에도 점수-결정 일관성 강제 로직 추가 (동일 버그 예방)

## Root Cause (3 compounding failures)
1. **Bull 감지 도달 불가**: "S&P 500이 2주간 5% 상승" = ~12.5 표준편차 → 사실상 항상 Bear/Sideways
2. **심리적 점수 천장**: Score 6 = "Conditional entry (bull market only)" → LLM이 Bear시장에서 6 이상 부여 안함
3. **진입 게이트 불일치**: 실제 진입 조건 = `normalized_decision == "entry"` (LLM 텍스트), score >= min_score가 아님

## Changes

### US Prompt (`prism-us/cores/agents/trading_agents.py`)
- Bull 감지 완화: `5%+ in 2 weeks` → `2%+ in 4 weeks OR 3%+ in 2 weeks`
- Score 6 디커플링: "Conditional entry (bull market only)" → "Entry with caution (momentum present, manageable risk factors)"
- Score 7 명확화: "basic conditions met" → "solid risk/reward with acceptable fundamentals"
- Bear/Sideways 가이드: "Stay Conservative" → "Selective but Active" (score 6 진입 허용)
- min_score 하향: Bull 6→5, Bear/Sideways 7→6

### Score-Decision Consistency (`us_stock_tracking_agent.py`, `stock_tracking_enhanced_agent.py`)
- US: `adjusted_score >= min_score`이면 decision을 "entry"로 강제 오버라이드
- KR: `buy_score >= min_score AND sector_diverse`이면 decision을 "Enter"로 강제 오버라이드

## Expected Impact
- US 진입률: 0% → 예상 ~50% (score 6 이상 36/71건)
- KR: 기존 16.9% 유지 + 점수 높은데 LLM이 미진입한 경우 보완

## Risk Mitigation
- 첫 주 Demo 모드 검증 권장
- Score 6 진입 시 stop-loss -5% (기본 -7%보다 타이트)
- 롤백 기준: 10건 후 평균 수익 < -5% → 즉시 원복

## Test plan
- [ ] US morning 분석 Demo 모드 실행하여 진입 발생 확인
- [ ] KR morning 분석으로 기존 동작 회귀 테스트
- [ ] Score-decision override 로그 메시지 확인
- [ ] Bear/Sideways 환경에서 score 6 진입 허용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)