### PR TITLE
fix: remove 7-day limit and 5% profit rule in bear/sideways sell agent

### DIFF
--- a/cores/agents/trading_agents.py
+++ b/cores/agents/trading_agents.py
@@ -825,8 +825,7 @@ def create_sell_decision_agent(language: str = "ko"):
         **B) Bear/Sideways Mode → Secure Profit (Defensive)**
         - Consider immediate sell when target reached
         - Trailing Stop: **-3~5%** from peak
-        - Maximum observation period: 7 trading days
-        - Sell conditions: Target achieved or profit 5%+
+        - Sell conditions: Target achieved or trailing stop breached (no fixed time or profit % limit)
 
         **Priority 3: Time Management**
         - Short-term (~1 month): Active sell when target achieved
@@ -1001,8 +1000,7 @@ def create_sell_decision_agent(language: str = "ko"):
         **B) 약세장/횡보장 모드 → 수익 확보 (방어적)**
         - 목표가 도달 시 즉시 매도 고려
         - Trailing Stop: 고점 대비 **-3~5%**
-        - 최대 관찰 기간: 7거래일
-        - 매도 조건: 목표가 달성 or 수익 5% 이상
+        - 매도 조건: 목표가 달성 or 트레일링스탑 이탈 (고정 관찰 기간·수익률 기준 없음)
 
         **3순위: 시간 관리**
         - 단기(~1개월): 목표가 달성 시 적극 매도

--- a/prism-us/cores/agents/trading_agents.py
+++ b/prism-us/cores/agents/trading_agents.py
@@ -834,8 +834,7 @@ Trailing Stop %: 강세장 고점 × 0.92 (-8%), 약세장 고점 × 0.95 (-5%)
 **B) 약세장/횡보장 모드 → 수익 확보 (방어적)**
 - 목표가 도달 시 즉시 매도 고려
 - Trailing Stop: 고점 대비 **-3~5%**
-- 최대 관찰 기간: 7거래일
-- 매도 조건: 목표가 달성 or 수익 5% 이상
+- 매도 조건: 목표가 달성 or 트레일링스탑 이탈 (고정 관찰 기간·수익률 기준 없음)
 
 **3순위: 시간 관리**
 - 단기(~1개월): 목표가 달성 시 적극 매도
@@ -1009,8 +1008,7 @@ Trailing Stop %: Bull market peak × 0.92 (-8%), Bear/Sideways peak × 0.95 (-5%
 **B) Bear/Sideways Mode → Secure Profit (Defensive)**
 - Consider immediate sell when target reached
 - Trailing Stop: **-3~5%** from peak
-- Maximum observation period: 7 trading days
-- Sell conditions: Target achieved or profit 5%+
+- Sell conditions: Target achieved or trailing stop breached (no fixed time or profit % limit)
 
 **Priority 3: Time Management**
 - Short-term (~1 month): Active sell when target achieved


### PR DESCRIPTION
## Summary
- 약세장/횡보장 모드에서 수익 종목을 조기 매도시키던 두 규칙 제거
- KR (`cores/agents/trading_agents.py`) + US (`prism-us/cores/agents/trading_agents.py`) 동시 적용 (한국어/영어 버전 각각)

## 제거한 규칙
- ~~최대 관찰 기간: 7거래일~~ → 날짜 기반 강제 청산 제거
- ~~매도 조건: 수익 5% 이상~~ → 수익률 기반 조기 익절 제거

매도 조건을 **"목표가 달성 or 트레일링스탑 이탈"** 로 단순화

## 근거 (실거래 데이터 분석)
**KR (92건):**
- 중기 설정: 평균 11.4일 보유, 승률 51%, 평균 +3.74%
- 단기 설정: 평균 4.2일 보유, 승률 40%, 평균 +2.04%
- 7일 경계 매도 종목: 005850(+19.9%), 009420(+18.7%) — 수익 중에 강제 청산 의심

**US (15건):**
- 15~30일 보유: 승률 100%, 평균 +5.81%
- 0~3일 보유: 승률 20%, 평균 -3.34%

## 유지한 것
- Trailing Stop -3~5% (약세장/횡보장) — 현행 유지
- 손절가 일방향 래칫 규칙 — 현행 유지
- 기계적 손절가 체크 (코드 레벨) — 현행 유지

## Test plan
- [ ] 운영 서버에서 수익 중인 종목이 7일 이후에도 hold 유지되는지 확인
- [ ] trailing stop 이탈 시 정상 매도되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)