### PR TITLE
fix: US 장중 매수 시 시장가→지정가 주문으로 변경 (APBK1507 해결)

### DIFF
--- a/prism-us/trading/us_stock_trading.py
+++ b/prism-us/trading/us_stock_trading.py
@@ -1018,8 +1018,22 @@ class USStockTrading:
             }
 
         if self.is_market_open():
-            logger.info(f"[{ticker}] Market is open - executing market buy")
-            return self.buy_market_price(ticker, buy_amount, exchange)
+            # US stocks do NOT support market price buy (시장가 매수).
+            # KIS API TTTT1002U ORD_DVSN "00" = limit price (지정가), not market price.
+            # Sending OVRS_ORD_UNPR "0" causes APBK1507 error.
+            # Always use limit price buy with the provided price.
+            if limit_price and limit_price > 0:
+                logger.info(f"[{ticker}] Market is open - executing limit buy @ ${limit_price:.2f}")
+                return self.buy_limit_price(ticker, limit_price, buy_amount, exchange)
+            else:
+                logger.warning(f"[{ticker}] Market is open but no limit_price provided - cannot execute buy")
+                return {
+                    'success': False,
+                    'order_no': None,
+                    'ticker': ticker,
+                    'quantity': 0,
+                    'message': 'US stocks require limit_price for buy orders (no market price buy supported)'
+                }
         else:
             # Market is closed - use reserved order if limit_price provided
             if limit_price and limit_price > 0:


### PR DESCRIPTION
## Summary
- KIS API에서 US 매수(TTTT1002U)는 **시장가 주문을 지원하지 않음** (`ORD_DVSN "00"` = 지정가)
- 기존 `buy_market_price()`가 `OVRS_ORD_UNPR: "0"`을 전송 → $0.00 지정가로 해석 → `APBK1507` 에러
- `smart_buy()`에서 장중에도 `buy_limit_price()`를 사용하도록 변경

## Bugs Fixed
- **LLY (APBK1507)**: `가격 $0.01 미만시 온라인 주문불가` → 실제 가격으로 지정가 주문
- **EXE (수량 0)**: `buy_market_price` 내 가격 재조회 실패 → pre-fetched `limit_price` 사용으로 해결

## Test plan
- [ ] 장중 매수: `smart_buy(limit_price=실제가격)` → `buy_limit_price` 호출 확인
- [ ] 장마감 매수: 기존 `buy_reserved_order` 경로 변경 없음 확인
- [ ] `limit_price` 미제공 시 적절한 에러 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)