### PR TITLE
feat: Add lang field to Firestore messages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,4 +77,14 @@ TELEGRAM_CHANNEL_ID=your_channel_id
 #
 # FIREBASE_BRIDGE_ENABLED=false
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/firebase-service-account.json
+#
+# Default Telegram channel username (Korean / main channel)
 # TELEGRAM_CHANNEL_USERNAME=your_telegram_channel_username
+#
+# Per-language channel usernames (for public channel deep links in the app)
+# Pairs with TELEGRAM_CHANNEL_ID_{LANG} above to resolve lang + build links.
+# Private channels (no username) are supported via t.me/c/{id}/{msg_id} fallback.
+# TELEGRAM_CHANNEL_USERNAME_EN=your_english_channel_username
+# TELEGRAM_CHANNEL_USERNAME_JA=your_japanese_channel_username
+# TELEGRAM_CHANNEL_USERNAME_ZH=your_chinese_channel_username
+# TELEGRAM_CHANNEL_USERNAME_ES=your_spanish_channel_username


### PR DESCRIPTION
## Summary
- Add `lang` field to Firestore `messages` collection, resolved from `TELEGRAM_CHANNEL_ID_{LANG}` env vars
- Support private Telegram channel deep links via `t.me/c/{id}/{msg_id}` fallback
- Document `TELEGRAM_CHANNEL_USERNAME_{LANG}` env vars in `.env.example`

## Why
The PRISM-Mobile app now supports 5 languages (ko, en, ja, zh, es) and needs to filter messages by language. Previously all messages had Korean channel links regardless of which channel they were sent to. The `lang` field lets the app show only messages matching the user's selected language.

## Changes
- `firebase_bridge.py`: Add `_get_channel_lang()`, `_build_telegram_link()`, store `lang` in Firestore doc
- `.env.example`: Document per-language channel username env vars

## Test plan
- [ ] Verify `_get_channel_lang()` returns correct lang for each `TELEGRAM_CHANNEL_ID_{LANG}`
- [ ] Verify private channel links generate `t.me/c/{stripped_id}/{msg_id}` format
- [ ] Verify public channel links still generate `t.me/{username}/{msg_id}` format
- [ ] Verify `lang` field appears in new Firestore documents
- [ ] Verify PRISM-Mobile app filters messages by language correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)