### PR TITLE
fix: Firecrawl 봇 명령어 현재 날짜 앵커링 — 1년 전 데이터 조회 수정 (#283)

### DIFF
--- a/report_generator.py
+++ b/report_generator.py
@@ -1409,10 +1409,13 @@ async def generate_firecrawl_search_response(search_query: str, analysis_prompt:
         # Step 3: Use global MCPApp + Claude Sonnet for analysis
         app = await get_or_create_global_mcp_app()
 
+        current_date = datetime.now().strftime("%Y년 %m월 %d일")
         agent = Agent(
             name="firecrawl_search_analyst",
             instruction=(
-                "당신은 웹 검색 결과를 분석하여 투자자에게 유용한 인사이트를 제공하는 전문가입니다.\n"
+                f"당신은 웹 검색 결과를 분석하여 투자자에게 유용한 인사이트를 제공하는 전문가입니다.\n"
+                f"오늘은 {current_date}입니다. '최근'·'올해'·'현재' 등은 이 날짜 기준으로 해석하고, "
+                f"모델 학습 시점의 연도로 착각하지 마세요.\n"
                 "텔레그램 메시지 형태로, 이모지를 포함하여 자연스럽게 작성하세요.\n"
                 "마크다운 형식 대신 텔레그램에 적합한 플레인 텍스트로 작성하세요.\n"
                 "검색 결과에 없는 내용을 지어내지 마세요."
@@ -1447,12 +1450,15 @@ async def generate_firecrawl_search_response(search_query: str, analysis_prompt:
 
 
 # MCP server config per Firecrawl command type
+# "time" gives the followup agent get_current_time so date-ranged tool calls
+# (kospi_kosdaq / yahoo_finance) are anchored to the real year, not the model's
+# training cutoff — otherwise Sonnet queries ~1-year-old data (#283).
 _FIRECRAWL_CMD_SERVERS = {
-    "signal":    ["perplexity", "kospi_kosdaq"],
-    "us_signal": ["perplexity", "yahoo_finance"],
-    "theme":     ["perplexity", "kospi_kosdaq"],
-    "us_theme":  ["perplexity", "yahoo_finance"],
-    "ask":       ["perplexity", "kospi_kosdaq", "yahoo_finance"],
+    "signal":    ["perplexity", "kospi_kosdaq", "time"],
+    "us_signal": ["perplexity", "yahoo_finance", "time"],
+    "theme":     ["perplexity", "kospi_kosdaq", "time"],
+    "us_theme":  ["perplexity", "yahoo_finance", "time"],
+    "ask":       ["perplexity", "kospi_kosdaq", "yahoo_finance", "time"],
 }
 
 _FIRECRAWL_CMD_PERSONA = {
@@ -1488,6 +1494,7 @@ async def generate_firecrawl_followup_response(
         app = await get_or_create_global_mcp_app()
         server_names = _FIRECRAWL_CMD_SERVERS.get(command, ["perplexity"])
         persona = _FIRECRAWL_CMD_PERSONA.get(command, "투자 분석 전문가")
+        current_date = datetime.now().strftime("%Y년 %m월 %d일")
 
         _data_tool_guide = (
             "- 미국 종목 주가·재무·거래량 조회는 yahoo_finance 도구를 우선 사용하세요.\n"
@@ -1499,6 +1506,11 @@ async def generate_firecrawl_followup_response(
         agent = Agent(
             name="firecrawl_followup_agent",
             instruction=f"""당신은 {persona}입니다.
+
+## 현재 날짜 (매우 중요)
+- 오늘은 {current_date}입니다.
+- 주가·거래량 등 기간 기반 도구를 호출할 때는 반드시 위 '오늘' 날짜의 연도를 기준으로 조회하세요. 모델 학습 시점의 연도를 사용하지 마세요.
+- 가능하면 먼저 time 서버의 get_current_time 툴로 현재 날짜를 확인한 뒤, 그 연도를 도구 조회에 사용하세요.
 
 ## 초기 질의
 {query}

--- a/telegram_ai_bot.py
+++ b/telegram_ai_bot.py
@@ -2790,6 +2790,7 @@ class TelegramAIBot:
         logger.info(f"/signal query - user={user_id}, event='{event[:50]}'")
         search_query = f"{event} 한국증시 영향 {today}"
         analysis_prompt = (
+            f"오늘은 {today} 기준입니다. '최근/현재'는 이 시점으로 해석하세요.\n"
             f"위 검색 결과를 바탕으로, '{event}'가 한국 주식시장에 미치는 영향을 분석해줘.\n"
             "1. 수혜 예상 섹터와 대표 종목 3개\n"
             "2. 피해 예상 섹터와 대표 종목 3개\n"
@@ -2839,6 +2840,7 @@ class TelegramAIBot:
         logger.info(f"/us_signal query - user={user_id}, event='{event[:50]}'")
         search_query = f"{event} stock market impact {today}"
         analysis_prompt = (
+            f"오늘은 {today} 기준입니다. '최근/현재'는 이 시점으로 해석하세요.\n"
             f"위 검색 결과를 바탕으로, '{event}'가 미국 주식시장(S&P500, NASDAQ)에 미치는 영향을 분석해줘.\n"
             "1. 수혜 예상 섹터와 대표 종목 3개 (가능하면 yfinance로 최근 주가 흐름 포함)\n"
             "2. 피해 예상 섹터와 대표 종목 3개 (가능하면 yfinance로 최근 주가 흐름 포함)\n"
@@ -2888,6 +2890,7 @@ class TelegramAIBot:
         logger.info(f"/theme query - user={user_id}, theme='{theme[:50]}'")
         search_query = f"{theme} 테마주 뉴스 {today}"
         analysis_prompt = (
+            f"오늘은 {today} 기준입니다. '최근/현재'는 이 시점으로 해석하세요.\n"
             f"위 검색 결과를 바탕으로, 한국 주식시장에서 '{theme}' 테마의 현재 건강도를 진단해줘.\n"
             "1. 테마 온도 (🟢과열/🟡적정/🔴냉각 중 택1, 근거 포함)\n"
             "2. 대장주 3개와 최근 주가 동향\n"
@@ -2938,6 +2941,7 @@ class TelegramAIBot:
         logger.info(f"/us_theme query - user={user_id}, theme='{theme[:50]}'")
         search_query = f"{theme} sector stocks news {today}"
         analysis_prompt = (
+            f"오늘은 {today} 기준입니다. '최근/현재'는 이 시점으로 해석하세요.\n"
             f"위 검색 결과를 바탕으로, 미국 주식시장(S&P500, NASDAQ)에서 '{theme}' 테마의 현재 건강도를 진단해줘.\n"
             "1. 테마 온도 (🟢과열/🟡적정/🔴냉각 중 택1, 근거 포함)\n"
             "2. 대장주 3개와 최근 주가 동향 (yfinance 실시간 데이터 기반)\n"


### PR DESCRIPTION
## 근본 원인

`/ask`(및 `/signal` `/theme` `/us_signal` `/us_theme`)의 **답장(reply) 후속 대화**는 Sonnet 4.6 + `kospi_kosdaq`/`yahoo_finance` **MCP 도구**로 실시간 조회합니다. 그런데 해당 에이전트(`generate_firecrawl_followup_response`) instruction에 **현재 날짜 앵커가 없고 `time` 서버도 없었습니다.**

→ Sonnet이 `get_stock_ohlcv`/`get_historical_stock_prices`의 날짜 범위를 **자기 학습 시점(약 1년 전)** 으로 계산 → "툴호출 시 1년 전 데이터 조회" 증상.

정식 종목분석 에이전트(`report_generator.py` 681~1210)는 이미 `현재 날짜:{current_date}` 주입 + `time` 서버 + `get_current_time` 사용으로 이 문제를 피하고 있어서, **검증된 동일 패턴**을 봇 경로에 적용했습니다.

## 변경

**`report_generator.py`**
- `_FIRECRAWL_CMD_SERVERS`: 5개 명령어 전부에 `time` 서버 추가 → followup이 `get_current_time` 호출 가능
- `generate_firecrawl_followup_response`: instruction에 "오늘은 {today}" + "기간 기반 도구 조회는 이 연도 기준, 학습시점 연도 쓰지 말 것, 가능하면 get_current_time으로 확인" 명시
- `generate_firecrawl_search_response`: instruction에 현재 날짜 명시 → '최근/올해/현재' 올바른 해석

**`telegram_ai_bot.py`**
- signal/theme/us_signal/us_theme의 `analysis_prompt`에 날짜 명시 (기존엔 검색 쿼리에만 있었음. `/ask`는 이미 프롬프트에 날짜 있었음)

## 안전성

- **프롬프트 전용 변경.** 로직·도구 배선 변경 없음(이미 설정된 `time` 서버 추가만)
- `ast.parse` 양쪽 파일 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)