### PR TITLE
fix: Firebase notify 호출 경로에 msg_type 명시적 전달

### DIFF
--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -428,13 +428,14 @@ class USStockAnalysisOrchestrator:
             await bot_agent.process_messages_directory(
                 str(US_TELEGRAM_MSGS_DIR),
                 chat_id,
-                str(US_TELEGRAM_MSGS_DIR / "sent")
+                str(US_TELEGRAM_MSGS_DIR / "sent"),
+                msg_type="analysis"
             )
 
             # Send PDF files to main channel
             for pdf_path in pdf_paths:
                 logger.info(f"Sending US PDF file: {pdf_path}")
-                success = await bot_agent.send_document(chat_id, str(pdf_path))
+                success = await bot_agent.send_document(chat_id, str(pdf_path), msg_type="pdf")
                 if success:
                     logger.info(f"PDF file transmission successful: {pdf_path}")
                 else:
@@ -470,7 +471,7 @@ class USStockAnalysisOrchestrator:
                             from_lang="ko",
                             to_lang=lang
                         )
-                        success = await bot_agent.send_message(channel_id, translated_message)
+                        success = await bot_agent.send_message(channel_id, translated_message, msg_type="analysis")
                         if success:
                             logger.info(f"US telegram message sent successfully to {lang} channel")
                         else:
@@ -538,7 +539,7 @@ class USStockAnalysisOrchestrator:
                         if translated_pdf_paths and len(translated_pdf_paths) > 0:
                             translated_pdf_path = translated_pdf_paths[0]
                             logger.info(f"Sending translated US PDF {translated_pdf_path} to {lang} channel")
-                            success = await bot_agent.send_document(channel_id, str(translated_pdf_path))
+                            success = await bot_agent.send_document(channel_id, str(translated_pdf_path), msg_type="pdf")
 
                             if success:
                                 logger.info(f"Translated US PDF sent successfully to {lang} channel")
@@ -612,7 +613,7 @@ class USStockAnalysisOrchestrator:
 
             try:
                 bot_agent = TelegramBotAgent()
-                success = await bot_agent.send_message(chat_id, message)
+                success = await bot_agent.send_message(chat_id, message, msg_type="trigger")
 
                 if success:
                     logger.info("US Prism Signal alert transmission successful")
@@ -655,7 +656,7 @@ class USStockAnalysisOrchestrator:
                         from_lang="ko",
                         to_lang=lang
                     )
-                    success = await bot_agent.send_message(channel_id, translated_message)
+                    success = await bot_agent.send_message(channel_id, translated_message, msg_type="trigger")
                     if success:
                         logger.info(f"US trigger alert sent successfully to {lang} channel")
                     else:

--- a/stock_analysis_orchestrator.py
+++ b/stock_analysis_orchestrator.py
@@ -470,13 +470,14 @@ class StockAnalysisOrchestrator:
             await bot_agent.process_messages_directory(
                 str(TELEGRAM_MSGS_DIR),
                 chat_id,
-                str(TELEGRAM_MSGS_DIR / "sent")
+                str(TELEGRAM_MSGS_DIR / "sent"),
+                msg_type="analysis"
             )
 
             # Send PDF files to main channel
             for pdf_path in pdf_paths:
                 logger.info(f"Sending PDF file: {pdf_path}")
-                success = await bot_agent.send_document(chat_id, str(pdf_path))
+                success = await bot_agent.send_document(chat_id, str(pdf_path), msg_type="pdf")
                 if success:
                     logger.info(f"PDF file transmission successful: {pdf_path}")
                 else:
@@ -516,7 +517,7 @@ class StockAnalysisOrchestrator:
                             from_lang="ko",
                             to_lang=lang
                         )
-                        success = await bot_agent.send_message(channel_id, translated_message)
+                        success = await bot_agent.send_message(channel_id, translated_message, msg_type="analysis")
                         if success:
                             logger.info(f"Telegram message sent successfully to {lang} channel")
                         else:
@@ -586,7 +587,7 @@ class StockAnalysisOrchestrator:
                         if translated_pdf_paths and len(translated_pdf_paths) > 0:
                             translated_pdf_path = translated_pdf_paths[0]
                             logger.info(f"Sending translated PDF {translated_pdf_path} to {lang} channel")
-                            success = await bot_agent.send_document(channel_id, str(translated_pdf_path))
+                            success = await bot_agent.send_document(channel_id, str(translated_pdf_path), msg_type="pdf")
 
                             if success:
                                 logger.info(f"Translated PDF sent successfully to {lang} channel")
@@ -678,7 +679,7 @@ class StockAnalysisOrchestrator:
                 bot_agent = TelegramBotAgent()
 
                 # Send message to main channel
-                success = await bot_agent.send_message(chat_id, message)
+                success = await bot_agent.send_message(chat_id, message, msg_type="trigger")
 
                 if success:
                     logger.info("Prism Signal alert transmission successful")
@@ -723,7 +724,7 @@ class StockAnalysisOrchestrator:
                         from_lang="ko",
                         to_lang=lang
                     )
-                    success = await bot_agent.send_message(channel_id, translated_message)
+                    success = await bot_agent.send_message(channel_id, translated_message, msg_type="trigger")
                     if success:
                         logger.info(f"Trigger alert sent successfully to {lang} channel")
                     else:


### PR DESCRIPTION
## Summary

- `_get_trigger_win_rate()`가 반환하는 문자열(`"📡 이 트리거 과거 승률: N%"`)에 `트리거` 키워드가 포함되어, 매수/매도 메시지가 `detect_type()` 텍스트 휴리스틱에 의해 `trigger`로 오분류되는 버그 수정
- 모든 Firebase `notify()` 호출 경로에서 `msg_type`을 명시적으로 전달
- `detect_type()`은 `msg_type=None`일 때만 동작하는 fallback으로 유지

## Changed Files

| 파일 | 변경 내용 |
|------|-----------|
| `telegram_bot_agent.py` | `send_message`, `send_document`, `process_messages_directory`에 `msg_type` 파라미터 추가 및 전달 |
| `tracking/telegram.py` | `send_messages`, `_send_single_message`에 `msg_type` 파라미터 추가 및 전달 |
| `stock_analysis_orchestrator.py` | 6개 호출 사이트에 `analysis`/`pdf`/`trigger` 타입 명시 |
| `prism-us/us_stock_analysis_orchestrator.py` | 동일 패턴 (6곳) |
| `stock_tracking_agent.py` | `_msg_types` 병렬 리스트 도입, 전체 notify 호출 경로 전달 |
| `prism-us/us_stock_tracking_agent.py` | 동일 패턴 + `_save_watchlist_item` 추가 |

## Type Mapping

| 호출 사이트 | msg_type |
|---|---|
| 매수/매도/watchlist skip 메시지 | `"analysis"` |
| 포트폴리오 요약 | `"portfolio"` |
| 트리거 얼럿 | `"trigger"` |
| PDF 전송 | `"pdf"` |

## Test Plan

- [x] 6개 파일 Python AST 문법 검증 통과
- [x] `tests/test_firebase_bridge.py` 실행 — 기존 10/12 pass 유지 (2개 실패는 pre-existing)
- [x] `tracking.telegram` import 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)