### PR TITLE
fix: telegram evaluator multi-JSON 파싱 에러 수정

### DIFF
--- a/telegram_summary_agent.py
+++ b/telegram_summary_agent.py
@@ -15,6 +15,60 @@ from mcp_agent.workflows.evaluator_optimizer.evaluator_optimizer import (
     QualityRating,
 )
 
+
+def _extract_last_valid_json(text: str) -> str:
+    """Extract the last complete JSON object from text that may contain multiple objects.
+
+    gpt-5.x reasoning models sometimes emit empty {} thinking tokens before the
+    real JSON payload, producing strings like '{}\n{}\n{"rating":1,...}'.
+    This helper finds the last (most complete) top-level JSON object.
+    """
+    depth = 0
+    start = -1
+    last_complete = None
+    for i, ch in enumerate(text):
+        if ch == '{':
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == '}':
+            depth -= 1
+            if depth == 0 and start != -1:
+                last_complete = text[start:i + 1]
+    return last_complete or text
+
+
+class _RobustEvaluatorLLM:
+    """Thin wrapper around an AugmentedLLM that recovers from multi-JSON responses.
+
+    gpt-5.x reasoning models sometimes return several JSON objects in a single
+    completion (e.g. empty `{}` thinking tokens followed by the real payload).
+    The mcp_agent library calls `json.loads` / `model_validate_json` on the raw
+    content and raises a Pydantic ValidationError for trailing characters.
+
+    This wrapper intercepts that failure, calls `generate_str` as a fallback to
+    get the raw text, extracts the last well-formed JSON object, and re-validates.
+    """
+
+    def __init__(self, llm):
+        self._llm = llm
+
+    def __getattr__(self, name):
+        return getattr(self._llm, name)
+
+    async def generate_structured(self, message, response_model, request_params=None):
+        try:
+            return await self._llm.generate_structured(message, response_model, request_params)
+        except Exception as e:
+            logger.warning(f"generate_structured failed ({e}), retrying with JSON extraction fallback")
+            text = await self._llm.generate_str(message=message, request_params=request_params)
+            candidate = _extract_last_valid_json(text)
+            try:
+                data = json.loads(candidate)
+                return response_model.model_validate(data)
+            except Exception:
+                return response_model.model_validate_json(candidate)
+
 # Logging setup
 logging.basicConfig(
     level=logging.INFO,
@@ -214,6 +268,9 @@ class TelegramSummaryGenerator:
             llm_factory=OpenAIAugmentedLLM,
             min_rating=QualityRating.EXCELLENT
         )
+
+        # Wrap evaluator_llm to handle multi-JSON responses from gpt-5.x reasoning models
+        evaluator_optimizer.evaluator_llm = _RobustEvaluatorLLM(evaluator_optimizer.evaluator_llm)
 
         # Construct message prompt
         prompt_message = f"""다음은 {metadata['stock_name']}({metadata['stock_code']}) 종목에 대한 상세 분석 보고서입니다.


### PR DESCRIPTION
## Summary

- `gpt-5.x` reasoning 모델이 `EvaluationResult` JSON 응답 앞에 빈 `{}` thinking 토큰을 출력해 Pydantic `ValidationError: trailing characters` 발생
- `mcp_agent` 라이브러리의 `generate_structured`가 `json.loads` → `model_validate_json` 순으로 파싱 시도하나 둘 다 실패
- `EvaluatorOptimizerLLM`의 evaluator 단계에서 예외 발생 → 보고서 전체 처리 중단

## Changes

- `_extract_last_valid_json(text)`: 중괄호 깊이 추적으로 텍스트에서 마지막 완전한 JSON 객체만 추출
- `_RobustEvaluatorLLM`: `evaluator_llm.generate_structured()` 래퍼 클래스 — 파싱 실패 시 `generate_str()` fallback + JSON 추출 후 재파싱
- `EvaluatorOptimizerLLM` 생성 직후 `evaluator_llm`에 래퍼 적용

## Test plan

- [ ] `telegram_summary_agent.py` 실행 후 `gpt-5.x` 모델이 multi-JSON 응답 반환 시 fallback 경고 로그 출력 확인
- [ ] `EvaluationResult` 파싱 성공 및 보고서 처리 완료 확인
- [ ] 정상 응답(단일 JSON) 케이스에서 기존 동작 변화 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)