### PR TITLE
fix(chatgpt-oauth): collect SSE output items + oauth_login --force flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,17 @@ proudly sponsors **PRISM-INSIGHT** - the AI assistant for investors.
 **No API key? No problem.** PRISM-INSIGHT now supports running analysis directly through your ChatGPT Plus ($20/mo) or Pro ($200/mo) subscription via the **Codex OAuth Proxy**.
 
 ```bash
-# One-time login
+# One-time login (browser will open for ChatGPT auth)
 python -m cores.chatgpt_proxy.oauth_login
+
+# Re-authenticate (switch account, or refresh expired tokens)
+python -m cores.chatgpt_proxy.oauth_login --force
 
 # Run with your ChatGPT subscription
 PRISM_OPENAI_AUTH_MODE=chatgpt_oauth python stock_analysis_orchestrator.py --mode morning
 ```
+
+> Tokens auto-refresh in the background, so you only need to log in again if you change ChatGPT accounts or your password.
 
 Zero API bills. Same powerful analysis. Your existing subscription does the work.
 

--- a/README_es.md
+++ b/README_es.md
@@ -47,12 +47,17 @@ patrocina con orgullo **PRISM-INSIGHT** — el asistente de IA para inversionist
 **Sin clave de API? No hay problema.** PRISM-INSIGHT ahora admite ejecutar analisis directamente a traves de tu suscripcion ChatGPT Plus ($20/mes) o Pro ($200/mes) mediante el **Proxy OAuth de Codex**.
 
 ```bash
-# Inicio de sesion unico
+# Primer inicio de sesion (el navegador se abrira para autenticar con ChatGPT)
 python -m cores.chatgpt_proxy.oauth_login
+
+# Re-autenticar (cambiar de cuenta o renovar tokens expirados)
+python -m cores.chatgpt_proxy.oauth_login --force
 
 # Ejecutar con tu suscripcion de ChatGPT
 PRISM_OPENAI_AUTH_MODE=chatgpt_oauth python stock_analysis_orchestrator.py --mode morning
 ```
+
+> Los tokens se renuevan automaticamente en segundo plano, asi que solo necesitas iniciar sesion de nuevo si cambias de cuenta de ChatGPT o de contrasena.
 
 Sin costos de API. El mismo analisis potente. Tu suscripcion existente hace el trabajo.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -47,12 +47,17 @@
 **APIキーがなくても大丈夫です。** PRISM-INSIGHTは、**Codex OAuth プロキシ**を通じて、ChatGPT Plus（月$20）またはPro（月$200）のサブスクリプションで直接分析を実行できるようになりました。
 
 ```bash
-# 初回ログイン（一度だけ）
+# 初回ログイン（ブラウザが自動で開きChatGPT認証）
 python -m cores.chatgpt_proxy.oauth_login
+
+# 再認証が必要な場合（アカウント切替、トークン期限切れなど）
+python -m cores.chatgpt_proxy.oauth_login --force
 
 # ChatGPTサブスクリプションで実行
 PRISM_OPENAI_AUTH_MODE=chatgpt_oauth python stock_analysis_orchestrator.py --mode morning
 ```
+
+> トークンはバックグラウンドで自動更新されるため、ChatGPTアカウントを変更するかパスワードを変更した場合のみ再ログインが必要です。
 
 APIの請求ゼロ。同等の高精度分析。既存のサブスクリプションがそのまま活用できます。
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -47,12 +47,17 @@
 **API 키 없어도 됩니다.** PRISM-INSIGHT는 이제 ChatGPT Plus($20/월) 또는 Pro($200/월) 구독을 통해 **Codex OAuth 프록시** 방식으로 분석을 직접 실행할 수 있습니다.
 
 ```bash
-# 최초 1회 로그인
+# 최초 1회 로그인 (브라우저가 자동으로 열려 ChatGPT 인증 진행)
 python -m cores.chatgpt_proxy.oauth_login
+
+# 재인증이 필요할 때 (계정 변경, 토큰 만료 등)
+python -m cores.chatgpt_proxy.oauth_login --force
 
 # ChatGPT 구독으로 실행
 PRISM_OPENAI_AUTH_MODE=chatgpt_oauth python stock_analysis_orchestrator.py --mode morning
 ```
+
+> 토큰은 백그라운드에서 자동 갱신되므로, ChatGPT 계정을 바꾸거나 비밀번호를 변경한 경우에만 다시 로그인하면 됩니다.
 
 API 요금 0원. 동일한 강력한 분석. 기존 구독으로 충분합니다.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -47,12 +47,17 @@
 **没有 API 密钥？没关系。** PRISM-INSIGHT 现在支持通过 **Codex OAuth 代理**直接使用您的 ChatGPT Plus（$20/月）或 Pro（$200/月）订阅进行分析。
 
 ```bash
-# 一次性登录
+# 首次登录（浏览器会自动打开进行 ChatGPT 认证）
 python -m cores.chatgpt_proxy.oauth_login
+
+# 需要重新登录时（切换账号、令牌过期等）
+python -m cores.chatgpt_proxy.oauth_login --force
 
 # 使用 ChatGPT 订阅运行分析
 PRISM_OPENAI_AUTH_MODE=chatgpt_oauth python stock_analysis_orchestrator.py --mode morning
 ```
+
+> 令牌会在后台自动刷新，仅在更换 ChatGPT 账号或修改密码时才需要重新登录。
 
 零 API 账单。同等强大的分析能力。让您现有的订阅发挥价值。
 

--- a/cores/chatgpt_proxy/api_translator.py
+++ b/cores/chatgpt_proxy/api_translator.py
@@ -52,6 +52,12 @@ def translate_request(body: dict) -> dict:
         if key in body:
             translated[key] = body[key]
 
+    # reasoning_effort -> Responses API {"reasoning": {"effort": "..."}}
+    # "none" means disable reasoning (omit the field entirely)
+    reasoning_effort = body.get("reasoning_effort")
+    if reasoning_effort and reasoning_effort != "none":
+        translated["reasoning"] = {"effort": reasoning_effort}
+
     # max_tokens -> max_output_tokens
     if "max_tokens" in body:
         translated["max_output_tokens"] = body["max_tokens"]
@@ -236,89 +242,79 @@ def translate_error(error_body: dict, status_code: int) -> tuple[dict, int]:
 def collect_sse_to_response(sse_text: str) -> dict:
     """Parse SSE stream text and extract the final Responses API object.
 
-    Looks for 'event: response.completed' or 'event: response.failed' events
-    and extracts the JSON data from the subsequent data: line.
+    The ChatGPT Codex SSE stream sends output items via separate events
+    (response.output_item.done) and the final response.completed event may
+    arrive with an empty output array. We collect output items from the
+    .done events and merge them into the final response.
     """
     lines = sse_text.split("\n")
     current_event = ""
     data_lines: list[str] = []
     completed_data: dict | None = None
     failed_data: dict | None = None
-
-    # Also track incremental text for delta reconstruction
+    output_items: list[dict] = []
     text_chunks: list[str] = []
+
+    def _process(event: str, raw: str) -> None:
+        nonlocal completed_data, failed_data
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return
+        if event == "response.completed":
+            completed_data = parsed
+        elif event == "response.failed":
+            failed_data = parsed
+        elif event == "response.output_text.delta":
+            delta = parsed.get("delta", "")
+            if delta:
+                text_chunks.append(delta)
+        elif event == "response.output_item.done":
+            item = parsed.get("item")
+            if isinstance(item, dict):
+                output_items.append(item)
 
     for line in lines:
         if line.startswith("event: "):
-            # If we had accumulated data for a previous event, process it
             if data_lines and current_event:
-                raw = "\n".join(data_lines)
-                try:
-                    parsed = json.loads(raw)
-                    if current_event == "response.completed":
-                        completed_data = parsed
-                    elif current_event == "response.failed":
-                        failed_data = parsed
-                    elif current_event == "response.output_text.delta":
-                        delta = parsed.get("delta", "")
-                        if delta:
-                            text_chunks.append(delta)
-                except json.JSONDecodeError:
-                    pass
-
+                _process(current_event, "\n".join(data_lines))
             current_event = line[7:].strip()
             data_lines = []
-
         elif line.startswith("data: "):
             data_lines.append(line[6:])
-
         elif line == "" and data_lines and current_event:
-            raw = "\n".join(data_lines)
-            try:
-                parsed = json.loads(raw)
-                if current_event == "response.completed":
-                    completed_data = parsed
-                elif current_event == "response.failed":
-                    failed_data = parsed
-                elif current_event == "response.output_text.delta":
-                    delta = parsed.get("delta", "")
-                    if delta:
-                        text_chunks.append(delta)
-            except json.JSONDecodeError:
-                pass
+            _process(current_event, "\n".join(data_lines))
             data_lines = []
 
     # Process any remaining data
     if data_lines and current_event:
-        raw = "\n".join(data_lines)
-        try:
-            parsed = json.loads(raw)
-            if current_event == "response.completed":
-                completed_data = parsed
-            elif current_event == "response.failed":
-                failed_data = parsed
-        except json.JSONDecodeError:
-            pass
+        _process(current_event, "\n".join(data_lines))
 
-    if completed_data:
-        # Unwrap nested structure: {"type":"response.completed","response":{...}} -> {...}
-        return completed_data.get("response", completed_data)
-
-    if failed_data:
-        return failed_data.get("response", failed_data)
-
-    # Fallback: reconstruct from deltas if no completed event
-    if text_chunks:
-        return {
-            "id": "resp_reconstructed",
-            "output": [
+    def _ensure_output(response_obj: dict) -> dict:
+        """Fill in output array from collected items/deltas if completed event lacks it."""
+        if response_obj.get("output"):
+            return response_obj
+        if output_items:
+            response_obj["output"] = output_items
+        elif text_chunks:
+            response_obj["output"] = [
                 {
                     "type": "message",
                     "role": "assistant",
                     "content": [{"type": "output_text", "text": "".join(text_chunks)}],
                 }
-            ],
-            "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
-        }
+            ]
+        return response_obj
+
+    if completed_data:
+        return _ensure_output(completed_data.get("response", completed_data))
+
+    if failed_data:
+        return failed_data.get("response", failed_data)
+
+    # No completed event — synthesize from collected items/deltas
+    if output_items or text_chunks:
+        synthesized: dict = {"id": "resp_reconstructed", "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}}
+        return _ensure_output(synthesized)
 
     raise ValueError("No response.completed or response.failed event found in SSE stream")

--- a/cores/chatgpt_proxy/oauth_login.py
+++ b/cores/chatgpt_proxy/oauth_login.py
@@ -264,5 +264,43 @@ async def status() -> None:
     print(f"Auth file: {AUTH_FILE}")
 
 
+def _main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="python -m cores.chatgpt_proxy.oauth_login",
+        description="ChatGPT OAuth login. Re-uses an existing token unless --force is set.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force re-authentication even if a valid token already exists.",
+    )
+    args = parser.parse_args()
+
+    if not args.force and AUTH_FILE.exists():
+        try:
+            with open(AUTH_FILE) as f:
+                auth = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            auth = {}
+
+        if auth.get("refresh_token"):
+            now = time.time()
+            expires_at = auth.get("expires_at", 0)
+            status_str = "VALID" if expires_at > now else "EXPIRED (will auto-refresh on next API call)"
+
+            print("Already authenticated — no login needed.")
+            print(f"  Status:        {status_str}")
+            print(f"  Expires at:    {time.ctime(expires_at)}")
+            print(f"  Account ID:    {auth.get('account_id', 'unknown')}")
+            print(f"  Token file:    {AUTH_FILE}")
+            print()
+            print("Run again with --force to re-authenticate (switch account, refresh expired refresh token, etc.).")
+            return
+
+    asyncio.run(login(force=args.force))
+
+
 if __name__ == "__main__":
-    asyncio.run(login())
+    _main()

--- a/cores/chatgpt_proxy/proxy_server.py
+++ b/cores/chatgpt_proxy/proxy_server.py
@@ -125,6 +125,9 @@ async def handle_chat_completions(request: web.Request) -> web.Response:
                 if is_sse:
                     try:
                         api_response = api_translator.collect_sse_to_response(raw_body)
+                        logger.debug("SSE parsed: output_items=%s status=%s",
+                                     [i.get("type") for i in api_response.get("output", [])],
+                                     api_response.get("status"))
                     except ValueError as e:
                         logger.error("SSE parsing failed: %s (Content-Type: %s, body[:200]: %s)", e, content_type, raw_body[:200])
                         return web.json_response(


### PR DESCRIPTION
## Summary

- **Root fix**: ChatGPT Codex's SSE stream delivers completed output items through `response.output_item.done` events, while the final `response.completed` event arrives with an empty `output` array. The proxy was only reading from the completed event, so every agent call returned 0-character content and analyses silently fell back to the computed regime with empty sectors / risk events.
- Translate `reasoning_effort` to the Responses API's `reasoning.effort` field so reasoning models on the Codex endpoint behave correctly.
- Add `--force` flag to `oauth_login` and surface a clear "already authenticated" status (validity, expires_at, account_id) when running without it, so end users no longer have to manually `rm` the token file to re-login.
- Update all README language variants (en/ko/ja/zh/es) to document the `--force` flag and the auto-refresh behavior.

## Verification

Before this fix (logs from running US morning analysis with `PRISM_OPENAI_AUTH_MODE=chatgpt_oauth`):

```
SSE_PARSED output_items=[] finish=completed
US macro intelligence raw output: 0 chars
Failed to parse US macro intelligence output as JSON
LLM output parsing failed, using computed regime only
US macro intelligence complete - regime: strong_bull, leading_sectors: 0, risk_events: 0
```

After this fix:

```
SSE_PARSED output_items=['function_call'] finish=completed   # 1st turn: perplexity tool call
SSE_PARSED output_items=['message']       finish=completed   # 2nd turn: JSON output
US macro intelligence raw output: 3222 chars
US macro intelligence complete - regime: strong_bull, leading_sectors: 4, risk_events: 4
```

`oauth_login` UX:

```
$ python -m cores.chatgpt_proxy.oauth_login
Already authenticated — no login needed.
  Status:        VALID
  Expires at:    Fri May 15 23:54:22 2026
  Account ID:    ce1e2f52-...
  Token file:    /Users/.../chatgpt_auth.json

Run again with --force to re-authenticate (switch account, refresh expired refresh token, etc.).
```

## Test plan

- [x] `python -m cores.chatgpt_proxy.oauth_login --help` shows the new `--force` flag
- [x] Running without `--force` while authenticated prints status instead of silently exiting
- [x] `PRISM_OPENAI_AUTH_MODE=chatgpt_oauth python prism-us/us_stock_analysis_orchestrator.py --mode morning` produces non-empty macro intelligence output (verified `leading_sectors=4, risk_events=4`)
- [x] First turn (tool call) and second turn (final JSON) both extracted correctly from the SSE stream
- [ ] Run a full KR analysis with `chatgpt_oauth` to confirm the same behavior end-to-end on the KR pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)