### PR TITLE
fix: US 매수 보류(sector 집중) 시 텔레그램 관망 메시지 누락 수정

### DIFF
--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -1813,7 +1813,22 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                 rank_change_msg = analysis_result.get("rank_change_msg", "")
 
                 if not sector_diverse:
-                    logger.info(f"Purchase deferred: {company_name} ({ticker}) - Sector over-concentration")
+                    sector = analysis_result.get("sector", "Unknown")
+                    reason = f"Sector '{sector}' over-concentration prevention"
+                    logger.info(f"Purchase deferred: {company_name} ({ticker}) - {reason}")
+
+                    await self._save_watchlist_item(
+                        ticker=ticker,
+                        company_name=company_name,
+                        current_price=current_price,
+                        buy_score=scenario.get("buy_score", 0),
+                        min_score=scenario.get("min_score", 0),
+                        decision="Skip",
+                        skip_reason=reason,
+                        scenario=scenario,
+                        sector=sector,
+                        was_traded=False
+                    )
                     continue
 
                 buy_score = scenario.get("buy_score", 0)


### PR DESCRIPTION
## Summary
- US 트래킹 에이전트에서 `sector_diverse=False`일 때 `continue`로 바로 넘어가서 텔레그램 관망 메시지가 발송되지 않던 버그 수정
- `_save_watchlist_item` 호출을 추가하여 관망 메시지 생성 + `message_queue` 추가가 정상 동작하도록 변경
- KR `stock_tracking_enhanced_agent.py`와 동일한 패턴으로 통일

## Root Cause
`prism-us/us_stock_tracking_agent.py:1815-1817`에서 sector 집중도 초과 시 로그만 찍고 `continue` → 텔레그램 메시지 큐에 추가하지 않음

## Test plan
- [ ] XOM처럼 sector 집중도로 보류되는 종목 발생 시 텔레그램 관망 메시지 수신 확인
- [ ] 기존 매수/매도 메시지 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)