### PR TITLE
fix: load kis_auth via importlib to resolve prism-us/trading namespace collision

### DIFF
--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -133,7 +133,11 @@ except ImportError as e:
     )
     from tracking.journal import USJournalManager
     from tracking.compression import USCompressionManager
-from trading import kis_auth as ka
+# Load kis_auth from main project trading/ (prism-us/trading/ has no kis_auth)
+import importlib.util as _importlib_util
+_kis_auth_spec = _importlib_util.spec_from_file_location("kis_auth", PROJECT_ROOT / "trading/kis_auth.py")
+ka = _importlib_util.module_from_spec(_kis_auth_spec)
+_kis_auth_spec.loader.exec_module(ka)
 
 # Create MCPApp instance
 app = MCPApp(name="us_stock_tracking")


### PR DESCRIPTION
## Summary
- `us_stock_tracking_agent.py:136`에서 `from trading import kis_auth as ka` 사용 시 `prism-us/trading/__init__.py`(빈 파일)로 resolve되어 `ImportError` 발생
- `PROJECT_ROOT / "trading/kis_auth.py"`를 직접 로드하는 `importlib.util` 패턴으로 교체 (파일 내 기존 패턴과 동일)

## Root Cause
운영 서버 에러 로그:
```
ImportError: cannot import name 'kis_auth' from 'trading' (/root/prism-insight/prism-us/trading/__init__.py)
```
`prism-us/` 하위에서 실행 시 `trading` 패키지가 `prism-us/trading/`으로 해석되나, 실제 `kis_auth.py`는 루트 `trading/`에만 존재.

## Fix
```python
# Before
from trading import kis_auth as ka

# After
import importlib.util as _importlib_util
_kis_auth_spec = _importlib_util.spec_from_file_location("kis_auth", PROJECT_ROOT / "trading/kis_auth.py")
ka = _importlib_util.module_from_spec(_kis_auth_spec)
_kis_auth_spec.loader.exec_module(ka)
```

## Test plan
- [ ] `prism-us/us_stock_analysis_orchestrator.py --mode morning` 실행 시 `kis_auth` ImportError 없이 `USStockTrackingAgent` 로드 확인
- [ ] `ka.getEnv()`, `ka.get_configured_accounts()`, `ka.mask_account_number()` 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)