### PR TITLE
fix: Remove analyst recommendation signals from US trading agents

### DIFF
--- a/prism-us/cores/agents/trading_agents.py
+++ b/prism-us/cores/agents/trading_agents.py
@@ -94,9 +94,8 @@ yahoo_finance-get_historical_stock_prices로 S&P 500 (^GSPC) 최근 20일 데이
 
 **강한 모멘텀 신호 조건** (2개 이상 충족 시 더 공격적 진입 가능):
 1. 거래량 20일 평균 대비 200% 이상
-2. 애널리스트 투자의견 긍정적 (Buy/Strong Buy 비율 높음, get_recommendations 확인)
-3. 신고가 근접 (52주 고가 대비 95% 이상)
-4. 섹터 전체 상승 추세
+2. 신고가 근접 (52주 고가 대비 95% 이상)
+3. 섹터 전체 상승 추세
 
 **손절가 설정 철칙 (엄격 - 협상 불가):**
 - 약세장/횡보장: 손절가는 매수가 기준 -5% ~ -7% 이내
@@ -219,7 +218,6 @@ time-get_current_time tool을 사용하여 현재 시간을 확인 (미국 동�
 ### 4. 모멘텀 가산점 요소
 다음 신호 확인 시 매수 점수 가산:
 - 거래량 급증 (관심 상승. 이전의 돌파 시도 흐름을 면밀히 살펴보고, 이 종목이 돌파에 필요한 거래량의 흐름을 파악해야 함.)
-- 애널리스트 투자의견 상향 (Strong Buy/Buy 증가 추세, 스마트 머니 유입 신호)
 - 기술적 추세 전환 (강한 거래량 동반 돌파)
 - 기술적 박스권 상향 돌파 (단, 캔들이 기존 박스 고점까지 가는데 그치지 않고, 박스 업그레이드 되는 움직임이 보여야 함)
 - 동종업계 대비 저평가 (P/E, P/B 섹터 평균 이하)
@@ -247,8 +245,8 @@ time-get_current_time tool을 사용하여 현재 시간을 확인 (미국 동�
 2. P/E 업종 평균 2배+ (극단적 고평가)
 
 **복합 조건 필요 (둘 다 충족 시에만 미진입):**
-3. (RSI 85+ 또는 괴리율 +25%+) AND (애널리스트 투자의견 하향, Hold/Sell 비율 증가)
-   → RSI 높아도 수급 좋으면 진입 가능
+3. (RSI 85+ 또는 괴리율 +25%+) AND (거래량 감소 추세 또는 갭 하락 발생)
+   → RSI 높아도 거래량 뒷받침되면 진입 가능
 
 **불충분한 표현 (사용 금지):** "과열 우려", "변곡 신호", "추가 확인 필요", "리스크 통제 불가"
 
@@ -390,9 +388,8 @@ When Trigger Info is provided, use the following as guidelines:
 
 **Strong Momentum Signal Conditions** (2+ of following allows more aggressive entry):
 1. Volume 200%+ of 20-day average
-2. Positive analyst consensus (high Buy/Strong Buy ratio, check via get_recommendations)
-3. Near 52-week high (95%+)
-4. Sector-wide uptrend
+2. Near 52-week high (95%+)
+3. Sector-wide uptrend
 
 **Stop Loss Rules (STRICT - Non-negotiable):**
 - Bear/Sideways: Stop loss within -5% to -7%
@@ -508,7 +505,6 @@ Note: US market hours in Korea Standard Time (KST) are approximately 23:30~06:00
 ### 4. Momentum Bonus Factors
 Add buy score when these signals confirmed:
 - Volume surge (Interest rising - need to analyze previous breakout attempts)
-- Analyst upgrades (increasing Strong Buy/Buy trend, smart money inflow proxy)
 - Technical trend shift (breakout with strong volume)
 - Technical breakout (price moving to higher range)
 - Undervalued vs peers (P/E, P/B below sector average)
@@ -536,8 +532,8 @@ Add buy score when these signals confirmed:
 2. P/E 2x+ industry average (extreme overvaluation)
 
 **Compound Condition Required (both must be met for No Entry):**
-3. (RSI 85+ or deviation +25%+) AND (analyst downgrades, increasing Hold/Sell ratio)
-   → Entry OK if RSI high but supply is good
+3. (RSI 85+ or deviation +25%+) AND (declining volume trend or gap down)
+   → Entry OK if RSI high but volume supports
 
 **Insufficient Expressions (PROHIBITED):** "overheating concern", "inflection signal", "need more confirmation", "risk uncontrollable"
 
@@ -658,10 +654,9 @@ def create_us_sell_decision_agent(language: str = "ko"):
 **매 판단 시 반드시 먼저 확인:**
 1. yahoo_finance-get_historical_stock_prices로 S&P 500 (^GSPC) 최근 20일 데이터 확인
 2. 20일 이동평균선 위에서 상승 중인가?
-3. 애널리스트 투자의견이 긍정적인가? (Buy/Strong Buy 비율 확인, get_recommendations)
-4. 개별 종목 거래량이 평균 이상인가?
+3. 개별 종목 거래량이 평균 이상인가?
 
-→ **강세장 판단**: 위 4개 중 2개 이상 Yes
+→ **강세장 판단**: 위 3개 중 2개 이상 Yes
 → **약세장/횡보장**: 위 조건 미충족
 
 ### 매도 결정 우선순위 (손실은 짧게, 수익은 길게!)
@@ -673,8 +668,7 @@ def create_us_sell_decision_agent(language: str = "ko"):
   1. 손실이 -5% ~ -7% 사이 (-7.1% 이상은 예외 불가)
   2. 당일 종가 반등률 ≥ +3%
   3. 당일 거래량 ≥ 20일 평균 × 2배
-  4. 애널리스트 투자의견 지지 (Buy/Strong Buy 비율 높음, get_recommendations 확인)
-  5. 유예 기간: 최대 1일 (2일차 회복 없으면 무조건 매도)
+  4. 유예 기간: 최대 1일 (2일차 회복 없으면 무조건 매도)
 - 급격한 하락(-5% 이상): 추세가 꺾였는지 확인 후 전량 손절 여부 결정
 - 시장 충격 상황: 방어적 전량 매도 고려
 
@@ -685,7 +679,6 @@ def create_us_sell_decision_agent(language: str = "ko"):
 - Trailing Stop: 고점 대비 **-8~10%** (노이즈 무시)
 - 매도 조건: **명확한 추세 약화 시에만**
   * 3일 연속 하락 + 거래량 감소
-  * 애널리스트 투자의견 악화 (Hold/Sell 비율 증가, get_recommendations 확인)
   * 주요 지지선(50일선) 이탈
 
 **⭐ Trailing Stop 관리 (매 실행 시)**
@@ -827,10 +820,9 @@ You need to comprehensively analyze the data of currently held stocks to decide 
 **Must check first for every decision:**
 1. Check S&P 500 (^GSPC) recent 20 days data with yahoo_finance-get_historical_stock_prices
 2. Is it rising above 20-day moving average?
-3. Is analyst consensus positive? (check Buy/Strong Buy ratio via get_recommendations)
-4. Is individual stock volume above average?
+3. Is individual stock volume above average?
 
-→ **Bull market**: 2 or more of above 4 are Yes
+→ **Bull market**: 2 or more of above 3 are Yes
 → **Bear/Sideways market**: Conditions not met
 
 ### Sell Decision Priority (Cut Losses Short, Let Profits Run!)
@@ -842,8 +834,7 @@ You need to comprehensively analyze the data of currently held stocks to decide 
   1. Loss between -5% and -7% (NOT -7.1% or worse)
   2. Same-day bounce ≥ +3%
   3. Same-day volume ≥ 2× of 20-day average
-  4. Analyst consensus support (high Buy/Strong Buy ratio, check via get_recommendations)
-  5. Grace period: 1 day MAXIMUM (Day 2: no recovery → SELL)
+  4. Grace period: 1 day MAXIMUM (Day 2: no recovery → SELL)
 - Sharp decline (-5%+): Check if trend broken, decide on full stop loss
 - Market shock situation: Consider defensive full exit
 
@@ -854,7 +845,6 @@ You need to comprehensively analyze the data of currently held stocks to decide 
 - Trailing Stop: **-8~10%** from peak (ignore noise)
 - Sell only when **clear trend weakness**:
   * 3 consecutive days decline + volume decrease
-  * Analyst consensus deterioration (increasing Hold/Sell ratio, check via get_recommendations)
   * Break major support (50-day line)
 
 **⭐ Trailing Stop Management (Execute Every Run)**


### PR DESCRIPTION
## Summary
- 매수/매도 에이전트에서 애널리스트 투자의견(Buy/Hold/Sell) 신호 전면 제거
- 순수 가격/거래량 기반 신호만 사용하도록 변경 (O'Neil 모멘텀 매매 원칙에 부합)

## Why remove?
1. **후행 지표**: 주가 상승 후 Buy 상향, 하락 후 Sell 하향
2. **구조적 편향**: Buy ~55%, Hold ~35%, Sell ~10% (sell-side 이해충돌)
3. **군집 행동**: 독립적 신호가 아닌 컨센서스 추종
4. **MCP 한계**: `get_analyst_price_targets` 도구 없음 (목표가 조회 불가)
5. **실질적 알파 없음**: 가격/거래량이 모멘텀 매매에 더 효과적

## Changes (14 insertions, 24 deletions)

| 위치 | Before | After |
|------|--------|-------|
| 매수 모멘텀 조건 | 4개 (거래량, 애널리스트, 신고가, 섹터) | 3개 (거래량, 신고가, 섹터) |
| 매수 가산점 | 애널리스트 상향 포함 | 제거 |
| 매수 미진입 복합조건 | RSI + 애널리스트 하향 | RSI + 거래량 감소/갭 하락 |
| 매도 시장판단 | 4개 (S&P, MA, 애널리스트, 거래량) | 3개 (S&P, MA, 거래량) |
| 매도 손절 예외 | 5개 조건 | 4개 (애널리스트 지지 제거) |
| 매도 강세장 매도 | 애널리스트 악화 포함 | 제거 (가격/거래량만) |

## Test plan
- [x] 애널리스트/analyst/get_recommendations 참조 0개 확인
- [ ] KO/EN 프롬프트 일관성 확인
- [ ] 모든 신호가 yahoo_finance 가격/거래량 데이터로 검증 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)