### PR TITLE
feat: portfolio adjustment history log + journal injection logging

### DIFF
--- a/prism-us/tracking/db_schema.py
+++ b/prism-us/tracking/db_schema.py
@@ -210,6 +210,23 @@ CREATE TABLE IF NOT EXISTS us_pending_orders (
 )
 """
 
+# Table: us_portfolio_adjustment_log (target/stop_loss change history)
+TABLE_US_PORTFOLIO_ADJUSTMENT_LOG = """
+CREATE TABLE IF NOT EXISTS us_portfolio_adjustment_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    account_key TEXT NOT NULL,
+    ticker TEXT NOT NULL,
+    adjusted_at TEXT NOT NULL,
+    old_target_price REAL,
+    new_target_price REAL,
+    old_stop_loss REAL,
+    new_stop_loss REAL,
+    adjustment_reason TEXT,
+    urgency TEXT,
+    created_at TEXT DEFAULT (datetime('now', 'localtime'))
+)
+"""
+
 # =============================================================================
 # Indexes for US Tables
 # =============================================================================
@@ -246,6 +263,9 @@ US_INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_us_pending_account_key ON us_pending_orders(account_key)",
     "CREATE INDEX IF NOT EXISTS idx_us_pending_status ON us_pending_orders(status)",
     "CREATE INDEX IF NOT EXISTS idx_us_pending_created ON us_pending_orders(created_at)",
+    # us_portfolio_adjustment_log indexes
+    "CREATE INDEX IF NOT EXISTS idx_us_adj_log_ticker ON us_portfolio_adjustment_log(account_key, ticker)",
+    "CREATE INDEX IF NOT EXISTS idx_us_adj_log_date ON us_portfolio_adjustment_log(adjusted_at DESC)",
 ]
 
 # =============================================================================
@@ -569,6 +589,7 @@ def create_us_tables(cursor, conn):
         ("us_analysis_performance_tracker", TABLE_US_PERFORMANCE_TRACKER),
         ("us_holding_decisions", TABLE_US_HOLDING_DECISIONS),
         ("us_pending_orders", TABLE_US_PENDING_ORDERS),
+        ("us_portfolio_adjustment_log", TABLE_US_PORTFOLIO_ADJUSTMENT_LOG),
     ]
 
     for table_name, table_sql in tables:

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -671,8 +671,10 @@ class USStockTrackingAgent:
                 if journal_context:
                     logger.info(f"[Journal] US injected context for {ticker} ({len(journal_context)} chars)")
                     logger.debug(f"[Journal] US context preview: {journal_context[:500]}")
+                elif self.enable_journal:
+                    logger.warning(f"[Journal] US empty context for {ticker} despite journal being enabled")
                 else:
-                    logger.warning(f"[Journal] US empty context for {ticker} (enable_journal={self.enable_journal})")
+                    logger.debug(f"[Journal] US journal disabled, no context for {ticker}")
                 # Get score adjustment suggestion
                 adjustment, reasons = self.get_score_adjustment(ticker, sector, trigger_type)
                 if adjustment != 0 or reasons:
@@ -1277,9 +1279,11 @@ class USStockTrackingAgent:
                 if adj_rows:
                     lines = ["### Portfolio Adjustment History:"]
                     for r in adj_rows:
+                        ot = r[1] or 0; nt = r[2] or 0; os_ = r[3] or 0; ns = r[4] or 0
+                        reason = r[5] or "N/A"; urg = r[6] or "N/A"
                         lines.append(
-                            f"- [{r[0][:16]}] Target: ${r[1]:,.2f}→${r[2]:,.2f} / "
-                            f"Stop: ${r[3]:,.2f}→${r[4]:,.2f} ({r[6]}) — {r[5]}"
+                            f"- [{r[0][:16]}] Target: ${ot:,.2f}→${nt:,.2f} / "
+                            f"Stop: ${os_:,.2f}→${ns:,.2f} ({urg}) — {reason}"
                         )
                     adjustment_history_section = "\n".join(lines)
                     logger.info(f"[_analyze_sell_decision] {ticker} adjustment history: {len(adj_rows)} records injected")
@@ -1552,8 +1556,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
             if db_updated:
                 # Log adjustment history (single record for both target + stop_loss changes)
                 try:
-                    from datetime import datetime as _dt
-                    now = _dt.now().strftime("%Y-%m-%d %H:%M:%S")
+                    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                     acct_key = self._account_scope()[0]
                     # Determine final new values
                     final_new_target = old_target_price
@@ -1772,8 +1775,8 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     "DELETE FROM us_portfolio_adjustment_log WHERE ticker = ? AND account_key = ?",
                     (ticker, account_key)
                 )
-            except Exception:
-                pass  # Table may not exist yet
+            except Exception as e:
+                logger.debug(f"{ticker} Cleanup adjustment log skipped: {e}")
             self.conn.commit()
 
             # Build sell message (same format as KR template)

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -668,6 +668,11 @@ class USStockTrackingAgent:
                     sector=sector,
                     trigger_type=trigger_type
                 )
+                if journal_context:
+                    logger.info(f"[Journal] US injected context for {ticker} ({len(journal_context)} chars)")
+                    logger.debug(f"[Journal] US context preview: {journal_context[:500]}")
+                else:
+                    logger.warning(f"[Journal] US empty context for {ticker} (enable_journal={self.enable_journal})")
                 # Get score adjustment suggestion
                 adjustment, reasons = self.get_score_adjustment(ticker, sector, trigger_type)
                 if adjustment != 0 or reasons:
@@ -1258,6 +1263,29 @@ class USStockTrackingAgent:
             logger.info(f"[_analyze_sell_decision] {ticker}({company_name}) portfolio_info:")
             logger.info(f"  - Holdings: {len(holdings)}/{self.max_slots}, Sectors: {json.dumps(sector_distribution)}")
 
+            # Fetch portfolio adjustment history for this ticker
+            adjustment_history_section = ""
+            try:
+                self.cursor.execute("""
+                    SELECT adjusted_at, old_target_price, new_target_price,
+                           old_stop_loss, new_stop_loss, adjustment_reason, urgency
+                    FROM us_portfolio_adjustment_log
+                    WHERE ticker = ? AND account_key = ?
+                    ORDER BY adjusted_at DESC LIMIT 10
+                """, (ticker, self._account_scope()[0]))
+                adj_rows = self.cursor.fetchall()
+                if adj_rows:
+                    lines = ["### Portfolio Adjustment History:"]
+                    for r in adj_rows:
+                        lines.append(
+                            f"- [{r[0][:16]}] Target: ${r[1]:,.2f}→${r[2]:,.2f} / "
+                            f"Stop: ${r[3]:,.2f}→${r[4]:,.2f} ({r[6]}) — {r[5]}"
+                        )
+                    adjustment_history_section = "\n".join(lines)
+                    logger.info(f"[_analyze_sell_decision] {ticker} adjustment history: {len(adj_rows)} records injected")
+            except Exception:
+                pass  # Table may not exist yet on first run
+
             # Dynamic trailing stop threshold: min 1.5%, max 5%, scales with price appreciation
             trailing_stop_threshold_pct = max(1.5, min(5.0, (highest_price - buy_price) / buy_price * 100 * 0.3)) if buy_price > 0 else 3.0
 
@@ -1285,6 +1313,8 @@ Please make a sell/hold decision for the following US stock holding.
 
 ### Trading Scenario:
 {json.dumps(trading_scenarios, ensure_ascii=False) if trading_scenarios else "No scenario information"}
+
+{adjustment_history_section}
 
 ### Task:
 Use yahoo_finance and sqlite tools to check latest data, then decide whether to sell or continue holding.
@@ -1520,6 +1550,39 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                         logger.info(f"{ticker} Stop-loss AI {direction} adjustment: ${stop_loss_num:,.2f} (prev: ${old_stop_loss:,.2f})")
 
             if db_updated:
+                # Log adjustment history (single record for both target + stop_loss changes)
+                try:
+                    from datetime import datetime as _dt
+                    now = _dt.now().strftime("%Y-%m-%d %H:%M:%S")
+                    acct_key = self._account_scope()[0]
+                    # Determine final new values
+                    final_new_target = old_target_price
+                    try:
+                        t = float(str(portfolio_adjustment.get("new_target_price", 0)).replace(',', '').replace('$', ''))
+                        if t > 0:
+                            final_new_target = t
+                    except (ValueError, TypeError):
+                        pass
+                    final_new_sl = old_stop_loss
+                    try:
+                        s = float(str(portfolio_adjustment.get("new_stop_loss", 0)).replace(',', '').replace('$', ''))
+                        if s > 0:
+                            final_new_sl = s
+                    except (ValueError, TypeError):
+                        pass
+                    self.cursor.execute("""
+                        INSERT INTO us_portfolio_adjustment_log
+                        (account_key, ticker, adjusted_at, old_target_price, new_target_price,
+                         old_stop_loss, new_stop_loss, adjustment_reason, urgency)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """, (acct_key, ticker, now,
+                          old_target_price, final_new_target,
+                          old_stop_loss, final_new_sl,
+                          adjustment_reason, urgency))
+                    self.conn.commit()
+                except Exception as log_err:
+                    logger.warning(f"{ticker} Failed to log US portfolio adjustment (non-critical): {log_err}")
+
                 urgency_emoji = {"high": "🚨", "medium": "⚠️", "low": "💡"}.get(urgency, "🔄")
                 message = f"{urgency_emoji} Portfolio Adjustment: {company_name}({ticker})\n"
                 message += update_message
@@ -1703,6 +1766,14 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                 "DELETE FROM us_stock_holdings WHERE ticker = ? AND account_key = ?",
                 (ticker, account_key)
             )
+            # Cleanup portfolio adjustment history (lifecycle management)
+            try:
+                self.cursor.execute(
+                    "DELETE FROM us_portfolio_adjustment_log WHERE ticker = ? AND account_key = ?",
+                    (ticker, account_key)
+                )
+            except Exception:
+                pass  # Table may not exist yet
             self.conn.commit()
 
             # Build sell message (same format as KR template)

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -317,6 +317,11 @@ class StockTrackingAgent:
                     market_condition=None,
                     trigger_type=trigger_type
                 )
+                if journal_context:
+                    logger.info(f"[Journal] Injected context for {ticker} ({len(journal_context)} chars)")
+                    logger.debug(f"[Journal] Context preview: {journal_context[:500]}")
+                else:
+                    logger.warning(f"[Journal] Empty context for {ticker} (enable_journal={self.enable_journal})")
                 # Get score adjustment suggestion
                 adjustment, reasons = self._get_score_adjustment_from_context(ticker, sector, trigger_type)
                 if adjustment != 0 or reasons:

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -320,8 +320,10 @@ class StockTrackingAgent:
                 if journal_context:
                     logger.info(f"[Journal] Injected context for {ticker} ({len(journal_context)} chars)")
                     logger.debug(f"[Journal] Context preview: {journal_context[:500]}")
+                elif self.enable_journal:
+                    logger.warning(f"[Journal] Empty context for {ticker} despite journal being enabled")
                 else:
-                    logger.warning(f"[Journal] Empty context for {ticker} (enable_journal={self.enable_journal})")
+                    logger.debug(f"[Journal] Journal disabled, no context for {ticker}")
                 # Get score adjustment suggestion
                 adjustment, reasons = self._get_score_adjustment_from_context(ticker, sector, trigger_type)
                 if adjustment != 0 or reasons:

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -845,20 +845,32 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
             # Fetch portfolio adjustment history for this ticker
             adjustment_history_section = ""
             try:
-                self.cursor.execute("""
-                    SELECT adjusted_at, old_target_price, new_target_price,
-                           old_stop_loss, new_stop_loss, adjustment_reason, urgency
-                    FROM portfolio_adjustment_log
-                    WHERE ticker = ?
-                    ORDER BY adjusted_at DESC LIMIT 10
-                """, (ticker,))
+                acct_key = self._account_scope()[0] if hasattr(self, '_account_scope') else None
+                if acct_key:
+                    self.cursor.execute("""
+                        SELECT adjusted_at, old_target_price, new_target_price,
+                               old_stop_loss, new_stop_loss, adjustment_reason, urgency
+                        FROM portfolio_adjustment_log
+                        WHERE ticker = ? AND account_key = ?
+                        ORDER BY adjusted_at DESC LIMIT 10
+                    """, (ticker, acct_key))
+                else:
+                    self.cursor.execute("""
+                        SELECT adjusted_at, old_target_price, new_target_price,
+                               old_stop_loss, new_stop_loss, adjustment_reason, urgency
+                        FROM portfolio_adjustment_log
+                        WHERE ticker = ?
+                        ORDER BY adjusted_at DESC LIMIT 10
+                    """, (ticker,))
                 adj_rows = self.cursor.fetchall()
                 if adj_rows:
                     lines = ["### 📋 포트폴리오 조정 이력:"]
                     for r in adj_rows:
+                        ot = r[1] or 0; nt = r[2] or 0; os_ = r[3] or 0; ns = r[4] or 0
+                        reason = r[5] or "N/A"; urg = r[6] or "N/A"
                         lines.append(
-                            f"- [{r[0][:16]}] 목표가: {r[1]:,.0f}→{r[2]:,.0f} / "
-                            f"손절가: {r[3]:,.0f}→{r[4]:,.0f} ({r[6]}) — {r[5]}"
+                            f"- [{r[0][:16]}] 목표가: {ot:,.0f}→{nt:,.0f} / "
+                            f"손절가: {os_:,.0f}→{ns:,.0f} ({urg}) — {reason}"
                         )
                     adjustment_history_section = "\n".join(lines)
                     logger.info(f"[_analyze_sell_decision] {ticker} adjustment history: {len(adj_rows)} records injected")
@@ -1194,14 +1206,19 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                 try:
                     now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                     acct_key = self._account_scope()[0] if hasattr(self, '_account_scope') else 'default'
+                    # Use explicit None check to avoid falsy-zero bug with `or`
+                    new_tp_raw = portfolio_adjustment.get("new_target_price")
+                    new_tp_log = self._safe_number_conversion(new_tp_raw) if new_tp_raw is not None else old_target_price
+                    new_sl_raw = portfolio_adjustment.get("new_stop_loss")
+                    new_sl_log = self._safe_number_conversion(new_sl_raw) if new_sl_raw is not None else old_stop_loss
                     self.cursor.execute("""
                         INSERT INTO portfolio_adjustment_log
                         (account_key, ticker, adjusted_at, old_target_price, new_target_price,
                          old_stop_loss, new_stop_loss, adjustment_reason, urgency)
                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """, (acct_key, ticker, now,
-                          old_target_price, self._safe_number_conversion(portfolio_adjustment.get("new_target_price")) or old_target_price,
-                          old_stop_loss, self._safe_number_conversion(portfolio_adjustment.get("new_stop_loss")) or old_stop_loss,
+                          old_target_price, new_tp_log,
+                          old_stop_loss, new_sl_log,
                           adjustment_reason, urgency))
                     self.conn.commit()
                 except Exception as log_err:
@@ -1337,9 +1354,13 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
             bool: Delete success status
         """
         try:
+            acct_key = self._account_scope()[0] if hasattr(self, '_account_scope') else None
             self.cursor.execute("DELETE FROM holding_decisions WHERE ticker = ?", (ticker,))
             # Also delete portfolio adjustment history (lifecycle cleanup)
-            self.cursor.execute("DELETE FROM portfolio_adjustment_log WHERE ticker = ?", (ticker,))
+            if acct_key:
+                self.cursor.execute("DELETE FROM portfolio_adjustment_log WHERE ticker = ? AND account_key = ?", (ticker, acct_key))
+            else:
+                self.cursor.execute("DELETE FROM portfolio_adjustment_log WHERE ticker = ?", (ticker,))
             self.conn.commit()
             logger.info(f"{ticker} Sell decision data and adjustment history deleted")
             return True

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -842,6 +842,29 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
             logger.info(f"  - Sector distribution: {json.dumps(sector_distribution, ensure_ascii=False)}")
             logger.info(f"  - Investment periods: {json.dumps(investment_periods, ensure_ascii=False)}")
 
+            # Fetch portfolio adjustment history for this ticker
+            adjustment_history_section = ""
+            try:
+                self.cursor.execute("""
+                    SELECT adjusted_at, old_target_price, new_target_price,
+                           old_stop_loss, new_stop_loss, adjustment_reason, urgency
+                    FROM portfolio_adjustment_log
+                    WHERE ticker = ?
+                    ORDER BY adjusted_at DESC LIMIT 10
+                """, (ticker,))
+                adj_rows = self.cursor.fetchall()
+                if adj_rows:
+                    lines = ["### 📋 포트폴리오 조정 이력:"]
+                    for r in adj_rows:
+                        lines.append(
+                            f"- [{r[0][:16]}] 목표가: {r[1]:,.0f}→{r[2]:,.0f} / "
+                            f"손절가: {r[3]:,.0f}→{r[4]:,.0f} ({r[6]}) — {r[5]}"
+                        )
+                    adjustment_history_section = "\n".join(lines)
+                    logger.info(f"[_analyze_sell_decision] {ticker} adjustment history: {len(adj_rows)} records injected")
+            except Exception:
+                pass  # Table may not exist yet on first run
+
             # Dynamic trailing stop threshold: min 1.5%, max 5%, scales with price appreciation
             trailing_stop_threshold_pct = max(1.5, min(5.0, (highest_price - buy_price) / buy_price * 100 * 0.3)) if buy_price > 0 else 3.0
 
@@ -872,6 +895,8 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                 ### 매매 시나리오 정보:
                 {json.dumps(trading_scenarios, ensure_ascii=False) if trading_scenarios else "시나리오 정보 없음"}
 
+                {adjustment_history_section}
+
                 ### 분석 요청:
                 위 정보를 바탕으로 kospi_kosdaq과 sqlite 도구를 활용하여 최신 데이터를 확인하고,
                 매도할지 계속 보유할지 결정해주세요.
@@ -898,6 +923,8 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
 
                 ### Trading Scenario Information:
                 {json.dumps(trading_scenarios, ensure_ascii=False) if trading_scenarios else "No scenario information"}
+
+                {adjustment_history_section}
 
                 ### Analysis Request:
                 Based on the above information, use the kospi_kosdaq and sqlite tools to check the latest data,
@@ -1163,6 +1190,23 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
 
             # Generate Telegram message if DB was updated
             if db_updated:
+                # Log adjustment history (single record for both target + stop_loss changes)
+                try:
+                    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                    acct_key = self._account_scope()[0] if hasattr(self, '_account_scope') else 'default'
+                    self.cursor.execute("""
+                        INSERT INTO portfolio_adjustment_log
+                        (account_key, ticker, adjusted_at, old_target_price, new_target_price,
+                         old_stop_loss, new_stop_loss, adjustment_reason, urgency)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """, (acct_key, ticker, now,
+                          old_target_price, self._safe_number_conversion(portfolio_adjustment.get("new_target_price")) or old_target_price,
+                          old_stop_loss, self._safe_number_conversion(portfolio_adjustment.get("new_stop_loss")) or old_stop_loss,
+                          adjustment_reason, urgency))
+                    self.conn.commit()
+                except Exception as log_err:
+                    logger.warning(f"{ticker} Failed to log portfolio adjustment (non-critical): {log_err}")
+
                 urgency_emoji = {"high": "🚨", "medium": "⚠️", "low": "💡"}.get(urgency, "🔄")
                 message = f"{urgency_emoji} 포트폴리오 조정: {company_name}({ticker})\n"
                 message += update_message
@@ -1294,10 +1338,12 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
         """
         try:
             self.cursor.execute("DELETE FROM holding_decisions WHERE ticker = ?", (ticker,))
+            # Also delete portfolio adjustment history (lifecycle cleanup)
+            self.cursor.execute("DELETE FROM portfolio_adjustment_log WHERE ticker = ?", (ticker,))
             self.conn.commit()
-            logger.info(f"{ticker} Sell decision data deleted")
+            logger.info(f"{ticker} Sell decision data and adjustment history deleted")
             return True
-            
+
         except Exception as e:
             logger.error(f"{ticker} Sell decision delete failed (main flow continues): {str(e)}")
             return False

--- a/tracking/db_schema.py
+++ b/tracking/db_schema.py
@@ -213,6 +213,23 @@ CREATE TABLE IF NOT EXISTS trading_principles (
 )
 """
 
+# Table: portfolio_adjustment_log (target/stop_loss change history)
+TABLE_PORTFOLIO_ADJUSTMENT_LOG = """
+CREATE TABLE IF NOT EXISTS portfolio_adjustment_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    account_key TEXT NOT NULL,
+    ticker TEXT NOT NULL,
+    adjusted_at TEXT NOT NULL,
+    old_target_price REAL,
+    new_target_price REAL,
+    old_stop_loss REAL,
+    new_stop_loss REAL,
+    adjustment_reason TEXT,
+    urgency TEXT,
+    created_at TEXT DEFAULT (datetime('now', 'localtime'))
+)
+"""
+
 # Table: user_memories (per-user memory storage)
 TABLE_USER_MEMORIES = """
 CREATE TABLE IF NOT EXISTS user_memories (
@@ -266,6 +283,9 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_intuitions_scope ON trading_intuitions(scope)",
     "CREATE INDEX IF NOT EXISTS idx_principles_scope ON trading_principles(scope)",
     "CREATE INDEX IF NOT EXISTS idx_principles_priority ON trading_principles(priority)",
+    # Portfolio adjustment log indexes
+    "CREATE INDEX IF NOT EXISTS idx_adj_log_ticker ON portfolio_adjustment_log(account_key, ticker)",
+    "CREATE INDEX IF NOT EXISTS idx_adj_log_date ON portfolio_adjustment_log(adjusted_at DESC)",
     # User memory indexes
     "CREATE INDEX IF NOT EXISTS idx_memories_user ON user_memories(user_id)",
     "CREATE INDEX IF NOT EXISTS idx_memories_type ON user_memories(user_id, memory_type)",
@@ -609,6 +629,7 @@ def create_all_tables(cursor, conn):
         TABLE_TRADING_PRINCIPLES,
         TABLE_USER_MEMORIES,
         TABLE_USER_PREFERENCES,
+        TABLE_PORTFOLIO_ADJUSTMENT_LOG,
     ]
 
     for table_sql in tables:


### PR DESCRIPTION
## Summary
- **포트폴리오 조정 이력 테이블** (`portfolio_adjustment_log` / `us_portfolio_adjustment_log`) 추가 — 목표가/손절가 변경 시 old→new 값, 사유, 긴급도를 기록
- 매도 시 해당 종목의 조정 이력 자동 삭제 (생명주기 관리)
- 매도 에이전트 프롬프트에 **조정 이력 주입** — AI가 과거 조정 맥락을 참고하여 판단
- **Journal context injection 로깅** (KR/US) — 매수 에이전트에 장기기억이 실제 주입되는지 INFO/WARNING 레벨로 확인 가능

## Changed Files
| File | Change |
|------|--------|
| `tracking/db_schema.py` | KR `portfolio_adjustment_log` 테이블 + 인덱스 |
| `prism-us/tracking/db_schema.py` | US `us_portfolio_adjustment_log` 테이블 + 인덱스 |
| `stock_tracking_enhanced_agent.py` | 조정 로그 기록, 매도 시 삭제, 프롬프트 히스토리 주입 |
| `prism-us/us_stock_tracking_agent.py` | US 동일 로직 + 매도 시 cleanup |
| `stock_tracking_agent.py` | Journal injection 로깅 추가 |

## Test plan
- [ ] 로컬 DB에서 `portfolio_adjustment_log` 테이블 생성 확인 (`python -c "from tracking.db_schema import *"`)
- [ ] 운영서버 배포 후 매도 에이전트 실행 시 조정 이력이 프롬프트에 포함되는지 로그 확인
- [ ] Journal context injection 로그 확인: `[Journal] Injected context for` 메시지가 출력되는지
- [ ] 매도 완료 후 `portfolio_adjustment_log`에서 해당 종목 레코드 삭제 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)