### PR TITLE
fix: US pending order batch import 실패 수정

### DIFF
--- a/prism-us/us_pending_order_batch.py
+++ b/prism-us/us_pending_order_batch.py
@@ -25,9 +25,11 @@ import argparse
 import datetime
 from pathlib import Path
 
-# Add project paths
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+# Add project paths (prism-us first so its trading/ takes priority over KR trading/)
+_prism_us_dir = str(Path(__file__).resolve().parent)
+_project_root = str(Path(__file__).resolve().parent.parent)
+sys.path.insert(0, _project_root)
+sys.path.insert(0, _prism_us_dir)
 
 import pytz
 
@@ -113,11 +115,8 @@ def process_pending_orders(dry_run: bool = False):
 
     logger.info(f"Found {len(pending_orders)} pending order(s) to process")
 
-    # Import trading module
-    try:
-        from trading.us_stock_trading import USStockTrading
-    except ImportError:
-        from prism_us.trading.us_stock_trading import USStockTrading
+    # Import trading module (prism-us/trading/ is first in sys.path)
+    from trading.us_stock_trading import USStockTrading
 
     # Initialize trading (uses config from environment)
     try:


### PR DESCRIPTION
## Summary
- `us_pending_order_batch.py`의 `sys.path.insert(0, ...)` 호출 순서가 잘못되어 프로젝트 루트의 KR용 `trading/` 패키지를 먼저 찾아 `ModuleNotFoundError` 발생
- insert 순서를 교정하여 `prism-us/`가 sys.path 최우선이 되도록 수정
- 작동 불가능한 `prism_us`(언더스코어) fallback import 제거

## Test plan
- [ ] 운영서버에서 `python prism-us/us_pending_order_batch.py --dry-run` 실행하여 import 성공 확인
- [ ] 다음 cron 실행(10:35 KST)에서 pending order 정상 처리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)