### PR TITLE
fix: KR 장후 시간외 매수 ORD_DVSN 02→06 수정

### DIFF
--- a/trading/domestic_stock_trading.py
+++ b/trading/domestic_stock_trading.py
@@ -540,7 +540,7 @@ class DomesticStockTrading:
             "CANO": self.trenv.my_acct,
             "ACNT_PRDT_CD": self.trenv.my_prod,
             "PDNO": stock_code,
-            "ORD_DVSN": "02",  # 02: After-hours closing price
+            "ORD_DVSN": "06",  # 06: Post-market after-hours (장후 시간외, 15:40~16:00)
             "ORD_QTY": str(buy_quantity),
             "ORD_UNPR": "0",  # 0 for closing price trading
             "EXCG_ID_DVSN_CD": "KRX",


### PR DESCRIPTION
## Summary
- `buy_closing_price()`의 `ORD_DVSN`을 `"02"`(조건부지정가, 정규장 전용)에서 `"06"`(장후 시간외, 15:40~16:00)으로 수정
- 매도 함수(`sell_all_closing_price`)는 이미 `"06"`을 사용 중이었으나 매수만 잘못 설정되어 있었음
- 이로 인해 15:30 이후 파이프라인 완료 시 `APBK0918 - 장운영시간이 아닙니다.(장종료동시마감(129) 주문불가시간)` 에러 발생

## Test plan
- [ ] 15:40~16:00 사이에 장후 시간외 매수 주문 정상 체결 확인
- [ ] 종가 기준 자동 체결 확인 (ORD_UNPR: "0")

🤖 Generated with [Claude Code](https://claude.com/claude-code)