### PR TITLE
fix: Restore Korean messages + refund daily /report limit on server error

### DIFF
--- a/analysis_manager.py
+++ b/analysis_manager.py
@@ -26,11 +26,13 @@ class AnalysisRequest:
     """Analysis request object"""
     def __init__(self, stock_code: str, company_name: str, chat_id: int = None,
                  avg_price: float = None, period: int = None, tone: str = None,
-                 background: str = None, message_id: int = None, market_type: str = "kr"):
+                 background: str = None, message_id: int = None, market_type: str = "kr",
+                 user_id: int = None):
         self.id = str(uuid.uuid4())
         self.stock_code = stock_code  # KR: stock code (6 digits), US: ticker symbol (AAPL, etc.)
         self.company_name = company_name
         self.chat_id = chat_id  # Telegram chat ID
+        self.user_id = user_id  # Telegram user ID (for daily limit refund on server error)
         self.avg_price = avg_price
         self.period = period
         self.tone = tone


### PR DESCRIPTION
## Summary

- **Commit 1** (`51ff7b4`): Telegram 봇 사용자 대면 메시지를 한국어 템플릿으로 복원
- **Commit 2** (`ed78939`): 서버 오류 시 `/report` · `/us_report` 일일 사용 횟수 환급 처리

## 버그 상세 (Commit 2)

`check_daily_limit()`은 `/report` 명령어 입력 즉시 횟수를 차감하는 구조여서, 서버 측 오류로 리포트 생성이 실패해도 차감이 유지되는 문제가 있었습니다.

실패 케이스:
- **Mode A**: 서브프로세스 30분 타임아웃 → `status="failed"`
- **Mode B**: 내부 AI 에이전트 오류 → `status="completed"` 이지만 HTML에 에러 메시지 포함

## Changes

- `AnalysisRequest`: `user_id` 필드 추가 (환급 키 조회용)
- `TelegramAIBot.refund_daily_limit()`: `daily_report_usage` 엔트리 삭제
- `TelegramAIBot._is_server_error()`: Mode A / B 모두 감지
- `send_report_result()`: 전송 전 환급 처리 (캐시 경로·큐 경로 모두 커버)
- KR/US 티커 핸들러: `AnalysisRequest` 생성 시 `user_id` 전달

## Test plan

- [ ] 정상 리포트 생성 → 차감 유지, 당일 재사용 불가 확인
- [ ] 30분 타임아웃 유발 → 차감 환급, 즉시 재시도 가능 확인
- [ ] 내부 에러로 에러 HTML 생성 → 차감 환급 확인
- [ ] `/us_report` 동일 시나리오 확인
- [ ] 캐시된 정상 리포트 반환 → 환급 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)