### PR TITLE
fix: Firebase 메시지 타입/마켓 오감지 수정

### DIFF
--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -435,7 +435,7 @@ class USStockAnalysisOrchestrator:
             # Send PDF files to main channel
             for pdf_path in pdf_paths:
                 logger.info(f"Sending US PDF file: {pdf_path}")
-                success = await bot_agent.send_document(chat_id, str(pdf_path), msg_type="pdf")
+                success = await bot_agent.send_document(chat_id, str(pdf_path), msg_type="pdf", market="us")
                 if success:
                     logger.info(f"PDF file transmission successful: {pdf_path}")
                 else:
@@ -539,7 +539,7 @@ class USStockAnalysisOrchestrator:
                         if translated_pdf_paths and len(translated_pdf_paths) > 0:
                             translated_pdf_path = translated_pdf_paths[0]
                             logger.info(f"Sending translated US PDF {translated_pdf_path} to {lang} channel")
-                            success = await bot_agent.send_document(channel_id, str(translated_pdf_path), msg_type="pdf")
+                            success = await bot_agent.send_document(channel_id, str(translated_pdf_path), msg_type="pdf", market="us")
 
                             if success:
                                 logger.info(f"Translated US PDF sent successfully to {lang} channel")

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -456,6 +456,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                     if trigger_win_rate:
                         skip_message += f"\n{trigger_win_rate}"
 
+                    self._msg_types.append("analysis")
                     self.message_queue.append(skip_message)
                     logger.info(f"Purchase deferred: {company_name}({ticker}) - {reason}")
 
@@ -1085,6 +1086,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                     message += f"기술적 추세: {analysis_summary.get('technical_trend', 'N/A')}\n"
                     message += f"시장 환경 영향: {analysis_summary.get('market_condition_impact', 'N/A')}"
 
+                self._msg_types.append("portfolio")
                 self.message_queue.append(message)
                 logger.info(f"{ticker} AI-based portfolio adjustment complete: {update_message.strip()}")
             else:

--- a/telegram_bot_agent.py
+++ b/telegram_bot_agent.py
@@ -121,7 +121,7 @@ class TelegramBotAgent:
                     return False
             return False
 
-    async def send_document(self, chat_id, document_path, caption=None, retry_count=0, max_retries=3, msg_type=None):
+    async def send_document(self, chat_id, document_path, caption=None, retry_count=0, max_retries=3, msg_type=None, market=None):
         """
         Send file to Telegram channel
 
@@ -131,6 +131,7 @@ class TelegramBotAgent:
             caption (str, optional): File description
             retry_count (int): Current retry count
             max_retries (int): Maximum retry attempts
+            market (str, optional): Market identifier ('kr' or 'us'). Auto-detected if None.
 
         Returns:
             bool: Transmission success status
@@ -149,6 +150,7 @@ class TelegramBotAgent:
                 telegram_link = f"https://t.me/{os.environ.get('TELEGRAM_CHANNEL_USERNAME', 'stock_ai_agent')}/{result.message_id}"
                 await notify(
                     message=caption or str(document_path),
+                    market=market,
                     telegram_message_id=result.message_id,
                     channel_id=chat_id,
                     has_pdf=True,
@@ -164,7 +166,7 @@ class TelegramBotAgent:
             logger.warning(f"Rate limit hit. Waiting {wait_time} seconds before retry...")
             await asyncio.sleep(wait_time)
             if retry_count < max_retries:
-                return await self.send_document(chat_id, document_path, caption, retry_count + 1, max_retries, msg_type=msg_type)
+                return await self.send_document(chat_id, document_path, caption, retry_count + 1, max_retries, msg_type=msg_type, market=market)
             else:
                 logger.error(f"Max retries reached after rate limit")
                 return False
@@ -174,7 +176,7 @@ class TelegramBotAgent:
                 wait_time = 2 ** retry_count  # 1, 2, 4 seconds
                 logger.warning(f"Timeout occurred. Retrying in {wait_time} seconds... (attempt {retry_count + 1}/{max_retries})")
                 await asyncio.sleep(wait_time)
-                return await self.send_document(chat_id, document_path, caption, retry_count + 1, max_retries, msg_type=msg_type)
+                return await self.send_document(chat_id, document_path, caption, retry_count + 1, max_retries, msg_type=msg_type, market=market)
             else:
                 logger.error(f"Max retries reached after timeout")
                 return False


### PR DESCRIPTION
## Summary

- **매수 보류 메시지 → 'trigger' 오분류 수정**: `stock_tracking_enhanced_agent.py`에서 매수 보류 메시지와 포트폴리오 조정 메시지를 `message_queue`에 추가할 때 `_msg_types.append()`가 누락되어 있었음. 배열 길이 불일치로 `msg_type=None`이 되어 `detect_type()` 기본값 `'trigger'`로 잘못 분류되던 버그 수정
- **US PDF → 'kr' 마켓 오감지 수정**: `telegram_bot_agent.send_document()`에 `market` 파라미터를 추가하고, `us_stock_analysis_orchestrator.py`에서 US PDF 전송 시 `market="us"`를 명시적으로 전달

## 변경 파일

| 파일 | 수정 내용 |
|------|----------|
| `stock_tracking_enhanced_agent.py` | 매수 보류(`analysis`), 포트폴리오 조정(`portfolio`) `_msg_types.append()` 추가 |
| `telegram_bot_agent.py` | `send_document()`에 `market` 파라미터 추가 |
| `prism-us/us_stock_analysis_orchestrator.py` | US PDF 전송 2곳에 `market="us"` 추가 |

## Test plan

- [ ] 매수 보류 발생 시 Firebase 메시지 타입이 `analysis`로 전달되는지 확인
- [ ] 포트폴리오 조정 발생 시 Firebase 메시지 타입이 `portfolio`로 전달되는지 확인
- [ ] US PDF 전송 시 Firebase market이 `us`로 저장되는지 확인
- [ ] KR PDF 전송 시 기존 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)