### PR TITLE
fix: switch /signal, /theme, weekly to /search + Claude (75x cost savings)

### DIFF
--- a/report_generator.py
+++ b/report_generator.py
@@ -1382,7 +1382,8 @@ async def generate_firecrawl_search_response(search_query: str, analysis_prompt:
         from firecrawl_client import firecrawl_search
 
         # Step 1: Firecrawl search (2 credits per 10 results)
-        result = await asyncio.get_event_loop().run_in_executor(
+        loop = asyncio.get_running_loop()
+        result = await loop.run_in_executor(
             None, lambda: firecrawl_search(search_query, limit=limit)
         )
         items = result.web if result and result.web else []

--- a/report_generator.py
+++ b/report_generator.py
@@ -1359,3 +1359,83 @@ async def generate_journal_conversation_response(
             pass
 
         return "죄송해요, 응답 생성 중 문제가 생겼어요. 다시 말씀해주시겠어요? 💭"
+
+
+# =============================================================================
+# Firecrawl Search + Claude analysis
+# =============================================================================
+
+async def generate_firecrawl_search_response(search_query: str, analysis_prompt: str, limit: int = 5) -> Optional[str]:
+    """
+    Cost-efficient Firecrawl /search (2 credits) + Claude Sonnet analysis.
+    Uses the same global MCPApp pattern as other generate_* functions.
+
+    Args:
+        search_query: Web search query for Firecrawl
+        analysis_prompt: Prompt for Claude to analyze the search results
+        limit: Number of search results (default 5)
+
+    Returns:
+        str: Claude-generated analysis, or None on error
+    """
+    try:
+        from firecrawl_client import firecrawl_search
+
+        # Step 1: Firecrawl search (2 credits per 10 results)
+        result = await asyncio.get_event_loop().run_in_executor(
+            None, lambda: firecrawl_search(search_query, limit=limit)
+        )
+        items = result.web if result and result.web else []
+
+        if not items:
+            logger.warning(f"No search results for: {search_query[:50]}")
+            return None
+
+        # Step 2: Build context from search snippets
+        context = ""
+        for item in items:
+            title = getattr(item, 'title', '') or ''
+            url = getattr(item, 'url', '') or ''
+            desc = getattr(item, 'description', '') or ''
+            context += f"- {title}\n  URL: {url}\n  {desc}\n\n"
+
+        logger.info(f"Search context built: {len(items)} results, {len(context)} chars")
+
+        # Step 3: Use global MCPApp + Claude Sonnet for analysis
+        app = await get_or_create_global_mcp_app()
+
+        agent = Agent(
+            name="firecrawl_search_analyst",
+            instruction=(
+                "당신은 웹 검색 결과를 분석하여 투자자에게 유용한 인사이트를 제공하는 전문가입니다.\n"
+                "텔레그램 메시지 형태로, 이모지를 포함하여 자연스럽게 작성하세요.\n"
+                "마크다운 형식 대신 텔레그램에 적합한 플레인 텍스트로 작성하세요.\n"
+                "검색 결과에 없는 내용을 지어내지 마세요."
+            ),
+            server_names=[]
+        )
+
+        llm = await agent.attach_llm(AnthropicAugmentedLLM)
+
+        response = await llm.generate_str(
+            message=f"다음은 웹 검색 결과입니다:\n\n{context}\n\n---\n\n{analysis_prompt}",
+            request_params=RequestParams(
+                model="claude-sonnet-4-6",
+                maxTokens=2000
+            )
+        )
+        app.logger.info(f"Firecrawl search+Claude response: {len(response)} chars")
+
+        return clean_model_response(response)
+
+    except Exception as e:
+        logger.error(f"generate_firecrawl_search_response failed: {e}")
+        import traceback
+        logger.error(traceback.format_exc())
+
+        try:
+            await reset_global_mcp_app()
+        except Exception:
+            pass
+
+        return None

--- a/telegram_ai_bot.py
+++ b/telegram_ai_bot.py
@@ -2510,12 +2510,17 @@ class TelegramAIBot:
             )
             return
 
-        event = update.message.text.replace("/signal", "").strip()
+        event = update.message.text.replace("/signal", "").strip()[:200]
         if not event:
             await update.message.reply_text(
                 "사용법: /signal [이벤트/뉴스]\n"
                 "예시: /signal 트럼프 관세 인상"
             )
+            return
+
+        allowed, _ = self.check_daily_limit_count(user_id, "signal", max_count=10)
+        if not allowed:
+            await update.message.reply_text("⚠️ 오늘의 /signal 사용 횟수(10회)를 모두 소진하였습니다.")
             return
 
         logger.info(f"/signal command - user={user_id}, event='{event[:50]}'")
@@ -2544,12 +2549,17 @@ class TelegramAIBot:
             )
             return
 
-        event = update.message.text.replace("/us_signal", "").strip()
+        event = update.message.text.replace("/us_signal", "").strip()[:200]
         if not event:
             await update.message.reply_text(
                 "사용법: /us_signal [이벤트/뉴스]\n"
                 "예시: /us_signal TSMC 실적 서프라이즈"
             )
+            return
+
+        allowed, _ = self.check_daily_limit_count(user_id, "us_signal", max_count=10)
+        if not allowed:
+            await update.message.reply_text("⚠️ 오늘의 /us_signal 사용 횟수(10회)를 모두 소진하였습니다.")
             return
 
         logger.info(f"/us_signal command - user={user_id}, event='{event[:50]}'")
@@ -2578,12 +2588,17 @@ class TelegramAIBot:
             )
             return
 
-        theme = update.message.text.replace("/theme", "").strip()
+        theme = update.message.text.replace("/theme", "").strip()[:200]
         if not theme:
             await update.message.reply_text(
                 "사용법: /theme [테마/섹터]\n"
                 "예시: /theme 2차전지"
             )
+            return
+
+        allowed, _ = self.check_daily_limit_count(user_id, "theme", max_count=10)
+        if not allowed:
+            await update.message.reply_text("⚠️ 오늘의 /theme 사용 횟수(10회)를 모두 소진하였습니다.")
             return
 
         logger.info(f"/theme command - user={user_id}, theme='{theme[:50]}'")
@@ -2613,12 +2628,17 @@ class TelegramAIBot:
             )
             return
 
-        theme = update.message.text.replace("/us_theme", "").strip()
+        theme = update.message.text.replace("/us_theme", "").strip()[:200]
         if not theme:
             await update.message.reply_text(
                 "사용법: /us_theme [테마/섹터]\n"
                 "예시: /us_theme AI semiconductor"
             )
+            return
+
+        allowed, _ = self.check_daily_limit_count(user_id, "us_theme", max_count=10)
+        if not allowed:
+            await update.message.reply_text("⚠️ 오늘의 /us_theme 사용 횟수(10회)를 모두 소진하였습니다.")
             return
 
         logger.info(f"/us_theme command - user={user_id}, theme='{theme[:50]}'")
@@ -2648,7 +2668,7 @@ class TelegramAIBot:
             )
             return
 
-        question = update.message.text.replace("/ask", "").strip()
+        question = update.message.text.replace("/ask", "").strip()[:500]
         if not question:
             await update.message.reply_text(
                 "사용법: /ask [질문]\n"

--- a/telegram_ai_bot.py
+++ b/telegram_ai_bot.py
@@ -34,7 +34,8 @@ from report_generator import (
     generate_evaluation_response, get_cached_report, generate_follow_up_response,
     get_or_create_global_mcp_app, cleanup_global_mcp_app,
     generate_us_evaluation_response, generate_us_follow_up_response,
-    get_cached_us_report, generate_journal_conversation_response
+    get_cached_us_report, generate_journal_conversation_response,
+    generate_firecrawl_search_response
 )
 from tracking.user_memory import UserMemoryManager
 from firecrawl_client import firecrawl_agent
@@ -2446,8 +2447,58 @@ class TelegramAIBot:
             )
             return False
 
+    async def _run_search_and_claude(self, update: Update, search_query: str, analysis_prompt: str, disclaimer: str) -> bool:
+        """
+        Cost-efficient helper using Firecrawl /search (2 credits) + Claude Sonnet 4.6.
+        Uses the same global MCPApp + AnthropicAugmentedLLM pattern as /evaluate.
+
+        Returns:
+            bool: True if successful, False on failure
+        """
+        chat_id = update.effective_chat.id
+        waiting_msg = await update.message.reply_text("🔍 리서치 중...")
+
+        try:
+            result = await generate_firecrawl_search_response(search_query, analysis_prompt)
+
+            try:
+                await waiting_msg.delete()
+            except Exception:
+                pass
+
+            if result:
+                full_text = result + disclaimer
+                if len(full_text) > 4096:
+                    for i in range(0, len(result), 4096):
+                        chunk = result[i:i + 4096]
+                        await self.application.bot.send_message(chat_id=chat_id, text=chunk)
+                    await self.application.bot.send_message(chat_id=chat_id, text=disclaimer.strip())
+                else:
+                    await self.application.bot.send_message(chat_id=chat_id, text=full_text)
+                return True
+            else:
+                await self.application.bot.send_message(
+                    chat_id=chat_id,
+                    text="⚠️ 검색 결과가 부족하거나 분석 생성에 실패했습니다.\n"
+                         "질문을 바꿔서 다시 시도해보세요."
+                )
+                return False
+
+        except Exception as e:
+            logger.error(f"Search+Claude command error: {e}", exc_info=True)
+            try:
+                await waiting_msg.delete()
+            except Exception:
+                pass
+            await self.application.bot.send_message(
+                chat_id=chat_id,
+                text=f"⚠️ 리서치 중 오류가 발생했습니다: {type(e).__name__}\n"
+                     "잠시 후 다시 시도해주세요."
+            )
+            return False
+
     async def handle_signal(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
-        """Handle /signal command — KR event impact analysis"""
+        """Handle /signal command — KR event impact analysis (search + Claude)"""
         user_id = update.effective_user.id
 
         is_subscribed = await self.check_channel_subscription(user_id)
@@ -2459,7 +2510,6 @@ class TelegramAIBot:
             )
             return
 
-        # Extract event text after the command
         event = update.message.text.replace("/signal", "").strip()
         if not event:
             await update.message.reply_text(
@@ -2470,18 +2520,19 @@ class TelegramAIBot:
 
         logger.info(f"/signal command - user={user_id}, event='{event[:50]}'")
 
-        prompt = (
-            f"{event}가 한국 주식시장에 미치는 영향을 분석해줘.\n"
+        search_query = f"{event} 한국 주식시장 수혜주 피해주"
+        analysis_prompt = (
+            f"위 검색 결과를 바탕으로, '{event}'가 한국 주식시장에 미치는 영향을 분석해줘.\n"
             "1. 수혜 예상 섹터와 대표 종목 3개\n"
             "2. 피해 예상 섹터와 대표 종목 3개\n"
             "3. 과거 유사 사례\n"
             "4. 개인투자자 대응 전략\n"
-            "한국어로, 텔레그램 메시지 형태로 이모지 포함하여 작성. 3000자 이내."
+            "텔레그램 메시지 형태로 이모지 포함하여 작성. 3000자 이내."
         )
-        await self._run_firecrawl_command(update, prompt, self._DISCLAIMER_KR)
+        await self._run_search_and_claude(update, search_query, analysis_prompt, self._DISCLAIMER_KR)
 
     async def handle_us_signal(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
-        """Handle /us_signal command — US event impact analysis"""
+        """Handle /us_signal command — US event impact analysis (search + Claude)"""
         user_id = update.effective_user.id
 
         is_subscribed = await self.check_channel_subscription(user_id)
@@ -2496,25 +2547,26 @@ class TelegramAIBot:
         event = update.message.text.replace("/us_signal", "").strip()
         if not event:
             await update.message.reply_text(
-                "사용법: /us_signal [event/news]\n"
-                "예시: /us_signal tariff impact on tech stocks"
+                "사용법: /us_signal [이벤트/뉴스]\n"
+                "예시: /us_signal TSMC 실적 서프라이즈"
             )
             return
 
         logger.info(f"/us_signal command - user={user_id}, event='{event[:50]}'")
 
-        prompt = (
-            f"'{event}'가 미국 주식시장(S&P500, NASDAQ)에 미치는 영향을 분석해줘.\n"
+        search_query = f"{event} US stock market impact beneficiary"
+        analysis_prompt = (
+            f"위 검색 결과를 바탕으로, '{event}'가 미국 주식시장(S&P500, NASDAQ)에 미치는 영향을 분석해줘.\n"
             "1. 수혜 예상 섹터와 대표 종목 3개\n"
             "2. 피해 예상 섹터와 대표 종목 3개\n"
             "3. 과거 유사 사례\n"
             "4. 개인투자자 대응 전략\n"
             "한국어로, 텔레그램 메시지 형태로 이모지 포함하여 작성. 3000자 이내."
         )
-        await self._run_firecrawl_command(update, prompt, self._DISCLAIMER_KR)
+        await self._run_search_and_claude(update, search_query, analysis_prompt, self._DISCLAIMER_KR)
 
     async def handle_theme(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
-        """Handle /theme command — KR theme health check"""
+        """Handle /theme command — KR theme health check (search + Claude)"""
         user_id = update.effective_user.id
 
         is_subscribed = await self.check_channel_subscription(user_id)
@@ -2536,19 +2588,20 @@ class TelegramAIBot:
 
         logger.info(f"/theme command - user={user_id}, theme='{theme[:50]}'")
 
-        prompt = (
-            f"한국 주식시장에서 '{theme}' 테마의 현재 건강도를 진단해줘.\n"
+        search_query = f"{theme} 테마 전망 주도주 대장주 2026"
+        analysis_prompt = (
+            f"위 검색 결과를 바탕으로, 한국 주식시장에서 '{theme}' 테마의 현재 건강도를 진단해줘.\n"
             "1. 테마 온도 (🟢과열/🟡적정/🔴냉각 중 택1, 근거 포함)\n"
             "2. 대장주 3개와 최근 주가 동향\n"
             "3. 긍정 요인 3개\n"
             "4. 부정 요인 3개\n"
             "5. 진입 타이밍 의견\n"
-            "한국어로, 텔레그램 메시지 형태로 이모지 포함하여 작성. 3000자 이내."
+            "텔레그램 메시지 형태로 이모지 포함하여 작성. 3000자 이내."
         )
-        await self._run_firecrawl_command(update, prompt, self._DISCLAIMER_KR)
+        await self._run_search_and_claude(update, search_query, analysis_prompt, self._DISCLAIMER_KR)
 
     async def handle_us_theme(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
-        """Handle /us_theme command — US theme health check"""
+        """Handle /us_theme command — US theme health check (search + Claude)"""
         user_id = update.effective_user.id
 
         is_subscribed = await self.check_channel_subscription(user_id)
@@ -2563,15 +2616,16 @@ class TelegramAIBot:
         theme = update.message.text.replace("/us_theme", "").strip()
         if not theme:
             await update.message.reply_text(
-                "사용법: /us_theme [theme/sector]\n"
+                "사용법: /us_theme [테마/섹터]\n"
                 "예시: /us_theme AI semiconductor"
             )
             return
 
         logger.info(f"/us_theme command - user={user_id}, theme='{theme[:50]}'")
 
-        prompt = (
-            f"미국 주식시장(S&P500, NASDAQ)에서 '{theme}' 테마의 현재 건강도를 진단해줘.\n"
+        search_query = f"{theme} sector outlook leading stocks 2026"
+        analysis_prompt = (
+            f"위 검색 결과를 바탕으로, 미국 주식시장(S&P500, NASDAQ)에서 '{theme}' 테마의 현재 건강도를 진단해줘.\n"
             "1. 테마 온도 (🟢과열/🟡적정/🔴냉각 중 택1, 근거 포함)\n"
             "2. 대장주 3개와 최근 주가 동향\n"
             "3. 긍정 요인 3개\n"
@@ -2579,7 +2633,7 @@ class TelegramAIBot:
             "5. 진입 타이밍 의견\n"
             "한국어로, 텔레그램 메시지 형태로 이모지 포함하여 작성. 3000자 이내."
         )
-        await self._run_firecrawl_command(update, prompt, self._DISCLAIMER_KR)
+        await self._run_search_and_claude(update, search_query, analysis_prompt, self._DISCLAIMER_KR)
 
     async def handle_ask(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """Handle /ask command — free-form investment research (3 per day)"""

--- a/weekly_firecrawl_intelligence.py
+++ b/weekly_firecrawl_intelligence.py
@@ -27,40 +27,42 @@ logger = logging.getLogger(__name__)
 _DISCLAIMER = "\n\n⚠️ 본 내용은 투자 참고용이며, 투자 판단의 책임은 본인에게 있습니다."
 
 
-def _generate_kr_report() -> str:
-    """Generate KR market intelligence report via Firecrawl agent."""
-    from firecrawl_client import firecrawl_agent
+async def _generate_kr_report() -> str:
+    """Generate KR market intelligence report via Firecrawl search + Claude."""
+    from report_generator import generate_firecrawl_search_response
 
     today_str = datetime.now().strftime("%Y년 %m월 %d일")
 
-    prompt = (
+    search_query = f"코스피 코스닥 주간 시황 {today_str} 외국인 기관 수급"
+    analysis_prompt = (
         f"오늘 날짜는 {today_str}입니다.\n"
-        "이번 주 한국 주식시장 주간 인텔리전스 리포트를 작성해줘.\n\n"
+        "위 검색 결과를 바탕으로 이번 주 한국 주식시장 주간 인텔리전스 리포트를 작성해줘.\n\n"
         "포함 내용:\n"
         "1. 이번 주 KOSPI/KOSDAQ 주요 흐름 요약\n"
         "2. 가장 주목받은 테마 3개와 대표 종목\n"
         "3. 외국인/기관 수급 동향\n"
         "4. 다음 주 주요 일정 및 이벤트\n"
         "5. 개인투자자를 위한 전략 제안\n\n"
-        "한국어로, 텔레그램 메시지 형태로 이모지 포함하여 작성. 4000자 이내."
+        "텔레그램 메시지 형태로 이모지 포함하여 작성. 4000자 이내."
     )
 
-    result = firecrawl_agent(prompt, max_credits=200, model="spark-1-mini")
+    result = await generate_firecrawl_search_response(search_query, analysis_prompt, limit=10)
     if not result:
         logger.error("Failed to generate KR intelligence report")
         return ""
     return result
 
 
-def _generate_us_report() -> str:
-    """Generate US market intelligence report via Firecrawl agent."""
-    from firecrawl_client import firecrawl_agent
+async def _generate_us_report() -> str:
+    """Generate US market intelligence report via Firecrawl search + Claude."""
+    from report_generator import generate_firecrawl_search_response
 
     today_str = datetime.now().strftime("%Y년 %m월 %d일")
 
-    prompt = (
+    search_query = f"US stock market weekly recap S&P 500 NASDAQ {today_str}"
+    analysis_prompt = (
         f"오늘 날짜는 {today_str}입니다.\n"
-        "이번 주 미국 주식시장 주간 인텔리전스 리포트를 작성해줘.\n\n"
+        "위 검색 결과를 바탕으로 이번 주 미국 주식시장 주간 인텔리전스 리포트를 작성해줘.\n\n"
         "포함 내용:\n"
         "1. 이번 주 S&P500/NASDAQ 주요 흐름 요약\n"
         "2. 가장 주목받은 섹터 3개와 대표 종목\n"
@@ -70,20 +72,20 @@ def _generate_us_report() -> str:
         "한국어로, 텔레그램 메시지 형태로 이모지 포함하여 작성. 4000자 이내."
     )
 
-    result = firecrawl_agent(prompt, max_credits=200, model="spark-1-mini")
+    result = await generate_firecrawl_search_response(search_query, analysis_prompt, limit=10)
     if not result:
         logger.error("Failed to generate US intelligence report")
         return ""
     return result
 
 
-def generate_weekly_intelligence() -> str:
+async def generate_weekly_intelligence() -> str:
     """Generate combined weekly intelligence report."""
     today = datetime.now()
     date_display = today.strftime("%-m/%-d")
 
-    kr_report = _generate_kr_report()
-    us_report = _generate_us_report()
+    kr_report = await _generate_kr_report()
+    us_report = await _generate_us_report()
 
     sections = [f"🔥 PRISM 주간 Firecrawl 인텔리전스 ({date_display})"]
 
@@ -192,7 +194,7 @@ def main():
     )
 
     async def _run():
-        message = generate_weekly_intelligence()
+        message = await generate_weekly_intelligence()
         print(message)
 
         if not args.dry_run:


### PR DESCRIPTION
## Summary
`/signal`, `/us_signal`, `/theme`, `/us_theme`, weekly intelligence를
Firecrawl `/agent` (~150 credits) → `/search` (2 credits) + Claude Sonnet 4.6으로 변경.

`/ask`만 `/agent` 유지 (자유형 웹 탐색 필요).

## Cost per call
| Command | Before | After |
|---------|--------|-------|
| /signal, /theme | ~150 credits | 2 credits + ~$0.005 Claude |
| Weekly Intelligence | ~400 credits/week | 4 credits + ~$0.01 Claude |
| /ask | ~150 credits | unchanged |

## Files changed (3 files only, no unrelated changes)
- `report_generator.py` — Add `generate_firecrawl_search_response()` using MCPApp + AnthropicAugmentedLLM pattern
- `telegram_ai_bot.py` — `/signal`, `/theme` handlers use `_run_search_and_claude()`, import update
- `weekly_firecrawl_intelligence.py` — async + `generate_firecrawl_search_response`

## Test plan
- [ ] `/signal 이란 휴전` → 한국어 분석 응답 확인
- [ ] `/us_theme AI 데이터센터` → 한국어 분석 응답 확인
- [ ] `/ask 워렌 버핏` → agent 방식 유지 확인
- [ ] `weekly_firecrawl_intelligence.py --dry-run` 실행 확인
- [ ] Firecrawl 대시보드에서 크레딧 소모 비교

## Known issues from code review (to fix in follow-up)
- `Agent(server_names=[])` 빈 서버 리스트 동작 검증 필요
- `/signal`, `/theme` 일일 사용 제한 미설정 (남용 방지)
- 사용자 입력 길이 제한 미설정

🤖 Generated with [Claude Code](https://claude.com/claude-code)