### PR TITLE
fix(telegram): /us_evaluate 티커 자동 대문자 + /cancel 전체 핸들러 적용

### DIFF
--- a/telegram_ai_bot.py
+++ b/telegram_ai_bot.py
@@ -544,6 +544,7 @@ class TelegramAIBot:
             BotCommand("ask",         "자유 질문 (최신 정보 기반)"),
             BotCommand("insight",     "누적 인사이트 기반 장기 분석"),
             BotCommand("journal",     "매매 저널 조회"),
+            BotCommand("cancel",      "진행 중인 명령어 취소 (evaluate·us_evaluate·report·us_report·history·signal·us_signal·theme·us_theme·ask·insight·journal)"),
             BotCommand("help",        "도움말"),
         ]
         scopes = [
@@ -771,7 +772,7 @@ class TelegramAIBot:
         # Basic commands
         self.application.add_handler(CommandHandler("start", self.handle_start))
         self.application.add_handler(CommandHandler("help", self.handle_help))
-        self.application.add_handler(CommandHandler("cancel", self.handle_cancel_standalone))
+        self.application.add_handler(CommandHandler("cancel", self.handle_cancel_standalone), group=1)
         self.application.add_handler(CommandHandler("memories", self.handle_memories))
         self.application.add_handler(CommandHandler("triggers", self.handle_triggers))
 
@@ -1857,8 +1858,8 @@ class TelegramAIBot:
 
         await update.message.reply_text(
             "요청이 취소되었습니다.\n\n"
-            "🇰🇷 국내 주식: /evaluate, /report, /history\n"
-            "🇺🇸 해외 주식: /us_evaluate, /us_report"
+            "취소 가능한 명령어: /evaluate, /us_evaluate, /report, /us_report, /history, "
+            "/signal, /us_signal, /theme, /us_theme, /ask, /insight, /journal"
         )
         return ConversationHandler.END
 
@@ -1867,8 +1868,8 @@ class TelegramAIBot:
         """Handle conversation cancellation (called from outside conversation)"""
         await update.message.reply_text(
             "현재 진행 중인 대화가 없습니다.\n\n"
-            "🇰🇷 국내 주식: /evaluate, /report, /history\n"
-            "🇺🇸 해외 주식: /us_evaluate, /us_report"
+            "취소 가능한 명령어: /evaluate, /us_evaluate, /report, /us_report, /history, "
+            "/signal, /us_signal, /theme, /us_theme, /ask, /insight, /journal"
         )
 
     @staticmethod

--- a/telegram_ai_bot.py
+++ b/telegram_ai_bot.py
@@ -2101,7 +2101,7 @@ class TelegramAIBot:
     async def handle_us_ticker_input(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """Handle US ticker input"""
         user_id = update.effective_user.id
-        user_input = update.message.text.strip()
+        user_input = update.message.text.strip().upper()
         logger.info(f"Received US ticker input - User: {user_id}, Input: {user_input}")
 
         # Validate ticker


### PR DESCRIPTION
## Summary
- `/us_evaluate` 티커 입력 시 소문자 → 자동 대문자 치환 (`strip().upper()`)
- `/cancel` 명령어가 대화 중에도 동작하지 않던 버그 수정: standalone handler를 group=1로 이동하여 ConversationHandler(group=0)가 먼저 처리하도록 변경
- `/cancel` BotFather 명령어 목록에 추가 (취소 가능한 12개 명령어 명시)
- `/cancel` 안내문구에 누락된 명령어 추가 (signal, us_signal, theme, us_theme, ask, insight, journal)

## Test plan
- [ ] `/us_evaluate` 실행 후 소문자 티커(예: `aapl`) 입력 → 대문자로 처리되는지 확인
- [ ] `/evaluate` 또는 `/report` 진행 중 `/cancel` 입력 → "요청이 취소되었습니다" 응답 확인
- [ ] 대화 없을 때 `/cancel` 입력 → "현재 진행 중인 대화가 없습니다" 응답 확인
- [ ] 봇 재시작 후 BotFather 메뉴에 `/cancel` 항목 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)