### PR TITLE
fix: prism-us/tracking/journal.py cores.utils 네임스페이스 충돌 수정

### DIFF
--- a/prism-us/tracking/journal.py
+++ b/prism-us/tracking/journal.py
@@ -12,7 +12,6 @@ import traceback
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-from cores.utils import parse_llm_json
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +41,12 @@ def _import_from_main_cores(module_name: str, relative_path: str):
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+# Load parse_llm_json from main project cores/utils.py
+# (avoids prism-us/cores/ namespace collision)
+_utils_module = _import_from_main_cores("cores_utils", "cores/utils.py")
+parse_llm_json = _utils_module.parse_llm_json
 
 
 class USJournalManager:


### PR DESCRIPTION
## Summary

- `aa16fdb` PR에서 `prism-us/tracking/journal.py`에 추가된 `from cores.utils import parse_llm_json`이 `ModuleNotFoundError` 유발
- `60c895f`(`fix/us-tracking-cores-utils-import`)에서 `us_stock_tracking_agent.py`만 수정되었고 `journal.py`가 누락됨
- 기존 `_import_from_main_cores` 헬퍼를 동일하게 적용하여 수정

## Root Cause

`prism-us/` 기준 실행 시 `prism-us/cores/`가 sys.path에서 메인 프로젝트의 `cores/`를 가려 직접 import 불가.

## Change

`prism-us/tracking/journal.py`에서:
- `from cores.utils import parse_llm_json` 제거
- `_import_from_main_cores("cores_utils", "cores/utils.py")`로 대체

## Test plan

- [ ] `python prism-us/us_stock_analysis_orchestrator.py --mode morning` 실행 시 `ModuleNotFoundError: No module named 'cores.utils'` 미발생 확인
- [ ] `python prism-us/us_stock_tracking_agent.py` import 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)