### PR TITLE
fix: US trigger results 파일 경로 불일치 수정

### DIFF
--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -321,9 +321,9 @@ class USStockAnalysisOrchestrator:
         try:
             from us_trigger_batch import run_batch
 
-            # Results file path
+            # Results file path (use PRISM_US_DIR for consistent path with telegram_summary_agent)
             effective_date = override_date if override_date else datetime.now().strftime("%Y%m%d")
-            results_file = f"trigger_results_us_{mode}_{effective_date}.json"
+            results_file = str(PRISM_US_DIR / f"trigger_results_us_{mode}_{effective_date}.json")
 
             # Run batch
             loop = asyncio.get_event_loop()
@@ -919,7 +919,7 @@ class USStockAnalysisOrchestrator:
                 logger.warning("US macro intelligence unavailable - proceeding without macro context")
 
             # 1. Execute trigger batch
-            results_file = f"trigger_results_us_{mode}_{effective_date}.json"
+            results_file = str(PRISM_US_DIR / f"trigger_results_us_{mode}_{effective_date}.json")
             tickers = await self.run_trigger_batch(mode, macro_context=macro_context, override_date=override_date)
 
             if not tickers:
@@ -980,7 +980,7 @@ class USStockAnalysisOrchestrator:
                         # Use main channel (Korean) by default - same as Korean stock version
                         chat_id = self.telegram_config.channel_id if self.telegram_config.use_telegram else None
 
-                        trigger_results_file = f"trigger_results_us_{mode}_{effective_date}.json"
+                        trigger_results_file = str(PRISM_US_DIR / f"trigger_results_us_{mode}_{effective_date}.json")
 
                         # US uses fixed GICS sectors (fallback in trading_agents.py)
                         tracking_success = await tracking_agent.run(


### PR DESCRIPTION
## Summary
- US orchestrator가 `trigger_results_us_*.json`을 상대경로(CWD)에 저장하는데, `telegram_summary_agent`는 `_prism_us_dir`(prism-us/) 절대경로에서 찾아 경로 불일치 발생
- 3곳의 `results_file` 경로를 `PRISM_US_DIR` 기준 절대경로로 통일

## Root Cause
- crontab: `cd /root/prism-insight && python prism-us/us_stock_analysis_orchestrator.py`
- 파일 저장: `/root/prism-insight/trigger_results_us_morning_20260312.json` (CWD)
- 파일 탐색: `/root/prism-insight/prism-us/trigger_results_us_morning_20260312.json` (_prism_us_dir)
- 결과: trigger type 감지 실패 → "Notable Pattern, mode: unknown" fallback

## Changes
- `run_trigger_batch()`: `results_file` 절대경로화
- `run_full_pipeline()`: trigger alert용 `results_file` 절대경로화  
- tracking agent 호출: `trigger_results_file` 절대경로화

## Note
- KR 쪽은 orchestrator와 telegram agent 모두 상대경로를 사용하여 CWD 기준으로 일치하므로 영향 없음

## Test plan
- [ ] US morning batch 실행 후 trigger type이 정상 감지되는지 확인
- [ ] telegram 메시지에 올바른 trigger type이 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)