### PR TITLE
revert: PR #230 reasoning_effort='none' 롤백

### DIFF
--- a/cores/agents/telegram_translator_agent.py
+++ b/cores/agents/telegram_translator_agent.py
@@ -135,8 +135,7 @@ async def translate_telegram_message(
                 model=model,
                 maxTokens=100000,
                 temperature=0.3,  # Lower temperature for more consistent translations
-                max_iterations=1,  # Single pass translation, no complex reasoning needed
-                reasoning_effort="none",  # gpt-5-nano is not a reasoning model
+                max_iterations=1  # Single pass translation, no complex reasoning needed
             )
         )
 


### PR DESCRIPTION
## Summary
- PR #230에서 추가한 `reasoning_effort="none"` 롤백
- 테스트 결과 `gpt-5-nano`는 `'none'` 미지원 (`'minimal'`, `'low'`, `'medium'`, `'high'`만 유효)
- `reasoning_effort='high'`도 `gpt-5-nano`에서 정상 동작 확인 → reasoning_effort는 400 에러의 원인이 아님
- 간헐적 "could not parse the JSON body" 에러는 여러 에이전트에서 발생하며, 네트워크/OpenAI API 일시적 이슈로 추정

## Test plan
- [ ] 운영서버 반영 후 telegram_translator 번역 정상 동작 확인
- [ ] `reasoning_effort="none"` 에러 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)