### PR TITLE
fix: add missing tabulate dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ mdpdf>=0.0.9  # 간편한 마크다운 변환 (대체 방식)
 
 # 주식 데이터 관련
 pykrx==1.0.48
+tabulate>=0.9.0  # DataFrame to markdown table conversion
 
 # 한국투자증권 API 관련
 PyYAML>=6.0.1  # 설정 파일 파싱


### PR DESCRIPTION
## Summary
- `tabulate` 패키지가 `requirements.txt`에 누락되어 있어 `cores/data_prefetch.py`에서 DataFrame → markdown 변환 시 아래 오류 발생:
  ```
  Missing optional dependency 'tabulate'. Use pip or conda to install tabulate.
  ```
- `tabulate>=0.9.0` 추가로 해결

## Test plan
- [ ] `pip install -r requirements.txt` 후 `tabulate` 정상 설치 확인
- [ ] `cores/data_prefetch.py` OHLCV/거래량 prefetch 오류 없이 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)