### PR TITLE
fix: US 오케스트레이터 sys.path 순서 — cores.openai_debug + check_market_day 충돌 해결

### DIFF
--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -32,10 +32,11 @@ from pathlib import Path
 # Add paths for imports
 PROJECT_ROOT = Path(__file__).parent.parent
 PRISM_US_DIR = Path(__file__).parent
-sys.path.insert(0, str(PRISM_US_DIR))
 sys.path.insert(0, str(PROJECT_ROOT))
 
 import cores.openai_debug  # noqa: F401 — OpenAI 400 error request body logging
+
+sys.path.insert(0, str(PRISM_US_DIR))
 
 # Logger configuration
 logging.basicConfig(


### PR DESCRIPTION
## Summary
- `cores.openai_debug` 임포트를 `PRISM_US_DIR` sys.path 추가 전에 배치하여 양쪽 모듈 모두 정상 로딩되도록 수정
- PR #233, #234 머지 후에도 `check_market_day.is_us_market_day` 임포트 실패하던 문제 해결

## Root Cause
`prism-us/cores/`와 루트 `cores/`, `prism-us/check_market_day.py`와 루트 `check_market_day.py`가 동명이라 sys.path 순서에 따라 잘못된 모듈이 로딩됨:
- `PROJECT_ROOT` 우선 → `cores.openai_debug` OK, `check_market_day.is_us_market_day` NG
- `PRISM_US_DIR` 우선 → `cores.openai_debug` NG, `check_market_day.is_us_market_day` OK

## Fix
임포트 순서를 분리:
1. `sys.path.insert(0, PROJECT_ROOT)` → `import cores.openai_debug`
2. `sys.path.insert(0, PRISM_US_DIR)` → 이후 `check_market_day` 등 prism-us 모듈 우선 검색

## Test plan
- [ ] `cd /root/prism-insight && python prism-us/us_stock_analysis_orchestrator.py --mode morning --no-telegram` 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)