### PR TITLE
fix(us-tracking): importlib.util for OpenAIResponsesLLM (prism-us/cores/ shadow)

### DIFF
--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -66,7 +66,16 @@ logger = logging.getLogger(__name__)
 # MCP related imports
 from mcp_agent.app import MCPApp
 from mcp_agent.workflows.llm.augmented_llm import RequestParams
-from cores.llm.openai_responses_llm import OpenAIResponsesLLM as OpenAIAugmentedLLM
+import importlib.util as _ilu
+_spec = _ilu.spec_from_file_location(
+    "openai_responses_llm",
+    Path(__file__).resolve().parent.parent / "cores" / "llm" / "openai_responses_llm.py",
+)
+assert _spec is not None and _spec.loader is not None
+_mod = _ilu.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+OpenAIAugmentedLLM = _mod.OpenAIResponsesLLM
+del _ilu, _spec, _mod
 
 # Import US-specific modules
 # Use explicit path to avoid conflicts with main project


### PR DESCRIPTION
## Summary

- `prism-us/cores/__init__.py` shadows the root `cores/` package when `PRISM_US_DIR` is prepended to `sys.path` by `us_stock_analysis_orchestrator.py`
- `from cores.llm.openai_responses_llm import OpenAIResponsesLLM` therefore resolves to `prism-us/cores/llm/` (which doesn't exist) → `ModuleNotFoundError`
- Fix: use `importlib.util.spec_from_file_location` with absolute path, the same pattern already used for `openai_debug` in the US orchestrator

## Test plan

- [x] `python -c "from us_stock_tracking_agent import app"` with orchestrator-style `sys.path` (PRISM_US_DIR first) → import OK
- [ ] Run `us_stock_analysis_orchestrator.py --mode morning` to confirm end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)