### PR TITLE
fix(us-trading): PYPL APBK0656 — exchange code dynamic lookup + simulator independence

### DIFF
--- a/prism-us/trading/us_stock_trading.py
+++ b/prism-us/trading/us_stock_trading.py
@@ -110,34 +110,64 @@ PRICE_EXCHANGE_CODES = {
     "AMS": "AMS",
 }
 
-# Common NASDAQ stocks for exchange detection
-NASDAQ_TICKERS = {
-    "AAPL", "MSFT", "GOOGL", "GOOG", "AMZN", "META", "NVDA", "TSLA",
-    "AVGO", "COST", "ADBE", "CSCO", "PEP", "NFLX", "INTC", "AMD",
-    "QCOM", "TXN", "HON", "CMCSA", "SBUX", "GILD", "MDLZ", "ISRG",
-    "VRTX", "REGN", "ATVI", "ADP", "BKNG", "CHTR", "LRCX", "MU",
-    "KLAC", "SNPS", "CDNS", "MRVL", "PANW", "CRWD", "ZS", "DDOG"
+# yfinance exchange field → KIS OVRS_EXCG_CD mapping
+_YFINANCE_TO_KIS: Dict[str, str] = {
+    "NMS": "NASD",      # NASDAQ Global Select Market
+    "NGM": "NASD",      # NASDAQ Global Market
+    "NCM": "NASD",      # NASDAQ Capital Market
+    "NasdaqGS": "NASD",
+    "NasdaqGM": "NASD",
+    "NasdaqCM": "NASD",
+    "NYQ": "NYSE",
+    "NYSE": "NYSE",
+    "ASE": "AMEX",
+    "PCX": "AMEX",
+}
+
+# In-process cache: populated on first lookup, persists for process lifetime
+_EXCHANGE_CACHE: Dict[str, str] = {
+    "AAPL": "NASD", "MSFT": "NASD", "GOOGL": "NASD", "GOOG": "NASD",
+    "AMZN": "NASD", "META": "NASD", "NVDA": "NASD", "TSLA": "NASD",
+    "AVGO": "NASD", "COST": "NASD", "ADBE": "NASD", "CSCO": "NASD",
+    "PEP": "NASD",  "NFLX": "NASD", "INTC": "NASD", "AMD":  "NASD",
+    "QCOM": "NASD", "TXN":  "NASD", "CMCSA": "NASD", "SBUX": "NASD",
+    "GILD": "NASD", "MDLZ": "NASD", "ISRG": "NASD", "VRTX": "NASD",
+    "REGN": "NASD", "ADP":  "NASD", "BKNG": "NASD", "CHTR": "NASD",
+    "LRCX": "NASD", "MU":   "NASD", "KLAC": "NASD", "SNPS": "NASD",
+    "CDNS": "NASD", "MRVL": "NASD", "PANW": "NASD", "CRWD": "NASD",
+    "ZS":   "NASD", "DDOG": "NASD",
 }
 
 
 def get_exchange_code(ticker: str) -> str:
     """
-    Determine the exchange code for a given ticker.
+    Determine the KIS exchange code for a ticker.
 
-    Args:
-        ticker: Stock ticker symbol
+    Checks in-process cache first (instant), then queries yfinance for
+    unknown tickers, and falls back to NYSE if the lookup fails.
 
     Returns:
-        Exchange code (NASD, NYSE, AMEX)
+        Exchange code: "NASD", "NYSE", or "AMEX"
     """
-    # Simple heuristic - most tech stocks are on NASDAQ
-    # In production, you'd want to look this up from a database or API
     ticker_upper = ticker.upper()
 
-    if ticker_upper in NASDAQ_TICKERS:
-        return "NASD"
+    if ticker_upper in _EXCHANGE_CACHE:
+        return _EXCHANGE_CACHE[ticker_upper]
 
-    # Default to NYSE for unknown tickers (can be overridden)
+    try:
+        import yfinance as yf
+        info = yf.Ticker(ticker_upper).info
+        exch = info.get("exchange") or ""
+        kis_code = _YFINANCE_TO_KIS.get(exch)
+        if kis_code:
+            _EXCHANGE_CACHE[ticker_upper] = kis_code
+            logger.debug(f"[exchange] {ticker_upper}: yfinance={exch} → KIS={kis_code}")
+            return kis_code
+        logger.warning(f"[exchange] Unmapped yfinance exchange '{exch}' for {ticker_upper}, defaulting to NYSE")
+    except Exception as e:
+        logger.warning(f"[exchange] yfinance lookup failed for {ticker_upper}: {e}, defaulting to NYSE")
+
+    _EXCHANGE_CACHE[ticker_upper] = "NYSE"
     return "NYSE"
 
 

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -2256,11 +2256,17 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                             # KIS failure only affects real-money execution — the simulator holding stays.
                             trade_actually_succeeded = trade_result.get('success') or trade_result.get('partial_success')
 
+                            # Simulator state: always update when buy_stock() succeeded,
+                            # regardless of KIS result (simulator and real trading are independent).
+                            buy_count += 1
+                            state["traded"] = True
+
                             if not trade_actually_succeeded:
                                 logger.warning(
                                     f"[{ticker}] KIS order failed: {trade_result.get('message', 'Unknown')} "
                                     f"— simulator holding preserved, no skip notification"
                                 )
+                                logger.info(f"Simulator purchase recorded: {company_name} ({ticker}) @ ${current_price:.2f} (KIS order failed)")
                             else:
                                 if trade_result.get("partial_success"):
                                     successful = trade_result.get("successful_accounts", [])
@@ -2300,8 +2306,6 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
 
                                     signaled_tickers.add(ticker)
 
-                                buy_count += 1
-                                state["traded"] = True
                                 logger.info(f"Purchase complete: {company_name} ({ticker}) @ ${current_price:.2f}")
                         else:
                             state["should_save_watchlist"] = True

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -2252,26 +2252,14 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                             else:
                                 logger.warning(f"Skipping actual purchase for {ticker}: invalid current_price ({current_price})")
 
-                            # Only mark as traded if KIS order actually succeeded
+                            # Simulator DB record (inserted by buy_stock) is independent of KIS result.
+                            # KIS failure only affects real-money execution — the simulator holding stays.
                             trade_actually_succeeded = trade_result.get('success') or trade_result.get('partial_success')
 
                             if not trade_actually_succeeded:
-                                # Rollback the DB holding inserted by buy_stock() before the order attempt
-                                try:
-                                    account_key_rb, _ = self._account_scope()
-                                    self.cursor.execute(
-                                        "DELETE FROM us_stock_holdings WHERE account_key=? AND ticker=?",
-                                        (account_key_rb, ticker)
-                                    )
-                                    self.conn.commit()
-                                    logger.warning(f"Rolled back DB holding for {ticker}: KIS order not executed successfully")
-                                except Exception as rb_err:
-                                    logger.warning(f"Failed to rollback holding for {ticker}: {rb_err}")
-                                # KIS execution failure is separate from analysis-level skip.
-                                # The buy signal (simulator) was already sent correctly — do NOT trigger 보류 메시지.
                                 logger.warning(
                                     f"[{ticker}] KIS order failed: {trade_result.get('message', 'Unknown')} "
-                                    f"— buy signal already sent, no skip notification"
+                                    f"— simulator holding preserved, no skip notification"
                                 )
                             else:
                                 if trade_result.get("partial_success"):


### PR DESCRIPTION
## 문제

운영서버에서 PYPL 매수 시 KIS `APBK0656 - 해당종목정보가 없습니다` 에러 발생.
시뮬레이터 보유종목 테이블에도 PYPL이 기록되지 않음.

## 원인

### 1. 거래소 코드 하드코딩 (`us_stock_trading.py`)
`get_exchange_code()`가 40개 하드코딩 목록 밖 종목을 모두 `NYSE`로 감지.
PYPL(PayPal)은 NASDAQ 종목이므로 KIS API가 NYSE에서 찾지 못해 에러 반환.
S&P500 500개 중 목록 밖 NASDAQ 종목 전부 동일 문제.

### 2. DB 롤백 버그 (`us_stock_tracking_agent.py`, `f6ef9fb` 도입)
KIS 실주문 실패 시 시뮬레이터 DB 레코드(`us_stock_holdings`)까지 삭제.
시뮬레이터와 실거래는 독립적이어야 하며, KR `stock_tracking_agent.py`는 처음부터 이 설계를 따름.

## 수정

### `efcb41b` — yfinance 동적 거래소 조회
- `NASDAQ_TICKERS` 하드코딩 제거
- `_EXCHANGE_CACHE`: 기존 40개 pre-seed (네트워크 없이 즉시 응답)
- `get_exchange_code()`: 캐시 미스 시 yfinance 조회 → `NMS/NGM/NCM → NASD`, `NYQ → NYSE`, `ASE/PCX → AMEX`
- yfinance 이미 `requirements.txt`에 있고 prism-us 전반에서 사용 중

### `8754a34` — KIS 실패 시 DB 롤백 제거
- KIS 주문 실패해도 `us_stock_holdings` 레코드 유지
- KIS 결과는 경고 로그만 남김

### `078a5f2` — 시뮬레이터 상태 독립화
- `buy_count` / `state["traded"]`를 `trade_actually_succeeded`가 아닌 `buy_success`(시뮬레이터) 기준으로 변경
- Redis/GCP 외부 시그널만 KIS 성공 시 발행 (기존 유지)
- KR 에이전트와 동일한 설계로 통일

## 검증

```
AAPL: NASD  ← cache hit
MSFT: NASD  ← cache hit
PYPL: NASD  ← yfinance 동적 조회 (NMS → NASD)
JPM:  NYSE  ← yfinance 동적 조회 (NYQ → NYSE)
```

## 영향 범위
- `prism-us/trading/us_stock_trading.py`
- `prism-us/us_stock_tracking_agent.py`
- KR 로직 변경 없음 (버그 없음 확인)