### PR TITLE
fix: telegram JSON sanitize, KIS API price format, market order type

### DIFF
--- a/cores/agents/telegram_translator_agent.py
+++ b/cores/agents/telegram_translator_agent.py
@@ -122,6 +122,11 @@ async def translate_telegram_message(
     from mcp_agent.workflows.llm.augmented_llm import RequestParams
 
     try:
+        # Sanitize: strip control characters that break JSON serialization
+        # (NUL bytes and other ASCII control chars except \t \n \r are invalid in JSON strings)
+        import re as _re
+        message = _re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]', '', message)
+
         # Create translator agent
         translator = create_telegram_translator_agent(from_lang=from_lang, to_lang=to_lang)
 

--- a/prism-us/trading/us_stock_trading.py
+++ b/prism-us/trading/us_stock_trading.py
@@ -356,9 +356,9 @@ class USStockTrading:
             "OVRS_EXCG_CD": exchange,
             "PDNO": ticker.upper(),
             "ORD_QTY": str(buy_quantity),
-            "OVRS_ORD_UNPR": "0",  # Market price = 0
+            "OVRS_ORD_UNPR": "0",  # Market order price = 0
             "ORD_SVR_DVSN_CD": "0",
-            "ORD_DVSN": "00"  # 00: Market price
+            "ORD_DVSN": "01"   # Market order (시장가)
         }
 
         try:
@@ -457,7 +457,7 @@ class USStockTrading:
             "OVRS_EXCG_CD": exchange,
             "PDNO": ticker.upper(),
             "ORD_QTY": str(buy_quantity),
-            "OVRS_ORD_UNPR": str(limit_price),
+            "OVRS_ORD_UNPR": f"{limit_price:.2f}",
             "ORD_SVR_DVSN_CD": "0",
             "ORD_DVSN": "00"  # Limit order
         }
@@ -572,10 +572,10 @@ class USStockTrading:
             "OVRS_EXCG_CD": exchange,
             "PDNO": ticker.upper(),
             "ORD_QTY": str(quantity),
-            "OVRS_ORD_UNPR": "0",  # Market price = 0
+            "OVRS_ORD_UNPR": "0",  # Market order price = 0
             "ORD_SVR_DVSN_CD": "0",
             "SLL_TYPE": "00",  # Sell type
-            "ORD_DVSN": "00"   # Order type: limit (US only supports 지정가)
+            "ORD_DVSN": "01"   # Market order (시장가)
         }
 
         try:
@@ -819,7 +819,7 @@ class USStockTrading:
             "OVRS_EXCG_CD": exchange,
             "PDNO": ticker.upper(),
             "FT_ORD_QTY": str(int(buy_quantity)),  # Must be integer string for KIS API
-            "FT_ORD_UNPR3": str(limit_price),
+            "FT_ORD_UNPR3": f"{limit_price:.2f}",
             "ORD_SVR_DVSN_CD": "0"
         }
 
@@ -938,7 +938,7 @@ class USStockTrading:
             order_price = "0"
             order_type_str = "MOO (Market On Open)"
         else:
-            order_price = str(limit_price)
+            order_price = f"{limit_price:.2f}"
             order_type_str = f"Limit ${limit_price:.2f}"
 
         params = {

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -792,8 +792,13 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
 
             # Hard mechanical stop-loss check BEFORE AI — cannot be overridden
             if stop_loss > 0 and current_price <= stop_loss:
+                loss_pct = ((current_price - buy_price) / buy_price * 100) if buy_price > 0 else 0
                 logger.info(f"{ticker} 기계적 손절 조건 도달 (손절가: {stop_loss:,.0f}원) — AI 판단 생략")
-                return True, f"손절 조건 도달 (손절가: {stop_loss:,.0f}원)"
+                return True, (
+                    f"사전 설정 손절가({stop_loss:,.0f}원) 도달로 기계적 손절 실행.\n"
+                    f"현재가 {current_price:,.0f}원 / 매수가 {buy_price:,.0f}원 / 손실률 {loss_pct:.1f}%.\n"
+                    f"손절가 이하 하락 시 AI 판단 없이 즉시 매도하는 규칙에 따라 처리되었습니다."
+                )
 
             # Collect current portfolio information
             self.cursor.execute("""


### PR DESCRIPTION
## Summary

- **Telegram 번역 400 오류**: markdown 리포트 내 NUL byte 등 ASCII 제어문자가 OpenAI JSON body 파싱 실패 유발 → `translate_telegram_message`에서 LLM 호출 전 제어문자 strip
- **KIS API APTR0057 (주문 가격 소수점 초과)**: `str(limit_price)` 변환 시 `166.285` 같은 3자리 소수가 그대로 전달 → `f"{limit_price:.2f}"` 적용 (buy_limit_price, buy_reserved_order, sell_reserved_order)
- **KIS API APBK1234 (주문단가 미입력)**: 시장가 주문 함수에서 `ORD_DVSN: "00"` (지정가)에 가격 "0"을 사용 → `ORD_DVSN: "01"` (시장가)로 수정 (buy_market_price, sell_all_market_price)
- **L2 손절 Telegram 메시지 개선**: "손절 조건 도달" 한 줄 → 현재가/매수가/손실률 포함한 3줄 설명

## Test plan

- [ ] US 실계좌 매수 주문 시 APTR0057 에러 재현 안 됨 (NVDA 등 소수점 3자리 가격)
- [ ] 시장가 매도 시 APBK1234 에러 재현 안 됨 (EQT 등)
- [ ] zh/ja/en 브로드캐스트 번역 시 400 Bad Request 재현 안 됨
- [ ] 한국주식 손절 발생 시 Telegram 메시지에 현재가/매수가/손실률 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)