### PR TITLE
fix(us-dashboard): resolve trading namespace collision blocking kis_auth

### DIFF
--- a/examples/generate_us_dashboard_json.py
+++ b/examples/generate_us_dashboard_json.py
@@ -35,10 +35,13 @@ SCRIPT_DIR = Path(__file__).parent
 PROJECT_ROOT = SCRIPT_DIR.parent
 PRISM_US_DIR = PROJECT_ROOT / "prism-us"
 TRADING_DIR = PROJECT_ROOT / "trading"
+# IMPORTANT: do NOT add PRISM_US_DIR to sys.path. prism-us/trading/ would shadow
+# the root trading/ package (which exposes kis_auth) and cause:
+#   ImportError: cannot import name 'kis_auth' from 'trading'
+#   (.../prism-us/trading/__init__.py)
+# USStockTrading is loaded via importlib.util below to avoid the namespace clash.
 sys.path.insert(0, str(SCRIPT_DIR))  # examples/ folder (for translation_utils)
 sys.path.insert(0, str(PROJECT_ROOT))
-sys.path.insert(0, str(PRISM_US_DIR))
-sys.path.insert(0, str(TRADING_DIR))
 
 # yfinance import for market index data
 try:
@@ -48,13 +51,24 @@ except ImportError:
     YFINANCE_AVAILABLE = False
     logger.warning("yfinance not installed. Market index data will be unavailable.")
 
-# KIS US Stock Trading import
+# KIS US Stock Trading import.
+# Loaded via importlib.util from an explicit path so prism-us/trading/__init__.py
+# does NOT get registered as the top-level `trading` package — see comment above.
+USStockTrading = None
+KIS_US_AVAILABLE = False
 try:
-    from trading.us_stock_trading import USStockTrading
-    KIS_US_AVAILABLE = True
-except ImportError:
-    KIS_US_AVAILABLE = False
-    logger.warning("KIS US Stock Trading module not available. Real portfolio will be empty.")
+    import importlib.util as _ilu
+    _us_trading_path = PRISM_US_DIR / "trading" / "us_stock_trading.py"
+    if _us_trading_path.exists():
+        _spec = _ilu.spec_from_file_location("prism_us_stock_trading", _us_trading_path)
+        _us_trading_module = _ilu.module_from_spec(_spec)
+        _spec.loader.exec_module(_us_trading_module)
+        USStockTrading = _us_trading_module.USStockTrading
+        KIS_US_AVAILABLE = True
+    else:
+        logger.warning(f"prism-us trading module not found at {_us_trading_path}.")
+except Exception as exc:
+    logger.warning(f"KIS US Stock Trading module not available: {exc}. Real portfolio will be empty.")
 
 # Translation utility import (after path setup)
 try:


### PR DESCRIPTION
## 증상

운영 서버 cron `0 08 * * 2-6 cd /home/prism/prism-insight && python examples/generate_us_dashboard_json.py >> logs/us_dashboard.log 2>&1` 가 매 실행마다 다음 에러로 실패:

```
File "/home/prism/prism-insight/examples/generate_us_dashboard_json.py", line 76, in <module>
    from trading import kis_auth as ka
ImportError: cannot import name 'kis_auth' from 'trading'
(/home/prism/prism-insight/prism-us/trading/__init__.py)
```

→ US 대시보드 JSON (`us_dashboard_data.json` / `us_dashboard_data_en.json`) 생성이 화~토 매일 08:00 KST 마다 실패해 대시보드 데이터가 갱신되지 않음.

## 원인

`examples/generate_us_dashboard_json.py` 의 path 설정이 다음 순서:

```python
sys.path.insert(0, str(SCRIPT_DIR))   # examples/
sys.path.insert(0, str(PROJECT_ROOT))  # prism-insight/
sys.path.insert(0, str(PRISM_US_DIR))  # prism-insight/prism-us/   ← 핵심 원인
sys.path.insert(0, str(TRADING_DIR))   # prism-insight/trading/    ← 사용 안됨
```

이로 인해 `sys.path` 우선순위가 `[TRADING_DIR, PRISM_US_DIR, PROJECT_ROOT, SCRIPT_DIR, …]` 가 되고:

1. line 53 `from trading.us_stock_trading import USStockTrading`
   → `PRISM_US_DIR` 가 먼저 매칭되어 `prism-us/trading/__init__.py` 가 `sys.modules["trading"]` 에 등록됨.
2. line 76 `from trading import kis_auth as ka` (`7d12548c` multi-account v2.9.0 에서 추가됨)
   → `sys.modules["trading"]` 가 이미 `prism-us/trading/` (kis_auth 없음) 을 가리키므로 `ImportError`.

## 변경 내용

`prism-us` 와 `trading` 디렉터리를 `sys.path` 에 끼워넣지 않고, `USStockTrading` 만 `importlib.util` 로 명시적 경로 로드.

- 모듈 이름은 `prism_us_stock_trading` 으로 등록되어 `trading` 네임스페이스를 점유하지 않음.
- 루트 `trading` 패키지는 그대로 `PROJECT_ROOT` 경유로 정상 해석되어 `kis_auth` 임포트 정상화.
- `demo.py` 의 `us_analysis` 동적 로드 패턴 / `us_stock_tracking_agent` 의 `OpenAIResponsesLLM` 로드 패턴과 동일한 접근 (#276, #275 참조).

## 검증

같은 워크트리 환경에서 (`trading/config/kis_devlp.yaml` 임시 배치 후):

**1. 기존 코드 회귀 재현 — 실패 확인**
```
After USStockTrading import, sys.modules[trading]: …/prism-us/trading/__init__.py
REPRODUCED OLD BUG: cannot import name 'kis_auth' from 'trading' (…/prism-us/trading/__init__.py)
```

**2. 수정된 코드 — import 섹션 정상 통과**
```
IMPORT SECTION SUCCESS
  KIS_US_AVAILABLE: True
  USStockTrading: <class 'prism_us_stock_trading.USStockTrading'>
  ka.resolve_account: True
  ka.__file__: …/trading/kis_auth.py
```

`ka.resolve_account` 는 line 103 `_get_primary_account_key` 에서 사용되는 메서드.

## Test plan

- [ ] 운영 서버에서 임의로 `python examples/generate_us_dashboard_json.py` 직접 실행 → 정상 종료, `examples/dashboard/public/us_dashboard_data.json` 갱신 확인
- [ ] 다음 화요일 08:00 KST cron 실행 후 `logs/us_dashboard.log` 에 `ImportError` 없는지 확인