### PR TITLE
fix: KR 매수 판단 시 AI의 Skip 결정 존중 (US 로직과 통일)

### DIFF
--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -414,14 +414,14 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                 decision = analysis_result.get("decision")
                 logger.info(f"Buy score check: {company_name}({ticker}) - Score: {buy_score}, Min required score: {min_score}")
 
-                # Score-decision consistency enforcement:
-                # If score meets threshold and sector is diverse, override LLM decision to Enter
+                # Respect AI agent's decision (consistent with US logic)
+                # AI considers qualitative factors (RSI, support structure, volume, sector outlook, etc.)
+                # beyond just the score, so do not override its decision
                 if buy_score > 0 and buy_score >= min_score and sector_diverse and decision != "Enter":
                     logger.info(
-                        f"Score-decision override: {company_name}({ticker}) - "
-                        f"Score {buy_score} >= {min_score} but decision='{decision}', forcing Enter"
+                        f"AI decision respected: {company_name}({ticker}) - "
+                        f"Score {buy_score} >= {min_score} but decision='{decision}', keeping Skip"
                     )
-                    decision = "Enter"
 
                 # Generate message if not buying (watch/insufficient score/sector constraints)
                 if decision != "Enter" or buy_score < min_score or not sector_diverse:


### PR DESCRIPTION
## Summary
- KR `stock_tracking_enhanced_agent`의 score-decision override 로직 제거
- 기존: 점수가 min_score 이상이면 AI가 Skip해도 **강제 Enter** → 리스크 높은 종목 진입
- 변경: AI의 정성적 판단(RSI, 지지선, 섹터 전망, 손절 가능성 등)을 **존중**
- US는 이미 #203에서 수정 완료. KR도 동일하게 맞춤

## Context
2026-03-19 오후 배치에서 대우건설(047040), SK증권(001510) 두 종목이 AI decision='Skip'이었음에도 score-decision override로 강제 진입 시도됨. AI는 "소외 섹터 과열 추격", "손실 통제 불가" 등 명확한 리스크 사유를 제시한 상태였음.

## Test plan
- [ ] AI decision='Skip' + score >= min_score 시 진입하지 않는지 확인
- [ ] AI decision='Enter' + score >= min_score 시 정상 진입 확인
- [ ] 로그에 `AI decision respected` 메시지 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)