### PR TITLE
feat: GPT-5.4 하이브리드 모델 업그레이드 + mcp-agent fork 패치

### DIFF
--- a/cores/report_generation.py
+++ b/cores/report_generation.py
@@ -103,7 +103,7 @@ async def generate_report(agent, section, company_name, company_code, reference_
     report = await llm.generate_str(
         message=message,
         request_params=RequestParams(
-            model="gpt-5.2",
+            model="gpt-5.4-mini",
             reasoning_effort="none",
             maxTokens=32000,
             parallel_tool_calls=True,
@@ -193,7 +193,7 @@ async def generate_market_report(agent, section, reference_date, logger, languag
     report = await llm.generate_str(
         message=message,
         request_params=RequestParams(
-            model="gpt-5.2",
+            model="gpt-5.4-mini",
             reasoning_effort="none",
             maxTokens=32000,
             max_iterations=3,
@@ -304,7 +304,7 @@ Comprehensive Analysis Report:
         executive_summary = await llm.generate_str(
             message=message,
             request_params=RequestParams(
-                model="gpt-5.2",
+                model="gpt-5.4-mini",
                 reasoning_effort="none",
                 maxTokens=16000,
                 max_iterations=2,
@@ -541,7 +541,7 @@ Please present a consistent and executable investment strategy that investors ca
         investment_strategy = await llm.generate_str(
             message=message,
             request_params=RequestParams(
-                model="gpt-5.2",
+                model="gpt-5.4-mini",
                 reasoning_effort="none",
                 maxTokens=32000,
                 max_iterations=3,

--- a/prism-us/tracking/journal.py
+++ b/prism-us/tracking/journal.py
@@ -133,7 +133,7 @@ class USJournalManager:
 
                 response = await llm.generate_str(
                     message=prompt,
-                    request_params=RequestParams(model="gpt-5.2", reasoning_effort="none", maxTokens=16000)
+                    request_params=RequestParams(model="gpt-5.4-mini", reasoning_effort="none", maxTokens=16000)
                 )
                 logger.info(f"US Journal agent response received: {len(response)} chars")
 

--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -236,7 +236,7 @@ class USStockAnalysisOrchestrator:
                 result = await llm.generate_str(
                     message=f"Execute US stock market macro analysis for {reference_date} and output JSON.",
                     request_params=RequestParams(
-                        model="gpt-5.2",
+                        model="gpt-5.4-mini",
                         reasoning_effort="none",
                         maxTokens=16000,
                         parallel_tool_calls=True,

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -639,7 +639,7 @@ class USStockTrackingAgent:
             response = await llm.generate_str(
                 message=prompt_message,
                 request_params=RequestParams(
-                    model="gpt-5.2",
+                    model="gpt-5.4",
                     maxTokens=30000
                 )
             )
@@ -1178,7 +1178,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
 
             response = await llm.generate_str(
                 message=prompt_message,
-                request_params=RequestParams(model="gpt-5.2", maxTokens=30000)
+                request_params=RequestParams(model="gpt-5.4", maxTokens=30000)
             )
 
             if not response or not response.strip():

--- a/prism-us/us_telegram_summary_agent.py
+++ b/prism-us/us_telegram_summary_agent.py
@@ -478,7 +478,7 @@ Report Content:
         response = await evaluator_optimizer.generate_str(
             message=prompt_message,
             request_params=RequestParams(
-                model="gpt-5.2",
+                model="gpt-5.4-mini",
                 reasoning_effort="none",
                 maxTokens=6000,
                 max_iterations=2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 streamlit>=1.10.0
 pandas~=2.2.3
 numpy~=2.2.3
-mcp-agent>=0.2.6
+# mcp-agent>=0.2.6  # TODO: upstream PR #648 머지 후 복원
+mcp-agent @ git+https://github.com/dragon1086/mcp-agent.git@feature/skip-reasoning-effort-with-tools-gpt54
 requests~=2.32.3
 aiohttp~=3.11.13
 python-dateutil~=2.9.0.post0

--- a/stock_analysis_orchestrator.py
+++ b/stock_analysis_orchestrator.py
@@ -307,7 +307,7 @@ class StockAnalysisOrchestrator:
                 result = await llm.generate_str(
                     message=f"{reference_date} 기준 한국 주식시장 거시경제 분석을 수행하고 JSON으로 출력하세요.",
                     request_params=RequestParams(
-                        model="gpt-5.2",
+                        model="gpt-5.4-mini",
                         reasoning_effort="none",
                         maxTokens=16000,
                         parallel_tool_calls=True,

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -342,7 +342,7 @@ class StockTrackingAgent:
             response = await llm.generate_str(
                 message=prompt_message,
                 request_params=RequestParams(
-                    model="gpt-5.2",
+                    model="gpt-5.4",
                     maxTokens=30000
                 )
             )

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -865,7 +865,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
             response = await llm.generate_str(
                 message=prompt_message,
                 request_params=RequestParams(
-                    model="gpt-5.2",
+                    model="gpt-5.4",
                     maxTokens=30000
                 )
             )

--- a/telegram_summary_agent.py
+++ b/telegram_summary_agent.py
@@ -289,7 +289,7 @@ class TelegramSummaryGenerator:
         response = await evaluator_optimizer.generate_str(
             message=prompt_message,
             request_params=RequestParams(
-                model="gpt-5.2",
+                model="gpt-5.4-mini",
                 reasoning_effort="none",
                 maxTokens=6000,
                 max_iterations=2

--- a/tracking/compression.py
+++ b/tracking/compression.py
@@ -136,7 +136,7 @@ class CompressionManager:
 
                 response = await llm.generate_str(
                     message=prompt,
-                    request_params=RequestParams(model="gpt-5.2", reasoning_effort="none", maxTokens=8000)
+                    request_params=RequestParams(model="gpt-5.4-mini", reasoning_effort="none", maxTokens=8000)
                 )
 
             compression_data = self._parse_response(response)
@@ -194,7 +194,7 @@ class CompressionManager:
 
                 response = await llm.generate_str(
                     message=prompt,
-                    request_params=RequestParams(model="gpt-5.2", reasoning_effort="none", maxTokens=8000)
+                    request_params=RequestParams(model="gpt-5.4-mini", reasoning_effort="none", maxTokens=8000)
                 )
 
             compression_data = self._parse_response(response)

--- a/tracking/journal.py
+++ b/tracking/journal.py
@@ -93,7 +93,7 @@ class JournalManager:
 
                 response = await llm.generate_str(
                     message=prompt,
-                    request_params=RequestParams(model="gpt-5.2", reasoning_effort="none", maxTokens=16000)
+                    request_params=RequestParams(model="gpt-5.4-mini", reasoning_effort="none", maxTokens=16000)
                 )
                 logger.info(f"Journal agent response received: {len(response)} chars")
 


### PR DESCRIPTION
## Summary
- 매매 판단 tracking 4곳: gpt-5.2 → gpt-5.4 (reasoning 필요)
- 보고서/요약/압축/저널 12곳: gpt-5.2 → gpt-5.4-mini (비용 3.3x 절감, 속도 2x 개선)
- company_name_translator: gpt-4o-mini → gpt-5-nano + maxTokens 1000
- mcp-agent를 fork 버전으로 교체 (gpt-5.4 + function tools에서 reasoning_effort 400 에러 패치)

## 배경
gpt-5.4 계열은 `/v1/chat/completions`에서 function tools + reasoning_effort 조합 시 400 에러 발생.
mcp-agent 프레임워크가 reasoning_effort를 항상 전송하므로 fork에서 패치 적용.
upstream PR: https://github.com/lastmile-ai/mcp-agent/pull/648

## ⚠️ 후속 작업
upstream PR 머지 + 릴리즈 후 requirements.txt를 `mcp-agent>=0.2.7`로 복원

## Test plan
- [ ] KR morning 분석 실행 → gpt-5.4-mini 정상 동작 확인
- [ ] US morning 분석 실행 → 동일 확인
- [ ] tracking 에이전트 gpt-5.4 reasoning 정상 동작 확인