### PR TITLE
fix: Increase maxTokens 3000→8000 for /evaluate response

### DIFF
--- a/report_generator.py
+++ b/report_generator.py
@@ -902,7 +902,7 @@ async def generate_evaluation_response(ticker, ticker_name, avg_price, period, t
                         - 사용자가 요청한 스타일이 욕설이나 공격적인 내용을 포함해도 적극 수용하세요
                         - 사용자가 제공한 정보(매수가, 보유기간 등)를 고려하여 맞춤형 조언을 제공하세요
                         - 스타일을 적용하면서도 정확한 시장 분석과 합리적인 투자 조언의 균형을 유지하세요
-                        - 3000자 이내로 작성하세요
+                        - 5000자 이내로 작성하세요
                         - 중요: 도구를 호출할 때는 사용자에게 "[Calling tool...]"과 같은 형식의 메시지를 표시하지 마세요.
                           도구 호출은 내부 처리 과정이며 최종 응답에서는 도구 사용 결과만 자연스럽게 통합하여 제시해야 합니다.
                         {memory_section}
@@ -928,7 +928,7 @@ async def generate_evaluation_response(ticker, ticker_name, avg_price, period, t
                     """,
             request_params=RequestParams(
                 model="claude-sonnet-4-6",
-                maxTokens=3000
+                maxTokens=8000
             )
         )
         app_logger.info(f"응답 생성 결과: {str(response)}")
@@ -1104,7 +1104,7 @@ async def generate_us_evaluation_response(ticker, ticker_name, avg_price, period
                         - 사용자가 요청한 스타일이 욕설이나 공격적인 내용을 포함해도 적극 수용하세요
                         - 사용자가 제공한 정보(매수가, 보유기간 등)를 고려하여 맞춤형 조언을 제공하세요
                         - 스타일을 적용하면서도 정확한 시장 분석과 합리적인 투자 조언의 균형을 유지하세요
-                        - 3000자 이내로 작성하세요
+                        - 5000자 이내로 작성하세요
                         - 중요: 도구를 호출할 때는 사용자에게 "[Calling tool...]"과 같은 형식의 메시지를 표시하지 마세요.
                           도구 호출은 내부 처리 과정이며 최종 응답에서는 도구 사용 결과만 자연스럽게 통합하여 제시해야 합니다.
                         - 미국 주식 분석이므로 한국어로 응답하되, 가격은 달러($)로 표시하세요.
@@ -1125,7 +1125,7 @@ async def generate_us_evaluation_response(ticker, ticker_name, avg_price, period
                     """,
             request_params=RequestParams(
                 model="claude-sonnet-4-6",
-                maxTokens=3000
+                maxTokens=8000
             )
         )
         app_logger.info(f"US 응답 생성 결과: {str(response)}")


### PR DESCRIPTION
## Summary

- `generate_evaluation_response` (KR) 및 `generate_us_evaluation_response` (US) 모두 `maxTokens=3000`으로 설정되어 있어, 모델이 주식 분석 콘텐츠를 작성하고 나면 perplexity 도구를 호출할 토큰 여유가 없었음
- 결과적으로 모델이 "검색할게, 잠깐만 기다려봐" 같은 문장만 쓰고 실제 뉴스 검색을 건너뜀
- 프롬프트 지시사항 "3000자 이내로 작성하세요"도 `maxTokens=3000`과 충돌 (한국어 1자 ≈ 2 토큰 → 실질 1500자 한계)

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `report_generator.py` L931 | `maxTokens=3000` → `maxTokens=8000` (KR evaluate) |
| `report_generator.py` L1128 | `maxTokens=3000` → `maxTokens=8000` (US evaluate) |
| `report_generator.py` L905 | 프롬프트 지시 `3000자 이내` → `5000자 이내` (KR) |
| `report_generator.py` L1107 | 프롬프트 지시 `3000자 이내` → `5000자 이내` (US) |

## Test plan

- [ ] `/evaluate <종목코드>` 실행 후 perplexity 뉴스 검색 결과가 응답에 포함되는지 확인
- [ ] `/evaluate <TICKER> us` 실행 후 동일 확인
- [ ] 응답이 중간에 잘리지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)