### PR TITLE
feat: Convert broadcast translation to non-blocking fire-and-forget

### DIFF
--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -409,9 +409,17 @@ class USStockAnalysisOrchestrator:
         try:
             bot_agent = TelegramBotAgent()
 
-            # Send translated messages to broadcast channels BEFORE process_messages_directory moves files
+            # Pre-read message contents into memory for non-blocking broadcast translation
             if self.telegram_config.broadcast_languages:
-                await self._send_translated_messages(bot_agent, message_paths)
+                message_contents = []
+                for mp in message_paths:
+                    try:
+                        with open(mp, 'r', encoding='utf-8') as f:
+                            message_contents.append(f.read())
+                    except Exception as e:
+                        logger.error(f"Error reading message file {mp}: {str(e)}")
+                if message_contents:
+                    asyncio.create_task(self._send_translated_messages(bot_agent, message_contents))
 
             # Send messages to main channel (this moves files to sent folder)
             await bot_agent.process_messages_directory(
@@ -437,14 +445,13 @@ class USStockAnalysisOrchestrator:
         except Exception as e:
             logger.error(f"Error during telegram message transmission: {str(e)}")
 
-    async def _send_translated_messages(self, bot_agent, message_paths: list):
+    async def _send_translated_messages(self, bot_agent, message_contents: list):
         """
-        Send translated telegram messages to broadcast channels (synchronous)
-        Must be called BEFORE process_messages_directory moves the files
+        Send translated telegram messages to broadcast channels (non-blocking, fire-and-forget)
 
         Args:
             bot_agent: TelegramBotAgent instance
-            message_paths: List of original message file paths
+            message_contents: List of original message content strings (pre-read from files)
         """
         try:
             # Note: translate_telegram_message is pre-loaded at module level
@@ -460,15 +467,11 @@ class USStockAnalysisOrchestrator:
 
                     logger.info(f"Sending translated US messages to {lang} channel")
 
-                    # Translate and send each telegram message
-                    for message_path in message_paths:
+                    # Translate and send each message
+                    for original_message in message_contents:
                         try:
-                            # Read original message
-                            with open(message_path, 'r', encoding='utf-8') as f:
-                                original_message = f.read()
-
                             # Translate message
-                            logger.info(f"Translating US telegram message from {message_path} to {lang}")
+                            logger.info(f"Translating US telegram message to {lang}")
                             translated_message = await translate_telegram_message(
                                 original_message,
                                 model="gpt-5-nano",
@@ -487,7 +490,7 @@ class USStockAnalysisOrchestrator:
                             await asyncio.sleep(1)
 
                         except Exception as e:
-                            logger.error(f"Error translating/sending US message {message_path} to {lang}: {str(e)}")
+                            logger.error(f"Error translating/sending US message to {lang}: {str(e)}")
 
                 except Exception as e:
                     logger.error(f"Error processing language {lang}: {str(e)}")

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -1923,12 +1923,10 @@ class USStockTrackingAgent:
                 # Delay to prevent API rate limiting
                 await asyncio.sleep(1)
 
-            # Send to broadcast channels if configured (wait for completion)
+            # Send to broadcast channels if configured (non-blocking, fire-and-forget)
             if hasattr(self, 'telegram_config') and self.telegram_config and self.telegram_config.broadcast_languages:
-                # Create task and wait for it to complete
-                translation_task = asyncio.create_task(self._send_to_translation_channels(self.message_queue.copy()))
-                await translation_task
-                logger.info("US broadcast channel messages sent successfully")
+                asyncio.create_task(self._send_to_translation_channels(self.message_queue.copy()))
+                logger.info("US broadcast channel translation dispatched (non-blocking)")
 
             # Clear message queue
             self.message_queue = []

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -1521,12 +1521,10 @@ class StockTrackingAgent:
                 # Delay to prevent API rate limiting
                 await asyncio.sleep(1)
 
-            # Send to broadcast channels if configured (wait for completion)
+            # Send to broadcast channels if configured (non-blocking, fire-and-forget)
             if hasattr(self, 'telegram_config') and self.telegram_config and self.telegram_config.broadcast_languages:
-                # Create task and wait for it to complete
-                translation_task = asyncio.create_task(self._send_to_translation_channels(self.message_queue.copy()))
-                await translation_task
-                logger.info("Broadcast channel messages sent successfully")
+                asyncio.create_task(self._send_to_translation_channels(self.message_queue.copy()))
+                logger.info("Broadcast channel translation dispatched (non-blocking)")
 
             # Clear message queue
             self.message_queue = []

--- a/tracking/telegram.py
+++ b/tracking/telegram.py
@@ -118,7 +118,10 @@ class TelegramSender:
             return messages
 
     async def send_to_translation_channels(self, messages: List[str]):
-        """Send messages to broadcast translation channels."""
+        """Send messages to broadcast translation channels.
+
+        Note: Callers should wrap with asyncio.create_task() for non-blocking execution.
+        """
         if not self.config or not self.config.broadcast_languages:
             return
 


### PR DESCRIPTION
## Summary
- **4개 블락킹 포인트**를 `asyncio.create_task()` fire-and-forget 패턴으로 전환
- Orchestrator(KR/US): 메시지 파일을 메모리에 pre-read 후 백그라운드 번역 디스패치
- Tracking Agent(KR/US): `create_task + await` → `create_task` only (await 제거)
- `tracking/telegram.py`: non-blocking 호출 가이드 docstring 추가

## Why
- ja/zh/es 채널 추가 시 번역 대기 시간이 4배 증가 (1언어→4언어)
- 메시지 5개 × 4언어 = 40-60초 블락 → 코어 파이프라인 지연
- fire-and-forget으로 전환하면 메인 채널 발송은 즉시 진행

## Blocking Points Fixed

| File | Before | After |
|------|--------|-------|
| `stock_analysis_orchestrator.py` | `await _send_translated_messages(paths)` | pre-read → `create_task(contents)` |
| `us_stock_analysis_orchestrator.py` | `await _send_translated_messages(paths)` | pre-read → `create_task(contents)` |
| `stock_tracking_agent.py` | `create_task() + await task` | `create_task()` only |
| `us_stock_tracking_agent.py` | `create_task() + await task` | `create_task()` only |

## Verification
- [x] 잔여 blocking `await` 패턴: 0개
- [x] 전체 broadcast 호출 `create_task` 통일: 9/9
- [x] Python syntax check: 5/5 pass

## Test plan
- [ ] `--broadcast-languages en` 으로 KR/US 파이프라인 실행하여 메인 채널 즉시 발송 확인
- [ ] 백그라운드 번역 채널 메시지 정상 도착 확인
- [ ] 다중 언어 (`en,ja,zh,es`) 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)