### PR TITLE
feat: 포트폴리오 조정 메시지에 상향/하향 방향 표시 추가

### DIFF
--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -1066,7 +1066,12 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                     )
                     self.conn.commit()
                     db_updated = True
-                    direction = "상향" if target_price_num > old_target_price else "하향"
+                    if target_price_num == old_target_price:
+                        direction = "유지"
+                    elif target_price_num > old_target_price:
+                        direction = "상향"
+                    else:
+                        direction = "하향"
                     update_message += f"목표가: {target_price_num:,.0f}원으로 {direction}조정\n"
                     logger.info(
                         f"{ticker} Target price AI {direction} adjustment: "
@@ -1085,7 +1090,12 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                     )
                     self.conn.commit()
                     db_updated = True
-                    direction = "상향" if stop_loss_num > old_stop_loss else "하향"
+                    if stop_loss_num == old_stop_loss:
+                        direction = "유지"
+                    elif stop_loss_num > old_stop_loss:
+                        direction = "상향"
+                    else:
+                        direction = "하향"
                     update_message += f"손절가: {stop_loss_num:,.0f}원으로 {direction}조정\n"
                     logger.info(
                         f"{ticker} Stop-loss AI {direction} adjustment: "


### PR DESCRIPTION
## 요약

포트폴리오 조정 텔레그램 메시지에서 목표가/손절가 변경 시 **상향조정**인지 **하향조정**인지 방향을 표시합니다.

## 문제

조정 근거가 길고 복잡한 경우, 근거 텍스트를 끝까지 읽어야 올린 건지 내린 건지 파악할 수 있습니다. 이전 가격이 함께 제시되지 않아서 조정 방향을 직관적으로 이해하는데 어려움이 있습니다.

> 🚨 포트폴리오 조정: 종목A
손절가: XXX원으로 조정
조정 근거: 최근 고점을 형성했고, 강세장 모드 기준 트레일링 스탑(-N%)을
적용해 이익을 일부 방어하는 것이 합리적입니다...

## 해결

- UPDATE 전에 기존 값 SELECT → 비교하여 `상향`/`하향` 라벨 추가
- 호출부 변경 없음, `_process_portfolio_adjustment` 내부만 수정
- DB NULL 방어 처리 포함

> 🚨 포트폴리오 조정: 종목A
손절가: XXX원으로 상향조정
조정 근거: ...

> 🚨 포트폴리오 조정: 종목A
손절가: XXX원으로 하향조정

## 노트

기존 값을 DB에서 가져오는 김에 변경 폭을 숫자로도 표시하려 했는데, 상향/하향 라벨만 추가하는 쪽이 더 직관적이라고 판단했습니다. 의견 주시면 반영하겠습니다.