### PR TITLE
fix: OpenAI insufficient_quota 에러 시 Telegram 알림 전송

### DIFF
--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -632,6 +632,10 @@ class USStockAnalysisOrchestrator:
                         await asyncio.sleep(1)
                     except Exception as e:
                         logger.error(f"Error translating/sending US message to {lang}: {str(e)}")
+                        from telegram_config import is_openai_quota_error, send_openai_quota_alert
+                        if is_openai_quota_error(e):
+                            await send_openai_quota_alert(self.telegram_config, market="US")
+                            return
 
             lang_tasks = []
             for lang in self.telegram_config.broadcast_languages:
@@ -705,6 +709,10 @@ class USStockAnalysisOrchestrator:
 
                     except Exception as e:
                         logger.error(f"Error processing US report {report_path} for {lang}: {str(e)}")
+                        from telegram_config import is_openai_quota_error, send_openai_quota_alert
+                        if is_openai_quota_error(e):
+                            await send_openai_quota_alert(self.telegram_config, market="US")
+                            return
 
             # Process languages sequentially to limit memory usage
             # (each PDF generation spawns a Playwright/Chromium instance)
@@ -819,6 +827,10 @@ class USStockAnalysisOrchestrator:
                         logger.error(f"Failed to send US trigger alert to {lang} channel")
                 except Exception as e:
                     logger.error(f"Error sending translated US trigger alert to {lang}: {str(e)}")
+                    from telegram_config import is_openai_quota_error, send_openai_quota_alert
+                    if is_openai_quota_error(e):
+                        await send_openai_quota_alert(self.telegram_config, market="US")
+                        return
 
             lang_tasks = []
             for lang in self.telegram_config.broadcast_languages:
@@ -1101,6 +1113,10 @@ class USStockAnalysisOrchestrator:
             logger.error(f"Error during US pipeline execution: {str(e)}")
             import traceback
             logger.error(traceback.format_exc())
+            # Send Telegram alert for OpenAI quota errors
+            from telegram_config import is_openai_quota_error, send_openai_quota_alert
+            if is_openai_quota_error(e):
+                await send_openai_quota_alert(self.telegram_config, market="US")
 
         finally:
             # Always wait for background broadcast tasks, even on error/early return

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -2188,6 +2188,10 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
 
                         except Exception as e:
                             logger.error(f"Error translating/sending US message to {lang}: {str(e)}")
+                            from telegram_config import is_openai_quota_error, send_openai_quota_alert
+                            if is_openai_quota_error(e):
+                                await send_openai_quota_alert(self.telegram_config, market="US")
+                                return
 
                     # Gather Firebase notifications for this language
                     if firebase_tasks:

--- a/stock_analysis_orchestrator.py
+++ b/stock_analysis_orchestrator.py
@@ -678,6 +678,10 @@ class StockAnalysisOrchestrator:
                         await asyncio.sleep(1)
                     except Exception as e:
                         logger.error(f"Error translating/sending message to {lang}: {str(e)}")
+                        from telegram_config import is_openai_quota_error, send_openai_quota_alert
+                        if is_openai_quota_error(e):
+                            await send_openai_quota_alert(self.telegram_config, market="KR")
+                            return
 
             lang_tasks = []
             for lang in self.telegram_config.broadcast_languages:
@@ -753,6 +757,10 @@ class StockAnalysisOrchestrator:
 
                     except Exception as e:
                         logger.error(f"Error processing report {report_path} for {lang}: {str(e)}")
+                        from telegram_config import is_openai_quota_error, send_openai_quota_alert
+                        if is_openai_quota_error(e):
+                            await send_openai_quota_alert(self.telegram_config, market="KR")
+                            return
 
             # Process languages sequentially to limit memory usage
             # (each PDF generation spawns a Playwright/Chromium instance)
@@ -887,6 +895,10 @@ class StockAnalysisOrchestrator:
                         logger.error(f"Failed to send trigger alert to {lang} channel")
                 except Exception as e:
                     logger.error(f"Error sending translated trigger alert to {lang}: {str(e)}")
+                    from telegram_config import is_openai_quota_error, send_openai_quota_alert
+                    if is_openai_quota_error(e):
+                        await send_openai_quota_alert(self.telegram_config, market="KR")
+                        return
 
             lang_tasks = []
             for lang in self.telegram_config.broadcast_languages:
@@ -1157,6 +1169,10 @@ class StockAnalysisOrchestrator:
             logger.error(f"Error during pipeline execution: {str(e)}")
             import traceback
             logger.error(traceback.format_exc())
+            # Send Telegram alert for OpenAI quota errors
+            from telegram_config import is_openai_quota_error, send_openai_quota_alert
+            if is_openai_quota_error(e):
+                await send_openai_quota_alert(self.telegram_config, market="KR")
 
         finally:
             # Always wait for background broadcast tasks, even on error/early return

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -1574,6 +1574,10 @@ class StockTrackingAgent:
 
                         except Exception as e:
                             logger.error(f"Error sending tracking message to {lang}: {str(e)}")
+                            from telegram_config import is_openai_quota_error, send_openai_quota_alert
+                            if is_openai_quota_error(e):
+                                await send_openai_quota_alert(self.telegram_config, market="KR")
+                                return
 
                     # Gather Firebase notifications for this language
                     if firebase_tasks:

--- a/telegram_config.py
+++ b/telegram_config.py
@@ -161,3 +161,54 @@ class TelegramConfig:
             f"channel_id={'***' if self._channel_id else None}, "
             f"bot_token={'***' if self._bot_token else None})"
         )
+
+
+def is_openai_quota_error(error: Exception) -> bool:
+    """
+    Check if an exception is an OpenAI insufficient_quota error (429).
+
+    Args:
+        error: The caught exception
+
+    Returns:
+        True if this is an OpenAI quota exceeded error
+    """
+    error_str = str(error)
+    return "insufficient_quota" in error_str or (
+        "429" in error_str and "exceeded" in error_str.lower() and "quota" in error_str.lower()
+    )
+
+
+async def send_openai_quota_alert(telegram_config: "TelegramConfig", market: str = "KR"):
+    """
+    Send a Telegram alert when OpenAI API quota is exceeded.
+
+    Args:
+        telegram_config: TelegramConfig instance
+        market: Market identifier ("KR" or "US")
+    """
+    if not telegram_config or not telegram_config.use_telegram:
+        return
+
+    try:
+        from telegram import Bot
+        from telegram.request import HTTPXRequest
+
+        request = HTTPXRequest(connect_timeout=10.0, read_timeout=10.0)
+        bot = Bot(token=telegram_config.bot_token, request=request)
+
+        alert_message = (
+            f"🚨 [{market}] OpenAI API 크레딧 소진 알림\n\n"
+            f"OpenAI API 크레딧이 소진되어 분석 파이프라인이 중단되었습니다.\n\n"
+            f"• 오류: insufficient_quota (HTTP 429)\n"
+            f"• 조치 필요: OpenAI Platform → Billing에서 크레딧 충전 또는 Organization Budget 상향\n"
+            f"• https://platform.openai.com/settings/organization/billing"
+        )
+
+        await bot.send_message(
+            chat_id=telegram_config.channel_id,
+            text=alert_message
+        )
+        logger.info(f"[{market}] OpenAI quota alert sent to Telegram")
+    except Exception as e:
+        logger.error(f"[{market}] Failed to send OpenAI quota alert: {e}")


### PR DESCRIPTION
## Summary
- OpenAI API 크레딧 소진(`insufficient_quota`, HTTP 429) 시 메인 텔레그램 채널에 장애 알림을 자동 전송
- `telegram_config.py`에 `is_openai_quota_error()`, `send_openai_quota_alert()` 유틸리티 함수 추가
- KR/US 오케스트레이터 및 트래킹 에이전트의 모든 OpenAI 호출 에러 핸들러에 감지 로직 적용 (8곳)
- quota 에러 감지 시 즉시 `return`하여 불필요한 재시도/빈 메시지 전송 방지

## 배경
- 2026-03-24 06:40 US 파이프라인에서 OpenAI Organization Budget($200) 초과로 `insufficient_quota` 에러 발생
- 기존에는 로그에만 기록되고 텔레그램 알림이 없어 장애 인지가 늦어짐
- 빈 번역 메시지가 텔레그램에 전송 시도되어 추가 에러(`Message text is empty`) 발생

## 수정 파일
| 파일 | 변경 내용 |
|------|----------|
| `telegram_config.py` | `is_openai_quota_error()`, `send_openai_quota_alert()` 추가 |
| `stock_analysis_orchestrator.py` | KR 파이프라인/번역/PDF/트리거 에러 핸들러 (4곳) |
| `prism-us/us_stock_analysis_orchestrator.py` | US 파이프라인/번역/PDF/트리거 에러 핸들러 (4곳) |
| `stock_tracking_agent.py` | KR 트래킹 번역 채널 에러 핸들러 |
| `prism-us/us_stock_tracking_agent.py` | US 트래킹 번역 채널 에러 핸들러 |

## Test plan
- [ ] `is_openai_quota_error()` 단위 테스트 (insufficient_quota 문자열 매칭 확인)
- [ ] OpenAI budget 초과 상태에서 파이프라인 실행 → 텔레그램 알림 수신 확인
- [ ] 정상 에러(네트워크 타임아웃 등)에서는 quota 알림이 발송되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)