### PR TITLE
fix: compression Layer 2→3 intuition generation failure

### DIFF
--- a/tracking/compression.py
+++ b/tracking/compression.py
@@ -139,7 +139,7 @@ class CompressionManager:
 
                 response = await llm.generate_str(
                     message=prompt,
-                    request_params=RequestParams(model="gpt-5.4-mini", reasoning_effort="none", maxTokens=8000)
+                    request_params=RequestParams(model="gpt-5.4", reasoning_effort="none", maxTokens=8000)
                 )
 
             compression_data = self._parse_response(response)
@@ -198,7 +198,7 @@ class CompressionManager:
 
                 response = await llm.generate_str(
                     message=prompt,
-                    request_params=RequestParams(model="gpt-5.4-mini", reasoning_effort="none", maxTokens=8000)
+                    request_params=RequestParams(model="gpt-5.4", reasoning_effort="none", maxTokens=8000)
                 )
 
             compression_data = self._parse_response(response)


### PR DESCRIPTION
## Summary
- `tracking/compression.py`에서 `gpt-5.4-mini` → `gpt-5.4`로 변경
- `gpt-5.4-mini`는 mcp-agent가 보내는 `function tools + reasoning_effort` 파라미터 조합을 지원하지 않아 400 에러 발생
- Layer 1→2는 fallback(`_generate_simple_summary`)이 있어 작동했지만, Layer 2→3은 fallback 없이 silent failure
- **결과**: 2026-02-22 이후 `trading_intuitions` 테이블에 새 직관이 생성되지 않았음 (11건에서 정체)

## Root Cause
- 2026-03-18 커밋에서 `gpt-5.2` → `gpt-5.4-mini` 변경 시, `compression.py`도 함께 변경됨
- 이후 `gpt-5.4-mini` → `gpt-5.4` 롤백 커밋(17d4503)에서 `compression.py` 수정이 누락됨

## Test plan
- [ ] 서버에서 `python compress_trading_memory.py --dry-run` 실행하여 압축 대상 확인
- [ ] `python compress_trading_memory.py --force` 실행하여 Layer 2→3 압축 + intuition 생성 확인
- [ ] `trading_intuitions` 테이블에 새 항목 생성 확인
- [ ] 매주 일요일 03:00 cron 실행 후 `logs/compression.log` 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)