### PR TITLE
fix: US 매수 시 AI decision override 버그 수정

### DIFF
--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -1834,15 +1834,9 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                 if raw_decision and raw_decision.lower() != normalized_decision:
                     logger.debug(f"Decision normalized: '{raw_decision}' -> '{normalized_decision}'")
 
-                # Score-decision consistency enforcement:
-                # If adjusted score meets threshold, override LLM decision to entry
-                if adjusted_score >= min_score and normalized_decision != "entry":
-                    logger.info(
-                        f"Score-decision override: {company_name}({ticker}) - "
-                        f"Score {adjusted_score} >= {min_score} but decision='{normalized_decision}', forcing entry"
-                    )
-                    normalized_decision = "entry"
-
+                # Respect AI agent's decision (consistent with KR logic)
+                # AI considers qualitative factors (RSI, support structure, volume, etc.)
+                # beyond just the score, so do not override its decision
                 if normalized_decision == "entry":
                     buy_success = await self.buy_stock(ticker, company_name, current_price, scenario, rank_change_msg)
 


### PR DESCRIPTION
## Summary
- US tracking agent에서 `buy_score >= min_score`이면 AI의 "미진입" 판단을 무시하고 강제 매수하던 로직 제거
- KR tracking agent와 동일하게 AI agent의 decision을 존중하도록 변경
- AI가 정성적 분석(RSI 과열, 손절 구조, 거래량 등)을 반영해 "미진입"을 판단한 경우 이를 존중

## Root Cause
`us_stock_tracking_agent.py` 1837~1844줄의 "Score-decision consistency enforcement" 로직이 `adjusted_score >= min_score`일 때 AI decision을 `"entry"`로 강제 override함. 이로 인해 SNDK(score 5/5, 미진입), HAL(score 5/5, 미진입) 등 AI가 의도적으로 거부한 종목이 매수됨.

## KR vs US 비교
| | KR | US (before) | US (after) |
|---|---|---|---|
| 매수 조건 | `decision == "Enter"` | `score >= min_score` (decision 무시) | `decision == "entry"` |

## Test plan
- [ ] `--date 20260310 --mode afternoon --no-telegram` 재실행 시 HAL, SNDK가 미진입 처리되는지 확인
- [ ] KR morning batch에서 기존 매수 로직이 영향 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)