### PR TITLE
fix: 오후 배치 텔레그램 메시지 '장 마감 후' → '오후 분석'

### DIFF
--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -921,7 +921,7 @@ class USStockAnalysisOrchestrator:
                 time_desc = "장중 12시 30분 시점"
             else:
                 title = "🔔 미국주식 오후 프리즘 시그널 얼럿"
-                time_desc = "장 마감 후"
+                time_desc = "오후 분석"
             header = f"{title}\n📅 {formatted_date} {time_desc} 포착된 관심종목\n"
             volume_label = "거래량 증가"
             gap_label = "갭상승"

--- a/stock_analysis_orchestrator.py
+++ b/stock_analysis_orchestrator.py
@@ -941,7 +941,7 @@ class StockAnalysisOrchestrator:
             time_desc = "장 시작 후 10분 시점"
         else:
             title = "🔔 오후 프리즘 시그널 얼럿"
-            time_desc = "장 마감 후"
+            time_desc = "오후 분석"
 
         # Message header
         message = f"{title}\n"


### PR DESCRIPTION
## Summary
- 오후 배치 실행 시간을 15:40(장마감 후) → 14:50(장마감 40분 전)으로 변경함에 따라 텔레그램 시그널 얼럿 문구 수정
- KR: `time_desc = "장 마감 후"` → `"오후 분석"`
- US: `time_desc = "장 마감 후"` → `"오후 분석"`

## Test plan
- [ ] 오후 배치 실행 후 텔레그램 시그널 얼럿 메시지에서 "오후 분석 포착된 관심종목" 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)