### PR TITLE
feat: Firecrawl-powered telegram bot commands & weekly intelligence

### DIFF
--- a/firecrawl_client.py
+++ b/firecrawl_client.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Firecrawl Client Module
+
+Singleton FirecrawlApp instance with helper functions for search and agent calls.
+API key is loaded from FIRECRAWL_API_KEY env var or mcp_agent.config.yaml fallback.
+"""
+import logging
+import os
+from typing import Literal, Optional
+
+from dotenv import load_dotenv
+
+load_dotenv()
+logger = logging.getLogger(__name__)
+
+# Singleton instance
+_firecrawl_app = None
+
+def _get_api_key() -> str:
+    """Resolve Firecrawl API key from environment or mcp_agent.config.yaml."""
+    key = os.getenv("FIRECRAWL_API_KEY")
+    if key:
+        return key
+
+    # Fallback: read from mcp_agent.config.yaml
+    try:
+        import yaml
+        config_path = os.path.join(os.path.dirname(__file__), "mcp_agent.config.yaml")
+        with open(config_path, 'r') as f:
+            config = yaml.safe_load(f)
+        key = config.get("mcp", {}).get("servers", {}).get("firecrawl", {}).get("env", {}).get("FIRECRAWL_API_KEY")
+        if key:
+            logger.info("FIRECRAWL_API_KEY loaded from mcp_agent.config.yaml")
+            return key
+    except Exception as e:
+        logger.warning(f"Failed to read mcp_agent.config.yaml: {e}")
+
+    raise ValueError("FIRECRAWL_API_KEY not found in environment or mcp_agent.config.yaml")
+
+
+def get_firecrawl_app():
+    """Return singleton FirecrawlApp instance."""
+    global _firecrawl_app
+    if _firecrawl_app is None:
+        from firecrawl import FirecrawlApp
+        _firecrawl_app = FirecrawlApp(api_key=_get_api_key())
+        logger.info("FirecrawlApp singleton initialized")
+    return _firecrawl_app
+
+
+def firecrawl_search(query: str, limit: int = 10):
+    """
+    Search the web via Firecrawl.
+
+    Args:
+        query: Search query string
+        limit: Maximum number of results (default 10, costs 2 credits per 10)
+
+    Returns:
+        SearchData object with .web list of results, or None on error
+    """
+    try:
+        app = get_firecrawl_app()
+        result = app.search(query, limit=limit)
+        logger.info(f"Firecrawl search completed: query='{query[:50]}', results={len(result.web) if result and result.web else 0}")
+        return result
+    except Exception as e:
+        logger.error(f"Firecrawl search failed: {e}")
+        return None
+
+
+def firecrawl_agent(prompt: str, max_credits: int = 200, model: Literal["spark-1-mini", "spark-1-pro"] = "spark-1-mini") -> Optional[str]:
+    """
+    Run Firecrawl agent (Spark) with a prompt.
+
+    Args:
+        prompt: Natural language prompt for the agent
+        max_credits: Maximum credits to spend (default 200)
+        model: Agent model to use (default "spark-1-mini")
+
+    Returns:
+        Agent response text, or None on error
+    """
+    try:
+        app = get_firecrawl_app()
+        result = app.agent(
+            prompt=prompt,
+            model=model,
+            max_credits=max_credits,
+        )
+        # Extract text from result — result.data is a dict
+        if result and hasattr(result, 'data') and result.data:
+            data = result.data
+            if isinstance(data, dict):
+                # Try common keys
+                return data.get('result') or data.get('telegram_message') or data.get('text') or str(data)
+            return str(data)
+        logger.warning("Firecrawl agent returned empty result")
+        return None
+    except Exception as e:
+        logger.error(f"Firecrawl agent failed: {e}")
+        return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,3 +79,6 @@ lxml>=4.9.0  # HTML/XML parsing for pandas read_html
 
 # Firebase Bridge (PRISM-Mobile)
 firebase-admin>=6.0.0
+
+# Firecrawl AI Research
+firecrawl-py>=4.22.0

--- a/telegram_ai_bot.py
+++ b/telegram_ai_bot.py
@@ -37,6 +37,7 @@ from report_generator import (
     get_cached_us_report, generate_journal_conversation_response
 )
 from tracking.user_memory import UserMemoryManager
+from firecrawl_client import firecrawl_agent
 from datetime import datetime, timedelta
 from typing import Dict, Optional
 
@@ -418,6 +419,9 @@ class TelegramAIBot:
         # Daily usage limit (user_id:command -> date)
         self.daily_report_usage: Dict[str, str] = {}
 
+        # Daily count-based usage limit for /ask (user_id:command -> {date, count})
+        self.daily_ask_usage: Dict[str, Dict] = {}
+
         # Create bot application (including timeout settings)
         request = HTTPXRequest(
             connection_pool_size=8,
@@ -472,6 +476,16 @@ class TelegramAIBot:
         if daily_limit_expired:
             logger.info(f"Cleaned up expired daily limits: {len(daily_limit_expired)} entries")
 
+        # Clean up count-based daily limits (remove non-today dates)
+        daily_ask_expired = [
+            key for key, usage in self.daily_ask_usage.items()
+            if usage.get("date") != today
+        ]
+        for key in daily_ask_expired:
+            del self.daily_ask_usage[key]
+        if daily_ask_expired:
+            logger.info(f"Cleaned up expired ask limits: {len(daily_ask_expired)} entries")
+
     def compress_user_memories(self):
         """Compress user memories (nightly batch)"""
         if self.memory_manager:
@@ -512,6 +526,44 @@ class TelegramAIBot:
         if key in self.daily_report_usage:
             del self.daily_report_usage[key]
             logger.info(f"Daily limit refunded (server error): user={user_id}, command={command}")
+
+    def check_daily_limit_count(self, user_id: int, command: str, max_count: int = 3) -> tuple:
+        """
+        Check count-based daily usage limit.
+
+        Args:
+            user_id: User ID
+            command: Command name
+            max_count: Maximum allowed uses per day
+
+        Returns:
+            tuple: (allowed: bool, remaining: int)
+        """
+        today = datetime.now().strftime("%Y-%m-%d")
+        key = f"{user_id}:{command}"
+
+        usage = self.daily_ask_usage.get(key)
+        if usage and usage.get("date") == today:
+            if usage["count"] >= max_count:
+                logger.info(f"Daily count limit exceeded: user={user_id}, command={command}, count={usage['count']}/{max_count}")
+                return False, 0
+            usage["count"] += 1
+            remaining = max_count - usage["count"]
+            logger.info(f"Daily count usage recorded: user={user_id}, command={command}, count={usage['count']}/{max_count}")
+            return True, remaining
+        else:
+            self.daily_ask_usage[key] = {"date": today, "count": 1}
+            remaining = max_count - 1
+            logger.info(f"Daily count usage started: user={user_id}, command={command}, count=1/{max_count}")
+            return True, remaining
+
+    def refund_daily_limit_count(self, user_id: int, command: str):
+        """Refund one count-based daily usage when Firecrawl call fails."""
+        key = f"{user_id}:{command}"
+        usage = self.daily_ask_usage.get(key)
+        if usage and usage["count"] > 0:
+            usage["count"] -= 1
+            logger.info(f"Daily count limit refunded: user={user_id}, command={command}, count={usage['count']}")
 
     def _is_server_error(self, request) -> bool:
         """
@@ -738,6 +790,21 @@ class TelegramAIBot:
         )
         self.application.add_handler(journal_conv_handler)
 
+        # ==========================================================================
+        # Firecrawl AI Research commands
+        # BotFather commands to register manually:
+        #   signal - 이벤트/뉴스 임팩트 분석 (한국)
+        #   us_signal - 이벤트/뉴스 임팩트 분석 (미국)
+        #   theme - 테마/섹터 건강도 진단 (한국)
+        #   us_theme - 테마/섹터 건강도 진단 (미국)
+        #   ask - AI 투자 리서처 (자유 질문)
+        # ==========================================================================
+        self.application.add_handler(CommandHandler("signal", self.handle_signal))
+        self.application.add_handler(CommandHandler("us_signal", self.handle_us_signal))
+        self.application.add_handler(CommandHandler("theme", self.handle_theme))
+        self.application.add_handler(CommandHandler("us_theme", self.handle_us_theme))
+        self.application.add_handler(CommandHandler("ask", self.handle_ask))
+
         # General text messages - /help or /start guidance
         self.application.add_handler(MessageHandler(
             filters.TEXT & ~filters.COMMAND, self.handle_default_message
@@ -937,6 +1004,12 @@ class TelegramAIBot:
             "/memories - 내 기억 저장소 확인\n\n"
             "📡 <b>트리거 신뢰도</b>\n"
             "/triggers - 트리거 신뢰도 리포트 보기\n\n"
+            "🔥 <b>Firecrawl AI 리서치</b>\n"
+            "/signal - 이벤트/뉴스 임팩트 분석 (한국)\n"
+            "/us_signal - 이벤트/뉴스 임팩트 분석 (미국)\n"
+            "/theme - 테마/섹터 건강도 진단 (한국)\n"
+            "/us_theme - 테마/섹터 건강도 진단 (미국)\n"
+            "/ask - AI 투자 리서처 (자유 질문)\n\n"
             "💡 평가 응답에 답장(Reply)하여 추가 질문을 할 수 있습니다!\n\n"
             "이 봇은 '프리즘 인사이트' 채널 구독자만 사용할 수 있습니다.\n"
             "채널에서는 장 시작과 마감 시 AI가 선별한 특징주 3개를 소개하고,\n"
@@ -968,6 +1041,12 @@ class TelegramAIBot:
             "  • 과거 평가 시 기억으로 활용됨\n\n"
             "📡 <b>트리거 신뢰도:</b>\n"
             "/triggers - KR & US 트리거 신뢰도 리포트 보기\n\n"
+            "🔥 <b>Firecrawl AI 리서치:</b>\n"
+            "/signal [이벤트] - 이벤트/뉴스 임팩트 분석 (한국)\n"
+            "/us_signal [event] - 이벤트/뉴스 임팩트 분석 (미국)\n"
+            "/theme [테마] - 테마/섹터 건강도 진단 (한국)\n"
+            "/us_theme [theme] - 테마/섹터 건강도 진단 (미국)\n"
+            "/ask [질문] - AI 투자 리서처 자유 질문 (일 3회)\n\n"
             "<b>보유 종목 평가 방법 (한국/미국 동일):</b>\n"
             "1. /evaluate 또는 /us_evaluate 명령어 입력\n"
             "2. 종목 코드/티커 입력 (예: 005930 또는 AAPL)\n"
@@ -2295,6 +2374,250 @@ class TelegramAIBot:
                 pass
 
         return None, None, 'kr'
+
+    # ==========================================================================
+    # Firecrawl AI Research handlers
+    # ==========================================================================
+
+    _DISCLAIMER_KR = "\n\n⚠️ 본 내용은 투자 참고용이며, 투자 판단의 책임은 본인에게 있습니다."
+    _DISCLAIMER_US = "\n\n⚠️ This is for informational purposes only. Investment decisions are your own responsibility."
+
+    async def _run_firecrawl_command(self, update: Update, prompt: str, disclaimer: str) -> bool:
+        """
+        Common helper for Firecrawl-based commands.
+        Sends a waiting message, calls firecrawl_agent, then replaces it with the result.
+
+        Returns:
+            bool: True if successful, False on failure
+        """
+        chat_id = update.effective_chat.id
+        waiting_msg = await update.message.reply_text("🔍 리서치 중...")
+
+        try:
+            result = await asyncio.get_event_loop().run_in_executor(
+                None, lambda: firecrawl_agent(prompt, max_credits=200, model="spark-1-mini")
+            )
+
+            # Delete waiting message
+            try:
+                await waiting_msg.delete()
+            except Exception:
+                pass
+
+            if result:
+                # Telegram message limit is 4096 chars — chunk if needed
+                full_text = result + disclaimer
+                if len(full_text) > 4096:
+                    # Send in chunks, keep disclaimer on last chunk
+                    for i in range(0, len(result), 4096):
+                        chunk = result[i:i + 4096]
+                        await self.application.bot.send_message(chat_id=chat_id, text=chunk)
+                    await self.application.bot.send_message(chat_id=chat_id, text=disclaimer.strip())
+                else:
+                    await self.application.bot.send_message(chat_id=chat_id, text=full_text)
+                return True
+            else:
+                await self.application.bot.send_message(
+                    chat_id=chat_id,
+                    text="⚠️ 리서치 결과를 가져오지 못했습니다. 잠시 후 다시 시도해주세요."
+                )
+                return False
+
+        except Exception as e:
+            logger.error(f"Firecrawl command error: {e}")
+            try:
+                await waiting_msg.delete()
+            except Exception:
+                pass
+            await self.application.bot.send_message(
+                chat_id=chat_id,
+                text="⚠️ 리서치 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
+            )
+            return False
+
+    async def handle_signal(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Handle /signal command — KR event impact analysis"""
+        user_id = update.effective_user.id
+
+        is_subscribed = await self.check_channel_subscription(user_id)
+        if not is_subscribed:
+            await update.message.reply_text(
+                "이 봇은 채널 구독자만 사용할 수 있습니다.\n"
+                "아래 링크를 통해 채널을 구독해주세요:\n\n"
+                "https://t.me/stock_ai_agent"
+            )
+            return
+
+        # Extract event text after the command
+        event = update.message.text.replace("/signal", "").strip()
+        if not event:
+            await update.message.reply_text(
+                "사용법: /signal [이벤트/뉴스]\n"
+                "예시: /signal 트럼프 관세 인상"
+            )
+            return
+
+        logger.info(f"/signal command - user={user_id}, event='{event[:50]}'")
+
+        prompt = (
+            f"{event}가 한국 주식시장에 미치는 영향을 분석해줘.\n"
+            "1. 수혜 예상 섹터와 대표 종목 3개\n"
+            "2. 피해 예상 섹터와 대표 종목 3개\n"
+            "3. 과거 유사 사례\n"
+            "4. 개인투자자 대응 전략\n"
+            "한국어로, 텔레그램 메시지 형태로 이모지 포함하여 작성. 3000자 이내."
+        )
+        await self._run_firecrawl_command(update, prompt, self._DISCLAIMER_KR)
+
+    async def handle_us_signal(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Handle /us_signal command — US event impact analysis"""
+        user_id = update.effective_user.id
+
+        is_subscribed = await self.check_channel_subscription(user_id)
+        if not is_subscribed:
+            await update.message.reply_text(
+                "이 봇은 채널 구독자만 사용할 수 있습니다.\n"
+                "아래 링크를 통해 채널을 구독해주세요:\n\n"
+                "https://t.me/stock_ai_agent"
+            )
+            return
+
+        event = update.message.text.replace("/us_signal", "").strip()
+        if not event:
+            await update.message.reply_text(
+                "사용법: /us_signal [event/news]\n"
+                "예시: /us_signal tariff impact on tech stocks"
+            )
+            return
+
+        logger.info(f"/us_signal command - user={user_id}, event='{event[:50]}'")
+
+        prompt = (
+            f"Analyze the impact of '{event}' on the US stock market (S&P500, NASDAQ).\n"
+            "1. Top 3 beneficiary sectors and representative stocks\n"
+            "2. Top 3 negatively impacted sectors and representative stocks\n"
+            "3. Historical precedents\n"
+            "4. Retail investor strategy\n"
+            "Write in Korean, Telegram message format with emojis. Under 3000 characters."
+        )
+        await self._run_firecrawl_command(update, prompt, self._DISCLAIMER_KR)
+
+    async def handle_theme(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Handle /theme command — KR theme health check"""
+        user_id = update.effective_user.id
+
+        is_subscribed = await self.check_channel_subscription(user_id)
+        if not is_subscribed:
+            await update.message.reply_text(
+                "이 봇은 채널 구독자만 사용할 수 있습니다.\n"
+                "아래 링크를 통해 채널을 구독해주세요:\n\n"
+                "https://t.me/stock_ai_agent"
+            )
+            return
+
+        theme = update.message.text.replace("/theme", "").strip()
+        if not theme:
+            await update.message.reply_text(
+                "사용법: /theme [테마/섹터]\n"
+                "예시: /theme 2차전지"
+            )
+            return
+
+        logger.info(f"/theme command - user={user_id}, theme='{theme[:50]}'")
+
+        prompt = (
+            f"한국 주식시장에서 '{theme}' 테마의 현재 건강도를 진단해줘.\n"
+            "1. 테마 온도 (🟢과열/🟡적정/🔴냉각 중 택1, 근거 포함)\n"
+            "2. 대장주 3개와 최근 주가 동향\n"
+            "3. 긍정 요인 3개\n"
+            "4. 부정 요인 3개\n"
+            "5. 진입 타이밍 의견\n"
+            "한국어로, 텔레그램 메시지 형태로 이모지 포함하여 작성. 3000자 이내."
+        )
+        await self._run_firecrawl_command(update, prompt, self._DISCLAIMER_KR)
+
+    async def handle_us_theme(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Handle /us_theme command — US theme health check"""
+        user_id = update.effective_user.id
+
+        is_subscribed = await self.check_channel_subscription(user_id)
+        if not is_subscribed:
+            await update.message.reply_text(
+                "이 봇은 채널 구독자만 사용할 수 있습니다.\n"
+                "아래 링크를 통해 채널을 구독해주세요:\n\n"
+                "https://t.me/stock_ai_agent"
+            )
+            return
+
+        theme = update.message.text.replace("/us_theme", "").strip()
+        if not theme:
+            await update.message.reply_text(
+                "사용법: /us_theme [theme/sector]\n"
+                "예시: /us_theme AI semiconductor"
+            )
+            return
+
+        logger.info(f"/us_theme command - user={user_id}, theme='{theme[:50]}'")
+
+        prompt = (
+            f"Analyze the current health of the '{theme}' theme in the US stock market (S&P500, NASDAQ).\n"
+            "1. Theme temperature (🟢Hot/🟡Neutral/🔴Cooling — pick one with reasoning)\n"
+            "2. Top 3 leading stocks with recent price trends\n"
+            "3. 3 positive factors\n"
+            "4. 3 negative factors\n"
+            "5. Entry timing opinion\n"
+            "Write in Korean, Telegram message format with emojis. Under 3000 characters."
+        )
+        await self._run_firecrawl_command(update, prompt, self._DISCLAIMER_KR)
+
+    async def handle_ask(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Handle /ask command — free-form investment research (3 per day)"""
+        user_id = update.effective_user.id
+
+        is_subscribed = await self.check_channel_subscription(user_id)
+        if not is_subscribed:
+            await update.message.reply_text(
+                "이 봇은 채널 구독자만 사용할 수 있습니다.\n"
+                "아래 링크를 통해 채널을 구독해주세요:\n\n"
+                "https://t.me/stock_ai_agent"
+            )
+            return
+
+        question = update.message.text.replace("/ask", "").strip()
+        if not question:
+            await update.message.reply_text(
+                "사용법: /ask [질문]\n"
+                "예시: /ask 워렌 버핏이 올해 뭘 샀어?"
+            )
+            return
+
+        # Check daily limit (3 per day)
+        allowed, remaining = self.check_daily_limit_count(user_id, "ask", max_count=3)
+        if not allowed:
+            await update.message.reply_text(
+                "⚠️ 오늘의 /ask 사용 횟수(3회)를 모두 소진하였습니다.\n"
+                "내일 다시 이용해주세요."
+            )
+            return
+
+        logger.info(f"/ask command - user={user_id}, question='{question[:50]}', remaining={remaining}")
+
+        prompt = (
+            f"다음 투자 관련 질문에 대해 최신 정보를 기반으로 답변해줘:\n\n"
+            f"{question}\n\n"
+            "한국어로, 텔레그램 메시지 형태로 이모지 포함하여 작성. 3000자 이내."
+        )
+        success = await self._run_firecrawl_command(update, prompt, self._DISCLAIMER_KR)
+
+        if success:
+            # Show remaining count
+            await update.message.reply_text(
+                f"📊 오늘 남은 /ask 횟수: {remaining}회"
+            )
+        else:
+            # Refund on failure
+            self.refund_daily_limit_count(user_id, "ask")
+            logger.info(f"/ask refunded for user={user_id} due to failure")
 
     async def process_results(self):
         """Check items to process from result queue"""

--- a/telegram_ai_bot.py
+++ b/telegram_ai_bot.py
@@ -2493,12 +2493,12 @@ class TelegramAIBot:
         logger.info(f"/us_signal command - user={user_id}, event='{event[:50]}'")
 
         prompt = (
-            f"Analyze the impact of '{event}' on the US stock market (S&P500, NASDAQ).\n"
-            "1. Top 3 beneficiary sectors and representative stocks\n"
-            "2. Top 3 negatively impacted sectors and representative stocks\n"
-            "3. Historical precedents\n"
-            "4. Retail investor strategy\n"
-            "Write in Korean, Telegram message format with emojis. Under 3000 characters."
+            f"'{event}'가 미국 주식시장(S&P500, NASDAQ)에 미치는 영향을 분석해줘.\n"
+            "1. 수혜 예상 섹터와 대표 종목 3개\n"
+            "2. 피해 예상 섹터와 대표 종목 3개\n"
+            "3. 과거 유사 사례\n"
+            "4. 개인투자자 대응 전략\n"
+            "한국어로, 텔레그램 메시지 형태로 이모지 포함하여 작성. 3000자 이내."
         )
         await self._run_firecrawl_command(update, prompt, self._DISCLAIMER_KR)
 
@@ -2560,13 +2560,13 @@ class TelegramAIBot:
         logger.info(f"/us_theme command - user={user_id}, theme='{theme[:50]}'")
 
         prompt = (
-            f"Analyze the current health of the '{theme}' theme in the US stock market (S&P500, NASDAQ).\n"
-            "1. Theme temperature (🟢Hot/🟡Neutral/🔴Cooling — pick one with reasoning)\n"
-            "2. Top 3 leading stocks with recent price trends\n"
-            "3. 3 positive factors\n"
-            "4. 3 negative factors\n"
-            "5. Entry timing opinion\n"
-            "Write in Korean, Telegram message format with emojis. Under 3000 characters."
+            f"미국 주식시장(S&P500, NASDAQ)에서 '{theme}' 테마의 현재 건강도를 진단해줘.\n"
+            "1. 테마 온도 (🟢과열/🟡적정/🔴냉각 중 택1, 근거 포함)\n"
+            "2. 대장주 3개와 최근 주가 동향\n"
+            "3. 긍정 요인 3개\n"
+            "4. 부정 요인 3개\n"
+            "5. 진입 타이밍 의견\n"
+            "한국어로, 텔레그램 메시지 형태로 이모지 포함하여 작성. 3000자 이내."
         )
         await self._run_firecrawl_command(update, prompt, self._DISCLAIMER_KR)
 

--- a/weekly_firecrawl_intelligence.py
+++ b/weekly_firecrawl_intelligence.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+Weekly Firecrawl Intelligence Report — AI-powered market research via Firecrawl Agent
+Generates KR and US market intelligence reports and sends to Telegram channel.
+
+Usage:
+    python3 weekly_firecrawl_intelligence.py                              # Send to Telegram
+    python3 weekly_firecrawl_intelligence.py --dry-run                     # Print only
+    python3 weekly_firecrawl_intelligence.py --broadcast-languages en,ja   # With broadcast
+
+# Crontab entry (add to server):
+# 주간 Firecrawl 인텔리전스 (매주 일요일 11:00 KST)
+# 0 11 * * 0 cd /root/prism-insight && /root/.pyenv/shims/python weekly_firecrawl_intelligence.py >> /root/prism-insight/logs/weekly_firecrawl_intelligence.log 2>&1
+"""
+import argparse
+import asyncio
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv()
+logger = logging.getLogger(__name__)
+
+_DISCLAIMER = "\n\n⚠️ 본 내용은 투자 참고용이며, 투자 판단의 책임은 본인에게 있습니다."
+
+
+def _generate_kr_report() -> str:
+    """Generate KR market intelligence report via Firecrawl agent."""
+    from firecrawl_client import firecrawl_agent
+
+    today_str = datetime.now().strftime("%Y년 %m월 %d일")
+
+    prompt = (
+        f"오늘 날짜는 {today_str}입니다.\n"
+        "이번 주 한국 주식시장 주간 인텔리전스 리포트를 작성해줘.\n\n"
+        "포함 내용:\n"
+        "1. 이번 주 KOSPI/KOSDAQ 주요 흐름 요약\n"
+        "2. 가장 주목받은 테마 3개와 대표 종목\n"
+        "3. 외국인/기관 수급 동향\n"
+        "4. 다음 주 주요 일정 및 이벤트\n"
+        "5. 개인투자자를 위한 전략 제안\n\n"
+        "한국어로, 텔레그램 메시지 형태로 이모지 포함하여 작성. 4000자 이내."
+    )
+
+    result = firecrawl_agent(prompt, max_credits=200, model="spark-1-mini")
+    if not result:
+        logger.error("Failed to generate KR intelligence report")
+        return ""
+    return result
+
+
+def _generate_us_report() -> str:
+    """Generate US market intelligence report via Firecrawl agent."""
+    from firecrawl_client import firecrawl_agent
+
+    today_str = datetime.now().strftime("%Y년 %m월 %d일")
+
+    prompt = (
+        f"오늘 날짜는 {today_str}입니다.\n"
+        "이번 주 미국 주식시장 주간 인텔리전스 리포트를 작성해줘.\n\n"
+        "포함 내용:\n"
+        "1. 이번 주 S&P500/NASDAQ 주요 흐름 요약\n"
+        "2. 가장 주목받은 섹터 3개와 대표 종목\n"
+        "3. 연준(Fed) 관련 동향 및 금리 전망\n"
+        "4. 다음 주 주요 일정 (FOMC, 실적 발표 등)\n"
+        "5. 개인투자자를 위한 전략 제안\n\n"
+        "한국어로, 텔레그램 메시지 형태로 이모지 포함하여 작성. 4000자 이내."
+    )
+
+    result = firecrawl_agent(prompt, max_credits=200, model="spark-1-mini")
+    if not result:
+        logger.error("Failed to generate US intelligence report")
+        return ""
+    return result
+
+
+def generate_weekly_intelligence() -> str:
+    """Generate combined weekly intelligence report."""
+    today = datetime.now()
+    date_display = today.strftime("%-m/%-d")
+
+    kr_report = _generate_kr_report()
+    us_report = _generate_us_report()
+
+    sections = [f"🔥 PRISM 주간 Firecrawl 인텔리전스 ({date_display})"]
+
+    if kr_report:
+        sections.append(f"\n🇰🇷 한국시장 인텔리전스\n━━━━━━━━━━━━━━━━━━━━\n{kr_report}")
+
+    if us_report:
+        sections.append(f"\n🇺🇸 미국시장 인텔리전스\n━━━━━━━━━━━━━━━━━━━━\n{us_report}")
+
+    if not kr_report and not us_report:
+        sections.append("\n⚠️ Firecrawl 리포트 생성에 실패했습니다. 로그를 확인해주세요.")
+
+    sections.append(_DISCLAIMER)
+
+    return "\n".join(sections)
+
+
+async def send_to_telegram(message: str):
+    """Send message to Telegram channel."""
+    try:
+        from telegram import Bot
+    except ImportError:
+        logger.error("python-telegram-bot not installed. Run: pip install python-telegram-bot")
+        return
+
+    token = os.getenv("TELEGRAM_BOT_TOKEN")
+    channel_id = os.getenv("TELEGRAM_CHANNEL_ID")
+
+    if not token or not channel_id:
+        logger.error("TELEGRAM_BOT_TOKEN or TELEGRAM_CHANNEL_ID not set in .env")
+        return
+
+    try:
+        bot = Bot(token=token)
+        # Split message if it exceeds Telegram limit
+        if len(message) > 4096:
+            # Send in chunks
+            for i in range(0, len(message), 4096):
+                chunk = message[i:i + 4096]
+                await bot.send_message(chat_id=channel_id, text=chunk, parse_mode=None)
+        else:
+            await bot.send_message(chat_id=channel_id, text=message, parse_mode=None)
+        logger.info("Weekly Firecrawl intelligence sent to Telegram successfully")
+    except Exception as e:
+        logger.error(f"Failed to send Telegram message: {e}")
+
+
+async def _send_broadcast(message: str, broadcast_languages: list):
+    """Send translated report to broadcast language channels."""
+    if not broadcast_languages:
+        return
+
+    try:
+        import sys
+        cores_path = str(Path(__file__).parent / "cores")
+        if cores_path not in sys.path:
+            sys.path.insert(0, cores_path)
+
+        from agents.telegram_translator_agent import translate_telegram_message
+        from telegram import Bot
+
+        token = os.getenv("TELEGRAM_BOT_TOKEN")
+        if not token:
+            logger.error("TELEGRAM_BOT_TOKEN not set")
+            return
+
+        bot = Bot(token=token)
+
+        for lang in broadcast_languages:
+            try:
+                lang_upper = lang.upper()
+                channel_id = os.getenv(f"TELEGRAM_CHANNEL_ID_{lang_upper}")
+                if not channel_id:
+                    logger.warning(f"No channel ID for language: {lang} (TELEGRAM_CHANNEL_ID_{lang_upper})")
+                    continue
+
+                logger.info(f"Translating intelligence report to {lang}")
+                translated = await translate_telegram_message(
+                    message, model="gpt-5-nano", from_lang="ko", to_lang=lang
+                )
+                if len(translated) > 4096:
+                    for i in range(0, len(translated), 4096):
+                        chunk = translated[i:i + 4096]
+                        await bot.send_message(chat_id=channel_id, text=chunk, parse_mode=None)
+                else:
+                    await bot.send_message(chat_id=channel_id, text=translated, parse_mode=None)
+                logger.info(f"Intelligence report sent to {lang} channel")
+
+            except Exception as e:
+                logger.error(f"Broadcast to {lang} failed: {e}")
+
+    except Exception as e:
+        logger.error(f"Broadcast error: {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Weekly Firecrawl Intelligence Report")
+    parser.add_argument("--dry-run", action="store_true", help="Print only, don't send")
+    parser.add_argument("--broadcast-languages", type=str, default="",
+                        help="Broadcast languages (comma-separated, e.g., 'en,ja,zh')")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s - %(levelname)s - %(message)s'
+    )
+
+    async def _run():
+        message = generate_weekly_intelligence()
+        print(message)
+
+        if not args.dry_run:
+            await send_to_telegram(message)
+
+            broadcast_languages = [l.strip() for l in args.broadcast_languages.split(",") if l.strip()]
+            if broadcast_languages:
+                await _send_broadcast(message, broadcast_languages)
+        else:
+            logger.info("Dry run mode — message not sent")
+
+    try:
+        asyncio.run(_run())
+    except Exception as e:
+        logger.error(f"Failed to generate intelligence report: {e}", exc_info=True)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())


### PR DESCRIPTION
## Summary
- 5 new Telegram bot commands powered by Firecrawl AI (Spark model)
  - `/signal`, `/us_signal` — Event/news impact analysis (beneficiary/damaged sectors+stocks)
  - `/theme`, `/us_theme` — Theme/sector health diagnosis (temperature, leading stocks, entry timing)
  - `/ask` — Free-form AI investment research (3 uses/day limit with refund on failure)
- New `weekly_firecrawl_intelligence.py` for automated weekly market intelligence delivery
- New `firecrawl_client.py` — Singleton SDK client with dynamic API key loading

## Key Design Decisions
- **Spark-only architecture**: Firecrawl's Spark model generates Korean text directly — no Claude post-processing needed (tested 3/3 EXCELLENT)
- **No conversation flow**: All commands are single-input/single-output (unlike `/evaluate` which has multi-step)
- **Count-based daily limit**: `/ask` uses a new `check_daily_limit_count()` method (3/day) with auto-refund on Firecrawl failure
- **API key security**: No hardcoded keys — loaded from `FIRECRAWL_API_KEY` env var or dynamically parsed from `mcp_agent.config.yaml`

## Credit Budget
| Command | Credits/call | Monthly estimate |
|---------|-------------|-----------------|
| `/signal`, `/us_signal` | ~150 | ~60 (6 uses) |
| `/theme`, `/us_theme` | ~150 | ~90 (10 uses) |
| `/ask` | ~150 | ~110 (daily) |
| Weekly Intelligence | ~400 (2×200) | ~1,600 (4 weeks) |

## Files Changed
- `firecrawl_client.py` — NEW: Singleton Firecrawl SDK client
- `telegram_ai_bot.py` — Added 5 command handlers, daily count limit, /start & /help updates
- `weekly_firecrawl_intelligence.py` — NEW: Weekly intelligence script with `--dry-run` support
- `requirements.txt` — Added `firecrawl-py>=4.22.0`

## Post-merge TODO
- [ ] Register new commands with BotFather
- [ ] Add `FIRECRAWL_API_KEY` to server `.env` (or verify `mcp_agent.config.yaml` is present)
- [ ] Add crontab entry: `0 11 * * 0 cd /root/prism-insight && /root/.pyenv/shims/python weekly_firecrawl_intelligence.py >> /root/prism-insight/logs/weekly_firecrawl_intelligence.log 2>&1`
- [ ] Test commands in Telegram with real users
- [ ] Monitor Firecrawl credit usage on dashboard

## Test plan
- [x] Phase 0 validation: `/search` 10/10 GOOD, `/agent` 3/3 EXCELLENT (Korean quality)
- [ ] Deploy to staging and test each command manually
- [ ] Verify `/ask` daily limit (3/day) and refund on failure
- [ ] Verify weekly intelligence `--dry-run` mode
- [ ] Monitor Firecrawl dashboard for credit consumption

🤖 Generated with [Claude Code](https://claude.com/claude-code)