### PR TITLE
fix: US 오케스트레이터 cores.openai_debug 임포트 순서 수정

### DIFF
--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -19,7 +19,6 @@ Key Differences from Korean Version:
 from dotenv import load_dotenv
 load_dotenv()
 
-import cores.openai_debug  # noqa: F401 — OpenAI 400 error request body logging
 import argparse
 import asyncio
 import json
@@ -35,6 +34,8 @@ PROJECT_ROOT = Path(__file__).parent.parent
 PRISM_US_DIR = Path(__file__).parent
 sys.path.insert(0, str(PROJECT_ROOT))
 sys.path.insert(0, str(PRISM_US_DIR))
+
+import cores.openai_debug  # noqa: F401 — OpenAI 400 error request body logging
 
 # Logger configuration
 logging.basicConfig(


### PR DESCRIPTION
## Summary
- `prism-us/us_stock_analysis_orchestrator.py`에서 `cores.openai_debug` 임포트를 `sys.path.insert()` 이후로 이동
- `decf991`에서 도입된 regression 수정 — US 오케스트레이터 실행 시 `ModuleNotFoundError` 발생

## Root Cause
`import cores.openai_debug`가 `sys.path`에 프로젝트 루트를 추가하기 전(line 22)에 위치하여, `prism-us/` 디렉토리에서 실행 시 모듈을 찾지 못함. KR 오케스트레이터는 프로젝트 루트에서 실행되므로 영향 없음.

## Test plan
- [ ] `cd /root/prism-insight && python prism-us/us_stock_analysis_orchestrator.py --mode morning --no-telegram` 정상 실행 확인
- [ ] `cd /root/prism-insight && python stock_analysis_orchestrator.py --mode morning --no-telegram` 기존 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)