### PR TITLE
feat: Add Firebase Bridge to tracking agents for Prism Mobile push

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md - AI Assistant Guide for PRISM-INSIGHT
 
-> **Version**: 2.4.3 | **Updated**: 2026-02-11
+> **Version**: 2.4.4 | **Updated**: 2026-02-11
 
 ## Quick Overview
 
@@ -196,6 +196,7 @@ For comprehensive guides, see:
 
 | Ver | Date | Changes |
 |-----|------|---------|
+| 2.4.4 | 2026-02-11 | **Tracking 시스템 Firebase Bridge 통합** - stock_tracking_agent(KR)·us_stock_tracking_agent(US) 전체 메시지 전송 포인트에 `firebase_bridge.notify()` 추가 (매수/매도/보류/포트폴리오/요약 메시지 + 다국어 브로드캐스트 채널), Prism Mobile 푸시 알림 지원, `_notify_firebase()` 헬퍼 메서드 (KR: market="kr", US: market="us"), 분할 메시지 시 첫 파트 message_id로 deep link 생성 |
 | 2.4.3 | 2026-02-11 | **Broadcast PDF 순차 처리 + Tracking 리소스 경합 해결** - `_send_translated_pdfs` 언어별 병렬→순차 처리 (Playwright 동시 실행 OOM 방지), broadcast tasks를 tracking system(매매 시뮬레이션) 전에 완료 대기 (저사양 서버 리소스 경합 해결), finally 블록 안전망 유지 (KR/US 공통) |
 | 2.4.2 | 2026-02-11 | **Broadcast finally 블록 수정 + 언어별 병렬 처리** - broadcast gather를 `finally` 블록으로 이동 (early return/예외 시에도 반드시 대기), `_send_translated_messages`·`_send_translated_pdfs`·`_send_translated_trigger_alert` 언어별 `asyncio.gather()` 병렬 처리 (KR/US 6개 메서드), 다국어 채널 PDF 생성 중단 버그 해결 |
 | 2.4.1 | 2026-02-11 | **다국어 채널 + Broadcast 논블락킹 + US 진입전략 수정** - KR/US 결정문자열 정규화(`_normalize_decision`), US 0% 진입률 버그 수정 (bull detection 완화, score 6 정의 변경, min_score 하향, score-decision 일관성 강제), KR score-decision 일관성 강제 추가, Broadcast 번역 논블락킹 전환 (fire-and-forget + 파이프라인 끝 수거), 언어별 병렬 번역 (`asyncio.gather`), ja/zh/es 다국어 텔레그램 채널 지원, Firebase Bridge lang 필드 추가 |


### PR DESCRIPTION
## Summary
- KR/US tracking agents (`stock_tracking_agent.py`, `us_stock_tracking_agent.py`) used raw `telegram.Bot.send_message()` without `firebase_bridge.notify()`, so buy/sell/hold/portfolio/summary messages from the tracking system never reached Prism Mobile
- Added `_notify_firebase()` helper method to both agents (KR: `market="kr"`, US: `market="us"`)
- Wired Firebase Bridge notify into all 8 send points (4 per agent):
  - Main channel short message
  - Main channel split parts (uses first part's `message_id` for deep link)
  - Broadcast translated short message
  - Broadcast translated split parts
- `portfolio_telegram_reporter.py` already uses `TelegramBotAgent` which has Firebase Bridge built-in — no changes needed

## Test plan
- [ ] Run KR tracking batch with `FIREBASE_BRIDGE_ENABLED=true` and verify Firestore documents appear for each tracking message
- [ ] Run US tracking batch and verify US messages get `market="us"` in Firestore
- [ ] Verify broadcast channel messages (en/ja/zh/es) also create Firestore entries
- [ ] Verify split messages use first part's `message_id` for Telegram deep link
- [ ] Verify `FIREBASE_BRIDGE_ENABLED=false` (default) has zero impact on existing Telegram delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)