### PR TITLE
fix(mcp-config): pin firecrawl-mcp@3.17.0 to avoid broken npx cache

### DIFF
--- a/mcp_agent.config.yaml.example
+++ b/mcp_agent.config.yaml.example
@@ -20,7 +20,10 @@ mcp:
 
     firecrawl:
         command: "npx"
-        args: [ "-y", "firecrawl-mcp" ]
+        # Pin firecrawl-mcp version to avoid broken npx cache states (see issue #286).
+        # Unpinned `firecrawl-mcp` cached a release with a nested zod ESM/CJS mismatch,
+        # causing the MCP server to crash on startup and tools to silently disappear.
+        args: [ "-y", "firecrawl-mcp@3.17.0" ]
         env:
           FIRECRAWL_API_KEY: "example key"
 


### PR DESCRIPTION
## Summary
- Pin `firecrawl-mcp` to `3.17.0` in `mcp_agent.config.yaml.example` so the npx cache is deterministic and immune to a bad future release.
- Root cause for #286 was a broken cached install of unpinned `firecrawl-mcp` on the prod server — nested `@mendable/firecrawl-js/node_modules/zod` shipped only `index.cjs` while firecrawl-js imported `index.js`, so the MCP server crashed on startup and exposed zero tools. The LLM then fell back to training-data text, producing spam tokens and the "실시간 원문 데이터가 확보되지 않아…" boilerplate seen in the report.

## Why pin instead of clearing the cache only
Clearing `/root/.npm/_npx/*` fixes the immediate state, but the next bad upstream release of `firecrawl-mcp` would silently break us again the same way. Pinning makes the npx cache key stable and shifts version bumps to an explicit PR.

## Test plan
- [x] Confirm the broken cache reproduces locally (zod ESM/CJS resolve error on cold start of the cached version).
- [x] Confirm `firecrawl-mcp@3.17.0` boots cleanly via JSON-RPC handshake: `initialize` → `tools/list` returns 12 firecrawl_* tools.
- [ ] On prod, sync the real `mcp_agent.config.yaml` (gitignored) to match this pin.
- [ ] Run `cores/main.py` (orchestrator-bypass) against a previously broken stock and verify the 기업현황 / 기업개요 sections cite real WiseReport data instead of falling back to boilerplate.

Closes #286