### PR TITLE
Fix US trading import in Pub/Sub subscriber

### DIFF
--- a/examples/messaging/gcp_pubsub_subscriber_example.py
+++ b/examples/messaging/gcp_pubsub_subscriber_example.py
@@ -38,6 +38,7 @@ import logging
 import argparse
 import asyncio
 import threading
+import importlib.util
 from datetime import datetime, time, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -412,6 +413,17 @@ class ScheduledOrderManager:
 scheduled_order_manager: Optional[ScheduledOrderManager] = None
 
 
+def load_us_stock_trading_class():
+    """Load prism-us trading module without colliding with root trading package."""
+    module_path = PROJECT_ROOT / "prism-us" / "trading" / "us_stock_trading.py"
+    spec = importlib.util.spec_from_file_location("prism_us_stock_trading", module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load US trading module: {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.USStockTrading
+
+
 def setup_logging(log_file: str = None) -> logging.Logger:
     """Configure logging"""
     log_dir = PROJECT_ROOT / "logs"
@@ -521,10 +533,7 @@ async def execute_us_buy_trade(ticker: str, company_name: str, logger: logging.L
         limit_price: Limit price in USD for reserved orders (required for off-hours trading)
     """
     try:
-        # Import from prism-us module
-        import sys
-        sys.path.insert(0, str(PROJECT_ROOT / "prism-us"))
-        from trading.us_stock_trading import USStockTrading
+        USStockTrading = load_us_stock_trading_class()
 
         trading = USStockTrading()
 
@@ -562,10 +571,7 @@ async def execute_us_sell_trade(ticker: str, company_name: str, logger: logging.
         limit_price: Limit price in USD for reserved orders (required for off-hours trading)
     """
     try:
-        # Import from prism-us module
-        import sys
-        sys.path.insert(0, str(PROJECT_ROOT / "prism-us"))
-        from trading.us_stock_trading import USStockTrading
+        USStockTrading = load_us_stock_trading_class()
 
         trading = USStockTrading()
 


### PR DESCRIPTION
## Summary
- Load the prism-us trading module by file path in the Pub/Sub subscriber to avoid collision with the root trading package
- Reuse the loader for US buy and sell execution paths

## Verification
- .venv/bin/python -m py_compile examples/messaging/gcp_pubsub_subscriber_example.py
- .venv/bin/python - <<'PY'
import sys
from pathlib import Path
sys.path.insert(0, str(Path('.').resolve()))
import trading.domestic_stock_trading
from examples.messaging.gcp_pubsub_subscriber_example import load_us_stock_trading_class
assert load_us_stock_trading_class().__name__ == 'USStockTrading'
print('domestic_then_us_load: ok')
PY

## Runtime note
- Live Pub/Sub subscriber is running separately in tmux session prism_pubsub_live and is not affected by this PR operation.