### PR TITLE
fix: KR score-decision override 가드 + KR/US maxTokens 확대

### DIFF
--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -640,7 +640,7 @@ class USStockTrackingAgent:
                 message=prompt_message,
                 request_params=RequestParams(
                     model="gpt-5.2",
-                    maxTokens=20000
+                    maxTokens=30000
                 )
             )
 
@@ -1167,7 +1167,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
 
             response = await llm.generate_str(
                 message=prompt_message,
-                request_params=RequestParams(model="gpt-5.2", maxTokens=16000)
+                request_params=RequestParams(model="gpt-5.2", maxTokens=30000)
             )
 
             if not response or not response.strip():

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -343,7 +343,7 @@ class StockTrackingAgent:
                 message=prompt_message,
                 request_params=RequestParams(
                     model="gpt-5.2",
-                    maxTokens=20000
+                    maxTokens=30000
                 )
             )
 

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -416,7 +416,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
 
                 # Score-decision consistency enforcement:
                 # If score meets threshold and sector is diverse, override LLM decision to Enter
-                if buy_score >= min_score and sector_diverse and decision != "Enter":
+                if buy_score > 0 and buy_score >= min_score and sector_diverse and decision != "Enter":
                     logger.info(
                         f"Score-decision override: {company_name}({ticker}) - "
                         f"Score {buy_score} >= {min_score} but decision='{decision}', forcing Enter"
@@ -866,7 +866,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                 message=prompt_message,
                 request_params=RequestParams(
                     model="gpt-5.2",
-                    maxTokens=16000
+                    maxTokens=30000
                 )
             )
 


### PR DESCRIPTION
## Summary
- KR `stock_tracking_enhanced_agent`의 score-decision override에 `buy_score > 0` 가드 추가 — LLM 빈 응답 시 `default_scenario(buy_score=0, min_score=0)`로 `0 >= 0` 통과하여 강제 매수되는 버그 수정 (US는 #203에서 수정 완료, KR 미적용 상태였음)
- KR/US 매수·매도 시나리오 에이전트 `maxTokens` 16000~20000 → 30000 통일 (gpt-5.2 reasoning 토큰 소진으로 빈 응답 반환 방지)

## Test plan
- [ ] KR morning 분석 실행 후 trading scenario 정상 파싱 확인
- [ ] LLM 빈 응답 시 score 0 종목이 매수되지 않는지 확인
- [ ] US morning 분석 실행 후 시나리오/매도 판단 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)