### PR TITLE
fix: US 오케스트레이터 cores.openai_debug importlib 로드로 패키지 충돌 해결

### DIFF
--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -33,10 +33,14 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).parent.parent
 PRISM_US_DIR = Path(__file__).parent
 sys.path.insert(0, str(PROJECT_ROOT))
-
-import cores.openai_debug  # noqa: F401 — OpenAI 400 error request body logging
-
 sys.path.insert(0, str(PRISM_US_DIR))
+
+# Load openai_debug from project root via importlib (prism-us/cores/ shadows root cores/)
+import importlib.util as _ilu
+_spec = _ilu.spec_from_file_location("cores.openai_debug", PROJECT_ROOT / "cores" / "openai_debug.py")
+if _spec and _spec.loader:
+    _mod = _ilu.module_from_spec(_spec)
+    _spec.loader.exec_module(_mod)
 
 # Logger configuration
 logging.basicConfig(


### PR DESCRIPTION
## Summary
- `prism-us/cores/`와 루트 `cores/`의 동명 패키지 충돌을 `importlib`로 해결
- PR #233~#235의 연쇄 임포트 에러 최종 수정

## Root Cause
`prism-us/cores/`와 루트 `cores/`가 동명 패키지. Python은 `sys.path`에서 먼저 찾은 하나의 `cores`만 사용:
- `PRISM_US_DIR` 우선 → `cores.openai_debug` 못 찾음
- `PROJECT_ROOT` 우선 → `cores.us_surge_detector`, `cores.data_prefetch` US 함수 못 찾음

sys.path 순서로는 해결 불가능한 구조적 문제.

## Fix
- `sys.path` 순서는 원래대로 유지 (`PRISM_US_DIR` 우선)
- `cores.openai_debug`만 `importlib.util`로 프로젝트 루트에서 명시적 로드

## Test plan
- [ ] `cd /root/prism-insight && python prism-us/us_stock_analysis_orchestrator.py --mode morning --no-telegram` 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)