### PR TITLE
fix: FCM lang 필터 버그 수정 - lang 미설정 디바이스 알림 누락 해결

### DIFF
--- a/firebase_bridge.py
+++ b/firebase_bridge.py
@@ -425,9 +425,9 @@ async def _send_push(title: str, body: str, msg_type: str, market: str, lang: st
             if msg_type not in pref_types:
                 continue
 
-            # Check lang preference (default 'ko' for devices without lang set)
-            pref_lang = prefs.get('lang', 'ko')
-            if lang and pref_lang != lang:
+            # Check lang preference: only filter if device has explicit lang set
+            pref_lang = prefs.get('lang')  # None if not set → receives all notifications
+            if lang and pref_lang and pref_lang != lang:
                 continue
 
             token = device.get('token')


### PR DESCRIPTION
## 문제

앱 푸시 알림이 전혀 오지 않는 버그. 프로덕션 로그에서 반복 확인:
```
Firebase: No matching devices for push notification
```

## 원인 분석

Firestore `devices` 컬렉션의 모든 디바이스가 `lang=None` 상태 (앱에서 언어를 명시적으로 선택하지 않으면 미등록).

```python
# 기존 코드 (버그)
pref_lang = prefs.get('lang', 'ko')   # 미설정 시 'ko' 기본값
if lang and pref_lang != lang:         # US채널(en/ja/zh/es) 전송 시 → 'ko' != 'en' → 전체 제외
    continue
```

- KR 채널: `lang='ko'` → `'ko' == 'ko'` → 수신 (부분 작동)
- US 채널: `lang='en'/'ja'/'zh'/'es'` → `'ko' != 'en'` → **전체 디바이스 제외**

## 수정

```python
# 수정 후
pref_lang = prefs.get('lang')                    # None if not set
if lang and pref_lang and pref_lang != lang:     # None → short-circuit → pass through
    continue
```

`lang`이 명시적으로 설정된 디바이스만 언어 필터 적용. 미설정 디바이스는 모든 알림 수신 (기존 `markets`/`types` 필터는 그대로 유지).

## 변경 사항

- `firebase_bridge.py`: `pref_lang` 기본값 `'ko'` 제거 + 필터 조건에 `pref_lang` null 체크 추가

## 프로덕션 적용

동일 수정이 프로덕션 서버(`64.176.227.37:/root/prism-insight/firebase_bridge.py`)에 이미 직접 적용됨. 이 PR은 코드베이스 동기화 목적.

🤖 Generated with [Claude Code](https://claude.com/claude-code)