### PR TITLE
fix: Add uv fallback when pip is not available in quickstart.sh

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -50,10 +50,14 @@ echo -e "       Python $PYTHON_VERSION detected ✓"
 echo -e "${BLUE}[2/5]${NC} Installing Python dependencies..."
 if command -v pip &> /dev/null; then
     pip install -q -r requirements.txt
-else
+elif command -v uv &> /dev/null; then
     echo -e "       pip not found, using uv..."
-    uv init
-    uv add -r requirements.txt
+    uv pip install --system -q -r requirements.txt
+else
+    echo -e "${RED}Error: pip 또는 uv가 필요합니다.${NC}"
+    echo "       pip:  https://pip.pypa.io/en/stable/installation/"
+    echo "       uv:   https://docs.astral.sh/uv/getting-started/installation/"
+    exit 1
 fi
 echo -e "       Dependencies installed ✓"
 


### PR DESCRIPTION
## Summary
   - `quickstart.sh`에서 `pip`이 설치되지 않은 환경을 위해 `uv`로 fallback하는 로직 추가
   - `pip` 사용 불가 시 자동으로 `uv pip install` 명령으로 전환하여 의존성 설치 수행

   ## Test plan
   - [ ] `pip`이 설치된 환경에서 `quickstart.sh` 정상 동작 확인
   - [ ] `pip`이 없고 `uv`만 있는 환경에서 fallback 동작 확인
   - [ ] `pip`과 `uv` 모두 없는 환경에서 적절한 에러 메시지 출력 확인