### PR TITLE
fix: Make Firebase notify non-blocking and remove broadcast-before-tracking wait

### DIFF
--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -819,18 +819,7 @@ class USStockAnalysisOrchestrator:
             else:
                 logger.info("Telegram disabled - skipping US message generation and transmission")
 
-            # 5-1. Wait for broadcast tasks before tracking system
-            # (prevents resource contention on low-spec servers: 1 core / 2GB RAM)
-            if self._broadcast_tasks:
-                logger.info(f"Waiting for {len(self._broadcast_tasks)} broadcast task(s) before tracking system...")
-                bc_results = await asyncio.gather(*self._broadcast_tasks, return_exceptions=True)
-                for i, bc_result in enumerate(bc_results):
-                    if isinstance(bc_result, Exception):
-                        logger.error(f"Broadcast task {i+1} failed: {bc_result}")
-                self._broadcast_tasks.clear()
-                logger.info("All broadcast tasks completed before tracking system")
-
-            # 6. Tracking system batch
+            # 6. Tracking system batch (runs concurrently with broadcast I/O tasks via async)
             if pdf_paths:
                 try:
                     logger.info("Starting US stock tracking system batch execution")

--- a/stock_analysis_orchestrator.py
+++ b/stock_analysis_orchestrator.py
@@ -882,18 +882,7 @@ class StockAnalysisOrchestrator:
             else:
                 logger.info("Telegram disabled - skipping message generation and transmission steps")
 
-            # 5-1. Wait for broadcast tasks before tracking system
-            # (prevents resource contention on low-spec servers: 1 core / 2GB RAM)
-            if self._broadcast_tasks:
-                logger.info(f"Waiting for {len(self._broadcast_tasks)} broadcast task(s) before tracking system...")
-                bc_results = await asyncio.gather(*self._broadcast_tasks, return_exceptions=True)
-                for i, bc_result in enumerate(bc_results):
-                    if isinstance(bc_result, Exception):
-                        logger.error(f"Broadcast task {i+1} failed: {bc_result}")
-                self._broadcast_tasks.clear()
-                logger.info("All broadcast tasks completed before tracking system")
-
-            # 6. Tracking system batch
+            # 6. Tracking system batch (runs concurrently with broadcast I/O tasks via async)
             if pdf_paths:
                 try:
                     logger.info("Starting stock tracking system batch execution")


### PR DESCRIPTION
## Summary
- **Firebase notify 논블로킹 전환**: tracking agents에서 `await _notify_firebase()` → `_schedule_firebase()` 태스크로 변경, 메시지 루프 끝에서 `asyncio.gather()`로 수거. Telegram 전송이 Firestore/FCM 대기 없이 즉시 진행됨
- **Step 5-1 제거**: KR/US 오케스트레이터에서 broadcast 번역 완료를 tracking 시작 전에 기다리던 블로킹 코드 삭제. 번역(LLM API) + Telegram 전송은 I/O 바운드이므로 1코어에서도 async로 동시 실행 가능. `finally` 블록이 broadcast 완료를 보장

### Pipeline flow change
```
Before: Korean channel → wait ALL broadcast translations → start tracking
After:  Korean channel → start tracking immediately (broadcast runs concurrently) → finally ensures broadcast completion
```

## Test plan
- [ ] Run KR morning pipeline and verify tracking starts immediately after Korean channel messages (no long wait for broadcast)
- [ ] Verify broadcast translations still complete (check finally block logs)
- [ ] Verify Firebase notifications appear in Firestore without delaying Telegram delivery
- [ ] Confirm Playwright PDF generation (sequential per language) still works without OOM on 1-core/2GB server

🤖 Generated with [Claude Code](https://claude.com/claude-code)