### PR TITLE
fix: US 오케스트레이터 sys.path 순서 수정 (cores.openai_debug)

### DIFF
--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -32,8 +32,8 @@ from pathlib import Path
 # Add paths for imports
 PROJECT_ROOT = Path(__file__).parent.parent
 PRISM_US_DIR = Path(__file__).parent
-sys.path.insert(0, str(PROJECT_ROOT))
 sys.path.insert(0, str(PRISM_US_DIR))
+sys.path.insert(0, str(PROJECT_ROOT))
 
 import cores.openai_debug  # noqa: F401 — OpenAI 400 error request body logging
 


### PR DESCRIPTION
## Summary
- `prism-us/us_stock_analysis_orchestrator.py`에서 `sys.path.insert` 순서를 변경하여 `PROJECT_ROOT`가 `PRISM_US_DIR`보다 우선 검색되도록 수정
- PR #233 머지 후에도 `cores.openai_debug` 임포트 실패하던 문제 해결

## Root Cause
`sys.path.insert(0, ...)` 호출 순서상 `PRISM_US_DIR`(`prism-us/`)이 `PROJECT_ROOT`(`.`)보다 `sys.path[0]`에 위치. `prism-us/cores/__init__.py`가 존재하므로 Python이 `prism-us/cores` 패키지를 먼저 찾고, 거기에 `openai_debug.py`가 없어 `ModuleNotFoundError` 발생.

## Fix
insert 순서를 바꿔 `PROJECT_ROOT`가 `sys.path[0]`에 오도록 수정.

## Test plan
- [ ] `cd /root/prism-insight && python prism-us/us_stock_analysis_orchestrator.py --mode morning --no-telegram` 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)