### PR TITLE
refactor: 중복 JSON 파싱 로직을 cores/utils.py로 추출

### DIFF
--- a/cores/utils.py
+++ b/cores/utils.py
@@ -1,5 +1,8 @@
+import json
+import logging
 import re
 import subprocess
+from typing import Any, Dict, Optional
 
 # WiseReport URL template configuration
 WISE_REPORT_BASE = "https://comp.wisereport.co.kr/company/"
@@ -182,10 +185,6 @@ def get_wise_report_url(report_type: str, company_code: str) -> str:
 # --- LLM JSON Response Parsing ---
 # Consolidates duplicated regex + json_repair fallback chains.
 # TODO: Replace with generate_structured() + Pydantic models to eliminate JSON parsing entirely.
-
-import json
-import logging
-from typing import Any, Dict, Optional
 
 _json_logger = logging.getLogger(__name__)
 

--- a/prism-us/tracking/journal.py
+++ b/prism-us/tracking/journal.py
@@ -229,6 +229,7 @@ Please review the following completed US stock trade:
         result = parse_llm_json(response, context='US journal response')
         if result is not None:
             return result
+        logger.error(f"US journal response parse failed. Full response: {response}")
         return {
             "situation_analysis": {"raw_response": response[:500]},
             "judgment_evaluation": {},

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -640,6 +640,7 @@ class USStockTrackingAgent:
                 logger.info(f"Scenario parsed: {json.dumps(scenario_json, ensure_ascii=False)[:200]}")
                 return scenario_json
 
+            logger.error(f"US trading scenario parse failed. Full response: {response}")
             return default_scenario()
 
         except Exception as e:

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -352,6 +352,7 @@ class StockTrackingAgent:
                 logger.info(f"Scenario parsed: {json.dumps(scenario_json, ensure_ascii=False)[:200]}")
                 return scenario_json
 
+            logger.error(f"Trading scenario parse failed. Full response: {response}")
             return self._default_scenario()
 
         except Exception as e:

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -876,7 +876,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
 
                 decision_json = parse_llm_json(response, context=f'{ticker} sell decision')
                 if decision_json is None:
-                    logger.warning(f"{ticker} JSON parse failed, falling back to legacy algorithm")
+                    logger.error(f"{ticker} sell decision parse failed. Full response: {response}")
                     return await self._fallback_sell_decision(stock_data)
 
                 logger.info(f"Sell decision parse successful: {json.dumps(decision_json, ensure_ascii=False)[:500]}")

--- a/tracking/compression.py
+++ b/tracking/compression.py
@@ -398,6 +398,7 @@ Respond in JSON.
         result = parse_llm_json(response, context='compression response')
         if result is not None:
             return result
+        logger.error(f"Compression response parse failed. Full response: {response}")
         return {"compressed_entries": [], "new_intuitions": []}
 
     def _save_intuition(self, intuition: Dict[str, Any], source_ids: List[int]) -> bool:

--- a/tracking/journal.py
+++ b/tracking/journal.py
@@ -190,6 +190,7 @@ Please review the following completed trade:
         result = parse_llm_json(response, context='journal response')
         if result is not None:
             return result
+        logger.error(f"Journal response parse failed. Full response: {response}")
         return {
             "situation_analysis": {"raw_response": response[:500]},
             "judgment_evaluation": {},


### PR DESCRIPTION
## 요약

프로젝트 전체에 6곳 중복되어 있던 LLM JSON 파싱 로직을 cores/utils.py의 parse_llm_json() 함수로 통합했습니다.

기존 TODO 주석을 참고했습니다:
> `# TODO: Move JSON conversion function to utils for better maintainability`

## 동작 차이 안내

기존 journal `_parse_response`에는 실패 시 두 경로가 있었습니다:

| 경로 | `situation_analysis` | `confidence_score` |
|---|---|---|
| 파싱 실패 | `{"raw_response": ...}` | 0.3 |
| except Exception | `{"error": str(e)}` | 0.2 |

변경 후에는 `parse_llm_json()`이 내부에서 모든 예외를 처리하므로, except 경로 없이 첫 번째(`raw_response`, 0.3)만 남습니다. `situation_analysis["error"]` 키와 `confidence_score` 0.2 값은 코드베이스 전체에서 읽는 곳이 없어 영향 없음을 확인했습니다. 

더불어, 에러 메시지는 `parse_llm_json` 내부에서 로깅되고, DB에는 원본 응답(`raw_response`)이 남아 디버깅 시 오히려 더 유용할 것으로 판단했습니다.

## 노트

혹시 새로운 의존성 추가를 의도적으로 피하신 것인가 싶어서, Pydantic structured output은 포함하지 않았습니다. 기존 TODO(`generate_structured`)는 향후 개선 참고용으로 남겨두었습니다.

개인적으로는 Pydantic 모델 + `generate_structured()`를 도입하면 regex 파싱 자체를 없앨 수 있어서 더 깔끔할 것 같다고 생각합니다. 관심 있으시면 후속 PR로 작업해 보겠습니다.