### PR TITLE
feat: add optional social sentiment context to US news analysis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,10 @@ TELEGRAM_CHANNEL_ID=your_channel_id
 # TELEGRAM_CHANNEL_ID_US=your_us_channel_id
 # TELEGRAM_CHANNEL_ID_US_EN=your_us_english_channel_id
 
+# Optional structured social sentiment context for US stock news analysis
+# ADANOS_API_KEY=your_adanos_api_key
+# ADANOS_API_BASE_URL=https://api.adanos.org
+
 # ============================================
 # Firebase Bridge (Optional - PRISM-Mobile app)
 # ============================================

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ python3 demo.py TSLA --language ko  # Tesla (Korean report)
 > **Get your OpenAI API key** from [OpenAI Platform](https://platform.openai.com/api-keys)
 >
 > **Optional**: Add a [Perplexity API key](https://www.perplexity.ai/) to `mcp_agent.config.yaml` for news analysis
+>
+> **Optional**: Add `ADANOS_API_KEY` to enrich US stock news analysis with structured social sentiment context
 
 Your AI-generated PDF reports will be saved in `prism-us/pdf_reports/`.
 

--- a/prism-us/cores/agents/__init__.py
+++ b/prism-us/cores/agents/__init__.py
@@ -118,7 +118,11 @@ def get_us_agent_directory(
             prefetched_data={"company_profile": pf.get("company_profile", ""), "holder_info": pf.get("holder_info", ""), "segment_revenue": pf.get("segment_revenue", "")} if pf.get("company_profile") else None
         ),
         "news_analysis": lambda: create_us_news_analysis_agent(
-            company_name, ticker, reference_date, language
+            company_name,
+            ticker,
+            reference_date,
+            language,
+            prefetched_social_sentiment=pf.get("social_sentiment"),
         ),
         "market_index_analysis": lambda: create_us_market_index_analysis_agent(
             reference_date, max_years_ago, max_years, language,

--- a/prism-us/cores/agents/news_strategy_agents.py
+++ b/prism-us/cores/agents/news_strategy_agents.py
@@ -100,6 +100,7 @@ def create_us_news_analysis_agent(
 3. 주요 뉴스 (카테고리별)
 4. 향후 주목 포인트
 5. 정보 신뢰도 평가
+6. 공개 소셜 센티먼트 정렬 여부 (제공된 경우)와 뉴스 내러티브의 일치/불일치 여부
 
 ## 보고서 구조 (마크다운 제목 형식 필수)
 
@@ -121,6 +122,8 @@ def create_us_news_analysis_agent(
 - 깊이 있는 분석과 인사이트 제공
 - 명확한 출처 표기: [YahooFinance:TICKER] / [Perplexity:Number, Date]
 - 최근 정보만 사용 (분석일 기준 1개월 이내)
+
+{social_context}
 
 ## 출력 형식
 
@@ -202,6 +205,7 @@ def create_us_news_analysis_agent(
 3. Major news (by category)
 4. Future watch points
 5. Information reliability evaluation
+6. Social sentiment alignment (if provided) and whether it reinforces or diverges from the news narrative
 
 ## Report Structure (MUST use markdown heading format)
 
@@ -223,6 +227,8 @@ def create_us_news_analysis_agent(
 - Clear source notation: [YahooFinance:TICKER] / [Perplexity:Number, Date]
 - Use only recent info (within 1 month of analysis date)
 
+{social_context}
+
 ## Output Format
 
 - No tool usage process mentions
@@ -233,8 +239,6 @@ def create_us_news_analysis_agent(
 Company: {company_name} ({ticker})
 Analysis Date: {reference_date}(YYYYMMDD format)
 """
-
-    instruction += social_context
 
     return Agent(
         name="us_news_analysis_agent",

--- a/prism-us/cores/agents/news_strategy_agents.py
+++ b/prism-us/cores/agents/news_strategy_agents.py
@@ -12,7 +12,8 @@ def create_us_news_analysis_agent(
     company_name: str,
     ticker: str,
     reference_date: str,
-    language: str = "ko"
+    language: str = "ko",
+    prefetched_social_sentiment: str = None,
 ):
     """Create US news analysis agent
 
@@ -25,6 +26,23 @@ def create_us_news_analysis_agent(
     Returns:
         Agent: News analysis agent
     """
+
+    social_context = ""
+    if prefetched_social_sentiment:
+        if language == "ko":
+            social_context = (
+                "\n## 추가 구조화 소셜 센티먼트 데이터\n"
+                "다음 데이터는 사전 수집된 공개 소셜/뉴스 센티먼트 스냅샷입니다. "
+                "최근 뉴스 해석에 이 데이터를 함께 반영하되, 소셜 센티먼트 데이터를 위해 별도 도구 호출은 하지 마세요.\n\n"
+                f"{prefetched_social_sentiment}\n"
+            )
+        else:
+            social_context = (
+                "\n## Additional Structured Social Sentiment Context\n"
+                "The following snapshot has already been prefetched. Use it alongside the news analysis, "
+                "but do not make extra tool calls for social sentiment.\n\n"
+                f"{prefetched_social_sentiment}\n"
+            )
 
     # Format date for display
     ref_year = reference_date[:4]
@@ -215,6 +233,8 @@ def create_us_news_analysis_agent(
 Company: {company_name} ({ticker})
 Analysis Date: {reference_date}(YYYYMMDD format)
 """
+
+    instruction += social_context
 
     return Agent(
         name="us_news_analysis_agent",

--- a/prism-us/cores/us_analysis.py
+++ b/prism-us/cores/us_analysis.py
@@ -148,7 +148,7 @@ async def analyze_us_stock(
             logger.warning(f"US data prefetch failed, falling back to MCP: {e}")
             prefetched = {}
 
-        if os.getenv("ADANOS_API_KEY"):
+        if include_news and os.getenv("ADANOS_API_KEY"):
             try:
                 social_client = USSocialSentimentClient()
                 social_snapshot = social_client.get_social_sentiment_markdown(ticker=ticker, days=7)

--- a/prism-us/cores/us_analysis.py
+++ b/prism-us/cores/us_analysis.py
@@ -71,6 +71,12 @@ get_us_price_chart_html = _chart_module.get_us_price_chart_html
 get_us_institutional_chart_html = _chart_module.get_us_institutional_chart_html
 get_us_technical_chart_html = _chart_module.get_us_technical_chart_html
 
+_social_client_module = _import_from_project_root(
+    "us_social_sentiment_client",
+    _prism_us_dir / "cores" / "us_social_sentiment_client.py"
+)
+USSocialSentimentClient = _social_client_module.USSocialSentimentClient
+
 
 async def analyze_us_stock(
     ticker: str = "AAPL",
@@ -141,6 +147,16 @@ async def analyze_us_stock(
         except Exception as e:
             logger.warning(f"US data prefetch failed, falling back to MCP: {e}")
             prefetched = {}
+
+        if os.getenv("ADANOS_API_KEY"):
+            try:
+                social_client = USSocialSentimentClient()
+                social_snapshot = social_client.get_social_sentiment_markdown(ticker=ticker, days=7)
+                if social_snapshot:
+                    prefetched["social_sentiment"] = social_snapshot
+                    logger.info("Prefetched social sentiment for %s", ticker)
+            except Exception as e:
+                logger.warning(f"US social sentiment prefetch failed, continuing without it: {e}")
 
         # 5. Get US-specific agents (with prefetched data)
         agents = get_us_agent_directory(company_name, ticker, reference_date, base_sections, language, prefetched_data=prefetched)

--- a/prism-us/cores/us_analysis.py
+++ b/prism-us/cores/us_analysis.py
@@ -158,7 +158,7 @@ async def analyze_us_stock(
                 )
                 if social_snapshot:
                     prefetched["social_sentiment"] = social_snapshot
-                    logger.info("Prefetched social sentiment for %s", ticker)
+                    logger.info(f"Prefetched social sentiment for {ticker}")
             except Exception as e:
                 logger.warning(f"US social sentiment prefetch failed, continuing without it: {e}")
 

--- a/prism-us/cores/us_analysis.py
+++ b/prism-us/cores/us_analysis.py
@@ -151,7 +151,11 @@ async def analyze_us_stock(
         if include_news and os.getenv("ADANOS_API_KEY"):
             try:
                 social_client = USSocialSentimentClient()
-                social_snapshot = social_client.get_social_sentiment_markdown(ticker=ticker, days=7)
+                social_snapshot = await asyncio.to_thread(
+                    social_client.get_social_sentiment_markdown,
+                    ticker,
+                    7,
+                )
                 if social_snapshot:
                     prefetched["social_sentiment"] = social_snapshot
                     logger.info("Prefetched social sentiment for %s", ticker)

--- a/prism-us/cores/us_social_sentiment_client.py
+++ b/prism-us/cores/us_social_sentiment_client.py
@@ -1,0 +1,241 @@
+"""
+US Social Sentiment Client
+
+Fetches structured US stock social sentiment snapshots from the Adanos API.
+The client is intentionally read-only and optional so the existing PRISM-US
+analysis flow continues to work unchanged when no API key is configured.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from statistics import mean
+from typing import Any, Dict, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class USSocialSentimentClient:
+    """Small client for fetching structured social sentiment snapshots."""
+
+    PLATFORM_SPECS = {
+        "reddit": {
+            "path": "/reddit/stocks/v1/compare",
+            "activity_field": "mentions",
+            "activity_label": "Mentions",
+            "label": "Reddit",
+        },
+        "x": {
+            "path": "/x/stocks/v1/compare",
+            "activity_field": "mentions",
+            "activity_label": "Mentions",
+            "label": "X.com",
+        },
+        "news": {
+            "path": "/news/stocks/v1/compare",
+            "activity_field": "mentions",
+            "activity_label": "Mentions",
+            "label": "News",
+        },
+        "polymarket": {
+            "path": "/polymarket/stocks/v1/compare",
+            "activity_field": "trade_count",
+            "activity_label": "Trades",
+            "label": "Polymarket",
+        },
+    }
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        timeout: int = 10,
+    ) -> None:
+        self.api_key = api_key or os.getenv("ADANOS_API_KEY")
+        self.base_url = (base_url or os.getenv("ADANOS_API_BASE_URL") or "https://api.adanos.org").rstrip("/")
+        self.timeout = timeout
+
+    @property
+    def enabled(self) -> bool:
+        """Return True when the client has an API key configured."""
+        return bool(self.api_key)
+
+    def get_social_sentiment_snapshot(self, ticker: str, days: int = 7) -> Optional[Dict[str, Any]]:
+        """Fetch and aggregate social sentiment snapshot for a single ticker."""
+        if not self.enabled:
+            return None
+
+        ticker = (ticker or "").strip().upper()
+        if not ticker:
+            return None
+
+        sources: Dict[str, Dict[str, Any]] = {}
+        for platform in self.PLATFORM_SPECS:
+            parsed = self._fetch_platform_snapshot(platform, ticker, days)
+            if parsed:
+                sources[platform] = parsed
+
+        if not sources:
+            return None
+
+        buzz_values = [item["buzz_score"] for item in sources.values() if item["buzz_score"] is not None]
+        bullish_values = [item["bullish_pct"] for item in sources.values() if item["bullish_pct"] is not None]
+
+        return {
+            "ticker": ticker,
+            "days": days,
+            "average_buzz": round(mean(buzz_values), 1) if buzz_values else None,
+            "bullish_avg": round(mean(bullish_values), 1) if bullish_values else None,
+            "source_alignment": self._calculate_alignment(bullish_values),
+            "coverage": len(sources),
+            "sources": sources,
+        }
+
+    def render_snapshot(self, snapshot: Optional[Dict[str, Any]]) -> str:
+        """Render a compact markdown snapshot for LLM consumption."""
+        if not snapshot:
+            return ""
+
+        lines = [
+            f"### Structured Social Sentiment Snapshot ({snapshot['days']}d)",
+            "",
+            f"- Average Buzz: {self._format_buzz(snapshot.get('average_buzz'))}",
+            f"- Bullish Avg: {self._format_percent(snapshot.get('bullish_avg'))}",
+            f"- Source Alignment: {snapshot.get('source_alignment', 'Insufficient data')}",
+            f"- Coverage: {snapshot.get('coverage', 0)}/{len(self.PLATFORM_SPECS)} sources",
+            "",
+        ]
+
+        for platform in ("reddit", "x", "news", "polymarket"):
+            source = snapshot["sources"].get(platform)
+            if not source:
+                continue
+
+            lines.extend(
+                [
+                    f"#### {source['label']}",
+                    f"- Buzz: {self._format_buzz(source.get('buzz_score'))}",
+                    f"- Bullish: {self._format_percent(source.get('bullish_pct'))}",
+                    f"- {source['activity_label']}: {self._format_count(source.get('activity_value'))}",
+                    f"- Trend: {source.get('trend') or 'n/a'}",
+                    "",
+                ]
+            )
+
+        return "\n".join(lines).strip()
+
+    def get_social_sentiment_markdown(self, ticker: str, days: int = 7) -> str:
+        """Convenience helper returning markdown directly."""
+        snapshot = self.get_social_sentiment_snapshot(ticker=ticker, days=days)
+        return self.render_snapshot(snapshot)
+
+    def _fetch_platform_snapshot(self, platform: str, ticker: str, days: int) -> Optional[Dict[str, Any]]:
+        """Fetch and normalize one compare endpoint."""
+        spec = self.PLATFORM_SPECS[platform]
+        try:
+            response = requests.get(
+                f"{self.base_url}{spec['path']}",
+                headers={"X-API-Key": self.api_key},
+                params={"tickers": ticker, "days": days},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except Exception as exc:  # pragma: no cover - exercised through tests via mocks
+            logger.warning("Adanos %s compare fetch failed for %s: %s", platform, ticker, exc)
+            return None
+
+        row = self._extract_row(payload, ticker)
+        if not row:
+            return None
+
+        buzz_score = self._coerce_float(row.get("buzz_score"))
+        bullish_pct = self._coerce_float(row.get("bullish_pct"))
+        activity_value = self._coerce_int(row.get(spec["activity_field"]))
+
+        if buzz_score is None and bullish_pct is None and activity_value is None:
+            return None
+
+        return {
+            "label": spec["label"],
+            "buzz_score": buzz_score,
+            "bullish_pct": bullish_pct,
+            "trend": row.get("trend"),
+            "activity_label": spec["activity_label"],
+            "activity_value": activity_value,
+        }
+
+    @staticmethod
+    def _extract_row(payload: Any, ticker: str) -> Optional[Dict[str, Any]]:
+        """Extract a ticker row from compare payloads."""
+        if isinstance(payload, list):
+            candidates = payload
+        elif isinstance(payload, dict) and isinstance(payload.get("data"), list):
+            candidates = payload["data"]
+        elif isinstance(payload, dict):
+            candidates = [payload]
+        else:
+            return None
+
+        ticker_upper = ticker.upper()
+        for item in candidates:
+            if isinstance(item, dict) and str(item.get("ticker", "")).upper() == ticker_upper:
+                return item
+        return None
+
+    @staticmethod
+    def _coerce_float(value: Any) -> Optional[float]:
+        """Parse float-like values safely."""
+        if value is None or value == "":
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _coerce_int(value: Any) -> Optional[int]:
+        """Parse int-like values safely."""
+        if value is None or value == "":
+            return None
+        try:
+            return int(float(value))
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _calculate_alignment(values: list[float]) -> str:
+        """Convert bullish spread into a simple alignment label."""
+        if len(values) < 2:
+            return "Insufficient data"
+
+        spread = max(values) - min(values)
+        if spread <= 12:
+            return "Strong alignment"
+        if spread <= 25:
+            return "Mixed"
+        return "Wide divergence"
+
+    @staticmethod
+    def _format_buzz(value: Optional[float]) -> str:
+        """Format buzz score consistently."""
+        if value is None:
+            return "n/a"
+        return f"{value:.1f}/100"
+
+    @staticmethod
+    def _format_percent(value: Optional[float]) -> str:
+        """Format percentage values consistently."""
+        if value is None:
+            return "n/a"
+        return f"{value:.1f}%"
+
+    @staticmethod
+    def _format_count(value: Optional[int]) -> str:
+        """Format count-like values consistently."""
+        if value is None:
+            return "n/a"
+        return f"{value:,}"

--- a/prism-us/cores/us_social_sentiment_client.py
+++ b/prism-us/cores/us_social_sentiment_client.py
@@ -1,9 +1,10 @@
 """
 US Social Sentiment Client
 
-Fetches structured US stock social sentiment snapshots from the Adanos API.
-The client is intentionally read-only and optional so the existing PRISM-US
-analysis flow continues to work unchanged when no API key is configured.
+Fetches structured US stock social sentiment snapshots from an optional
+third-party API. The client is intentionally read-only and optional so the
+existing PRISM-US analysis flow continues to work unchanged when no API key is
+configured.
 """
 
 from __future__ import annotations

--- a/prism-us/cores/us_social_sentiment_client.py
+++ b/prism-us/cores/us_social_sentiment_client.py
@@ -180,10 +180,10 @@ class USSocialSentimentClient:
         """Extract a ticker row from compare payloads."""
         if isinstance(payload, list):
             candidates = payload
-        elif isinstance(payload, dict) and isinstance(payload.get("data"), list):
-            candidates = payload["data"]
         elif isinstance(payload, dict):
-            candidates = [payload]
+            candidates = payload.get("stocks") or payload.get("data")
+            if not isinstance(candidates, list):
+                candidates = [payload]
         else:
             return None
 

--- a/prism-us/cores/us_social_sentiment_client.py
+++ b/prism-us/cores/us_social_sentiment_client.py
@@ -9,6 +9,7 @@ configured.
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 import logging
 import os
 from statistics import mean
@@ -74,10 +75,15 @@ class USSocialSentimentClient:
             return None
 
         sources: Dict[str, Dict[str, Any]] = {}
-        for platform in self.PLATFORM_SPECS:
-            parsed = self._fetch_platform_snapshot(platform, ticker, days)
-            if parsed:
-                sources[platform] = parsed
+        with ThreadPoolExecutor(max_workers=len(self.PLATFORM_SPECS)) as pool:
+            futures = {
+                platform: pool.submit(self._fetch_platform_snapshot, platform, ticker, days)
+                for platform in self.PLATFORM_SPECS
+            }
+            for platform in self.PLATFORM_SPECS:
+                parsed = futures[platform].result()
+                if parsed:
+                    sources[platform] = parsed
 
         if not sources:
             return None
@@ -110,7 +116,7 @@ class USSocialSentimentClient:
             "",
         ]
 
-        for platform in ("reddit", "x", "news", "polymarket"):
+        for platform in self.PLATFORM_SPECS:
             source = snapshot["sources"].get(platform)
             if not source:
                 continue

--- a/prism-us/tests/test_phase2_social_sentiment_client.py
+++ b/prism-us/tests/test_phase2_social_sentiment_client.py
@@ -1,0 +1,118 @@
+"""
+Phase 2: Social Sentiment Client Tests
+
+Tests for the optional Adanos-based social sentiment client used by PRISM-US.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add paths for imports
+PRISM_US_DIR = Path(__file__).parent.parent
+PROJECT_ROOT = PRISM_US_DIR.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+sys.path.insert(0, str(PRISM_US_DIR))
+
+from cores.us_social_sentiment_client import USSocialSentimentClient
+
+
+class _MockResponse:
+    """Minimal requests-like response helper."""
+
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"http {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+def test_social_sentiment_snapshot_aggregates_sources(monkeypatch):
+    """Client should aggregate reddit/x/news/polymarket into one snapshot."""
+    payloads = {
+        "reddit": [{"ticker": "TSLA", "buzz_score": 80.0, "bullish_pct": 45, "trend": "rising", "mentions": 640}],
+        "x": [{"ticker": "TSLA", "buzz_score": 70.0, "bullish_pct": 60, "trend": "stable", "mentions": 1200}],
+        "news": [{"ticker": "TSLA", "buzz_score": 60.0, "bullish_pct": 55, "trend": "stable", "mentions": 90}],
+        "polymarket": [{"ticker": "TSLA", "buzz_score": 90.0, "bullish_pct": 70, "trend": "falling", "trade_count": 333}],
+    }
+
+    def fake_get(url, headers, params, timeout):
+        assert headers["X-API-Key"] == "sk_test"
+        assert params == {"tickers": "TSLA", "days": 7}
+        for platform in payloads:
+            if f"/{platform}/stocks/v1/compare" in url:
+                return _MockResponse(payloads[platform])
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    monkeypatch.setattr("cores.us_social_sentiment_client.requests.get", fake_get)
+
+    client = USSocialSentimentClient(api_key="sk_test", base_url="https://api.example.com")
+    snapshot = client.get_social_sentiment_snapshot("TSLA", days=7)
+
+    assert snapshot["ticker"] == "TSLA"
+    assert snapshot["coverage"] == 4
+    assert snapshot["average_buzz"] == 75.0
+    assert snapshot["bullish_avg"] == 57.5
+    assert snapshot["source_alignment"] == "Mixed"
+    assert snapshot["sources"]["reddit"]["activity_value"] == 640
+    assert snapshot["sources"]["polymarket"]["activity_label"] == "Trades"
+
+
+def test_social_sentiment_snapshot_tolerates_partial_source_failures(monkeypatch):
+    """Malformed or failing sources should be skipped without aborting the snapshot."""
+
+    def fake_get(url, headers, params, timeout):
+        if "/reddit/stocks/v1/compare" in url:
+            return _MockResponse([{"ticker": "AAPL", "buzz_score": "82.5", "bullish_pct": "61", "trend": "rising", "mentions": "512"}])
+        if "/x/stocks/v1/compare" in url:
+            return _MockResponse([{"ticker": "AAPL", "buzz_score": "n/a", "bullish_pct": "", "trend": "stable", "mentions": None}])
+        if "/news/stocks/v1/compare" in url:
+            return _MockResponse([], status_code=500)
+        if "/polymarket/stocks/v1/compare" in url:
+            return _MockResponse([{"ticker": "AAPL", "buzz_score": 76, "bullish_pct": 58, "trend": "stable", "trade_count": 44}])
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    monkeypatch.setattr("cores.us_social_sentiment_client.requests.get", fake_get)
+
+    client = USSocialSentimentClient(api_key="sk_test", base_url="https://api.example.com")
+    snapshot = client.get_social_sentiment_snapshot("AAPL", days=7)
+
+    assert snapshot["coverage"] == 2
+    assert snapshot["average_buzz"] == 79.2
+    assert snapshot["bullish_avg"] == 59.5
+    assert "x" not in snapshot["sources"]
+    assert "news" not in snapshot["sources"]
+
+
+def test_social_sentiment_markdown_renders_expected_fields(monkeypatch):
+    """Rendered markdown should expose the summary and per-source metrics."""
+
+    def fake_get(url, headers, params, timeout):
+        if "/reddit/stocks/v1/compare" in url:
+            return _MockResponse([{"ticker": "MSFT", "buzz_score": 74.3, "bullish_pct": 52, "trend": "rising", "mentions": 200}])
+        if "/x/stocks/v1/compare" in url:
+            return _MockResponse([{"ticker": "MSFT", "buzz_score": 68.8, "bullish_pct": 49, "trend": "stable", "mentions": 180}])
+        if "/news/stocks/v1/compare" in url:
+            return _MockResponse([{"ticker": "MSFT", "buzz_score": 63.0, "bullish_pct": 51, "trend": "stable", "mentions": 42}])
+        if "/polymarket/stocks/v1/compare" in url:
+            return _MockResponse([{"ticker": "MSFT", "buzz_score": 71.0, "bullish_pct": 50, "trend": "falling", "trade_count": 18}])
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    monkeypatch.setattr("cores.us_social_sentiment_client.requests.get", fake_get)
+
+    client = USSocialSentimentClient(api_key="sk_test", base_url="https://api.example.com")
+    markdown = client.get_social_sentiment_markdown("MSFT", days=7)
+
+    assert "### Structured Social Sentiment Snapshot (7d)" in markdown
+    assert "- Average Buzz: 69.3/100" in markdown
+    assert "- Bullish Avg: 50.5%" in markdown
+    assert "#### Reddit" in markdown
+    assert "- Mentions: 200" in markdown
+    assert "#### Polymarket" in markdown
+    assert "- Trades: 18" in markdown

--- a/prism-us/tests/test_phase2_social_sentiment_client.py
+++ b/prism-us/tests/test_phase2_social_sentiment_client.py
@@ -117,3 +117,46 @@ def test_social_sentiment_markdown_renders_expected_fields(monkeypatch):
     assert "#### Polymarket" in markdown
     assert "- Trades: 18" in markdown
     assert markdown.index("#### Reddit") < markdown.index("#### X.com") < markdown.index("#### News") < markdown.index("#### Polymarket")
+
+
+def test_extract_row_supports_stocks_wrapper():
+    """Live compare responses wrap rows in a top-level stocks list."""
+    payload = {
+        "period_days": 7,
+        "stocks": [
+            {
+                "ticker": "AAPL",
+                "buzz_score": 73.8,
+                "bullish_pct": 32,
+                "trend": "rising",
+                "mentions": 426,
+            }
+        ],
+    }
+
+    row = USSocialSentimentClient._extract_row(payload, "AAPL")
+
+    assert row is not None
+    assert row["ticker"] == "AAPL"
+    assert row["buzz_score"] == 73.8
+
+
+def test_extract_row_supports_data_wrapper_for_compatibility():
+    """Older wrapper shapes should continue to work."""
+    payload = {
+        "data": [
+            {
+                "ticker": "MSFT",
+                "buzz_score": 60.0,
+                "bullish_pct": 55,
+                "trend": "stable",
+                "mentions": 200,
+            }
+        ]
+    }
+
+    row = USSocialSentimentClient._extract_row(payload, "MSFT")
+
+    assert row is not None
+    assert row["ticker"] == "MSFT"
+    assert row["buzz_score"] == 60.0

--- a/prism-us/tests/test_phase2_social_sentiment_client.py
+++ b/prism-us/tests/test_phase2_social_sentiment_client.py
@@ -1,7 +1,7 @@
 """
 Phase 2: Social Sentiment Client Tests
 
-Tests for the optional Adanos-based social sentiment client used by PRISM-US.
+Tests for the optional social sentiment client used by PRISM-US.
 """
 
 import sys

--- a/prism-us/tests/test_phase2_social_sentiment_client.py
+++ b/prism-us/tests/test_phase2_social_sentiment_client.py
@@ -116,3 +116,4 @@ def test_social_sentiment_markdown_renders_expected_fields(monkeypatch):
     assert "- Mentions: 200" in markdown
     assert "#### Polymarket" in markdown
     assert "- Trades: 18" in markdown
+    assert markdown.index("#### Reddit") < markdown.index("#### X.com") < markdown.index("#### News") < markdown.index("#### Polymarket")

--- a/prism-us/tests/test_phase4_agents.py
+++ b/prism-us/tests/test_phase4_agents.py
@@ -167,6 +167,22 @@ class TestAgentDirectory:
         assert 'unknown_section' not in agents
         assert 'price_volume_analysis' in agents
 
+    def test_news_agent_receives_prefetched_social_sentiment(self, sample_reference_date):
+        """News agent should embed prefetched social sentiment context when provided."""
+        agents = get_us_agent_directory(
+            company_name="Tesla, Inc.",
+            ticker="TSLA",
+            reference_date=sample_reference_date,
+            base_sections=['news_analysis'],
+            language="en",
+            prefetched_data={"social_sentiment": "### Structured Social Sentiment Snapshot (7d)\n- Average Buzz: 74.3/100"},
+        )
+
+        agent = agents['news_analysis']
+        assert "Structured Social Sentiment Snapshot" in agent.instruction
+        assert "do not make extra tool calls for social sentiment" in agent.instruction
+        assert agent.server_names == ["perplexity", "firecrawl"]
+
 
 # =============================================================================
 # Test: Individual Agent Imports

--- a/prism-us/tests/test_phase4_agents.py
+++ b/prism-us/tests/test_phase4_agents.py
@@ -167,23 +167,6 @@ class TestAgentDirectory:
         assert 'unknown_section' not in agents
         assert 'price_volume_analysis' in agents
 
-    def test_news_agent_receives_prefetched_social_sentiment(self, sample_reference_date):
-        """News agent should embed prefetched social sentiment context when provided."""
-        agents = get_us_agent_directory(
-            company_name="Tesla, Inc.",
-            ticker="TSLA",
-            reference_date=sample_reference_date,
-            base_sections=['news_analysis'],
-            language="en",
-            prefetched_data={"social_sentiment": "### Structured Social Sentiment Snapshot (7d)\n- Average Buzz: 74.3/100"},
-        )
-
-        agent = agents['news_analysis']
-        assert "Structured Social Sentiment Snapshot" in agent.instruction
-        assert "do not make extra tool calls for social sentiment" in agent.instruction
-        assert agent.server_names == ["perplexity", "firecrawl"]
-
-
 # =============================================================================
 # Test: Individual Agent Imports
 # =============================================================================

--- a/prism-us/tests/test_phase4_news_social_context.py
+++ b/prism-us/tests/test_phase4_news_social_context.py
@@ -1,0 +1,34 @@
+"""
+Phase 4: News Agent Social Context Tests
+
+Focused tests for optional prefetched social sentiment context in the US news
+analysis agent flow.
+"""
+
+import sys
+from pathlib import Path
+
+# Add paths for imports
+PRISM_US_DIR = Path(__file__).parent.parent
+PROJECT_ROOT = PRISM_US_DIR.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+sys.path.insert(0, str(PRISM_US_DIR))
+
+from cores.agents import get_us_agent_directory
+
+
+def test_news_agent_receives_prefetched_social_sentiment(sample_reference_date):
+    """News agent should embed prefetched social sentiment context when provided."""
+    agents = get_us_agent_directory(
+        company_name="Tesla, Inc.",
+        ticker="TSLA",
+        reference_date=sample_reference_date,
+        base_sections=["news_analysis"],
+        language="en",
+        prefetched_data={"social_sentiment": "### Structured Social Sentiment Snapshot (7d)\n- Average Buzz: 74.3/100"},
+    )
+
+    agent = agents["news_analysis"]
+    assert "Structured Social Sentiment Snapshot" in agent.instruction
+    assert "do not make extra tool calls for social sentiment" in agent.instruction
+    assert agent.server_names == ["perplexity", "firecrawl"]

--- a/prism-us/tests/test_phase4_news_social_context.py
+++ b/prism-us/tests/test_phase4_news_social_context.py
@@ -31,4 +31,6 @@ def test_news_agent_receives_prefetched_social_sentiment(sample_reference_date):
     agent = agents["news_analysis"]
     assert "Structured Social Sentiment Snapshot" in agent.instruction
     assert "do not make extra tool calls for social sentiment" in agent.instruction
+    assert "Social sentiment alignment" in agent.instruction
+    assert agent.instruction.index("Structured Social Sentiment Snapshot") < agent.instruction.index("## Output Format")
     assert agent.server_names == ["perplexity", "firecrawl"]

--- a/prism-us/tests/test_phase4_news_social_context.py
+++ b/prism-us/tests/test_phase4_news_social_context.py
@@ -5,14 +5,35 @@ Focused tests for optional prefetched social sentiment context in the US news
 analysis agent flow.
 """
 
+import importlib
 import sys
+import types
 from pathlib import Path
+
+import pytest
 
 # Add paths for imports
 PRISM_US_DIR = Path(__file__).parent.parent
 PROJECT_ROOT = PRISM_US_DIR.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 sys.path.insert(0, str(PRISM_US_DIR))
+
+try:
+    from mcp_agent.agents.agent import Agent as _Agent  # noqa: F401
+except ModuleNotFoundError:
+    class _DummyAgent:
+        def __init__(self, name, instruction, server_names):
+            self.name = name
+            self.instruction = instruction
+            self.server_names = server_names
+
+    mcp_agent = types.ModuleType("mcp_agent")
+    agents_module = types.ModuleType("mcp_agent.agents")
+    agent_module = types.ModuleType("mcp_agent.agents.agent")
+    agent_module.Agent = _DummyAgent
+    sys.modules.setdefault("mcp_agent", mcp_agent)
+    sys.modules.setdefault("mcp_agent.agents", agents_module)
+    sys.modules.setdefault("mcp_agent.agents.agent", agent_module)
 
 from cores.agents import get_us_agent_directory
 
@@ -34,3 +55,139 @@ def test_news_agent_receives_prefetched_social_sentiment(sample_reference_date):
     assert "Social sentiment alignment" in agent.instruction
     assert agent.instruction.index("Structured Social Sentiment Snapshot") < agent.instruction.index("## Output Format")
     assert agent.server_names == ["perplexity", "firecrawl"]
+
+
+def _import_us_analysis_with_stubbed_mcp_agent(monkeypatch):
+    """Import us_analysis with lightweight mcp_agent stubs for unit testing."""
+    class DummyAgent:
+        def __init__(self, name, instruction, server_names):
+            self.name = name
+            self.instruction = instruction
+            self.server_names = server_names
+
+    mcp_agent = types.ModuleType("mcp_agent")
+    app_module = types.ModuleType("mcp_agent.app")
+    app_module.MCPApp = object
+    agents_module = types.ModuleType("mcp_agent.agents")
+    agent_module = types.ModuleType("mcp_agent.agents.agent")
+    agent_module.Agent = DummyAgent
+    workflows_module = types.ModuleType("mcp_agent.workflows")
+    llm_module = types.ModuleType("mcp_agent.workflows.llm")
+    augmented_module = types.ModuleType("mcp_agent.workflows.llm.augmented_llm")
+    augmented_module.RequestParams = object
+    openai_module = types.ModuleType("mcp_agent.workflows.llm.augmented_llm_openai")
+    openai_module.OpenAIAugmentedLLM = object
+
+    monkeypatch.setitem(sys.modules, "mcp_agent", mcp_agent)
+    monkeypatch.setitem(sys.modules, "mcp_agent.app", app_module)
+    monkeypatch.setitem(sys.modules, "mcp_agent.agents", agents_module)
+    monkeypatch.setitem(sys.modules, "mcp_agent.agents.agent", agent_module)
+    monkeypatch.setitem(sys.modules, "mcp_agent.workflows", workflows_module)
+    monkeypatch.setitem(sys.modules, "mcp_agent.workflows.llm", llm_module)
+    monkeypatch.setitem(sys.modules, "mcp_agent.workflows.llm.augmented_llm", augmented_module)
+    monkeypatch.setitem(sys.modules, "mcp_agent.workflows.llm.augmented_llm_openai", openai_module)
+
+    sys.modules.pop("cores.us_analysis", None)
+    return importlib.import_module("cores.us_analysis")
+
+
+@pytest.mark.asyncio
+async def test_analyze_us_stock_logs_rendered_social_prefetch_ticker(monkeypatch):
+    """Social prefetch logging should emit a fully rendered ticker string."""
+    us_analysis = _import_us_analysis_with_stubbed_mcp_agent(monkeypatch)
+
+    class DummyLogger:
+        def __init__(self):
+            self.info_messages = []
+            self.warning_messages = []
+            self.error_messages = []
+
+        def info(self, message):
+            self.info_messages.append(message)
+
+        def warning(self, message):
+            self.warning_messages.append(message)
+
+        def error(self, message):
+            self.error_messages.append(message)
+
+    created_loggers = []
+
+    class DummyRunContext:
+        def __init__(self, logger):
+            self.logger = logger
+
+        async def __aenter__(self):
+            return types.SimpleNamespace(logger=self.logger)
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class DummyApp:
+        def __init__(self, name):
+            self.logger = DummyLogger()
+            created_loggers.append(self.logger)
+
+        def run(self):
+            return DummyRunContext(self.logger)
+
+    class DummyPrefetchLoader:
+        def exec_module(self, module):
+            module.prefetch_us_analysis_data = lambda ticker: {}
+
+    class FakeSocialClient:
+        def get_social_sentiment_markdown(self, ticker, days):
+            return "### Structured Social Sentiment Snapshot (7d)"
+
+    class DummyStock:
+        def history(self, period):
+            return types.SimpleNamespace(empty=True)
+
+    async def fake_generate_report(*args, **kwargs):
+        return "news report"
+
+    async def fake_generate_summary(*args, **kwargs):
+        return "summary"
+
+    async def fake_generate_strategy(*args, **kwargs):
+        return "strategy"
+
+    monkeypatch.setenv("ADANOS_API_KEY", "sk_test")
+    monkeypatch.setattr(us_analysis, "MCPApp", DummyApp)
+    monkeypatch.setattr(us_analysis, "USSocialSentimentClient", FakeSocialClient)
+    monkeypatch.setattr(
+        us_analysis.importlib.util,
+        "spec_from_file_location",
+        lambda *args, **kwargs: types.SimpleNamespace(loader=DummyPrefetchLoader()),
+    )
+    monkeypatch.setattr(
+        us_analysis.importlib.util,
+        "module_from_spec",
+        lambda spec: types.SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        us_analysis,
+        "get_us_agent_directory",
+        lambda *args, **kwargs: {"news_analysis": object()},
+    )
+    monkeypatch.setattr(us_analysis, "generate_report", fake_generate_report)
+    monkeypatch.setattr(us_analysis, "generate_summary", fake_generate_summary)
+    monkeypatch.setattr(us_analysis, "generate_investment_strategy", fake_generate_strategy)
+    monkeypatch.setattr(us_analysis, "clean_markdown", lambda text: text)
+    monkeypatch.setattr(us_analysis, "get_disclaimer", lambda language: "disclaimer")
+    monkeypatch.setitem(sys.modules, "yfinance", types.SimpleNamespace(Ticker=lambda ticker: DummyStock()))
+
+    report = await us_analysis.analyze_us_stock(
+        ticker="TSLA",
+        company_name="Tesla, Inc.",
+        reference_date="20260327",
+        language="en",
+    )
+
+    root_logger = created_loggers[0]
+    assert "Prefetched social sentiment for TSLA" in root_logger.info_messages
+    assert not any(
+        "US social sentiment prefetch failed" in message
+        for message in root_logger.warning_messages
+    )
+    assert "news report" in report


### PR DESCRIPTION
## Summary

- add an optional US social sentiment client that fetches structured snapshots for a ticker
- pass prefetched social sentiment context into the existing `news_analysis` agent
- keep the current US report section layout unchanged
- gate the feature behind `ADANOS_API_KEY`, so default behavior stays the same
- add focused tests for the client and the news agent integration

## Why

The US pipeline already combines price/volume, fundamentals, institutional holdings, market context, and qualitative news.

What it currently lacks is a compact public-sentiment layer that helps answer questions like:
- how much public attention is this stock getting right now?
- are public sources aligned or diverging?
- is the current discussion more bullish or mixed across sources?

This PR adds that as supplemental context for the existing US news analysis, rather than creating a new top-level workflow or replacing any current data source.

## Scope

This PR intentionally does not:
- change the existing report section order
- replace current news gathering
- modify KR flows
- require any new configuration for existing users

When `ADANOS_API_KEY` is not set, the US analysis flow behaves exactly as before.

## Included social snapshot fields

The prefetched context summarizes the last 7 days across available sources and includes:
- average buzz
- bullish average
- source alignment
- coverage
- per-source buzz / bullish % / mentions or trades / trend

## Validation

Ran locally:
- `python -m pytest prism-us/tests/test_phase2_social_sentiment_client.py prism-us/tests/test_phase4_news_social_context.py -q`
- `python -m compileall prism-us/cores prism-us/tests`

Note: the repository currently has some pre-existing US test expectation mismatches around `yahoo_finance` vs `yfinance_us`; this PR does not change those paths.
