### PR TITLE
feat: OpenAI 400 에러 request body 디버그 로깅

### DIFF
--- a/cores/openai_debug.py
+++ b/cores/openai_debug.py
@@ -1,0 +1,73 @@
+"""OpenAI API 400 error debug logging.
+
+Import this module early in orchestrator entry points to enable
+automatic request body logging when OpenAI returns 400 errors.
+
+Usage:
+    import cores.openai_debug  # noqa: F401 — side-effect import
+"""
+
+import logging
+import httpx
+
+logger = logging.getLogger("openai_debug")
+
+_original_async_init = httpx.AsyncClient.__init__
+_original_sync_init = httpx.Client.__init__
+
+
+async def _async_log_on_error(response: httpx.Response):
+    """Log request body when OpenAI API returns 400."""
+    if (
+        response.status_code == 400
+        and "openai.com" in str(response.request.url)
+    ):
+        body = response.request.content
+        logger.error(
+            "[OpenAI 400 Debug] %s %s | "
+            "Body(%d bytes): %s",
+            response.request.method,
+            response.request.url,
+            len(body),
+            body[:3000].decode("utf-8", errors="replace"),
+        )
+
+
+def _patched_async_init(self, *args, **kwargs):
+    _original_async_init(self, *args, **kwargs)
+    hooks = self.event_hooks.get("response", [])
+    if _async_log_on_error not in hooks:
+        hooks.append(_async_log_on_error)
+        self.event_hooks["response"] = hooks
+
+
+def _sync_log_on_error(response: httpx.Response):
+    """Log request body when OpenAI API returns 400 (sync)."""
+    if (
+        response.status_code == 400
+        and "openai.com" in str(response.request.url)
+    ):
+        body = response.request.content
+        logger.error(
+            "[OpenAI 400 Debug] %s %s | "
+            "Body(%d bytes): %s",
+            response.request.method,
+            response.request.url,
+            len(body),
+            body[:3000].decode("utf-8", errors="replace"),
+        )
+
+
+def _patched_sync_init(self, *args, **kwargs):
+    _original_sync_init(self, *args, **kwargs)
+    hooks = self.event_hooks.get("response", [])
+    if _sync_log_on_error not in hooks:
+        hooks.append(_sync_log_on_error)
+        self.event_hooks["response"] = hooks
+
+
+# Apply monkey-patches on import
+httpx.AsyncClient.__init__ = _patched_async_init
+httpx.Client.__init__ = _patched_sync_init
+
+logger.info("OpenAI 400 debug logging enabled")

--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -19,6 +19,7 @@ Key Differences from Korean Version:
 from dotenv import load_dotenv
 load_dotenv()
 
+import cores.openai_debug  # noqa: F401 — OpenAI 400 error request body logging
 import argparse
 import asyncio
 import json

--- a/stock_analysis_orchestrator.py
+++ b/stock_analysis_orchestrator.py
@@ -12,6 +12,7 @@ Overall Process:
 from dotenv import load_dotenv
 load_dotenv()  # Load environment variables from .env file
 
+import cores.openai_debug  # noqa: F401 — OpenAI 400 error request body logging
 import argparse
 import asyncio
 import json


### PR DESCRIPTION
## Summary
- 간헐적 "could not parse the JSON body" 400 에러 원인 파악을 위한 디버그 로깅 추가
- `cores/openai_debug.py`: httpx event hook으로 OpenAI 400 응답 시 request body 자동 로깅 (최대 3KB)
- KR/US orchestrator 진입점에 side-effect import 추가
- mcp-agent 수정 불필요 (monkey-patch 방식)

## 동작 방식
- `httpx.AsyncClient`/`httpx.Client` 생성 시 response hook 자동 주입
- 400 에러 + openai.com URL일 때만 request body 로깅
- 로거: `openai_debug` (기존 로깅 설정 따름)

## Test plan
- [ ] 운영서버 배포 후 다음 400 에러 발생 시 request body 로그 확인
- [ ] 정상 요청 시 불필요한 로그 미출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)