### PR TITLE
feat: 매매일지 피드백 루프 투명화 + 영향 추적 (#280, #282)

### DIFF
--- a/compress_trading_memory.py
+++ b/compress_trading_memory.py
@@ -63,6 +63,71 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+def _log_journal_influence_stats(cursor, table: str = "trading_history", days: int = 90) -> None:
+    """Measure whether journal-influenced buys outperformed non-influenced ones (#280).
+
+    Reads completed trades, inspects the persisted buy-scenario JSON for
+    ``journal_reflection.referenced`` / ``score_adjustment``, and logs comparative
+    outcomes. Purely observational — never mutates data. A trade counts as
+    "influenced" when the buy decision recorded that journal context materially
+    informed it (referenced=true) or an experience-based score adjustment was applied.
+    """
+    try:
+        cutoff = (datetime.now() - timedelta(days=days)).strftime("%Y-%m-%d")
+        cursor.execute(
+            f"SELECT scenario, profit_rate FROM {table} WHERE sell_date >= ?",
+            (cutoff,),
+        )
+        rows = cursor.fetchall()
+    except Exception as e:
+        logger.warning(f"Journal influence stats query failed ({table}): {e}")
+        return
+
+    influenced, non_influenced = [], []
+    for row in rows:
+        try:
+            profit = float(row["profit_rate"])
+        except (TypeError, ValueError, KeyError, IndexError):
+            continue
+        scenario_raw = None
+        try:
+            scenario_raw = row["scenario"]
+        except (KeyError, IndexError):
+            pass
+        is_influenced = False
+        if scenario_raw:
+            try:
+                sc = json.loads(scenario_raw) if isinstance(scenario_raw, str) else scenario_raw
+                if isinstance(sc, dict):
+                    jr = sc.get("journal_reflection") or {}
+                    sadj = sc.get("score_adjustment") or {}
+                    if (isinstance(jr, dict) and jr.get("referenced")) or \
+                       (isinstance(sadj, dict) and sadj.get("value")):
+                        is_influenced = True
+            except Exception:
+                pass
+        (influenced if is_influenced else non_influenced).append(profit)
+
+    def _avg(xs):
+        return sum(xs) / len(xs) if xs else 0.0
+
+    def _winrate(xs):
+        return (sum(1 for x in xs if x > 0) / len(xs) * 100) if xs else 0.0
+
+    logger.info(f"\n📒 Journal Influence on Outcomes (last {days} days, {table}):")
+    logger.info(
+        f"  Influenced buys : {len(influenced):3d} | avg {_avg(influenced):+.2f}% | win {_winrate(influenced):.0f}%"
+    )
+    logger.info(
+        f"  Non-influenced  : {len(non_influenced):3d} | avg {_avg(non_influenced):+.2f}% | win {_winrate(non_influenced):.0f}%"
+    )
+    if not influenced:
+        logger.info(
+            "  (journal_reflection is recorded only on trades opened after this feature shipped — "
+            "the influenced bucket fills in as new trades close)"
+        )
+
+
 async def run_compression(
     db_path: str = "stock_tracking_db.sqlite",
     layer1_age_days: int = 7,
@@ -265,6 +330,11 @@ async def run_compression(
             logger.info(f"  Active Intuitions: {active_intuitions}")
         else:
             logger.info("\n⏭️  Cleanup skipped (--skip-cleanup)")
+
+        # Observability: did journal-grounded decisions actually lead to better outcomes? (#280)
+        # Both KR and US trades live in the same SQLite db, so report each table.
+        _log_journal_influence_stats(agent.cursor, table="trading_history")
+        _log_journal_influence_stats(agent.cursor, table="us_trading_history")
 
         agent.conn.close()
 

--- a/cores/agents/trading_agents.py
+++ b/cores/agents/trading_agents.py
@@ -304,6 +304,11 @@ def create_trading_scenario_agent(language: str = "ko", sector_names: list = Non
             "sector": "KRX sector name. Must be one of: {sector_constraint}",
             "market_condition": "regime + 1-line evidence",
             "max_portfolio_size": Integer 6~10,
+            "journal_reflection": {
+                "referenced": true or false (did the injected trading journal/intuitions materially inform this decision),
+                "recent_exit_caution": "If this stock was exited recently (<=5 trading days) or shows a past similar-loss pattern, the 1-line caution; else null",
+                "applied_lessons": "1-line: which journal/intuition lesson was weighed and how it shifted the decision (null if none)"
+            },
             "trading_scenarios": {
                 "key_levels": {
                     "primary_support": Number,
@@ -554,6 +559,13 @@ def create_trading_scenario_agent(language: str = "ko", sector_names: list = Non
         - **오전장 (09:30~10:30 KST)**: 당일 거래량/캔들은 미완성입니다. "오늘 거래량이 약하다" 같은 확정 판단은 금지하십시오. 전일 종가/거래량 기준으로 분석하고, 당일 데이터는 추세 변화 참고용으로만 사용합니다.
         - **오후 장 (14:50+ KST)**: 당일 데이터가 확정됩니다. 모든 기술적 지표를 사용해도 됩니다.
 
+        ## 매매일지·직관 활용 (주입된 경우)
+        프롬프트에 "Same Stock Trade History" 또는 "Accumulated Trading Intuitions"가 주어지면 신중히 가중하십시오:
+        - 이 종목을 **최근(≤5거래일) 매도**했거나(특히 ⚠️ 태그가 붙은 경우), 과거 **유사 패턴·느낌의 손실 이력**이 있으면 추격 재진입을 한 박자 늦추고 손익비·셋업을 더 엄격히 보십시오.
+        - 다만 매매일지 하나만 보고 기계적으로 미진입하지는 마십시오 — 현재 셋업이 과거와 **무엇이 다른지**를 판단하는 것이 핵심입니다.
+        - 최근 매도 이력에도 진입한다면 rationale에 "지금이 왜 다른가"를 명시하고, journal_reflection 필드를 채우십시오.
+        - journal_reflection은 항상 출력하십시오. 주입된 일지가 없으면 referenced=false, 나머지는 null로 두십시오.
+
         ## JSON 응답 형식
 
         key_levels의 가격 필드 형식: `1700` / `"1,700"` / `"1700~1800"` (범위는 중간값 사용).
@@ -589,6 +601,11 @@ def create_trading_scenario_agent(language: str = "ko", sector_names: list = Non
             "sector": "KRX 업종명. 반드시 다음 중 하나: {sector_constraint}",
             "market_condition": "regime + 1줄 근거",
             "max_portfolio_size": 6~10 사이 정수,
+            "journal_reflection": {
+                "referenced": true 또는 false (주입된 매매일지/직관이 이번 판단에 실제로 영향을 줬는가),
+                "recent_exit_caution": "이 종목을 최근(≤5거래일) 매도했거나 과거 유사 손실 패턴이 있으면 그 주의점 1줄, 없으면 null",
+                "applied_lessons": "반영한 매매일지·직관 교훈 1줄과 그것이 판단을 어떻게 바꿨는지 (없으면 null)"
+            },
             "trading_scenarios": {
                 "key_levels": {
                     "primary_support": 숫자,

--- a/prism-us/cores/agents/trading_agents.py
+++ b/prism-us/cores/agents/trading_agents.py
@@ -262,6 +262,13 @@ risk_reward_ratio  = expected_return_pct / expected_loss_pct
 - **장 후반 (마감 1시간 전 이후)**: 당일 데이터가 사실상 확정. 모든 기술적 지표를 사용해도 됩니다.
 - 분석이 미국 시장 마감 후(아침 KST)에 실행되는 경우 직전 거래일 종가 기준으로 판단하십시오.
 
+## 매매일지·직관 활용 (주입된 경우)
+프롬프트에 "Same Stock Past Trading History" 또는 "Accumulated Trading Intuitions"가 주어지면 신중히 가중하십시오:
+- 이 종목을 **최근(≤5거래일) 매도**했거나(특히 ⚠️ 태그가 붙은 경우), 과거 **유사 패턴·느낌의 손실 이력**이 있으면 추격 재진입을 한 박자 늦추고 손익비·셋업을 더 엄격히 보십시오.
+- 다만 매매일지 하나만 보고 기계적으로 미진입하지는 마십시오 — 현재 셋업이 과거와 **무엇이 다른지**를 판단하는 것이 핵심입니다.
+- 최근 매도 이력에도 진입한다면 rationale에 "지금이 왜 다른가"를 명시하고, journal_reflection 필드를 채우십시오.
+- journal_reflection은 항상 출력하십시오. 주입된 일지가 없으면 referenced=false, 나머지는 null로 두십시오.
+
 ## JSON 응답 형식
 
 key_levels의 가격 필드 형식: `170` / `"170"` / `"170~180"` (범위는 중간값 사용).
@@ -297,6 +304,11 @@ key_levels의 가격 필드 형식: `170` / `"170"` / `"170~180"` (범위는 중
     "sector": "GICS 섹터명. 반드시 다음 중 하나: {sector_constraint}",
     "market_condition": "regime + 1줄 근거",
     "max_portfolio_size": 6~10 사이 정수,
+    "journal_reflection": {
+        "referenced": true 또는 false (주입된 매매일지/직관이 이번 판단에 실제로 영향을 줬는가),
+        "recent_exit_caution": "이 종목을 최근(≤5거래일) 매도했거나 과거 유사 손실 패턴이 있으면 그 주의점 1줄, 없으면 null",
+        "applied_lessons": "반영한 매매일지·직관 교훈 1줄과 그것이 판단을 어떻게 바꿨는지 (없으면 null)"
+    },
     "trading_scenarios": {
         "key_levels": {
             "primary_support": 숫자,
@@ -564,6 +576,13 @@ If the resulting R/R is below the matrix floor for the current regime → No Ent
 - **Closing hour onward**: today's data is settled. All technical indicators are usable.
 - When the analysis runs after US market close (KST morning), use the most recent settled session.
 
+## Using the Trading Journal & Intuitions (when injected)
+When the prompt includes "Same Stock Past Trading History" or "Accumulated Trading Intuitions", weigh them carefully:
+- If this stock was **exited recently (<=5 trading days)** (especially when tagged ⚠️), or shows a **past similar-loss pattern**, slow down a chase re-entry and apply stricter R/R and setup checks.
+- Do NOT mechanically skip based on the journal alone — the key is judging **what is different now** versus the past setup.
+- If you still enter despite a recent exit, state "why now is different" in the rationale and fill the journal_reflection field.
+- Always output journal_reflection. If no journal was injected, set referenced=false and the rest null.
+
 ## JSON Response Format
 
 key_levels price formats: `170` / `"170"` / `"170~180"` (range midpoint used).
@@ -599,6 +618,11 @@ Prohibited: `"$170"`, `"about $170"`, `"minimum 170"`.
     "sector": "GICS sector name. Must be one of: {sector_constraint}",
     "market_condition": "regime + 1-line evidence",
     "max_portfolio_size": Integer 6~10,
+    "journal_reflection": {
+        "referenced": true or false (did the injected trading journal/intuitions materially inform this decision),
+        "recent_exit_caution": "If this stock was exited recently (<=5 trading days) or shows a past similar-loss pattern, the 1-line caution; else null",
+        "applied_lessons": "1-line: which journal/intuition lesson was weighed and how it shifted the decision (null if none)"
+    },
     "trading_scenarios": {
         "key_levels": {
             "primary_support": Number,

--- a/prism-us/tracking/journal.py
+++ b/prism-us/tracking/journal.py
@@ -536,9 +536,22 @@ Please review the following completed US stock trade:
                     pass
 
                 profit_emoji = "✅" if entry[2] > 0 else "❌"
+                # Recency framing: flag names exited within the last ~5 trading days
+                # (≈7 calendar days) so the buy LLM does not overlook that it just
+                # closed this very stock (the same-day re-buy churn case, #282).
+                recency_tag = ""
+                try:
+                    exit_date = datetime.strptime(entry[7][:10], "%Y-%m-%d")
+                    days_since = (datetime.now() - exit_date).days
+                    if days_since <= 7:
+                        recency_tag = f" ⚠️ exited {days_since}d ago — be cautious chasing a re-entry"
+                    else:
+                        recency_tag = f" ({days_since}d ago)"
+                except Exception:
+                    pass
                 context_parts.append(
                     f"- [{entry[7][:10]}] {profit_emoji} Return {entry[2]:.1f}% "
-                    f"(Held {entry[3]} days) - {entry[4]}{lessons_str}"
+                    f"(Held {entry[3]} days) - {entry[4]}{lessons_str}{recency_tag}"
                 )
 
             if context_parts and context_parts[-1].startswith("-"):

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -691,6 +691,7 @@ class USStockTrackingAgent:
             # Get trading journal context for informed decisions
             journal_context = ""
             score_adjustment_info = ""
+            adjustment, reasons = 0, []
             if ticker:
                 journal_context = self.get_journal_context(
                     ticker=ticker,
@@ -752,6 +753,12 @@ class USStockTrackingAgent:
             # JSON parsing (consolidated in cores/utils.py)
             scenario_json = parse_llm_json(response, context='US trading scenario')
             if scenario_json is not None:
+                # Persist the experience-based score adjustment alongside the scenario.
+                # It rides inside the scenario JSON, stored in us_stock_holdings.scenario and
+                # copied to us_trading_history.scenario on sell — giving the weekly influence
+                # report a journal-impact signal for free (#280).
+                if adjustment != 0 or reasons:
+                    scenario_json["score_adjustment"] = {"value": adjustment, "reasons": reasons}
                 logger.info(f"Scenario parsed: {json.dumps(scenario_json, ensure_ascii=False)[:200]}")
                 return scenario_json
 
@@ -949,6 +956,19 @@ class USStockTrackingAgent:
                 message += f"Trading Value Analysis: {rank_change_msg}\n"
 
             message += f"Rationale: {scenario.get('rationale', 'No information')}\n"
+
+            # Surface journal-grounded reasoning so the feedback loop is transparent (#280).
+            # All fields optional — defends against scenarios without journal_reflection.
+            _jr = scenario.get('journal_reflection') or {}
+            if isinstance(_jr, dict):
+                if _jr.get('recent_exit_caution'):
+                    message += f"⚠️ 최근 매도 주의: {_jr.get('recent_exit_caution')}\n"
+                if _jr.get('applied_lessons'):
+                    message += f"📒 매매일지 반영: {_jr.get('applied_lessons')}\n"
+            _sadj = scenario.get('score_adjustment') or {}
+            if isinstance(_sadj, dict) and _sadj.get('value'):
+                _rsn = ', '.join(_sadj.get('reasons', []) or [])
+                message += f"📊 경험 기반 점수조정: {_sadj.get('value'):+d}점 ({_rsn})\n"
 
             # Trading scenario details (same format as KR version)
             trading_scenarios = scenario.get('trading_scenarios', {})
@@ -1183,6 +1203,19 @@ class USStockTrackingAgent:
             trigger_win_rate = self._get_trigger_win_rate(trigger_type)
             if trigger_win_rate:
                 skip_message += f"\n{trigger_win_rate}"
+
+            # Surface journal-grounded reasoning so the feedback loop is transparent (#280).
+            # All fields optional — defends against scenarios without journal_reflection.
+            _jr = scenario.get('journal_reflection') or {}
+            if isinstance(_jr, dict):
+                if _jr.get('recent_exit_caution'):
+                    skip_message += f"\n⚠️ 최근 매도 주의: {_jr.get('recent_exit_caution')}"
+                if _jr.get('applied_lessons'):
+                    skip_message += f"\n📒 매매일지 반영: {_jr.get('applied_lessons')}"
+            _sadj = scenario.get('score_adjustment') or {}
+            if isinstance(_sadj, dict) and _sadj.get('value'):
+                _rsn = ', '.join(_sadj.get('reasons', []) or [])
+                skip_message += f"\n📊 경험 기반 점수조정: {_sadj.get('value'):+d}점 ({_rsn})"
 
             self._msg_types.append("analysis")
             self.message_queue.append(skip_message)

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -310,6 +310,7 @@ class StockTrackingAgent:
             # Get trading journal context for informed decisions
             journal_context = ""
             score_adjustment_info = ""
+            adjustment, reasons = 0, []
             if ticker:
                 journal_context = self._get_relevant_journal_context(
                     ticker=ticker,
@@ -405,6 +406,12 @@ class StockTrackingAgent:
             # TODO: Create model and call generate_structured function to improve code maintainability
             scenario_json = parse_llm_json(response, context='trading scenario')
             if scenario_json is not None:
+                # Persist the experience-based score adjustment alongside the scenario.
+                # It rides inside the scenario JSON, which is stored in
+                # stock_holdings.scenario and copied to trading_history.scenario on sell —
+                # giving the weekly influence report a journal-impact signal for free (#280).
+                if adjustment != 0 or reasons:
+                    scenario_json["score_adjustment"] = {"value": adjustment, "reasons": reasons}
                 logger.info(f"Scenario parsed: {json.dumps(scenario_json, ensure_ascii=False)[:200]}")
                 return scenario_json
 
@@ -768,7 +775,20 @@ class StockTrackingAgent:
                 message += f"거래대금 분석: {rank_change_msg}\n"
 
             message += f"투자근거: {scenario.get('rationale', '정보 없음')}\n"
-            
+
+            # Surface journal-grounded reasoning so the feedback loop is transparent (#280).
+            # All fields are optional — defends against scenarios without journal_reflection.
+            _jr = scenario.get('journal_reflection') or {}
+            if isinstance(_jr, dict):
+                if _jr.get('recent_exit_caution'):
+                    message += f"⚠️ 최근 매도 주의: {_jr.get('recent_exit_caution')}\n"
+                if _jr.get('applied_lessons'):
+                    message += f"📒 매매일지 반영: {_jr.get('applied_lessons')}\n"
+            _sadj = scenario.get('score_adjustment') or {}
+            if isinstance(_sadj, dict) and _sadj.get('value'):
+                _rsn = ', '.join(_sadj.get('reasons', []) or [])
+                message += f"📊 경험 기반 점수조정: {_sadj.get('value'):+d}점 ({_rsn})\n"
+
             # Format trading scenario
             trading_scenarios = scenario.get('trading_scenarios', {})
             if trading_scenarios and isinstance(trading_scenarios, dict):

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -485,6 +485,19 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                     if trigger_win_rate:
                         skip_message += f"\n{trigger_win_rate}"
 
+                    # Surface journal-grounded reasoning so the feedback loop is transparent (#280).
+                    # All fields optional — defends against scenarios without journal_reflection.
+                    _jr = scenario.get('journal_reflection') or {}
+                    if isinstance(_jr, dict):
+                        if _jr.get('recent_exit_caution'):
+                            skip_message += f"\n⚠️ 최근 매도 주의: {_jr.get('recent_exit_caution')}"
+                        if _jr.get('applied_lessons'):
+                            skip_message += f"\n📒 매매일지 반영: {_jr.get('applied_lessons')}"
+                    _sadj = scenario.get('score_adjustment') or {}
+                    if isinstance(_sadj, dict) and _sadj.get('value'):
+                        _rsn = ', '.join(_sadj.get('reasons', []) or [])
+                        skip_message += f"\n📊 경험 기반 점수조정: {_sadj.get('value'):+d}점 ({_rsn})"
+
                     self._msg_types.append("analysis")
                     self.message_queue.append(skip_message)
                     logger.info(f"Purchase deferred: {company_name}({ticker}) - {reason}")

--- a/tracking/journal.py
+++ b/tracking/journal.py
@@ -496,9 +496,22 @@ Please review the following completed trade:
                     pass
 
                 profit_emoji = "✅" if entry[2] > 0 else "❌"
+                # Recency framing: flag names exited within the last ~5 trading days
+                # (≈7 calendar days) so the buy LLM does not overlook that it just
+                # closed this very stock (the same-day re-buy churn case, #282).
+                recency_tag = ""
+                try:
+                    exit_date = datetime.strptime(entry[7][:10], "%Y-%m-%d")
+                    days_since = (datetime.now() - exit_date).days
+                    if days_since <= 7:
+                        recency_tag = f" ⚠️ {days_since}일 전 매도 — 추격 재진입 신중 검토"
+                    else:
+                        recency_tag = f" ({days_since}일 전)"
+                except Exception:
+                    pass
                 context_parts.append(
                     f"- [{entry[7][:10]}] {profit_emoji} Return {entry[2]:.1f}% "
-                    f"(held {entry[3]} days) - {entry[4]}{lessons_str}"
+                    f"(held {entry[3]} days) - {entry[4]}{lessons_str}{recency_tag}"
                 )
 
                 # Enrich with sell context so the buy LLM understands WHY the stock was exited


### PR DESCRIPTION
## 배경

운영서버 실데이터 진단 결과, 매매일지 피드백 루프(기록→압축→주입)는 **이미 정상 작동** 중이었습니다:
- `ENABLE_TRADING_JOURNAL=true`, `trading_journal` 88건, 압축 주간 cron 성공(5/24)
- 매수 시 `[Journal] Injected context` 런타임 주입 확인(5/27~5/29, 12회)

**문제는 "불투명성"이었습니다:**
- 매수/보류 텔레그램 메시지에 *어떤 과거 거래가 판단에 반영됐는지* 안 보임
- 매매일지 영향 매수가 실제로 더 나은 결과로 이어졌는지 **측정 불가**

**#282(당일 재매수, 하이닉스 5/13 09:38 +73.8% 매도 → 09:47 재매수)**도 "일지를 무시한 사고"가 아니라, 루프가 **권고(advisory)**일 뿐이고 같은종목 가점(+73.8% → +1점)이 오히려 재진입을 부추긴 **설계상 자연스러운 결과**였습니다.

## 접근 (하드 게이트 ❌ — 노출·유도)

문답으로 확정된 방향: 차단하지 말고 **투명하게 드러내고 주의를 유도**한다.

1. **매수 에이전트 JSON에 `journal_reflection` 필드** (referenced / recent_exit_caution / applied_lessons) + 최근 매도·유사 손실 패턴을 신중히 가중하되 기계적으로 미진입하지 말라는 지침 — KR/US 양쪽 트레이딩 에이전트
2. **일지 컨텍스트 최근성 태그** — 최근 ~5거래일(≈7일) 내 매도 종목에 ⚠️ 표기 → LLM이 "방금 판 종목"을 놓치지 않게 (`tracking/journal.py` + `prism-us/tracking/journal.py`)
3. **경험 기반 점수조정 영속화** — 그동안 프롬프트에만 쓰고 버려지던 score_adjustment(값+사유)를 scenario에 첨부 → `stock_holdings.scenario`·`trading_history.scenario`로 자동 저장 (KR/US)
4. **텔레그램 매수 + 보류 메시지에 노출** — 📒 매매일지 반영 / ⚠️ 최근 매도 주의 / 📊 점수조정 (KR/US 매수·보류)
5. **학습 품질(측정 가능 방식)** — 주간 압축 배치가 *매매일지 영향 매수 vs 비영향 매수*의 건수·평균수익·승률을 `trading_history`·`us_trading_history` 양쪽에 로깅 → #280의 "정말 개선됐나?"를 시간이 지나며 답할 수 있게

> confidence 승률 재계산은 의도적으로 제외했습니다. 원칙(`조건→행동`)의 "행동 준수 여부"를 기록하지 않아 승률 기반 confidence는 방어적 양질 교훈을 오삭제할 위험이 있어, 데이터(4번)가 쌓인 뒤 안전하게 재설계하는 것이 옳습니다.

## 안전성

- **하드 재매수 게이트 없음**, 매수/매도 실행 로직 무변경
- 모든 신규 메시지·프롬프트 필드는 optional + `.get()` 방어 → `journal_reflection` 없는 기존 scenario와 완전 하위호환

## 변경 파일 (KR/US 미러, 8개)

| 영역 | KR | US |
|---|---|---|
| 에이전트 output 필드+지침 | `cores/agents/trading_agents.py` | `prism-us/cores/agents/trading_agents.py` |
| 일지 최근성 태그 | `tracking/journal.py` | `prism-us/tracking/journal.py` |
| score_adjustment 첨부 + 메시지 | `stock_tracking_agent.py`, `stock_tracking_enhanced_agent.py` | `prism-us/us_stock_tracking_agent.py` |
| 영향 추적 통계 | `compress_trading_memory.py` (KR+US 테이블 모두) | (동일 DB라 공유) |

## 검증

- 8개 파일 전부 `ast.parse` 통과
- 단위 테스트: 메시지 빌더 하위호환(필드 누락/null/타입오류/음수), 최근성 태그 계산(당일~7일/8일+/malformed), `_log_journal_influence_stats` 실제 함수(90일 윈도우·null·malformed·없는 테이블 안전)

🤖 Generated with [Claude Code](https://claude.com/claude-code)