### PR TITLE
fix(telegram): dedupe LLM-emitted investing warning on Firecrawl commands (#263)

### DIFF
--- a/cores/disclaimer_utils.py
+++ b/cores/disclaimer_utils.py
@@ -1,0 +1,35 @@
+"""Shared disclaimer/warning text helpers.
+
+Extracted from `telegram_ai_bot.py` so the regex can be unit-tested without
+pulling in the full telegram-bot dependency stack (gh #263).
+"""
+
+from __future__ import annotations
+
+import re
+
+# Trailing disclaimer-like lines the LLM tends to append on its own (gh #263).
+# Matches a final block of one or more lines starting with ⚠️/⚡/❗ that mention
+# 투자/investment + a responsibility/reference/advice/risk noun. Stripped before
+# the canonical disclaimer is appended so users do not see two warnings.
+_TRAILING_DISCLAIMER_RE = re.compile(
+    r"(?:\n[ \t]*[⚠⚡❗‼️]+[^\n]*?"
+    r"(?:투자\s*(?:참고|판단|권유|결정|책임|위험|유의)"
+    r"|investment[^\n]*?(?:reference|decision|responsibility|advice|risk|caution|disclaim)"
+    r"|not\s+(?:a\s+)?(?:financial|investment)\s+advice"
+    r")[^\n]*)+\s*\Z",
+    re.IGNORECASE,
+)
+
+
+def strip_trailing_disclaimer(text: str) -> str:
+    """Remove any disclaimer-like trailing block emitted by the LLM (gh #263).
+
+    Used before appending the bot's canonical disclaimer so users do not see
+    two near-identical investment warnings.
+
+    Returns ``text`` unchanged when it is empty or ``None``.
+    """
+    if not text:
+        return text
+    return _TRAILING_DISCLAIMER_RE.sub("", text).rstrip()

--- a/telegram_ai_bot.py
+++ b/telegram_ai_bot.py
@@ -40,6 +40,7 @@ from report_generator import (
 )
 from tracking.user_memory import UserMemoryManager
 from firecrawl_client import firecrawl_agent
+from cores.disclaimer_utils import strip_trailing_disclaimer as _strip_trailing_disclaimer
 from datetime import datetime, timedelta
 from dataclasses import dataclass
 from typing import Dict, Optional
@@ -2638,6 +2639,9 @@ class TelegramAIBot:
     _DISCLAIMER_KR = "\n\n⚠️ 본 내용은 투자 참고용이며, 투자 판단의 책임은 본인에게 있습니다."
     _DISCLAIMER_US = "\n\n⚠️ This is for informational purposes only. Investment decisions are your own responsibility."
 
+    # gh #263: strip LLM-emitted disclaimer block before appending our canonical one.
+    _strip_trailing_disclaimer = staticmethod(_strip_trailing_disclaimer)
+
     async def _run_firecrawl_command(self, update: Update, prompt: str, disclaimer: str):
         """
         Common helper for Firecrawl-based commands.
@@ -2661,6 +2665,8 @@ class TelegramAIBot:
                 pass
 
             if result:
+                # Strip any LLM-emitted disclaimer so it does not double up with our canonical one (gh #263).
+                result = self._strip_trailing_disclaimer(result)
                 # Telegram message limit is 4096 chars — chunk if needed
                 followup_hint = "\n\n💬 이 메시지에 답장(Reply)하여 추가 질문할 수 있습니다!"
                 full_text = result + disclaimer + followup_hint
@@ -2716,6 +2722,8 @@ class TelegramAIBot:
                 pass
 
             if result:
+                # Strip any LLM-emitted disclaimer so it does not double up with our canonical one (gh #263).
+                result = self._strip_trailing_disclaimer(result)
                 followup_hint = "\n\n💬 이 메시지에 답장(Reply)하여 추가 질문할 수 있습니다!"
                 full_text = result + disclaimer + followup_hint
                 if len(full_text) > 4096:

--- a/tests/test_strip_trailing_disclaimer.py
+++ b/tests/test_strip_trailing_disclaimer.py
@@ -1,0 +1,96 @@
+"""Regression tests for gh #263 — duplicate investing warning on /us_theme etc.
+
+The Firecrawl handlers in `telegram_ai_bot.py` always append a canonical
+`_DISCLAIMER_KR` / `_DISCLAIMER_US` line. The LLM frequently appends its own
+investment-warning line on top, producing two near-identical disclaimers.
+`cores.disclaimer_utils.strip_trailing_disclaimer` removes the LLM-emitted
+block before the canonical one is appended.
+"""
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from cores.disclaimer_utils import strip_trailing_disclaimer as _strip
+
+
+# --- Cases that MUST be stripped (the gh #263 reproductions) ----------------
+
+def test_strips_kr_recommendation_phrasing():
+    """The exact phrasing reported in gh #263."""
+    body = "🟢 AI 데이터센터 테마는 과열 구간입니다.\n대장주: NVDA, AVGO, MRVL"
+    text = body + "\n\n⚠️ 본 내용은 투자 권유가 아닌 정보 제공 목적이며, 최종 투자 판단은 본인 책임입니다."
+    assert _strip(text) == body
+
+
+def test_strips_kr_reference_phrasing():
+    """The other duplicate variant — same wording as our canonical disclaimer."""
+    body = "🟢 바이오 테마 진단 결과..."
+    text = body + "\n\n⚠️ 본 내용은 투자 참고용이며, 투자 판단의 책임은 본인에게 있습니다."
+    assert _strip(text) == body
+
+
+def test_strips_kr_responsibility_only():
+    body = "테마 온도: 🔴 냉각"
+    text = body + "\n⚠️ 투자 결정은 본인 책임입니다."
+    assert _strip(text) == body
+
+
+def test_strips_en_phrasing():
+    body = "Theme temperature: 🟢 Hot"
+    text = body + "\n\n⚠️ This is for informational purposes only. Investment decisions are your own responsibility."
+    assert _strip(text) == body
+
+
+def test_strips_not_financial_advice():
+    body = "Bullet 1\nBullet 2"
+    text = body + "\n\n⚠️ This is not financial advice."
+    assert _strip(text) == body
+
+
+def test_strips_multiple_trailing_warning_lines():
+    body = "본문 내용입니다."
+    text = body + (
+        "\n\n⚠️ 본 내용은 투자 권유가 아닙니다."
+        "\n⚠️ 투자 판단의 책임은 본인에게 있습니다."
+    )
+    assert _strip(text) == body
+
+
+def test_handles_trailing_whitespace():
+    body = "본문"
+    text = body + "\n\n⚠️ 본 내용은 투자 참고용이며, 투자 판단의 책임은 본인에게 있습니다.\n   \n"
+    assert _strip(text) == body
+
+
+# --- Cases that MUST be preserved ------------------------------------------
+
+def test_preserves_warning_in_middle_of_body():
+    """A ⚠️ inside the body (e.g. inline risk callout) must not be stripped."""
+    text = (
+        "1. 테마 온도: 🟡 적정\n"
+        "⚠️ 단, 단기 과열 우려가 있습니다.\n"
+        "2. 대장주: NVDA"
+    )
+    assert _strip(text) == text
+
+
+def test_preserves_text_without_warning():
+    text = "🟢 AI 데이터센터 테마 진단 완료.\n대장주: NVDA, AVGO"
+    assert _strip(text) == text
+
+
+def test_preserves_unrelated_warning_at_end():
+    """A trailing ⚠️ that is not investment-related must be preserved."""
+    text = "분석 완료.\n\n⚠️ 데이터 출처: 일부 종목은 거래량이 낮을 수 있습니다."
+    assert _strip(text) == text
+
+
+def test_preserves_empty_string():
+    assert _strip("") == ""
+
+
+def test_preserves_none_safely():
+    assert _strip(None) is None


### PR DESCRIPTION
Fixes #263.

## Problem

`/us_theme` (and other Firecrawl commands) display **two** near-identical investment warnings at the end of the response:

```
⚠️ 본 내용은 투자 권유가 아닌 정보 제공 목적이며, 최종 투자 판단은 본인 책임입니다.

⚠️ 본 내용은 투자 참고용이며, 투자 판단의 책임은 본인에게 있습니다.
```

The first line is emitted by the LLM on its own (LLMs reflexively append financial disclaimers). The second line is `_DISCLAIMER_KR`, which the bot always appends in `_run_firecrawl_command` / `_run_search_and_claude`.

## Fix

New helper `cores.disclaimer_utils.strip_trailing_disclaimer(text)` removes any trailing block of `⚠️`/`⚡`/`❗` lines that mention `투자` / `investment` + a responsibility/reference/advice/risk noun. Called inside both Firecrawl helpers **before** the canonical disclaimer is concatenated.

Affects all five commands routed through these helpers: `/signal`, `/us_signal`, `/theme`, `/us_theme`, `/ask`.

## Why a separate module

The helper lives in `cores/disclaimer_utils.py` (not inside `telegram_ai_bot.py`) so it can be unit-tested without importing `python-telegram-bot` and the rest of the bot's runtime stack.

## What it preserves

- Inline `⚠️` callouts inside the body (e.g. "⚠️ 단, 단기 과열 우려가 있습니다." between bullets)
- Trailing `⚠️` lines that are NOT investment-related (e.g. "⚠️ 데이터 출처: 일부 종목은 거래량이 낮을 수 있습니다.")
- Empty / `None` input

## Test plan

- [x] `pytest tests/test_strip_trailing_disclaimer.py -v` → **12 passed**
  - 7 strip cases: gh #263 exact phrasings (KR recommendation + KR reference), KR responsibility-only, EN phrasing, EN "not financial advice", multi-line trailing block, trailing whitespace
  - 5 preserve cases: middle-of-body warning, no warning, unrelated trailing warning, empty string, `None`
- [x] `python -m py_compile telegram_ai_bot.py` → SYNTAX OK
- [x] Import wiring verified: helper called at line 2669 (`_run_firecrawl_command`) and 2726 (`_run_search_and_claude`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
