### PR TITLE
fix: clarify Enter-but-deferred buy message (#281)

### DIFF
--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -468,11 +468,20 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                             market_condition_text = market_condition_text.replace(eng, ko, 1)
                             break
 
+                    # When the AI decided "Enter" but the trade was still deferred
+                    # (e.g., sector concentration cap), surface the contradiction on the
+                    # decision line itself. The standalone "보류 사유" line several rows
+                    # below is easy to miss, which made an Enter+hold look like a bug.
+                    if decision == "Enter":
+                        decision_display = f"Enter (실제 보류 — 사유: {reason})"
+                    else:
+                        decision_display = decision
+
                     # Generate skip message
                     skip_message = f"⚠️ 매수 보류: {company_name}({ticker})\n" \
                                    f"현재가: {current_price:,.0f}원\n" \
                                    f"매수 Score: {buy_score}/10\n" \
-                                   f"결정: {decision}\n" \
+                                   f"결정: {decision_display}\n" \
                                    f"시장 상황: {market_condition_text}\n" \
                                    f"산업군: {scenario.get('sector', '알 수 없음')}\n" \
                                    f"보류 사유: {reason}\n" \


### PR DESCRIPTION
## 배경 (#281)

삼성전기 알림에서 `결정: Enter`인데 `⚠️ 매수 보류`로 나와 모순처럼 보였습니다. 실제로는 **코드 버그가 아니라 메시지 가독성 문제**였습니다.

- AI 판단: `Enter` (Score 7/10) ✅
- 그러나 전기·전자 **3번째 편입 → `MAX_SAME_SECTOR=3` 상한 도달** → `sector_diverse=False`
- `stock_tracking_enhanced_agent.py:434` 보류 분기 진입 → `continue`로 **실제 매수는 실행 안 됨** (의도된 동작)
- 문제: `결정: Enter` 줄과 `보류 사유: 섹터 집중` 줄이 4줄 떨어져 있어 보류 사유가 눈에 안 들어옴

## 변경

AI 결정이 `Enter`인데 보류된 경우, `결정:` 줄에 보류 사실을 인라인으로 명시:

```
결정: Enter (실제 보류 — 사유: 섹터 집중 (전기·전자))
```

- **정책 변경 없음** — 섹터 집중 보류 로직은 그대로
- Skip/Watch 결정은 기존과 동일하게 표시
- **KR 전용** — US 버전은 `결정: Skip` 하드코딩이라 해당 모순 없음

## 검증

- `ast.parse` 문법 검증 통과
- Enter/Skip/Watch 3개 케이스 출력 격리 테스트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)