### PR TITLE
feat: KR/US 보고서 거시경제 섹션 소제목 추가

### DIFF
--- a/cores/analysis.py
+++ b/cores/analysis.py
@@ -247,6 +247,7 @@ async def analyze_stock(company_code: str = "000660", company_name: str = "SK하
                         "strong_bull": "강한 강세장", "moderate_bull": "보통 강세장",
                         "sideways": "횡보장", "moderate_bear": "보통 약세장", "strong_bear": "강한 약세장"
                     }
+                    macro_section += "### 거시경제 환경\n\n"
                     macro_section += f"**시장 체제**: {regime_labels.get(regime, regime)}\n\n"
                     if regime_rationale:
                         macro_section += f"**판단 근거**: {regime_rationale}\n\n"
@@ -261,6 +262,7 @@ async def analyze_stock(company_code: str = "000660", company_name: str = "SK하
                             macro_section += f"- ⚠️ {r.get('event', '')} (영향: {r.get('severity', 'medium')})\n"
                         macro_section += "\n"
                 else:
+                    macro_section += "### Macroeconomic Environment\n\n"
                     macro_section += f"**Market Regime**: {regime.replace('_', ' ').title()}\n\n"
                     if regime_rationale:
                         macro_section += f"**Rationale**: {regime_rationale}\n\n"
@@ -361,7 +363,8 @@ async def analyze_stock(company_code: str = "000660", company_name: str = "SK하
             final_report += main_headers["market"]
             final_report += section_reports["market_index_analysis"] + "\n\n"
             if macro_section:
-                final_report += macro_section
+                macro_header = "### 거시경제 환경\n\n" if language == "ko" else "### Macroeconomic Environment\n\n"
+                final_report += macro_header + macro_section
 
         # Investment Strategy section
         if "investment_strategy" in section_reports:

--- a/prism-us/cores/us_analysis.py
+++ b/prism-us/cores/us_analysis.py
@@ -342,8 +342,8 @@ async def analyze_us_stock(
         if macro_context:
             report_prose = macro_context.get("report_prose", "")
             if report_prose:
-                # Use LLM-generated prose directly — self-contained, no extra header needed
-                macro_section = report_prose + "\n\n"
+                macro_header = "### 거시경제 환경\n\n" if language == "ko" else "### Macroeconomic Environment\n\n"
+                macro_section = macro_header + report_prose + "\n\n"
             else:
                 # Fallback: build from structured fields if report_prose is empty
                 regime = macro_context.get("market_regime", "sideways")
@@ -357,6 +357,7 @@ async def analyze_us_stock(
                         "strong_bull": "강한 강세장", "moderate_bull": "보통 강세장",
                         "sideways": "횡보장", "moderate_bear": "보통 약세장", "strong_bear": "강한 약세장"
                     }
+                    macro_section += "### 거시경제 환경\n\n"
                     macro_section += f"**시장 체제**: {regime_labels.get(regime, regime)}\n\n"
                     if regime_rationale:
                         macro_section += f"**판단 근거**: {regime_rationale}\n\n"
@@ -371,6 +372,7 @@ async def analyze_us_stock(
                             macro_section += f"- ⚠️ {r.get('event', '')} (영향: {r.get('severity', 'medium')})\n"
                         macro_section += "\n"
                 else:
+                    macro_section += "### Macroeconomic Environment\n\n"
                     macro_section += f"**Market Regime**: {regime.replace('_', ' ').title()}\n\n"
                     if regime_rationale:
                         macro_section += f"**Rationale**: {regime_rationale}\n\n"


### PR DESCRIPTION
## Summary
- KR/US 보고서의 거시경제 섹션에 `### 거시경제 환경` / `### Macroeconomic Environment` 소제목 추가
- report_prose 경로와 fallback(구조화 필드) 경로 모두 적용

## Test plan
- [ ] KR 보고서 생성 후 거시경제 섹션에 소제목 표시 확인
- [ ] US 보고서 생성 후 동일 확인
- [ ] PDF 렌더링 시 소제목 정상 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)