### PR TITLE
fix: telegram_translator reasoning_effort 오분류 400 에러 수정

### DIFF
--- a/cores/agents/telegram_translator_agent.py
+++ b/cores/agents/telegram_translator_agent.py
@@ -135,7 +135,8 @@ async def translate_telegram_message(
                 model=model,
                 maxTokens=100000,
                 temperature=0.3,  # Lower temperature for more consistent translations
-                max_iterations=1  # Single pass translation, no complex reasoning needed
+                max_iterations=1,  # Single pass translation, no complex reasoning needed
+                reasoning_effort="none",  # gpt-5-nano is not a reasoning model
             )
         )
 


### PR DESCRIPTION
## Summary
- `gpt-5-nano`가 `gpt-5` prefix로 인해 mcp-agent의 `_reasoning()` 체크에서 reasoning 모델로 오분류
- config의 `reasoning_effort: 'high'`가 자동 적용되어 OpenAI API 400 Bad Request 발생
- `RequestParams`에 `reasoning_effort="none"` 명시하여 오버라이드

## Test plan
- [ ] 운영서버에서 US morning 분석 실행 후 zh/en 텔레그램 번역 정상 동작 확인
- [ ] 400 Bad Request 에러 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)