### PR TITLE
fix: 번역 시 누락된 base64 이미지 비율 기반 위치 재삽입

### DIFF
--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -168,11 +168,14 @@ class USStockAnalysisOrchestrator:
             Text with restored images
         """
         restored_text = translated_text
+        restored_count = 0
+        missing_images = []
 
         # First try exact match
         for placeholder, original_image in images.items():
             if placeholder in restored_text:
                 restored_text = restored_text.replace(placeholder, original_image)
+                restored_count += 1
                 logger.debug(f"Restored image (exact match): {placeholder}")
             else:
                 # Try without special characters (LLM might have modified the placeholder)
@@ -182,8 +185,35 @@ class USStockAnalysisOrchestrator:
                 simple_key = placeholder.replace("<<<", "").replace(">>>", "").replace("__", "_")
                 if simple_key in restored_text:
                     restored_text = restored_text.replace(simple_key, original_image)
+                    restored_count += 1
                     logger.debug(f"Restored image (simple key): {simple_key}")
+                else:
+                    match = regex.search(r'<<<__BASE64_IMAGE_(\d+)__>>>', placeholder)
+                    img_num = int(match.group(1)) if match else -1
+                    if img_num >= 0:
+                        missing_images.append((img_num, placeholder, original_image))
+                        logger.warning(f"Could not restore image {img_num}, placeholder not found: {placeholder}")
 
+        # Re-insert missing images at proportional positions in translated text
+        if missing_images:
+            logger.info(f"Re-inserting {len(missing_images)} missing images by position")
+            missing_images.sort(key=lambda x: x[0], reverse=True)
+            total_images = len(images)
+            text_len = len(restored_text)
+            for img_num, placeholder, original_image in missing_images:
+                ratio = (img_num + 1) / (total_images + 1)
+                insert_pos = int(text_len * ratio)
+                newline_pos = restored_text.rfind('\n', 0, insert_pos)
+                if newline_pos == -1:
+                    newline_pos = insert_pos
+                restored_text = restored_text[:newline_pos] + '\n\n' + original_image + '\n' + restored_text[newline_pos:]
+                restored_count += 1
+                logger.info(f"Re-inserted image {img_num} at position {newline_pos}")
+
+        if restored_count < len(images):
+            logger.warning(f"Restored {restored_count}/{len(images)} base64 images to translated text")
+        else:
+            logger.info(f"Restored {restored_count}/{len(images)} base64 images to translated text")
         return restored_text
 
     async def run_macro_intelligence(self, reference_date: str = None, language: str = "ko") -> dict:

--- a/stock_analysis_orchestrator.py
+++ b/stock_analysis_orchestrator.py
@@ -215,11 +215,14 @@ class StockAnalysisOrchestrator:
             Text with restored images
         """
         restored_text = translated_text
+        restored_count = 0
+        missing_images = []
 
         # First try exact match
         for placeholder, original_image in images.items():
             if placeholder in restored_text:
                 restored_text = restored_text.replace(placeholder, original_image)
+                restored_count += 1
                 logger.debug(f"Restored image (exact match): {placeholder}")
             else:
                 # Fallback: look for translated variations like [Image: ...] or ![...]
@@ -248,13 +251,37 @@ class StockAnalysisOrchestrator:
                             after = restored_text[match_obj.end():]
                             restored_text = before + original_image + after
                             logger.info(f"Restored image {img_num} using fallback pattern: {pattern}")
+                            restored_count += 1
                             replaced = True
                             break
 
                     if not replaced:
+                        missing_images.append((int(img_num), placeholder, original_image))
                         logger.warning(f"Could not restore image {img_num}, placeholder not found: {placeholder}")
 
-        logger.info(f"Restored {len(images)} base64 images to translated text")
+        # Re-insert missing images at proportional positions in translated text
+        if missing_images:
+            logger.info(f"Re-inserting {len(missing_images)} missing images by position")
+            # Sort by image number descending to insert from last to first (preserve positions)
+            missing_images.sort(key=lambda x: x[0], reverse=True)
+            total_images = len(images)
+            text_len = len(restored_text)
+            for img_num, placeholder, original_image in missing_images:
+                # Estimate position: image N out of total should be at ~(N+1)/(total+1) of text
+                ratio = (img_num + 1) / (total_images + 1)
+                insert_pos = int(text_len * ratio)
+                # Find nearest newline to avoid splitting a line
+                newline_pos = restored_text.rfind('\n', 0, insert_pos)
+                if newline_pos == -1:
+                    newline_pos = insert_pos
+                restored_text = restored_text[:newline_pos] + '\n\n' + original_image + '\n' + restored_text[newline_pos:]
+                restored_count += 1
+                logger.info(f"Re-inserted image {img_num} at position {newline_pos}")
+
+        if restored_count < len(images):
+            logger.warning(f"Restored {restored_count}/{len(images)} base64 images to translated text")
+        else:
+            logger.info(f"Restored {restored_count}/{len(images)} base64 images to translated text")
         return restored_text
 
     async def run_macro_intelligence(self, reference_date: str = None, language: str = "ko") -> dict:


### PR DESCRIPTION
## Summary
- 번역 모델(GPT-5.1 등)이 `<<<__BASE64_IMAGE_N__>>>` placeholder를 간헐적으로 누락시키는 문제 대응
- 누락된 이미지를 원본 텍스트 내 상대 위치(비율 기반)에 자동 재삽입하여 이미지 유실 방지
- 복원 로그를 `Restored N/M` 형식으로 변경하여 실제 성공/실패 수를 정확히 출력 (기존: 항상 전체 수 출력)
- KR/US 양쪽 orchestrator 모두 수정

## Test plan
- [ ] broadcast 번역 실행 후 PDF에 이미지가 정상 포함되는지 확인
- [ ] placeholder가 모두 보존된 경우 기존 동작과 동일한지 확인
- [ ] 일부 placeholder 누락 시 WARNING 로그 + 재삽입 로그 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)