### PR TITLE
feat: 강세장 추가매수(피라미딩) — 독립 행 모델 (#288, KR+US)

### DIFF
--- a/prism-us/tracking/__init__.py
+++ b/prism-us/tracking/__init__.py
@@ -17,6 +17,10 @@ from .db_schema import (
     is_us_ticker_in_holdings,
     get_us_holdings_count,
     get_us_holding,
+    get_us_existing_position_for_ticker,
+    evaluate_us_pyramid_add_gate,
+    compute_us_fractional_sell_quantity,
+    decide_us_sell_plan,
 )
 
 from .journal import USJournalManager
@@ -33,6 +37,10 @@ __all__ = [
     "is_us_ticker_in_holdings",
     "get_us_holdings_count",
     "get_us_holding",
+    "get_us_existing_position_for_ticker",
+    "evaluate_us_pyramid_add_gate",
+    "compute_us_fractional_sell_quantity",
+    "decide_us_sell_plan",
     # Journal
     "USJournalManager",
     # Compression

--- a/prism-us/tracking/db_schema.py
+++ b/prism-us/tracking/db_schema.py
@@ -55,8 +55,7 @@ CREATE TABLE IF NOT EXISTS us_stock_holdings (
     stop_loss REAL,                    -- USD
     trigger_type TEXT,                 -- intraday_surge, volume_surge, gap_up, etc.
     trigger_mode TEXT,                 -- morning, afternoon
-    sector TEXT,                       -- GICS sector (Technology, Healthcare, etc.)
-    UNIQUE(account_key, ticker)
+    sector TEXT                        -- GICS sector (Technology, Healthcare, etc.)
 )
 """
 
@@ -574,6 +573,85 @@ def migrate_multi_account_schema(cursor, conn):
         )
 
 
+def _us_holdings_table_has_unique_constraint(cursor, table_name: str) -> bool:
+    """Detect whether ``table_name`` was created with a UNIQUE constraint by
+    reading its CREATE statement from sqlite_master."""
+    cursor.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name = ?",
+        (table_name,),
+    )
+    row = cursor.fetchone()
+    if not row or not row[0]:
+        return False
+    return "UNIQUE" in row[0].upper()
+
+
+def migrate_drop_us_holdings_unique_constraint(cursor, conn):
+    """Drop the legacy UNIQUE(account_key, ticker) constraint from us_stock_holdings
+    so pyramiding (#288) can store multiple independent rows per ticker.
+
+    Idempotent and safe to run repeatedly. Preserves ALL rows using the same
+    backup -> rename-to-legacy -> create-new -> copy-all -> verify -> drop-legacy
+    pattern as the multi-account migration.
+    """
+    table_name = "us_stock_holdings"
+    if not _table_exists(cursor, table_name):
+        return
+
+    # Recover from an interrupted run before deciding.
+    _recover_interrupted_migration(cursor, conn, table_name)
+
+    if not _us_holdings_table_has_unique_constraint(cursor, table_name):
+        return  # already migrated (or never had it) -> no-op
+
+    legacy_table = f"{table_name}_legacy"
+    backup_table = f"{table_name}_pre_pyramiding_backup"
+
+    if _table_exists(cursor, legacy_table):
+        raise RuntimeError(
+            f"Ambiguous migration state for {table_name}: legacy table {legacy_table} already exists. "
+            "Manual intervention is required."
+        )
+
+    if not _table_exists(cursor, backup_table):
+        logger.info(f"Creating backup table {backup_table} before dropping UNIQUE on {table_name}")
+        cursor.execute(f"CREATE TABLE {backup_table} AS SELECT * FROM {table_name}")
+        conn.commit()
+    else:
+        logger.warning(f"Preserving existing backup table {backup_table} for {table_name}")
+
+    logger.info(f"Dropping UNIQUE(account_key, ticker) constraint on {table_name} (pyramiding migration)")
+
+    try:
+        cursor.execute(f"ALTER TABLE {table_name} RENAME TO {legacy_table}")
+        cursor.execute(TABLE_US_STOCK_HOLDINGS)  # canonical CREATE (UNIQUE-free)
+
+        columns = _get_columns(cursor, legacy_table)
+        col_list = ", ".join(columns)
+        cursor.execute(
+            f"INSERT INTO {table_name} ({col_list}) SELECT {col_list} FROM {legacy_table}"
+        )
+
+        source_count = _count_rows(cursor, legacy_table)
+        target_count = _count_rows(cursor, table_name)
+        if source_count != target_count:
+            raise RuntimeError(
+                f"Row count mismatch during {table_name} UNIQUE-drop migration: "
+                f"{legacy_table}={source_count}, {table_name}={target_count}"
+            )
+
+        cursor.execute(f"DROP TABLE {legacy_table}")
+        conn.commit()
+        logger.info(
+            f"{table_name} UNIQUE-drop migration complete ({target_count} rows preserved). "
+            f"Backup table {backup_table} retained for manual cleanup."
+        )
+    except Exception as exc:
+        logger.error(f"{table_name} UNIQUE-drop migration failed: {exc}")
+        logger.error(f"Manual recovery is available from backup table {backup_table}")
+        raise
+
+
 def create_us_tables(cursor, conn):
     """
     Create all US-specific database tables.
@@ -600,6 +678,7 @@ def create_us_tables(cursor, conn):
             logger.error(f"Error creating table {table_name}: {e}")
 
     migrate_multi_account_schema(cursor, conn)
+    migrate_drop_us_holdings_unique_constraint(cursor, conn)
     conn.commit()
     logger.info("US database tables created")
 
@@ -881,6 +960,134 @@ def is_us_ticker_in_holdings(cursor, ticker: str, account_key: Optional[str] = N
             (ticker,)
         )
     return cursor.fetchone()[0] > 0
+
+
+# ── Pyramiding (#288) ──────────────────────────────────────────────────────
+# Strong-bull add-on / pyramiding helpers for US. Mirror of the KR helpers in
+# tracking/helpers.py. Each pyramid entry is an independent us_stock_holdings row.
+
+# Market regimes in which pyramiding is allowed.
+US_PYRAMID_ALLOWED_REGIMES = ("strong_bull", "parabolic")
+US_PYRAMID_MIN_PROFIT_PCT = 5.0
+US_PYRAMID_MAX_ROWS = 3
+
+
+def get_us_existing_position_for_ticker(cursor, ticker: str, account_key: Optional[str] = None) -> dict:
+    """Aggregate the existing US holding for a ticker/account.
+
+    Returns {row_count, avg_buy_price}. Used by the pyramiding add-gate.
+
+    NOTE (#288, intentional): ``avg_buy_price`` is a SIMPLE MEAN of per-row entry
+    prices, NOT a share-weighted average. The independent-row model deliberately
+    stores no per-row quantity in ``us_stock_holdings``, and each add is ~1 unit,
+    so the simple mean is an accurate-enough proxy for both the +5% profit gate
+    and the Telegram "New Avg Price" display.
+    """
+    try:
+        if account_key:
+            cursor.execute(
+                "SELECT buy_price FROM us_stock_holdings WHERE ticker = ? AND account_key = ?",
+                (ticker, account_key),
+            )
+        else:
+            cursor.execute(
+                "SELECT buy_price FROM us_stock_holdings WHERE ticker = ?",
+                (ticker,),
+            )
+        prices = [float(r[0]) for r in cursor.fetchall() if r[0] is not None]
+        row_count = len(prices)
+        avg_buy_price = (sum(prices) / row_count) if row_count else 0.0
+        return {"row_count": row_count, "avg_buy_price": avg_buy_price}
+    except Exception as e:
+        logger.error(f"Error querying existing US position for {ticker}: {e}")
+        return {"row_count": 0, "avg_buy_price": 0.0}
+
+
+def _us_regime_label(market_condition) -> str:
+    """Extract the leading regime label from a market_condition string.
+
+    Mirror of KR ``_regime_label``: take the token before the first ':',
+    normalise, and canonicalise hyphen/space to underscore so "strong-bull"
+    maps to "strong_bull". Fail-closed: unrecognised -> "" (no add).
+    """
+    if not market_condition or not isinstance(market_condition, str):
+        return ""
+    text = market_condition.split(":", 1)[0].strip().lower()
+    text = text.replace("-", "_").replace(" ", "_")
+    return text
+
+
+def evaluate_us_pyramid_add_gate(
+    market_condition,
+    existing_avg_buy_price: float,
+    current_price: float,
+    existing_row_count: int,
+    min_profit_pct: float = US_PYRAMID_MIN_PROFIT_PCT,
+    max_rows: int = US_PYRAMID_MAX_ROWS,
+):
+    """Pure add-gate for US pyramiding (#288). Returns (allowed, reason).
+
+    All of: regime in allowed set, aggregate profit >= min_profit_pct,
+    existing_row_count < max_rows. Buy-agent Enter/score/sector checks apply
+    independently in the normal buy path.
+    """
+    regime = _us_regime_label(market_condition)
+    if regime not in US_PYRAMID_ALLOWED_REGIMES:
+        return False, f"regime '{regime or 'unknown'}' not in {US_PYRAMID_ALLOWED_REGIMES}"
+    if existing_row_count >= max_rows:
+        return False, f"row count {existing_row_count} >= max {max_rows}"
+    if not existing_avg_buy_price or existing_avg_buy_price <= 0 or not current_price or current_price <= 0:
+        return False, "insufficient price data for profit check"
+    profit_pct = (current_price - existing_avg_buy_price) / existing_avg_buy_price * 100.0
+    if profit_pct < min_profit_pct:
+        return False, f"profit {profit_pct:.2f}% < required {min_profit_pct:.1f}%"
+    return True, f"add allowed (regime={regime}, profit={profit_pct:.2f}%, rows={existing_row_count})"
+
+
+def compute_us_fractional_sell_quantity(total_quantity: int, remaining_rows: int) -> int:
+    """Shares to sell for one row when ``remaining_rows`` rows remain (US, #288).
+
+    remaining_rows <= 1 -> sell all; remaining_rows > 1 -> floor(total/remaining).
+    Recomputed live each sell so the last row sweeps the remainder.
+    """
+    try:
+        total = int(total_quantity)
+        n = int(remaining_rows)
+    except (TypeError, ValueError):
+        return int(total_quantity) if total_quantity else 0
+    if total <= 0:
+        return 0
+    if n <= 1:
+        return total
+    return total // n
+
+
+def decide_us_sell_plan(remaining_rows: int, will_queue: bool) -> str:
+    """Decide how to execute a US sell for a (possibly pyramided) ticker (#288, FIX 1).
+
+    Pure decision branch — keeps the timing-dependent choice testable.
+
+    Args:
+        remaining_rows: number of us_stock_holdings rows for this (ticker, account)
+            INCLUDING the row currently being sold (i.e. >=1).
+        will_queue: True when the KIS sell order would be QUEUED for the pending-
+            order batch instead of executing now (market closed AND reserved-order
+            window unavailable). The pending-order queue does NOT carry a partial
+            quantity, so a queued fractional order would later full-liquidate the
+            broker position while only one DB row was removed -> DB/broker desync.
+
+    Returns one of:
+        "single_full"  - one row left: sell the whole position (unchanged legacy).
+        "fractional"   - N>1 and order executes now: sell floor(available/N), one row.
+        "full_exit"    - N>1 but order WILL be queued: exit the ENTIRE position
+                          (full quantity) and delete ALL rows for the ticker, so
+                          the queued full-liquidation stays consistent with the DB.
+    """
+    if remaining_rows <= 1:
+        return "single_full"
+    if will_queue:
+        return "full_exit"
+    return "fractional"
 
 
 if __name__ == "__main__":

--- a/prism-us/trading/us_stock_trading.py
+++ b/prism-us/trading/us_stock_trading.py
@@ -95,6 +95,25 @@ def _safe_int(value, default: int = 0) -> int:
     except (ValueError, TypeError):
         return default
 
+
+def _resolve_sell_quantity(holding_quantity: int, quantity: int = None) -> int:
+    """Resolve the number of shares to sell (US, #288).
+
+    When ``quantity`` is None the full holding is sold (unchanged behavior).
+    When given, the requested partial quantity is used, clamped to
+    [1, holding_quantity] to avoid over-selling.
+    """
+    if quantity is None:
+        return holding_quantity
+    try:
+        q = int(quantity)
+    except (TypeError, ValueError):
+        return holding_quantity
+    if q <= 0:
+        return holding_quantity
+    return min(q, holding_quantity)
+
+
 # Exchange code mapping (for trading/portfolio APIs using OVRS_EXCG_CD)
 EXCHANGE_CODES = {
     "NASDAQ": "NASD",
@@ -697,9 +716,9 @@ class USStockTrading:
         return 0
 
     def sell_all_market_price(self, ticker: str, exchange: str = None,
-                              limit_price: float = None) -> Dict[str, Any]:
+                              limit_price: float = None, quantity: int = None) -> Dict[str, Any]:
         """
-        Sell all holdings at current market price (limit order at current price).
+        Sell holdings at current market price (limit order at current price).
 
         KIS TTTT1006U does not support ORD_DVSN "01" (market order) for sell.
         Valid values: 00=limit, 31=MOO, 32=LOO, 33=MOC, 34=LOC.
@@ -711,6 +730,7 @@ class USStockTrading:
             exchange: Exchange code
             limit_price: Current price to use as limit price. If not provided,
                          fetched automatically.
+            quantity: Partial sell quantity (None = full holding, unchanged).
 
         Returns:
             Order result dict
@@ -730,9 +750,9 @@ class USStockTrading:
             exchange = EXCHANGE_CODES.get(exchange.upper(), exchange)
 
         # Check holding quantity
-        quantity = self.get_holding_quantity(ticker)
+        holding_quantity = self.get_holding_quantity(ticker)
 
-        if quantity == 0:
+        if holding_quantity == 0:
             return {
                 'success': False,
                 'order_no': None,
@@ -740,6 +760,9 @@ class USStockTrading:
                 'quantity': 0,
                 'message': 'No holdings to sell'
             }
+
+        # Determine sell quantity (partial when quantity given, else full holding)
+        quantity = _resolve_sell_quantity(holding_quantity, quantity)
 
         # Fetch current price if not provided
         if not limit_price or limit_price <= 0:
@@ -1077,7 +1100,7 @@ class USStockTrading:
             }
 
     def sell_reserved_order(self, ticker: str, limit_price: float = None,
-                            use_moo: bool = False, exchange: str = None) -> Dict[str, Any]:
+                            use_moo: bool = False, exchange: str = None, quantity: int = None) -> Dict[str, Any]:
         """
         Reserved order sell for US stock (executed at next market open)
         Reserved sell order - automatically executed at next market open
@@ -1089,6 +1112,10 @@ class USStockTrading:
             limit_price: Limit price in USD (required if use_moo is False)
             use_moo: Use Market On Open order (default: False)
             exchange: Exchange code
+            quantity: Partial sell quantity (None = full holding, unchanged).
+                      NOTE: when the order must be queued for the pending-order
+                      batch (outside reserved-order window), the queued order
+                      liquidates the full holding (partial not supported there).
 
         Returns:
             Order result dict
@@ -1124,9 +1151,9 @@ class USStockTrading:
             )
 
         # Check holding quantity
-        quantity = self.get_holding_quantity(ticker)
+        holding_quantity = self.get_holding_quantity(ticker)
 
-        if quantity == 0:
+        if holding_quantity == 0:
             return {
                 'success': False,
                 'order_no': None,
@@ -1134,6 +1161,9 @@ class USStockTrading:
                 'quantity': 0,
                 'message': 'No holdings to sell'
             }
+
+        # Determine sell quantity (partial when quantity given, else full holding)
+        quantity = _resolve_sell_quantity(holding_quantity, quantity)
 
         # Reserved order API
         api_url = "/uapi/overseas-stock/v1/trading/order-resv"
@@ -1262,7 +1292,7 @@ class USStockTrading:
                 }
 
     def smart_sell_all(self, ticker: str, exchange: str = None,
-                       limit_price: float = None, use_moo: bool = False) -> Dict[str, Any]:
+                       limit_price: float = None, use_moo: bool = False, quantity: int = None) -> Dict[str, Any]:
         """
         Smart sell - automatically choose best method based on market hours
 
@@ -1276,6 +1306,7 @@ class USStockTrading:
             exchange: Exchange code
             limit_price: Limit price for reserved order when market is closed
             use_moo: Use Market On Open for reserved order (default: False)
+            quantity: Partial sell quantity (None = full holding, unchanged behavior)
 
         Returns:
             Order result dict
@@ -1291,15 +1322,15 @@ class USStockTrading:
 
         if self.is_market_open():
             logger.info(f"[{ticker}] Market is open - executing market sell")
-            return self.sell_all_market_price(ticker, exchange, limit_price=limit_price)
+            return self.sell_all_market_price(ticker, exchange, limit_price=limit_price, quantity=quantity)
         else:
             # Market is closed - use reserved order
             if limit_price and limit_price > 0:
                 logger.info(f"[{ticker}] Market is closed - placing reserved sell order (limit: ${limit_price:.2f})")
-                return self.sell_reserved_order(ticker, limit_price, use_moo=False, exchange=exchange)
+                return self.sell_reserved_order(ticker, limit_price, use_moo=False, exchange=exchange, quantity=quantity)
             elif use_moo:
                 logger.info(f"[{ticker}] Market is closed - placing reserved MOO sell order")
-                return self.sell_reserved_order(ticker, limit_price=None, use_moo=True, exchange=exchange)
+                return self.sell_reserved_order(ticker, limit_price=None, use_moo=True, exchange=exchange, quantity=quantity)
             else:
                 logger.warning(f"[{ticker}] Market is closed and no limit_price/use_moo provided")
                 return {
@@ -1438,7 +1469,7 @@ class USStockTrading:
 
     async def async_sell_stock(self, ticker: str, exchange: str = None,
                                timeout: float = 30.0, limit_price: Optional[float] = None,
-                               use_moo: bool = False) -> Dict[str, Any]:
+                               use_moo: bool = False, quantity: Optional[int] = None) -> Dict[str, Any]:
         """
         Async sell API with timeout
 
@@ -1448,13 +1479,14 @@ class USStockTrading:
             timeout: Timeout in seconds
             limit_price: Limit price for reserved order when market is closed
             use_moo: Use Market On Open for reserved order
+            quantity: Partial sell quantity (None = full holding, unchanged behavior)
 
         Returns:
             Order result dict
         """
         try:
             return await asyncio.wait_for(
-                self._execute_sell_stock(ticker, exchange, limit_price, use_moo),
+                self._execute_sell_stock(ticker, exchange, limit_price, use_moo, quantity=quantity),
                 timeout=timeout
             )
         except asyncio.TimeoutError:
@@ -1470,8 +1502,11 @@ class USStockTrading:
             }
 
     async def _execute_sell_stock(self, ticker: str, exchange: str = None,
-                                  limit_price: float = None, use_moo: bool = False) -> Dict[str, Any]:
-        """Execute sell stock logic with portfolio verification"""
+                                  limit_price: float = None, use_moo: bool = False, quantity: int = None) -> Dict[str, Any]:
+        """Execute sell stock logic with portfolio verification
+
+        quantity: partial sell quantity (None = full holding, unchanged behavior)
+        """
         result = {
             'success': False,
             'ticker': ticker,
@@ -1530,11 +1565,14 @@ class USStockTrading:
                             logger.warning(f"[Async Sell] {ticker} no valid limit_price, using MOO")
                             effective_use_moo = True
 
-                        logger.info(f"[Async Sell] {ticker} limit_price: ${effective_limit_price:.2f}, use_moo: {effective_use_moo}")
+                        # Resolve partial sell quantity (None = full holding)
+                        sell_quantity = _resolve_sell_quantity(target_stock['quantity'], quantity)
+
+                        logger.info(f"[Async Sell] {ticker} limit_price: ${effective_limit_price:.2f}, use_moo: {effective_use_moo}, qty: {sell_quantity}/{target_stock['quantity']}")
 
                         # Execute sell
                         sell_result = await asyncio.to_thread(
-                            self.smart_sell_all, ticker, exchange, effective_limit_price if effective_limit_price > 0 else None, effective_use_moo
+                            self.smart_sell_all, ticker, exchange, effective_limit_price if effective_limit_price > 0 else None, effective_use_moo, sell_quantity
                         )
 
                         if sell_result['success']:
@@ -1781,7 +1819,7 @@ class MultiAccountUSStockTrading:
 
     async def async_sell_stock(self, ticker: str, exchange: str = None,
                                timeout: float = 30.0, limit_price: Optional[float] = None,
-                               use_moo: bool = False) -> Dict[str, Any]:
+                               use_moo: bool = False, quantity: Optional[int] = None) -> Dict[str, Any]:
         if not self.account_configs:
             return self._aggregate_results(ticker, [], action="sell")
         results = []
@@ -1793,6 +1831,7 @@ class MultiAccountUSStockTrading:
                 timeout=timeout,
                 limit_price=limit_price,
                 use_moo=use_moo,
+                quantity=quantity,
             )
             result["account_name"] = account["name"]
             result["account_key"] = account["account_key"]

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -132,6 +132,10 @@ try:
         migrate_us_watchlist_history_columns,
         is_us_ticker_in_holdings,
         get_us_holdings_count,
+        get_us_existing_position_for_ticker,
+        evaluate_us_pyramid_add_gate,
+        compute_us_fractional_sell_quantity,
+        decide_us_sell_plan,
     )
     from tracking.journal import USJournalManager
     from tracking.compression import USCompressionManager
@@ -151,6 +155,10 @@ except ImportError as e:
         migrate_us_watchlist_history_columns,
         is_us_ticker_in_holdings,
         get_us_holdings_count,
+        get_us_existing_position_for_ticker,
+        evaluate_us_pyramid_add_gate,
+        compute_us_fractional_sell_quantity,
+        decide_us_sell_plan,
     )
     from tracking.journal import USJournalManager
     from tracking.compression import USCompressionManager
@@ -843,14 +851,31 @@ class USStockTrackingAgent:
         ticker = analysis_result.get("ticker")
         company_name = analysis_result.get("company_name")
         if await self._is_ticker_in_holdings(ticker):
-            logger.info(f"{ticker} ({company_name}) already in holdings")
-            return {
-                "success": True,
-                "decision": "holding",
-                "ticker": ticker,
-                "company_name": company_name,
-                "current_price": analysis_result.get("current_price", 0)
-            }
+            # Pyramiding (#288): allow an additional independent entry only when the
+            # strong-bull add-gate passes. Otherwise keep the legacy hard block.
+            scenario = analysis_result.get("scenario", {}) or {}
+            current_price = analysis_result.get("current_price", 0)
+            account_key = self._account_scope()[0]
+            existing = get_us_existing_position_for_ticker(self.cursor, ticker, account_key=account_key)
+            allowed, reason = evaluate_us_pyramid_add_gate(
+                market_condition=scenario.get("market_condition", ""),
+                existing_avg_buy_price=existing.get("avg_buy_price", 0.0),
+                current_price=current_price,
+                existing_row_count=existing.get("row_count", 0),
+            )
+            if not allowed:
+                logger.info(f"{ticker} ({company_name}) already in holdings — add gate blocked: {reason}")
+                return {
+                    "success": True,
+                    "decision": "holding",
+                    "ticker": ticker,
+                    "company_name": company_name,
+                    "current_price": current_price
+                }
+            logger.info(f"{ticker} ({company_name}) pyramiding add gate passed: {reason}")
+            analysis_result["is_add"] = True
+            analysis_result["existing_avg_buy_price"] = existing.get("avg_buy_price", 0.0)
+            analysis_result["existing_row_count"] = existing.get("row_count", 0)
 
         analysis_result["sector_diverse"] = await self._check_sector_diversity(
             analysis_result.get("sector", "Unknown")
@@ -858,7 +883,7 @@ class USStockTrackingAgent:
         return analysis_result
 
     async def buy_stock(self, ticker: str, company_name: str, current_price: float,
-                        scenario: Dict[str, Any], rank_change_msg: str = "") -> bool:
+                        scenario: Dict[str, Any], rank_change_msg: str = "", is_add: bool = False) -> bool:
         """
         Process stock purchase.
 
@@ -868,13 +893,15 @@ class USStockTrackingAgent:
             current_price: Current stock price in USD
             scenario: Trading scenario information
             rank_change_msg: Trading value ranking change info
+            is_add: Pyramiding add (#288) — bypass the already-holding re-check and
+                    insert an independent additional row instead of a first entry.
 
         Returns:
             bool: Purchase success status
         """
         try:
-            # Check if already holding
-            if await self._is_ticker_in_holdings(ticker):
+            # Check if already holding (skipped for a pyramiding add)
+            if not is_add and await self._is_ticker_in_holdings(ticker):
                 logger.warning(f"{ticker} ({company_name}) already in holdings")
                 return False
 
@@ -920,16 +947,31 @@ class USStockTrackingAgent:
             )
             self.conn.commit()
 
-            # Build buy message (same format as KR template)
+            # Build buy message (same format as KR template).
+            # Pyramiding adds (#288) get a distinct header showing the entry number
+            # and the new aggregate average price.
             target_price = scenario.get('target_price', 0)
             stop_loss = scenario.get('stop_loss', 0)
 
-            message = f"📈 New Buy: {company_name}({ticker})\n" \
-                      f"Buy Price: ${current_price:,.2f}\n" \
-                      f"Target: ${target_price:,.2f}\n" \
-                      f"Stop Loss: ${stop_loss:,.2f}\n" \
-                      f"Period: {scenario.get('investment_period', 'short')}\n" \
-                      f"Sector: {scenario.get('sector', 'Unknown')}\n"
+            if is_add:
+                agg = get_us_existing_position_for_ticker(self.cursor, ticker, account_key=account_key)
+                entry_no = agg.get("row_count", 1)  # this entry is the Nth row
+                new_avg = agg.get("avg_buy_price", current_price)
+                message = f"📈 Add-On Entry (#{entry_no}): {company_name}({ticker})\n" \
+                          f"This Entry: ${current_price:,.2f}\n" \
+                          f"New Avg Price: ${new_avg:,.2f}\n" \
+                          f"⚠️ Portfolio weight increased (1 independent slot consumed)\n" \
+                          f"Target: ${target_price:,.2f}\n" \
+                          f"Stop Loss: ${stop_loss:,.2f}\n" \
+                          f"Period: {scenario.get('investment_period', 'short')}\n" \
+                          f"Sector: {scenario.get('sector', 'Unknown')}\n"
+            else:
+                message = f"📈 New Buy: {company_name}({ticker})\n" \
+                          f"Buy Price: ${current_price:,.2f}\n" \
+                          f"Target: ${target_price:,.2f}\n" \
+                          f"Stop Loss: ${stop_loss:,.2f}\n" \
+                          f"Period: {scenario.get('investment_period', 'short')}\n" \
+                          f"Sector: {scenario.get('sector', 'Unknown')}\n"
 
             # Add trigger win rate
             trigger_win_rate = self._get_trigger_win_rate(trigger_type)
@@ -1252,10 +1294,19 @@ class USStockTrackingAgent:
                         highest_price = current_price
                         scenario_data['highest_price'] = highest_price
                         updated_scenario_str = json.dumps(scenario_data, ensure_ascii=False)
-                        self.cursor.execute(
-                            "UPDATE us_stock_holdings SET scenario = ? WHERE ticker = ? AND account_key = ?",
-                            (updated_scenario_str, ticker, self._account_scope()[0])
-                        )
+                        # Pyramiding (#288): scope by row id so only THIS row's
+                        # scenario is updated. Fall back to ticker when id missing.
+                        row_id = stock_data.get('id')
+                        if row_id is not None:
+                            self.cursor.execute(
+                                "UPDATE us_stock_holdings SET scenario = ? WHERE id = ?",
+                                (updated_scenario_str, row_id)
+                            )
+                        else:
+                            self.cursor.execute(
+                                "UPDATE us_stock_holdings SET scenario = ? WHERE ticker = ? AND account_key = ?",
+                                (updated_scenario_str, ticker, self._account_scope()[0])
+                            )
                         self.conn.commit()
                         logger.info(f"{ticker} highest_price updated in scenario: ${highest_price:,.2f}")
             except Exception:
@@ -1400,7 +1451,8 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
             # Process portfolio_adjustment when holding (not selling)
             if not should_sell and portfolio_adjustment.get("needed", False):
                 await self._process_portfolio_adjustment(
-                    ticker, company_name, portfolio_adjustment, analysis_summary, current_price
+                    ticker, company_name, portfolio_adjustment, analysis_summary, current_price,
+                    row_id=stock_data.get('id')
                 )
 
             return should_sell, sell_reason
@@ -1495,9 +1547,15 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
         company_name: str,
         portfolio_adjustment: Dict[str, Any],
         analysis_summary: Dict[str, Any],
-        current_price: float = 0
+        current_price: float = 0,
+        row_id: int = None
     ):
-        """Process DB updates and Telegram notifications based on portfolio_adjustment"""
+        """Process DB updates and Telegram notifications based on portfolio_adjustment
+
+        row_id: pyramiding (#288) — when provided, all UPDATEs/SELECT target only
+                this specific holding row (multi-row correctness). Falls back to
+                ticker-scoped queries when None.
+        """
         try:
             if not portfolio_adjustment.get("needed", False):
                 return
@@ -1508,10 +1566,16 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                 return
 
             # Verify holding exists in DB
-            self.cursor.execute(
-                "SELECT target_price, stop_loss FROM us_stock_holdings WHERE ticker = ? AND account_key = ?",
-                (ticker, self._account_scope()[0])
-            )
+            if row_id is not None:
+                self.cursor.execute(
+                    "SELECT target_price, stop_loss FROM us_stock_holdings WHERE id = ?",
+                    (row_id,)
+                )
+            else:
+                self.cursor.execute(
+                    "SELECT target_price, stop_loss FROM us_stock_holdings WHERE ticker = ? AND account_key = ?",
+                    (ticker, self._account_scope()[0])
+                )
             row = self.cursor.fetchone()
             if row is None:
                 logger.warning(f"{ticker} us_stock_holdings SELECT returned None - skipping adjustment")
@@ -1531,10 +1595,16 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                 except (ValueError, TypeError):
                     target_price_num = 0
                 if target_price_num > 0:
-                    self.cursor.execute(
-                        "UPDATE us_stock_holdings SET target_price = ? WHERE ticker = ? AND account_key = ?",
-                        (target_price_num, ticker, self._account_scope()[0])
-                    )
+                    if row_id is not None:
+                        self.cursor.execute(
+                            "UPDATE us_stock_holdings SET target_price = ? WHERE id = ?",
+                            (target_price_num, row_id)
+                        )
+                    else:
+                        self.cursor.execute(
+                            "UPDATE us_stock_holdings SET target_price = ? WHERE ticker = ? AND account_key = ?",
+                            (target_price_num, ticker, self._account_scope()[0])
+                        )
                     self.conn.commit()
                     db_updated = True
                     if target_price_num > old_target_price:
@@ -1568,10 +1638,16 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                             f"${stop_loss_num:,.2f} < ${old_stop_loss:,.2f} — ignoring."
                         )
                     else:
-                        self.cursor.execute(
-                            "UPDATE us_stock_holdings SET stop_loss = ? WHERE ticker = ? AND account_key = ?",
-                            (stop_loss_num, ticker, self._account_scope()[0])
-                        )
+                        if row_id is not None:
+                            self.cursor.execute(
+                                "UPDATE us_stock_holdings SET stop_loss = ? WHERE id = ?",
+                                (stop_loss_num, row_id)
+                            )
+                        else:
+                            self.cursor.execute(
+                                "UPDATE us_stock_holdings SET stop_loss = ? WHERE ticker = ? AND account_key = ?",
+                                (stop_loss_num, ticker, self._account_scope()[0])
+                            )
                         self.conn.commit()
                         db_updated = True
                         if stop_loss_num > old_stop_loss:
@@ -1794,19 +1870,33 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                 )
             )
 
-            # Remove from holdings
-            self.cursor.execute(
-                "DELETE FROM us_stock_holdings WHERE ticker = ? AND account_key = ?",
-                (ticker, account_key)
-            )
-            # Cleanup portfolio adjustment history (lifecycle management)
-            try:
+            # Remove from holdings.
+            # Pyramiding (#288): when the row carries an id AND the ticker has more
+            # than one row for this account, delete ONLY that row (preserving the
+            # remaining independent entries). Single-row tickers keep the legacy
+            # ticker-scoped delete + adjustment-log cleanup (zero behavior change).
+            row_id = stock_data.get('id')
+            existing = get_us_existing_position_for_ticker(self.cursor, ticker, account_key=account_key)
+            is_partial = row_id is not None and existing.get("row_count", 0) > 1
+            if is_partial:
                 self.cursor.execute(
-                    "DELETE FROM us_portfolio_adjustment_log WHERE ticker = ? AND account_key = ?",
+                    "DELETE FROM us_stock_holdings WHERE id = ?",
+                    (row_id,)
+                )
+            else:
+                self.cursor.execute(
+                    "DELETE FROM us_stock_holdings WHERE ticker = ? AND account_key = ?",
                     (ticker, account_key)
                 )
-            except Exception as e:
-                logger.debug(f"{ticker} Cleanup adjustment log skipped: {e}")
+                # Cleanup portfolio adjustment history only when the ticker is fully
+                # exited (no remaining rows).
+                try:
+                    self.cursor.execute(
+                        "DELETE FROM us_portfolio_adjustment_log WHERE ticker = ? AND account_key = ?",
+                        (ticker, account_key)
+                    )
+                except Exception as e:
+                    logger.debug(f"{ticker} Cleanup adjustment log skipped: {e}")
             self.conn.commit()
 
             # Build sell message (same format as KR template)
@@ -1860,8 +1950,10 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
             logger.info("Starting US holdings update")
 
             # Query holdings list
+            # id included for pyramiding (#288): enables per-row delete and
+            # fractional-sell quantity computation for multi-row tickers.
             self.cursor.execute(
-                """SELECT ticker, company_name, buy_price, buy_date, current_price,
+                """SELECT id, ticker, company_name, buy_price, buy_date, current_price,
                    scenario, target_price, stop_loss, last_updated,
                    trigger_type, trigger_mode, sector, account_key, account_name
                    FROM us_stock_holdings
@@ -1876,9 +1968,25 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
 
             sold_stocks = []
 
+            # Pyramiding (#288) FIX 2 — in-pass over-sell guard (mirror of KR):
+            # snapshot the ticker's total broker qty ONCE per pass and distribute
+            # from (snapshot - already_ordered), so unfilled limit/reserved orders
+            # cannot cause an over-sell on later iterations of the same ticker.
+            pass_total_qty: Dict[str, int] = {}   # ticker -> snapshot total qty
+            pass_sold_qty: Dict[str, int] = {}    # ticker -> cumulative ordered qty
+            # FIX 1 — tickers already FULL-exited this pass (all rows sold at once
+            # because the order had to be queued). Their remaining DB rows were
+            # already removed, so skip them when the loop reaches them.
+            fully_exited_tickers: set = set()
+
             for stock in holdings:
                 ticker = stock.get('ticker')
                 company_name = stock.get('company_name')
+
+                # FIX 1: skip rows whose ticker was already fully exited this pass.
+                if ticker in fully_exited_tickers:
+                    logger.info(f"{ticker} already fully exited this pass — skipping remaining row")
+                    continue
 
                 # Query current stock price
                 current_price = await self._get_current_stock_price(ticker)
@@ -1895,10 +2003,68 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                 should_sell, sell_reason = await self._analyze_sell_decision(stock)
 
                 if should_sell:
+                    # Pyramiding (#288): compute remaining row count N for this
+                    # (ticker, account) BEFORE any DB row is deleted by sell_stock.
+                    acct_key = stock.get("account_key")
+                    remaining_rows = get_us_existing_position_for_ticker(
+                        self.cursor, ticker, account_key=acct_key
+                    ).get("row_count", 1)
+
+                    # FIX 1: decide the execution plan. A fractional (N>1) order
+                    # that would be QUEUED for the pending-order batch must NOT be
+                    # sent as a partial (the queue drops the quantity and later
+                    # full-liquidates the broker position). In that case do a FULL
+                    # position exit instead: sell the whole holding once and delete
+                    # ALL rows for the ticker so DB and broker stay consistent.
+                    will_queue = False
+                    if remaining_rows > 1 and current_price > 0:
+                        try:
+                            try:
+                                from trading.us_stock_trading import AsyncUSTradingContext
+                            except ImportError:
+                                from prism_us.trading.us_stock_trading import AsyncUSTradingContext
+                            async with AsyncUSTradingContext(account_name=stock.get("account_name")) as _probe:
+                                # Order gets queued when market is closed AND the
+                                # reserved-order window is unavailable (pre-10:00 KST).
+                                will_queue = (not _probe.is_market_open()) and (not _probe.is_reserved_order_available())
+                        except Exception as probe_err:
+                            logger.warning(f"{ticker} could not probe order window ({probe_err}); assuming will_queue=True (safe full-exit)")
+                            will_queue = True
+
+                    plan = decide_us_sell_plan(remaining_rows, will_queue)
+                    logger.info(f"{ticker} sell plan: {plan} (remaining_rows={remaining_rows}, will_queue={will_queue})")
+
                     # Delete from holding_decisions when selling
                     await self._delete_holding_decision(ticker)
 
-                    sell_success = await self.sell_stock(stock, sell_reason)
+                    if plan == "full_exit":
+                        # Record P&L for EVERY remaining row at current price and
+                        # delete them all (sell_stock deletes one row per call;
+                        # the final call deletes the last row by ticker scope).
+                        self.cursor.execute(
+                            """SELECT id, ticker, company_name, buy_price, buy_date, current_price,
+                               scenario, target_price, stop_loss, last_updated,
+                               trigger_type, trigger_mode, sector, account_key, account_name
+                               FROM us_stock_holdings
+                               WHERE ticker = ? AND account_key = ?""",
+                            (ticker, acct_key),
+                        )
+                        sibling_rows = [dict(r) for r in self.cursor.fetchall()]
+                        sell_success = True
+                        for sib in sibling_rows:
+                            sib['current_price'] = current_price
+                            ok = await self.sell_stock(sib, sell_reason)
+                            sell_success = sell_success and ok
+                        # Mark immediately (independent of KIS result) so the
+                        # already-deleted sibling rows still in the in-memory
+                        # `holdings` snapshot are skipped later this pass.
+                        fully_exited_tickers.add(ticker)
+                        logger.info(
+                            f"{ticker} FULL-EXIT: closed {len(sibling_rows)} pyramid rows "
+                            f"(queued order cannot carry a partial quantity)"
+                        )
+                    else:
+                        sell_success = await self.sell_stock(stock, sell_reason)
 
                     if sell_success:
                         # Execute actual trading
@@ -1912,9 +2078,35 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                                 except ImportError:
                                     from prism_us.trading.us_stock_trading import AsyncUSTradingContext
                                 async with AsyncUSTradingContext(account_name=stock.get("account_name")) as trading:
+                                    # Determine sell quantity.
+                                    # FIX 1: full_exit -> quantity=None (sell whole position).
+                                    # FIX 2: fractional -> distribute from a per-pass snapshot
+                                    # (snapshot - already_ordered) so unfilled orders cannot over-sell.
+                                    sell_quantity = None
+                                    # The FINAL row of a ticker already split THIS pass
+                                    # (plan flips to "single_full" at remaining_rows==1) must also
+                                    # sell from the snapshot remainder, NOT re-query the broker —
+                                    # otherwise unfilled earlier limit orders make get_holding_quantity
+                                    # return the full position and the last row over-sells (#288 FIX 2).
+                                    if plan == "fractional" or (ticker in pass_total_qty and plan == "single_full"):
+                                        if ticker not in pass_total_qty:
+                                            pass_total_qty[ticker] = await asyncio.to_thread(
+                                                trading.get_holding_quantity, ticker
+                                            )
+                                            pass_sold_qty[ticker] = 0
+                                        available = pass_total_qty[ticker] - pass_sold_qty[ticker]
+                                        sell_quantity = compute_us_fractional_sell_quantity(available, remaining_rows)
+                                        pass_sold_qty[ticker] += sell_quantity
+                                        logger.info(
+                                            f"{ticker} pyramiding fractional sell: {sell_quantity} shares "
+                                            f"(available {available} of snapshot {pass_total_qty[ticker]}, "
+                                            f"remaining rows={remaining_rows})"
+                                        )
+                                    # plan == "full_exit" -> sell_quantity stays None (full position);
+                                    # the ticker was already added to fully_exited_tickers above.
                                     # Pass limit_price for reserved orders (required for US market)
                                     # If limit_price is 0, trading module will use MOO (Market On Open)
-                                    trade_result = await trading.async_sell_stock(ticker=ticker, limit_price=current_price)
+                                    trade_result = await trading.async_sell_stock(ticker=ticker, limit_price=current_price, quantity=sell_quantity)
 
                                 if trade_result['success']:
                                     logger.info(f"Actual sell successful: {trade_result['message']}")
@@ -1961,21 +2153,27 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                         except Exception as signal_err:
                             logger.warning(f"GCP sell signal publish failed (non-critical): {signal_err}")
 
-                        sold_stocks.append({
-                            "ticker": ticker,
-                            "company_name": company_name,
-                            "buy_price": stock.get('buy_price', 0),
-                            "sell_price": current_price,
-                            "profit_rate": ((current_price - stock.get('buy_price', 0)) / stock.get('buy_price', 0) * 100) if stock.get('buy_price', 0) > 0 else 0,
-                            "reason": sell_reason,
-                            "account_name": stock.get("account_name"),
-                            "account_label": self._safe_account_log_label(
-                                {
-                                    "name": stock.get("account_name"),
-                                    "account_key": stock.get("account_key"),
-                                }
-                            ),
-                        })
+                        # Report sold rows. For a full_exit, every closed pyramid
+                        # row is reported (so the sell count matches reality);
+                        # otherwise just the single row that triggered the sell.
+                        _exited_rows = sibling_rows if plan == "full_exit" else [stock]
+                        for _row in _exited_rows:
+                            _bp = _row.get('buy_price', 0)
+                            sold_stocks.append({
+                                "ticker": ticker,
+                                "company_name": _row.get('company_name', company_name),
+                                "buy_price": _bp,
+                                "sell_price": current_price,
+                                "profit_rate": ((current_price - _bp) / _bp * 100) if _bp > 0 else 0,
+                                "reason": sell_reason,
+                                "account_name": _row.get("account_name"),
+                                "account_label": self._safe_account_log_label(
+                                    {
+                                        "name": _row.get("account_name"),
+                                        "account_key": _row.get("account_key"),
+                                    }
+                                ),
+                            })
                 else:
                     # Save holding decision when not selling
                     await self._save_holding_decision(ticker, current_price, should_sell, sell_reason, stock)
@@ -2186,9 +2384,24 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     sector = analysis_result.get("sector", "Unknown")
                     rank_change_msg = analysis_result.get("rank_change_msg", "")
 
+                    # Pyramiding (#288): allow an additional independent entry for a
+                    # held ticker only when the strong-bull add-gate passes. Otherwise
+                    # keep the legacy skip. Computed per active account.
+                    is_add = False
                     if await self._is_ticker_in_holdings(ticker):
-                        logger.info(f"Skipping stock in holdings: {ticker}")
-                        continue
+                        acct_key = self._account_scope()[0]
+                        existing = get_us_existing_position_for_ticker(self.cursor, ticker, account_key=acct_key)
+                        allowed, gate_reason = evaluate_us_pyramid_add_gate(
+                            market_condition=scenario.get("market_condition", ""),
+                            existing_avg_buy_price=existing.get("avg_buy_price", 0.0),
+                            current_price=current_price,
+                            existing_row_count=existing.get("row_count", 0),
+                        )
+                        if not allowed:
+                            logger.info(f"Skipping stock in holdings: {ticker} — add gate blocked: {gate_reason}")
+                            continue
+                        logger.info(f"{ticker} pyramiding add gate passed: {gate_reason}")
+                        is_add = True
 
                     current_slots = await self._get_current_slots_count()
                     if current_slots >= self.max_slots:
@@ -2238,7 +2451,8 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                         logger.info(f"Scenario rationale ({company_name}/{ticker}): {rationale[:300]}")
 
                     if normalized_decision == "entry" and adjusted_score >= min_score and sector_diverse:
-                        buy_success = await self.buy_stock(ticker, company_name, current_price, scenario, rank_change_msg)
+                        # is_add => pyramiding additional independent row (#288)
+                        buy_success = await self.buy_stock(ticker, company_name, current_price, scenario, rank_change_msg, is_add=is_add)
 
                         if buy_success:
                             trade_result = {'success': False, 'message': 'Trading not executed'}

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -66,6 +66,9 @@ from tracking import (
     check_sector_diversity,
     parse_price_value,
     default_scenario,
+    get_existing_position_for_ticker,
+    evaluate_pyramid_add_gate,
+    compute_fractional_sell_quantity,
     analyze_sell_decision,
     format_buy_message,
     format_sell_message,
@@ -502,14 +505,34 @@ class StockTrackingAgent:
 
         is_holding = await self._is_ticker_in_holdings(ticker)
         if is_holding:
-            logger.info(f"{ticker}({company_name}) already in holdings")
-            return {
-                "success": True,
-                "decision": "Already holding",
-                "ticker": ticker,
-                "company_name": company_name,
-                "current_price": analysis_result.get("current_price", 0),
-            }
+            # Pyramiding (#288): allow an additional independent entry only when the
+            # strong-bull add-gate passes. Otherwise keep the legacy hard block.
+            scenario = analysis_result.get("scenario", {}) or {}
+            current_price = analysis_result.get("current_price", 0)
+            account_key, _ = self._account_scope()
+            existing = get_existing_position_for_ticker(self.cursor, ticker, account_key=account_key)
+            allowed, reason = evaluate_pyramid_add_gate(
+                market_condition=scenario.get("market_condition", ""),
+                existing_avg_buy_price=existing.get("avg_buy_price", 0.0),
+                current_price=current_price,
+                existing_row_count=existing.get("row_count", 0),
+            )
+            if not allowed:
+                logger.info(f"{ticker}({company_name}) already in holdings — add gate blocked: {reason}")
+                return {
+                    "success": True,
+                    "decision": "Already holding",
+                    "ticker": ticker,
+                    "company_name": company_name,
+                    "current_price": current_price,
+                }
+
+            logger.info(f"{ticker}({company_name}) pyramiding add gate passed: {reason}")
+            # Tag as an add and pass through to the normal buy path (which still
+            # independently gates on Enter/score/sector_diverse).
+            analysis_result["is_add"] = True
+            analysis_result["existing_avg_buy_price"] = existing.get("avg_buy_price", 0.0)
+            analysis_result["existing_row_count"] = existing.get("row_count", 0)
 
         sector = analysis_result.get("sector", "Unknown")
         analysis_result["sector_diverse"] = await self._check_sector_diversity(sector)
@@ -669,7 +692,7 @@ class StockTrackingAgent:
             logger.error(traceback.format_exc())
             return False
 
-    async def buy_stock(self, ticker: str, company_name: str, current_price: float, scenario: Dict[str, Any], rank_change_msg: str = "") -> bool:
+    async def buy_stock(self, ticker: str, company_name: str, current_price: float, scenario: Dict[str, Any], rank_change_msg: str = "", is_add: bool = False) -> bool:
         """
         Process stock purchase
 
@@ -679,13 +702,15 @@ class StockTrackingAgent:
             current_price: Current stock price
             scenario: Trading scenario information
             rank_change_msg: Trading value ranking change info
+            is_add: Pyramiding add (#288) — bypass the already-holding re-check and
+                    insert an independent additional row instead of a first entry.
 
         Returns:
             bool: Purchase success status
         """
         try:
-            # Check if already holding
-            if await self._is_ticker_in_holdings(ticker):
+            # Check if already holding (skipped for a pyramiding add)
+            if not is_add and await self._is_ticker_in_holdings(ticker):
                 logger.warning(f"{ticker}({company_name}) already in holdings")
                 return False
 
@@ -742,13 +767,27 @@ class StockTrackingAgent:
             )
             self.conn.commit()
 
-            # Add purchase message
-            message = f"📈 신규 매수: {company_name}({ticker})\n" \
-                      f"매수가: {current_price:,.0f}원\n" \
-                      f"목표가: {scenario.get('target_price', 0):,.0f}원\n" \
-                      f"손절가: {scenario.get('stop_loss', 0):,.0f}원\n" \
-                      f"투자기간: {scenario.get('investment_period', '단기')}\n" \
-                      f"산업군: {scenario.get('sector', '알 수 없음')}\n"
+            # Add purchase message — pyramiding adds (#288) get a distinct header
+            # showing the entry number and the new aggregate average price.
+            if is_add:
+                agg = get_existing_position_for_ticker(self.cursor, ticker, account_key=account_key)
+                entry_no = agg.get("row_count", 1)  # this entry is the Nth row
+                new_avg = agg.get("avg_buy_price", current_price)
+                message = f"📈 추가 진입 ({entry_no}차): {company_name}({ticker})\n" \
+                          f"이번 진입가: {current_price:,.0f}원\n" \
+                          f"누적 평단가: {new_avg:,.0f}원\n" \
+                          f"⚠️ 포트폴리오 비중이 증가했습니다 (독립 슬롯 1 소비)\n" \
+                          f"목표가: {scenario.get('target_price', 0):,.0f}원\n" \
+                          f"손절가: {scenario.get('stop_loss', 0):,.0f}원\n" \
+                          f"투자기간: {scenario.get('investment_period', '단기')}\n" \
+                          f"산업군: {scenario.get('sector', '알 수 없음')}\n"
+            else:
+                message = f"📈 신규 매수: {company_name}({ticker})\n" \
+                          f"매수가: {current_price:,.0f}원\n" \
+                          f"목표가: {scenario.get('target_price', 0):,.0f}원\n" \
+                          f"손절가: {scenario.get('stop_loss', 0):,.0f}원\n" \
+                          f"투자기간: {scenario.get('investment_period', '단기')}\n" \
+                          f"산업군: {scenario.get('sector', '알 수 없음')}\n"
 
             # Add trigger win rate
             trigger_win_rate = self._get_trigger_win_rate(trigger_type)
@@ -994,11 +1033,23 @@ class StockTrackingAgent:
                 )
             )
 
-            # Remove from holdings
-            self.cursor.execute(
-                "DELETE FROM stock_holdings WHERE ticker = ? AND account_key = ?",
-                (ticker, account_key)
-            )
+            # Remove from holdings.
+            # Pyramiding (#288): when the row carries an id AND the ticker has more
+            # than one row for this account, delete ONLY that row so the remaining
+            # independent entries are preserved. Single-row tickers keep the legacy
+            # ticker-scoped delete (zero behavior change).
+            row_id = stock_data.get('id')
+            existing = get_existing_position_for_ticker(self.cursor, ticker, account_key=account_key)
+            if row_id is not None and existing.get("row_count", 0) > 1:
+                self.cursor.execute(
+                    "DELETE FROM stock_holdings WHERE id = ?",
+                    (row_id,)
+                )
+            else:
+                self.cursor.execute(
+                    "DELETE FROM stock_holdings WHERE ticker = ? AND account_key = ?",
+                    (ticker, account_key)
+                )
 
             # Save changes
             self.conn.commit()
@@ -1149,8 +1200,10 @@ class StockTrackingAgent:
             logger.info("Starting holdings info update")
 
             # Query holdings list
+            # id included for pyramiding (#288): enables per-row delete and
+            # fractional-sell quantity computation for multi-row tickers.
             self.cursor.execute(
-                """SELECT ticker, company_name, buy_price, buy_date, current_price,
+                """SELECT id, ticker, company_name, buy_price, buy_date, current_price,
                    scenario, target_price, stop_loss, last_updated,
                    trigger_type, trigger_mode, account_key, account_name, sector
                    FROM stock_holdings
@@ -1164,6 +1217,17 @@ class StockTrackingAgent:
                 return []
 
             sold_stocks = []
+
+            # Pyramiding (#288) FIX 2 — in-pass over-sell guard:
+            # When several rows of the SAME ticker sell within one update pass,
+            # limit/reserved orders may not have filled yet, so re-reading the
+            # broker quantity each iteration would see the full (un-decremented)
+            # quantity and over-sell. Instead we snapshot the ticker's total
+            # broker quantity ONCE (first sell of that ticker this pass) and
+            # distribute from the snapshot using an in-pass accumulator —
+            # independent of fill timing.
+            pass_total_qty: Dict[str, int] = {}   # ticker -> snapshot total qty
+            pass_sold_qty: Dict[str, int] = {}    # ticker -> cumulative ordered qty
 
             for stock in holdings:
                 ticker = stock.get('ticker')
@@ -1202,15 +1266,51 @@ class StockTrackingAgent:
                 should_sell, sell_reason = await self._analyze_sell_decision(stock)
 
                 if should_sell:
-                    # Process sell
+                    # Pyramiding (#288): compute remaining row count N for this
+                    # (ticker, account) BEFORE the DB row is deleted by sell_stock.
+                    # N>1 => fractional KIS sell (floor(total/N)); N==1 => sell all
+                    # (unchanged). Recomputed live each sell so the last row sweeps.
+                    remaining_rows = get_existing_position_for_ticker(
+                        self.cursor, ticker, account_key=stock.get("account_key")
+                    ).get("row_count", 1)
+
+                    # Process sell (deletes only this row when N>1, else the ticker)
                     sell_success = await self.sell_stock(stock, sell_reason)
 
                     if sell_success:
                         # Call actual account trading function (async)
                         from trading.domestic_stock_trading import AsyncTradingContext
                         async with AsyncTradingContext(account_name=stock.get("account_name")) as trading:
+                            # Determine fractional sell quantity for multi-row tickers.
+                            # FIX 2: snapshot total qty once per ticker per pass and
+                            # distribute from (snapshot - already_ordered), so fills
+                            # that haven't settled yet cannot cause an over-sell.
+                            sell_quantity = None
+                            # Multi-row tickers sell fractionally. The FINAL row of a
+                            # ticker already split THIS pass (remaining_rows==1 but
+                            # ticker in pass_total_qty) must also sell from the snapshot
+                            # remainder (available), NOT re-query the broker — otherwise,
+                            # if the earlier limit orders are still unfilled, get_holding_quantity
+                            # returns the full position and the last row over-sells (#288 FIX 2).
+                            # Genuinely single-row tickers (never split) keep quantity=None → sell_all.
+                            if remaining_rows > 1 or ticker in pass_total_qty:
+                                if ticker not in pass_total_qty:
+                                    pass_total_qty[ticker] = await asyncio.to_thread(
+                                        trading.get_holding_quantity, ticker
+                                    )
+                                    pass_sold_qty[ticker] = 0
+                                available = pass_total_qty[ticker] - pass_sold_qty[ticker]
+                                sell_quantity = compute_fractional_sell_quantity(available, remaining_rows)
+                                pass_sold_qty[ticker] += sell_quantity
+                                logger.info(
+                                    f"{ticker} pyramiding fractional sell: {sell_quantity} shares "
+                                    f"(available {available} of snapshot {pass_total_qty[ticker]}, "
+                                    f"remaining rows={remaining_rows})"
+                                )
                             # Execute async sell with limit price for reserved orders
-                            trade_result = await trading.async_sell_stock(stock_code=ticker, limit_price=current_price)
+                            trade_result = await trading.async_sell_stock(
+                                stock_code=ticker, limit_price=current_price, quantity=sell_quantity
+                            )
 
                         if trade_result['success']:
                             logger.info(f"Actual sell successful: {trade_result['message']}")

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -407,6 +407,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                 sector_diverse = analysis_result.get("sector_diverse", True)
                 rank_change_percentage = analysis_result.get("rank_change_percentage", 0)
                 rank_change_msg = analysis_result.get("rank_change_msg", "")
+                is_add = analysis_result.get("is_add", False)  # pyramiding (#288)
 
                 # Check entry decision
                 buy_score = scenario.get("buy_score", 0)
@@ -506,8 +507,8 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
 
                 # Process buy if entry decision
                 if decision == "Enter" and buy_score >= min_score and sector_diverse:
-                    # Process buy
-                    buy_success = await self.buy_stock(ticker, company_name, current_price, scenario, rank_change_msg)
+                    # Process buy (is_add => pyramiding additional independent row, #288)
+                    buy_success = await self.buy_stock(ticker, company_name, current_price, scenario, rank_change_msg, is_add=is_add)
 
                     if buy_success:
                         # Call actual account trading function (async)
@@ -565,9 +566,11 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
             logger.error(traceback.format_exc())
             return 0, 0
 
-    async def buy_stock(self, ticker: str, company_name: str, current_price: float, scenario: Dict[str, Any], rank_change_msg: str = "") -> bool:
+    async def buy_stock(self, ticker: str, company_name: str, current_price: float, scenario: Dict[str, Any], rank_change_msg: str = "", is_add: bool = False) -> bool:
         """
         Stock buy processing (override parent class method)
+
+        is_add: pyramiding add (#288) — passed through to the parent buy path.
         """
         try:
             # Calculate dynamically if target price/stop-loss is missing or 0 in scenario
@@ -582,7 +585,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                 logger.info(f"{ticker} Dynamic stop-loss calculated: {stop_loss:,.0f} KRW")
 
             # Call parent class's buy_stock method
-            return await super().buy_stock(ticker, company_name, current_price, scenario, rank_change_msg)
+            return await super().buy_stock(ticker, company_name, current_price, scenario, rank_change_msg, is_add=is_add)
 
         except Exception as e:
             logger.error(f"{ticker} Error during purchase processing: {str(e)}")
@@ -809,10 +812,20 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                         highest_price = current_price
                         scenario_data['highest_price'] = highest_price
                         updated_scenario_str = json.dumps(scenario_data, ensure_ascii=False)
-                        self.cursor.execute(
-                            "UPDATE stock_holdings SET scenario = ? WHERE ticker = ?",
-                            (updated_scenario_str, ticker)
-                        )
+                        # Pyramiding (#288): scope by row id so only THIS row's
+                        # scenario is updated (multi-row tickers). Fall back to
+                        # ticker when id is unavailable (legacy callers).
+                        row_id = stock_data.get('id')
+                        if row_id is not None:
+                            self.cursor.execute(
+                                "UPDATE stock_holdings SET scenario = ? WHERE id = ?",
+                                (updated_scenario_str, row_id)
+                            )
+                        else:
+                            self.cursor.execute(
+                                "UPDATE stock_holdings SET scenario = ? WHERE ticker = ?",
+                                (updated_scenario_str, ticker)
+                            )
                         self.conn.commit()
                         logger.info(f"{ticker} highest_price updated in scenario: {highest_price:,.0f} KRW")
             except:
@@ -1019,7 +1032,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
 
                         # Process portfolio_adjustment
                         if portfolio_adjustment.get("needed", False):
-                            await self._process_portfolio_adjustment(ticker, company_name, portfolio_adjustment, analysis_summary, current_price)
+                            await self._process_portfolio_adjustment(ticker, company_name, portfolio_adjustment, analysis_summary, current_price, row_id=stock_data.get('id'))
                 except Exception as db_err:
                     # Main flow continues even if DB operation fails
                     logger.error(f"{ticker} Error processing holding_decisions DB (main flow continues): {str(db_err)}")
@@ -1137,8 +1150,13 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
             logger.error(f"Error in fallback sell analysis: {str(e)}")
             return False, "Analysis error"
 
-    async def _process_portfolio_adjustment(self, ticker: str, company_name: str, portfolio_adjustment: Dict[str, Any], analysis_summary: Dict[str, Any], current_price: float = 0):
-        """Process DB updates and Telegram notifications based on portfolio_adjustment"""
+    async def _process_portfolio_adjustment(self, ticker: str, company_name: str, portfolio_adjustment: Dict[str, Any], analysis_summary: Dict[str, Any], current_price: float = 0, row_id: int = None):
+        """Process DB updates and Telegram notifications based on portfolio_adjustment
+
+        row_id: pyramiding (#288) — when provided, all UPDATEs/SELECT target only
+                this specific holding row (multi-row correctness). Falls back to
+                ticker-scoped queries when None (legacy/single-row).
+        """
         try:
             # Return if adjustment not needed
             if not portfolio_adjustment.get("needed", False):
@@ -1151,10 +1169,16 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                 return
 
             # Verify holding exists in DB before processing
-            self.cursor.execute(
-                "SELECT target_price, stop_loss FROM stock_holdings WHERE ticker = ?",
-                (ticker,)
-            )
+            if row_id is not None:
+                self.cursor.execute(
+                    "SELECT target_price, stop_loss FROM stock_holdings WHERE id = ?",
+                    (row_id,)
+                )
+            else:
+                self.cursor.execute(
+                    "SELECT target_price, stop_loss FROM stock_holdings WHERE ticker = ?",
+                    (ticker,)
+                )
             row = self.cursor.fetchone()
             if row is None:
                 logger.warning(f"{ticker} stock_holdings SELECT returned None - skipping adjustment")
@@ -1172,10 +1196,16 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                 # Safe number conversion (including comma removal)
                 target_price_num = self._safe_number_conversion(new_target_price)
                 if target_price_num > 0:
-                    self.cursor.execute(
-                        "UPDATE stock_holdings SET target_price = ? WHERE ticker = ?",
-                        (target_price_num, ticker)
-                    )
+                    if row_id is not None:
+                        self.cursor.execute(
+                            "UPDATE stock_holdings SET target_price = ? WHERE id = ?",
+                            (target_price_num, row_id)
+                        )
+                    else:
+                        self.cursor.execute(
+                            "UPDATE stock_holdings SET target_price = ? WHERE ticker = ?",
+                            (target_price_num, ticker)
+                        )
                     self.conn.commit()
                     db_updated = True
                     if target_price_num == old_target_price:
@@ -1210,10 +1240,16 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                             f"{stop_loss_num:,.0f} < {old_stop_loss:,.0f} KRW — 무시합니다."
                         )
                     else:
-                        self.cursor.execute(
-                            "UPDATE stock_holdings SET stop_loss = ? WHERE ticker = ?",
-                            (stop_loss_num, ticker)
-                        )
+                        if row_id is not None:
+                            self.cursor.execute(
+                                "UPDATE stock_holdings SET stop_loss = ? WHERE id = ?",
+                                (stop_loss_num, row_id)
+                            )
+                        else:
+                            self.cursor.execute(
+                                "UPDATE stock_holdings SET stop_loss = ? WHERE ticker = ?",
+                                (stop_loss_num, ticker)
+                            )
                         self.conn.commit()
                         db_updated = True
                         if stop_loss_num == old_stop_loss:

--- a/tests/test_issue_288_pyramiding.py
+++ b/tests/test_issue_288_pyramiding.py
@@ -1,0 +1,486 @@
+"""
+Tests for #288 강세장 추가매수(피라미딩) — independent-row model.
+
+Pure-unit + temp-SQLite tests. Does NOT touch any live DB.
+
+Run:
+    python3 tests/test_issue_288_pyramiding.py
+"""
+
+import ast
+import os
+import sqlite3
+import sys
+import tempfile
+
+# Make project root importable
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+# Import pure helpers directly from the module file (avoid heavy package __init__).
+import importlib.util
+
+
+def _load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_helpers = _load_module(
+    "kr_helpers_for_test", os.path.join(PROJECT_ROOT, "tracking", "helpers.py")
+)
+_db_schema = _load_module(
+    "kr_db_schema_for_test", os.path.join(PROJECT_ROOT, "tracking", "db_schema.py")
+)
+
+evaluate_pyramid_add_gate = _helpers.evaluate_pyramid_add_gate
+compute_fractional_sell_quantity = _helpers.compute_fractional_sell_quantity
+get_existing_position_for_ticker = _helpers.get_existing_position_for_ticker
+migrate_drop_holdings_unique_constraint = _db_schema.migrate_drop_holdings_unique_constraint
+
+# US helpers + migration
+_us_db_schema = _load_module(
+    "us_db_schema_for_test",
+    os.path.join(PROJECT_ROOT, "prism-us", "tracking", "db_schema.py"),
+)
+evaluate_us_pyramid_add_gate = _us_db_schema.evaluate_us_pyramid_add_gate
+compute_us_fractional_sell_quantity = _us_db_schema.compute_us_fractional_sell_quantity
+migrate_drop_us_holdings_unique_constraint = _us_db_schema.migrate_drop_us_holdings_unique_constraint
+decide_us_sell_plan = _us_db_schema.decide_us_sell_plan
+
+
+_PASS = 0
+_FAIL = 0
+
+
+def check(cond, msg):
+    global _PASS, _FAIL
+    if cond:
+        _PASS += 1
+        print(f"  PASS: {msg}")
+    else:
+        _FAIL += 1
+        print(f"  FAIL: {msg}")
+
+
+# ── Old-schema holdings table WITH UNIQUE (pre-migration) ──────────────────
+_OLD_STOCK_HOLDINGS_WITH_UNIQUE = """
+CREATE TABLE stock_holdings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    account_key TEXT NOT NULL,
+    account_name TEXT,
+    ticker TEXT NOT NULL,
+    company_name TEXT NOT NULL,
+    buy_price REAL NOT NULL,
+    buy_date TEXT NOT NULL,
+    current_price REAL,
+    last_updated TEXT,
+    scenario TEXT,
+    target_price REAL,
+    stop_loss REAL,
+    trigger_type TEXT,
+    trigger_mode TEXT,
+    sector TEXT,
+    UNIQUE(account_key, ticker)
+)
+"""
+
+_OLD_US_STOCK_HOLDINGS_WITH_UNIQUE = """
+CREATE TABLE us_stock_holdings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    account_key TEXT NOT NULL,
+    account_name TEXT,
+    ticker TEXT NOT NULL,
+    company_name TEXT NOT NULL,
+    buy_price REAL NOT NULL,
+    buy_date TEXT NOT NULL,
+    current_price REAL,
+    last_updated TEXT,
+    scenario TEXT,
+    target_price REAL,
+    stop_loss REAL,
+    trigger_type TEXT,
+    trigger_mode TEXT,
+    sector TEXT,
+    UNIQUE(account_key, ticker)
+)
+"""
+
+
+def _insert_holding(cur, table, account_key, ticker, buy_price):
+    cur.execute(
+        f"""INSERT INTO {table}
+            (account_key, account_name, ticker, company_name, buy_price, buy_date)
+            VALUES (?, 'acct', ?, ?, ?, '2026-01-01 09:00:00')""",
+        (account_key, ticker, f"{ticker} Inc", buy_price),
+    )
+
+
+def _has_unique(cur, table):
+    cur.execute("SELECT sql FROM sqlite_master WHERE type='table' AND name = ?", (table,))
+    r = cur.fetchone()
+    return bool(r and r[0] and "UNIQUE" in r[0].upper())
+
+
+def _row_count(cur, table):
+    cur.execute(f"SELECT COUNT(*) FROM {table}")
+    return cur.fetchone()[0]
+
+
+# ── Test 1: migration idempotency + data preservation (KR + US) ────────────
+def test_migration():
+    print("\n[Test 1] Migration idempotency + data preservation")
+    fd, path = tempfile.mkstemp(suffix=".sqlite")
+    os.close(fd)
+    try:
+        conn = sqlite3.connect(path)
+        cur = conn.cursor()
+        cur.execute(_OLD_STOCK_HOLDINGS_WITH_UNIQUE)
+        cur.execute(_OLD_US_STOCK_HOLDINGS_WITH_UNIQUE)
+        conn.commit()
+
+        # Seed rows (KR + US)
+        _insert_holding(cur, "stock_holdings", "ACC1", "000660", 100000)
+        _insert_holding(cur, "stock_holdings", "ACC1", "005930", 70000)
+        _insert_holding(cur, "us_stock_holdings", "ACC1", "AAPL", 200.0)
+        conn.commit()
+
+        check(_has_unique(cur, "stock_holdings"), "KR table starts WITH UNIQUE")
+        check(_has_unique(cur, "us_stock_holdings"), "US table starts WITH UNIQUE")
+        kr_before = _row_count(cur, "stock_holdings")
+        us_before = _row_count(cur, "us_stock_holdings")
+
+        # Run KR migration (handles both stock_holdings and us_stock_holdings)
+        migrate_drop_holdings_unique_constraint(cur, conn)
+
+        check(not _has_unique(cur, "stock_holdings"), "KR UNIQUE removed after migration")
+        check(not _has_unique(cur, "us_stock_holdings"), "US UNIQUE removed (via KR migration helper)")
+        check(_row_count(cur, "stock_holdings") == kr_before, f"KR rows preserved ({kr_before})")
+        check(_row_count(cur, "us_stock_holdings") == us_before, f"US rows preserved ({us_before})")
+        check(_has_unique is not None, "sanity")
+
+        # Backup table exists
+        cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='stock_holdings_pre_pyramiding_backup'")
+        check(cur.fetchone() is not None, "KR backup table created")
+
+        # Now duplicate ticker insert should SUCCEED (UNIQUE gone) -> pyramiding row
+        try:
+            _insert_holding(cur, "stock_holdings", "ACC1", "000660", 110000)
+            conn.commit()
+            cur.execute("SELECT COUNT(*) FROM stock_holdings WHERE ticker='000660' AND account_key='ACC1'")
+            dup_count = cur.fetchone()[0]
+            check(dup_count == 2, "duplicate ticker now allowed (2 rows for 000660)")
+        except Exception as e:
+            check(False, f"duplicate ticker insert raised: {e}")
+
+        # Run migration AGAIN -> must be no-op, rows preserved, no error
+        kr_after_dup = _row_count(cur, "stock_holdings")
+        migrate_drop_holdings_unique_constraint(cur, conn)
+        check(_row_count(cur, "stock_holdings") == kr_after_dup, "second run is no-op (rows unchanged)")
+        check(not _has_unique(cur, "stock_holdings"), "still no UNIQUE after second run")
+
+        # US-specific migration entrypoint also idempotent
+        migrate_drop_us_holdings_unique_constraint(cur, conn)
+        check(not _has_unique(cur, "us_stock_holdings"), "US migration entrypoint idempotent")
+
+        conn.close()
+    finally:
+        os.remove(path)
+
+
+# ── Test 2: fractional-sell math ───────────────────────────────────────────
+def test_fractional_sell():
+    print("\n[Test 2] Fractional-sell math")
+
+    # total 33, N=3 -> 11,11,11 ; conserved
+    total = 33
+    sold = []
+    remaining = total
+    for n in (3, 2, 1):
+        q = compute_fractional_sell_quantity(remaining, n)
+        sold.append(q)
+        remaining -= q
+    check(sold == [11, 11, 11], f"33 over N=3,2,1 -> {sold} (expect 11,11,11)")
+    check(sum(sold) == total, "33 conserved")
+    check(remaining == 0, "33 fully swept")
+
+    # total 10, N=3 -> 3, then 7/N=2 -> 3, then 4 ; conserved, last sweeps remainder
+    total = 10
+    sold = []
+    remaining = total
+    for n in (3, 2, 1):
+        q = compute_fractional_sell_quantity(remaining, n)
+        sold.append(q)
+        remaining -= q
+    check(sold == [3, 3, 4], f"10 over N=3,2,1 -> {sold} (expect 3,3,4)")
+    check(sum(sold) == total, "10 conserved")
+    check(remaining == 0, "10 fully swept, last row sweeps remainder")
+
+    # N=1 -> sell all (regression guarantee)
+    check(compute_fractional_sell_quantity(57, 1) == 57, "N=1 sells all (57)")
+    check(compute_fractional_sell_quantity(57, 0) == 57, "N<=1 (0) sells all (defensive)")
+    check(compute_fractional_sell_quantity(0, 3) == 0, "0 holding -> 0")
+
+    # US mirror identical
+    check(compute_us_fractional_sell_quantity(33, 3) == 11, "US 33/3 -> 11")
+    check(compute_us_fractional_sell_quantity(10, 1) == 10, "US N=1 sells all")
+
+
+# ── Test 3: add-gate logic ─────────────────────────────────────────────────
+def test_add_gate():
+    print("\n[Test 3] Add-gate logic (regime / profit / rowcount)")
+
+    # Regime
+    for regime in ("strong_bull: blah", "parabolic: x"):
+        ok, _ = evaluate_pyramid_add_gate(regime, 100.0, 110.0, 0)
+        check(ok, f"regime '{regime.split(':')[0]}' passes")
+    for regime in ("moderate_bull: x", "sideways: x", "moderate_bear: x", "strong_bear: x", "", None):
+        ok, _ = evaluate_pyramid_add_gate(regime, 100.0, 110.0, 0)
+        check(not ok, f"regime '{regime}' fails")
+
+    # Profit: >=+5% pass, <+5% fail
+    ok, _ = evaluate_pyramid_add_gate("strong_bull: x", 100.0, 105.0, 1)
+    check(ok, "+5.0% profit passes")
+    ok, _ = evaluate_pyramid_add_gate("strong_bull: x", 100.0, 104.99, 1)
+    check(not ok, "+4.99% profit fails")
+    ok, _ = evaluate_pyramid_add_gate("strong_bull: x", 100.0, 99.0, 1)
+    check(not ok, "negative profit fails")
+
+    # Rowcount: <3 pass, ==3 fail
+    ok, _ = evaluate_pyramid_add_gate("strong_bull: x", 100.0, 110.0, 0)
+    check(ok, "rowcount 0 < 3 passes")
+    ok, _ = evaluate_pyramid_add_gate("strong_bull: x", 100.0, 110.0, 2)
+    check(ok, "rowcount 2 < 3 passes (the 3rd entry)")
+    ok, _ = evaluate_pyramid_add_gate("strong_bull: x", 100.0, 110.0, 3)
+    check(not ok, "rowcount 3 == max fails (no 4th)")
+
+    # Missing price data
+    ok, _ = evaluate_pyramid_add_gate("strong_bull: x", 0.0, 110.0, 1)
+    check(not ok, "zero avg buy price fails")
+
+    # US mirror
+    ok, _ = evaluate_us_pyramid_add_gate("parabolic: x", 200.0, 220.0, 1)
+    check(ok, "US parabolic +10% rows=1 passes")
+    ok, _ = evaluate_us_pyramid_add_gate("sideways: x", 200.0, 220.0, 1)
+    check(not ok, "US sideways fails")
+
+    # Realistic value (underscore + colon + long Korean description) — FIX 3
+    realistic = "strong_bull: 보고서 기준 KOSPI가 20일선 상회, 외국인 순매수 지속으로 위험선호 강화"
+    ok, _ = evaluate_pyramid_add_gate(realistic, 100.0, 110.0, 1)
+    check(ok, f"realistic 'strong_bull: ...' value passes (KR)")
+    ok, _ = evaluate_us_pyramid_add_gate("parabolic: NASDAQ breadth surging, VIX collapsing", 200.0, 230.0, 0)
+    check(ok, "realistic 'parabolic: ...' value passes (US)")
+
+
+# ── Test 4: single-row regression (N==1 sells all) ─────────────────────────
+def test_single_row_regression():
+    print("\n[Test 4] Single-row regression")
+    fd, path = tempfile.mkstemp(suffix=".sqlite")
+    os.close(fd)
+    try:
+        conn = sqlite3.connect(path)
+        cur = conn.cursor()
+        # Fresh-schema (no UNIQUE) table mirroring canonical CREATE
+        cur.execute(_db_schema.TABLE_STOCK_HOLDINGS)
+        conn.commit()
+        check(not _has_unique(cur, "stock_holdings"), "canonical KR CREATE has NO UNIQUE")
+
+        _insert_holding(cur, "stock_holdings", "ACC1", "000660", 100000)
+        conn.commit()
+
+        existing = get_existing_position_for_ticker(cur, "000660", account_key="ACC1")
+        n = existing["row_count"]
+        check(n == 1, "single-row ticker has row_count 1")
+
+        # With N==1 the fractional helper returns full quantity (sell all)
+        check(compute_fractional_sell_quantity(57, n) == 57, "N==1 => sell all (no behavior change)")
+
+        # avg buy price aggregation correctness for multi-row
+        _insert_holding(cur, "stock_holdings", "ACC1", "000660", 120000)
+        conn.commit()
+        existing2 = get_existing_position_for_ticker(cur, "000660", account_key="ACC1")
+        check(existing2["row_count"] == 2, "two rows after add")
+        check(abs(existing2["avg_buy_price"] - 110000.0) < 1e-6, "avg buy price = 110000 across 2 rows")
+
+        conn.close()
+    finally:
+        os.remove(path)
+
+
+# ── Test 6: FIX 2 — in-pass over-sell distribution from a fixed snapshot ───
+def _distribute_from_snapshot(snapshot, n_rows, broker_qty_each_iter, frac_fn):
+    """Simulate update_holdings' in-pass accumulator distribution.
+
+    broker_qty_each_iter: list mocking what get_holding_quantity() WOULD return
+    on each iteration (we IGNORE these to prove independence from fill timing —
+    the snapshot is taken ONCE on the first iteration only).
+    """
+    pass_total = None
+    pass_sold = 0
+    orders = []
+    remaining_rows = n_rows
+    for i in range(n_rows):
+        if pass_total is None:
+            # snapshot ONCE on first sell of this ticker (mock first reading)
+            pass_total = broker_qty_each_iter[0]
+            pass_sold = 0
+        available = pass_total - pass_sold
+        q = frac_fn(available, remaining_rows)
+        orders.append(q)
+        pass_sold += q
+        remaining_rows -= 1
+    return orders, pass_total
+
+
+def test_oversell_snapshot():
+    print("\n[Test 6] FIX 2 — in-pass over-sell guard (snapshot accumulator)")
+
+    # Broker qty does NOT decrement between iterations (limit orders unfilled).
+    # snapshot=33, 3 rows -> 11/11/11 ; never exceeds snapshot.
+    orders, snap = _distribute_from_snapshot(
+        33, 3, broker_qty_each_iter=[33, 33, 33], frac_fn=compute_fractional_sell_quantity
+    )
+    check(orders == [11, 11, 11], f"snapshot 33, 3 rows (broker stuck at 33) -> {orders}")
+    check(sum(orders) == snap == 33, "sum == snapshot (33), no over-sell")
+
+    # snapshot=10, 3 rows -> 3/3/4, last sweeps remainder, never exceeds.
+    orders, snap = _distribute_from_snapshot(
+        10, 3, broker_qty_each_iter=[10, 10, 10], frac_fn=compute_fractional_sell_quantity
+    )
+    check(orders == [3, 3, 4], f"snapshot 10, 3 rows (broker stuck at 10) -> {orders}")
+    check(sum(orders) == snap == 10, "sum == snapshot (10), last row sweeps remainder")
+
+    # Cumulative ordered must NEVER exceed the snapshot at any point.
+    running = 0
+    for q in orders:
+        running += q
+        check(running <= snap, f"cumulative {running} <= snapshot {snap}")
+
+    # Demonstrate the BUG the fix prevents: naive re-read (broker stuck at 33)
+    # would order floor(33/3)=11, floor(33/2)=16, 33 -> sum 60 >> snapshot 33.
+    naive = [compute_fractional_sell_quantity(33, n) for n in (3, 2, 1)]
+    check(naive == [11, 16, 33] and sum(naive) == 60 > 33,
+          f"naive re-read WOULD over-sell ({naive} sum={sum(naive)} > 33)")
+
+    # US mirror identical
+    us_orders, us_snap = _distribute_from_snapshot(
+        33, 3, broker_qty_each_iter=[33, 33, 33], frac_fn=compute_us_fractional_sell_quantity
+    )
+    check(us_orders == [11, 11, 11] and sum(us_orders) == us_snap, "US mirror snapshot 33 -> 11/11/11")
+
+
+# ── Test 7: FIX 1 — US queued vs live sell-plan decision branch ─────────────
+def test_us_sell_plan():
+    print("\n[Test 7] FIX 1 — US queued window -> full_exit vs live -> fractional")
+
+    # Single row: always full position (legacy, unaffected).
+    check(decide_us_sell_plan(1, will_queue=False) == "single_full", "N=1 live -> single_full")
+    check(decide_us_sell_plan(1, will_queue=True) == "single_full", "N=1 queued -> single_full")
+
+    # Multi-row + live (order executes now): fractional partial sell.
+    check(decide_us_sell_plan(3, will_queue=False) == "fractional", "N=3 live -> fractional")
+    check(decide_us_sell_plan(2, will_queue=False) == "fractional", "N=2 live -> fractional")
+
+    # Multi-row + queued window: FULL exit (queue can't carry partial qty).
+    check(decide_us_sell_plan(3, will_queue=True) == "full_exit", "N=3 queued -> full_exit")
+    check(decide_us_sell_plan(2, will_queue=True) == "full_exit", "N=2 queued -> full_exit")
+
+    # Simulate the DB consequence: full_exit deletes ALL rows; fractional one row.
+    fd, path = tempfile.mkstemp(suffix=".sqlite")
+    os.close(fd)
+    try:
+        conn = sqlite3.connect(path)
+        cur = conn.cursor()
+        cur.execute(_us_db_schema.TABLE_US_STOCK_HOLDINGS)
+        conn.commit()
+        for bp in (200.0, 210.0, 220.0):
+            _insert_holding(cur, "us_stock_holdings", "ACC1", "AAPL", bp)
+        conn.commit()
+
+        # full_exit branch -> delete ALL rows for ticker
+        cur.execute("DELETE FROM us_stock_holdings WHERE ticker='AAPL' AND account_key='ACC1'")
+        conn.commit()
+        cur.execute("SELECT COUNT(*) FROM us_stock_holdings WHERE ticker='AAPL'")
+        check(cur.fetchone()[0] == 0, "full_exit deletes ALL rows (DB consistent with full liquidation)")
+
+        # fractional branch -> delete ONLY one row by id (re-seed)
+        for bp in (200.0, 210.0, 220.0):
+            _insert_holding(cur, "us_stock_holdings", "ACC1", "AAPL", bp)
+        conn.commit()
+        cur.execute("SELECT id FROM us_stock_holdings WHERE ticker='AAPL' ORDER BY id LIMIT 1")
+        one_id = cur.fetchone()[0]
+        cur.execute("DELETE FROM us_stock_holdings WHERE id=?", (one_id,))
+        conn.commit()
+        cur.execute("SELECT COUNT(*) FROM us_stock_holdings WHERE ticker='AAPL'")
+        check(cur.fetchone()[0] == 2, "fractional deletes only ONE row (2 remain)")
+
+        conn.close()
+    finally:
+        os.remove(path)
+
+
+# ── Test 8: FIX 3 — regime parse on realistic / hyphen / no-colon values ───
+def test_regime_parse():
+    print("\n[Test 8] FIX 3 — regime label parsing")
+    _kr = _helpers._regime_label
+    _us = _us_db_schema._us_regime_label
+
+    cases = [
+        ("strong_bull: 보고서 기준 KOSPI가 20일선 상회...", "strong_bull", True),
+        ("parabolic: NASDAQ breadth surging", "parabolic", True),
+        ("moderate_bull: 완만한 상승", "moderate_bull", False),
+        ("sideways", "sideways", False),
+        ("strong-bull", "strong_bull", True),          # hyphen normalises
+        ("strong bull", "strong_bull", True),          # space normalises
+        ("STRONG_BULL: caps", "strong_bull", True),    # case-insensitive
+        ("", "", False),
+        (None, "", False),
+    ]
+    allowed = ("strong_bull", "parabolic")
+    for raw, expected_label, should_pass in cases:
+        kr_label = _kr(raw)
+        us_label = _us(raw)
+        check(kr_label == expected_label, f"KR _regime_label({raw!r}) -> {kr_label!r} (expect {expected_label!r})")
+        check(us_label == expected_label, f"US _us_regime_label({raw!r}) -> {us_label!r}")
+        check((kr_label in allowed) == should_pass, f"{raw!r} gate-pass == {should_pass}")
+
+
+# ── Test 5: ast.parse all edited files ─────────────────────────────────────
+def test_ast_parse():
+    print("\n[Test 5] ast.parse all edited files")
+    files = [
+        "stock_tracking_agent.py",
+        "stock_tracking_enhanced_agent.py",
+        "tracking/db_schema.py",
+        "tracking/helpers.py",
+        "tracking/__init__.py",
+        "trading/domestic_stock_trading.py",
+        "prism-us/us_stock_tracking_agent.py",
+        "prism-us/trading/us_stock_trading.py",
+        "prism-us/tracking/db_schema.py",
+        "prism-us/tracking/__init__.py",
+    ]
+    for f in files:
+        p = os.path.join(PROJECT_ROOT, f)
+        try:
+            with open(p, "r", encoding="utf-8") as fh:
+                ast.parse(fh.read())
+            check(True, f"ast.parse OK: {f}")
+        except SyntaxError as e:
+            check(False, f"ast.parse FAILED: {f} -> {e}")
+
+
+if __name__ == "__main__":
+    test_migration()
+    test_fractional_sell()
+    test_add_gate()
+    test_single_row_regression()
+    test_oversell_snapshot()
+    test_us_sell_plan()
+    test_regime_parse()
+    test_ast_parse()
+    print(f"\n===== RESULT: {_PASS} passed, {_FAIL} failed =====")
+    sys.exit(1 if _FAIL else 0)

--- a/tracking/__init__.py
+++ b/tracking/__init__.py
@@ -21,6 +21,9 @@ from tracking.helpers import (
     check_sector_diversity,
     parse_price_value,
     default_scenario,
+    get_existing_position_for_ticker,
+    evaluate_pyramid_add_gate,
+    compute_fractional_sell_quantity,
 )
 from tracking.trading_ops import (
     analyze_sell_decision,
@@ -49,6 +52,9 @@ __all__ = [
     "check_sector_diversity",
     "parse_price_value",
     "default_scenario",
+    "get_existing_position_for_ticker",
+    "evaluate_pyramid_add_gate",
+    "compute_fractional_sell_quantity",
     # Trading ops
     "analyze_sell_decision",
     "format_buy_message",

--- a/tracking/db_schema.py
+++ b/tracking/db_schema.py
@@ -27,8 +27,7 @@ CREATE TABLE IF NOT EXISTS stock_holdings (
     stop_loss REAL,
     trigger_type TEXT,
     trigger_mode TEXT,
-    sector TEXT,
-    UNIQUE(account_key, ticker)
+    sector TEXT
 )
 """
 
@@ -526,6 +525,133 @@ def migrate_multi_account_schema(cursor, conn):
         )
 
 
+def _holdings_table_has_unique_constraint(cursor, table_name: str) -> bool:
+    """Detect whether ``table_name`` was created with a UNIQUE(account_key, ticker)
+    constraint by reading its CREATE statement from sqlite_master.
+
+    Returns False when the table does not exist or has no such UNIQUE clause.
+    """
+    cursor.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name = ?",
+        (table_name,),
+    )
+    row = cursor.fetchone()
+    if not row or not row[0]:
+        return False
+    return "UNIQUE" in row[0].upper()
+
+
+def _drop_unique_constraint(cursor, conn, table_name: str, create_sql: str):
+    """Rebuild ``table_name`` WITHOUT the UNIQUE(account_key, ticker) constraint,
+    preserving all rows. Idempotent: no-op when the constraint is already gone.
+
+    Uses the same safe pattern as ``_rebuild_table``:
+    backup -> rename-to-legacy -> create-new -> copy-all -> verify-rowcount -> drop-legacy.
+    The new table SQL (``create_sql``) must NOT contain the UNIQUE clause.
+    """
+    if not _table_exists(cursor, table_name):
+        return
+
+    # Recover from an interrupted run (legacy table left behind) before deciding.
+    _recover_interrupted_migration(cursor, conn, table_name)
+
+    if not _holdings_table_has_unique_constraint(cursor, table_name):
+        # Already migrated (or never had the constraint) -> no-op.
+        return
+
+    legacy_table = f"{table_name}_legacy"
+    backup_table = f"{table_name}_pre_pyramiding_backup"
+
+    if _table_exists(cursor, legacy_table):
+        raise RuntimeError(
+            f"Ambiguous migration state for {table_name}: legacy table {legacy_table} already exists. "
+            "Manual intervention is required."
+        )
+
+    if not _table_exists(cursor, backup_table):
+        logger.info(f"Creating backup table {backup_table} before dropping UNIQUE on {table_name}")
+        cursor.execute(f"CREATE TABLE {backup_table} AS SELECT * FROM {table_name}")
+        conn.commit()
+    else:
+        logger.warning(f"Preserving existing backup table {backup_table} for {table_name}")
+
+    logger.info(f"Dropping UNIQUE(account_key, ticker) constraint on {table_name} (pyramiding migration)")
+
+    try:
+        cursor.execute(f"ALTER TABLE {table_name} RENAME TO {legacy_table}")
+        cursor.execute(create_sql)
+
+        columns = _get_columns(cursor, legacy_table)
+        col_list = ", ".join(columns)
+        cursor.execute(
+            f"INSERT INTO {table_name} ({col_list}) SELECT {col_list} FROM {legacy_table}"
+        )
+
+        source_count = _count_rows(cursor, legacy_table)
+        target_count = _count_rows(cursor, table_name)
+        if source_count != target_count:
+            raise RuntimeError(
+                f"Row count mismatch during {table_name} UNIQUE-drop migration: "
+                f"{legacy_table}={source_count}, {table_name}={target_count}"
+            )
+
+        cursor.execute(f"DROP TABLE {legacy_table}")
+        conn.commit()
+        logger.info(
+            f"{table_name} UNIQUE-drop migration complete ({target_count} rows preserved). "
+            f"Backup table {backup_table} retained for manual cleanup."
+        )
+    except Exception as exc:
+        logger.error(f"{table_name} UNIQUE-drop migration failed: {exc}")
+        logger.error(f"Manual recovery is available from backup table {backup_table}")
+        raise
+
+
+def migrate_drop_holdings_unique_constraint(cursor, conn):
+    """Drop the legacy UNIQUE(account_key, ticker) constraint from holdings tables
+    so pyramiding (#288) can store multiple independent rows per ticker.
+
+    Idempotent and safe to run repeatedly. Handles both KR (stock_holdings) and
+    US (us_stock_holdings) tables; either may be absent in a given DB.
+    """
+    _drop_unique_constraint(cursor, conn, "stock_holdings", TABLE_STOCK_HOLDINGS)
+
+    # US table is created by prism-us/tracking/db_schema.py; rebuild it here too
+    # only if it exists in this DB, mirroring its canonical (UNIQUE-free) schema.
+    if _table_exists(cursor, "us_stock_holdings"):
+        cursor.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name = ?",
+            ("us_stock_holdings",),
+        )
+        row = cursor.fetchone()
+        if row and row[0] and "UNIQUE" in row[0].upper():
+            # Reconstruct a UNIQUE-free CREATE from the existing column set so we
+            # don't depend on importing the US schema module from the KR side.
+            us_create_sql = _build_create_without_unique(cursor, "us_stock_holdings")
+            _drop_unique_constraint(cursor, conn, "us_stock_holdings", us_create_sql)
+
+
+def _build_create_without_unique(cursor, table_name: str) -> str:
+    """Build a CREATE TABLE statement for ``table_name`` preserving its columns
+    and types but omitting any table-level UNIQUE constraint. Used when the
+    canonical CREATE SQL is owned by another module."""
+    cursor.execute(f"PRAGMA table_info({table_name})")
+    cols = cursor.fetchall()  # (cid, name, type, notnull, dflt_value, pk)
+    defs = []
+    for _cid, name, col_type, notnull, dflt, pk in cols:
+        parts = [name, col_type or "TEXT"]
+        if pk:
+            parts.append("PRIMARY KEY")
+            if (col_type or "").upper() == "INTEGER":
+                parts.append("AUTOINCREMENT")
+        if notnull and not pk:
+            parts.append("NOT NULL")
+        if dflt is not None:
+            parts.append(f"DEFAULT {dflt}")
+        defs.append(" ".join(parts))
+    return f"CREATE TABLE {table_name} (\n    " + ",\n    ".join(defs) + "\n)"
+
+
 def migrate_watchlist_history_columns(cursor, conn):
     migrations = [
         ("watchlist_history", "min_score INTEGER"),
@@ -637,6 +763,7 @@ def create_all_tables(cursor, conn):
         cursor.execute(table_sql)
 
     migrate_multi_account_schema(cursor, conn)
+    migrate_drop_holdings_unique_constraint(cursor, conn)
     migrate_watchlist_history_columns(cursor, conn)
     migrate_analysis_performance_tracker_columns(cursor, conn)
     conn.commit()

--- a/tracking/helpers.py
+++ b/tracking/helpers.py
@@ -219,6 +219,134 @@ def get_current_slots_count(cursor, account_key: str | None = None) -> int:
         return 0
 
 
+# ── Pyramiding (#288) ──────────────────────────────────────────────────────
+# Strong-bull add-on / pyramiding helpers. Each pyramid entry is an independent
+# stock_holdings row. The gate below decides whether the "already holding" block
+# may be bypassed for an additional entry.
+
+# Market regimes in which pyramiding (adding to a winning position) is allowed.
+PYRAMID_ALLOWED_REGIMES = ("strong_bull", "parabolic")
+# Minimum aggregate profit (%) of the existing position to allow an add.
+PYRAMID_MIN_PROFIT_PCT = 5.0
+# Maximum number of rows (entries) per ticker/account (initial + up to 2 adds).
+PYRAMID_MAX_ROWS = 3
+# Table name for holdings (overridable for US: "us_stock_holdings").
+_HOLDINGS_TABLE = "stock_holdings"
+
+
+def get_existing_position_for_ticker(
+    cursor,
+    ticker: str,
+    account_key: str | None = None,
+    table_name: str = _HOLDINGS_TABLE,
+) -> Dict[str, Any]:
+    """Aggregate the existing holding for a ticker/account.
+
+    Returns a dict with:
+        row_count: number of existing rows for (ticker, account)
+        avg_buy_price: simple average buy_price across those rows (0 if none)
+    Used by the pyramiding add-gate.
+
+    NOTE (#288, intentional): ``avg_buy_price`` is a SIMPLE MEAN of per-row entry
+    prices, NOT a share-weighted average. The independent-row model deliberately
+    stores no per-row quantity in ``stock_holdings``, and each add is ~1 unit, so
+    the simple mean is an accurate-enough proxy for both the +5% profit gate and
+    the Telegram "누적 평단" display.
+    """
+    try:
+        if account_key:
+            cursor.execute(
+                f"SELECT buy_price FROM {table_name} WHERE ticker = ? AND account_key = ?",
+                (ticker, account_key),
+            )
+        else:
+            cursor.execute(
+                f"SELECT buy_price FROM {table_name} WHERE ticker = ?",
+                (ticker,),
+            )
+        prices = [float(r[0]) for r in cursor.fetchall() if r[0] is not None]
+        row_count = len(prices)
+        avg_buy_price = (sum(prices) / row_count) if row_count else 0.0
+        return {"row_count": row_count, "avg_buy_price": avg_buy_price}
+    except Exception as e:
+        logger.error(f"Error querying existing position for {ticker}: {str(e)}")
+        return {"row_count": 0, "avg_buy_price": 0.0}
+
+
+def _regime_label(market_condition: str | None) -> str:
+    """Extract the leading regime label from a market_condition string.
+
+    Real values look like ``"strong_bull: 보고서 기준 KOSPI가 20일선 상회..."`` —
+    the regime token (with underscore) comes before the first ':'. We take the
+    substring before the first ':', normalise it, and canonicalise separators so
+    a hyphen/space variant ("strong-bull"/"strong bull") maps to "strong_bull".
+    Fail-closed: anything unrecognised returns "" (no add).
+    """
+    if not market_condition or not isinstance(market_condition, str):
+        return ""
+    # Take the regime token before the first ':' (rest is the human description).
+    text = market_condition.split(":", 1)[0].strip().lower()
+    # Canonicalise separators: hyphen/space -> underscore (e.g. "strong-bull").
+    text = text.replace("-", "_").replace(" ", "_")
+    return text
+
+
+def evaluate_pyramid_add_gate(
+    market_condition: str | None,
+    existing_avg_buy_price: float,
+    current_price: float,
+    existing_row_count: int,
+    min_profit_pct: float = PYRAMID_MIN_PROFIT_PCT,
+    max_rows: int = PYRAMID_MAX_ROWS,
+) -> Tuple[bool, str]:
+    """Pure add-gate for pyramiding (#288).
+
+    Returns (allowed, reason). All of the following must hold to allow:
+      1) regime in PYRAMID_ALLOWED_REGIMES (parsed from market_condition prefix)
+      2) existing aggregate position profit >= min_profit_pct
+      3) existing_row_count < max_rows
+
+    Does NOT include the buy-agent Enter/score/sector checks — those are applied
+    independently by the normal buy path.
+    """
+    regime = _regime_label(market_condition)
+    if regime not in PYRAMID_ALLOWED_REGIMES:
+        return False, f"regime '{regime or 'unknown'}' not in {PYRAMID_ALLOWED_REGIMES}"
+
+    if existing_row_count >= max_rows:
+        return False, f"row count {existing_row_count} >= max {max_rows}"
+
+    if not existing_avg_buy_price or existing_avg_buy_price <= 0 or not current_price or current_price <= 0:
+        return False, "insufficient price data for profit check"
+
+    profit_pct = (current_price - existing_avg_buy_price) / existing_avg_buy_price * 100.0
+    if profit_pct < min_profit_pct:
+        return False, f"profit {profit_pct:.2f}% < required {min_profit_pct:.1f}%"
+
+    return True, f"add allowed (regime={regime}, profit={profit_pct:.2f}%, rows={existing_row_count})"
+
+
+def compute_fractional_sell_quantity(total_quantity: int, remaining_rows: int) -> int:
+    """Shares to sell for one row when ``remaining_rows`` rows remain (#288).
+
+    - remaining_rows <= 1  -> sell all (total_quantity)  [zero regression for non-pyramided]
+    - remaining_rows >  1  -> floor(total_quantity / remaining_rows)
+
+    Recomputed live at each sell so the LAST remaining row always sweeps the
+    remainder (since it sees remaining_rows == 1 and sells everything left).
+    """
+    try:
+        total = int(total_quantity)
+        n = int(remaining_rows)
+    except (TypeError, ValueError):
+        return int(total_quantity) if total_quantity else 0
+    if total <= 0:
+        return 0
+    if n <= 1:
+        return total
+    return total // n
+
+
 # Apply ratio guard only when portfolio is large enough that the ratio is meaningful.
 # With <4 holdings, a single same-sector position naturally produces 25-100% — blocking
 # every additional buy in that sector even though absolute count is well under the cap.

--- a/trading/domestic_stock_trading.py
+++ b/trading/domestic_stock_trading.py
@@ -39,6 +39,25 @@ with open(CONFIG_FILE, encoding="UTF-8") as f:
     _cfg = yaml.safe_load(f)
 
 
+def _resolve_sell_quantity(holding_quantity: int, quantity: int = None) -> int:
+    """Resolve the number of shares to sell.
+
+    When ``quantity`` is None the full holding is sold (unchanged behavior).
+    When given, the requested partial quantity is used, clamped to the range
+    [1, holding_quantity] to avoid over-selling. Used by pyramiding fractional
+    sells (#288).
+    """
+    if quantity is None:
+        return holding_quantity
+    try:
+        q = int(quantity)
+    except (TypeError, ValueError):
+        return holding_quantity
+    if q <= 0:
+        return holding_quantity
+    return min(q, holding_quantity)
+
+
 class DomesticStockTrading:
     """Domestic stock trading class"""
 
@@ -745,12 +764,15 @@ class DomesticStockTrading:
                 'message': f"Error during reserved buy order: {str(e)}"
             }
 
-    def sell_all_market_price(self, stock_code: str) -> Dict[str, Any]:
+    def sell_all_market_price(self, stock_code: str, quantity: int = None) -> Dict[str, Any]:
         """
-        Sell all at market price (liquidate entire holding)
+        Sell at market price.
 
         Args:
             stock_code: Stock code
+            quantity: Partial sell quantity. When None, sells the entire holding
+                (unchanged behavior). When given, sells exactly that many shares
+                (clamped to the current holding).
 
         Returns:
             {
@@ -772,9 +794,9 @@ class DomesticStockTrading:
             }
 
         # Check holding quantity
-        buy_quantity = self.get_holding_quantity(stock_code)
+        holding_quantity = self.get_holding_quantity(stock_code)
 
-        if buy_quantity == 0:
+        if holding_quantity == 0:
             return {
                 'success': False,
                 'order_no': None,
@@ -782,6 +804,9 @@ class DomesticStockTrading:
                 'quantity': 0,
                 'message': 'No holding quantity'
             }
+
+        # Determine sell quantity (partial when quantity given, else full holding)
+        buy_quantity = _resolve_sell_quantity(holding_quantity, quantity)
 
         # Execute sell order
         api_url = "/uapi/domestic-stock/v1/trading/order-cash"
@@ -842,9 +867,9 @@ class DomesticStockTrading:
                 'message': f'Error during sell order: {str(e)}'
             }
 
-    def smart_sell_all(self, stock_code: str, limit_price: int = None) -> Dict[str, Any]:
+    def smart_sell_all(self, stock_code: str, limit_price: int = None, quantity: int = None) -> Dict[str, Any]:
         """
-        Automatically sell all using the optimal method based on time (excluding after-hours single price trading due to high unfilled probability)
+        Automatically sell using the optimal method based on time (excluding after-hours single price trading due to high unfilled probability)
 
         - 09:00~15:30: Market price sell
         - 15:40~16:00: After-hours closing price trading
@@ -853,6 +878,7 @@ class DomesticStockTrading:
         Args:
             stock_code: Stock code
             limit_price: Limit price for reserved order (market order if None)
+            quantity: Partial sell quantity (None = full holding, unchanged behavior)
 
         Returns:
             Sell result
@@ -874,12 +900,12 @@ class DomesticStockTrading:
         if datetime.time(9, 0) <= current_time <= datetime.time(15, 30):
             # Regular trading hours - market sell
             logger.info(f"[{stock_code}] Regular trading hours - executing market sell")
-            return self.sell_all_market_price(stock_code)
+            return self.sell_all_market_price(stock_code, quantity=quantity)
 
         elif datetime.time(15, 40) <= current_time <= datetime.time(16, 0):
             # After-hours closing price trading
             logger.info(f"[{stock_code}] After-hours closing price time - executing closing price sell")
-            return self.sell_all_closing_price(stock_code)
+            return self.sell_all_closing_price(stock_code, quantity=quantity)
 
         else:
             # Reserved order (limit or market price)
@@ -887,12 +913,16 @@ class DomesticStockTrading:
                 logger.info(f"[{stock_code}] Outside trading hours - executing reserved order (limit: {limit_price:,} KRW)")
             else:
                 logger.info(f"[{stock_code}] Outside trading hours - executing reserved order (market)")
-            return self.sell_all_reserved_order(stock_code, limit_price=limit_price)
+            return self.sell_all_reserved_order(stock_code, limit_price=limit_price, quantity=quantity)
 
-    def sell_all_closing_price(self, stock_code: str) -> Dict[str, Any]:
+    def sell_all_closing_price(self, stock_code: str, quantity: int = None) -> Dict[str, Any]:
         """
-        Sell all at after-hours closing price (15:40~16:00)
+        Sell at after-hours closing price (15:40~16:00)
         Sell at closing price of the day
+
+        Args:
+            stock_code: Stock code
+            quantity: Partial sell quantity (None = full holding, unchanged)
         """
         if not self.auto_trading:
             return {
@@ -904,9 +934,9 @@ class DomesticStockTrading:
             }
 
         # Check holding quantity
-        buy_quantity = self.get_holding_quantity(stock_code)
+        holding_quantity = self.get_holding_quantity(stock_code)
 
-        if buy_quantity == 0:
+        if holding_quantity == 0:
             return {
                 'success': False,
                 'order_no': None,
@@ -914,6 +944,8 @@ class DomesticStockTrading:
                 'quantity': 0,
                 'message': 'No holding quantity'
             }
+
+        buy_quantity = _resolve_sell_quantity(holding_quantity, quantity)
 
         # After-hours closing price sell
         api_url = "/uapi/domestic-stock/v1/trading/order-cash"
@@ -970,15 +1002,16 @@ class DomesticStockTrading:
                 'message': f'Error during sell: {str(e)}'
             }
 
-    def sell_all_reserved_order(self, stock_code: str, end_date: str = None, limit_price: int = None) -> Dict[str, Any]:
+    def sell_all_reserved_order(self, stock_code: str, end_date: str = None, limit_price: int = None, quantity: int = None) -> Dict[str, Any]:
         """
-        Sell all with reserved order (auto-execute on next trading day)
+        Sell with reserved order (auto-execute on next trading day)
         Reserved order available: 15:40~next business day 07:30 (excluding 23:40~00:10)
 
         Args:
             stock_code: Stock code
             end_date: Period reservation end date (YYYYMMDD format, regular reservation if None)
             limit_price: Limit price (market order if None)
+            quantity: Partial sell quantity (None = full holding, unchanged)
 
         Returns:
             Sell result
@@ -994,8 +1027,8 @@ class DomesticStockTrading:
             }
 
         # Check holding quantity
-        buy_quantity = self.get_holding_quantity(stock_code)
-        if buy_quantity == 0:
+        holding_quantity = self.get_holding_quantity(stock_code)
+        if holding_quantity == 0:
             return {
                 'success': False,
                 'order_no': None,
@@ -1003,6 +1036,8 @@ class DomesticStockTrading:
                 'quantity': 0,
                 'message': 'No holding quantity'
             }
+
+        buy_quantity = _resolve_sell_quantity(holding_quantity, quantity)
 
         # Set order type and unit price
         if limit_price and limit_price > 0:
@@ -1214,15 +1249,16 @@ class DomesticStockTrading:
 
         return result
 
-    async def async_sell_stock(self, stock_code: str, timeout: float = 30.0, limit_price: Optional[int] = None) -> Dict[str, Any]:
+    async def async_sell_stock(self, stock_code: str, timeout: float = 30.0, limit_price: Optional[int] = None, quantity: Optional[int] = None) -> Dict[str, Any]:
         """
         Async sell API (with timeout)
-        Sell all holding quantity at market price
+        Sell holding quantity (full by default, partial when quantity given)
 
         Args:
             stock_code: Stock code (6 digits)
             timeout: Timeout in seconds
             limit_price: Limit price for reserved order (market order if None)
+            quantity: Partial sell quantity (None = full holding, unchanged behavior)
 
         Returns:
             {
@@ -1238,7 +1274,7 @@ class DomesticStockTrading:
         """
         try:
             return await asyncio.wait_for(
-                self._execute_sell_stock(stock_code, limit_price),
+                self._execute_sell_stock(stock_code, limit_price, quantity=quantity),
                 timeout=timeout
             )
         except asyncio.TimeoutError:
@@ -1253,8 +1289,11 @@ class DomesticStockTrading:
                 'timestamp': datetime.datetime.now().isoformat()
             }
 
-    async def _execute_sell_stock(self, stock_code: str, limit_price: int = None) -> Dict[str, Any]:
-        """Actual sell execution logic (includes portfolio verification defensive logic)"""
+    async def _execute_sell_stock(self, stock_code: str, limit_price: int = None, quantity: int = None) -> Dict[str, Any]:
+        """Actual sell execution logic (includes portfolio verification defensive logic)
+
+        quantity: partial sell quantity (None = full holding, unchanged behavior)
+        """
         result = {
             'success': False,
             'stock_code': stock_code,
@@ -1322,12 +1361,15 @@ class DomesticStockTrading:
                         # CRITICAL: Convert to int - KIS API requires integer strings, not float strings
                         effective_limit_price = int(limit_price) if (limit_price and limit_price > 0) else (int(result['current_price']) if result['current_price'] > 0 else None)
 
+                        # Resolve partial sell quantity (None = full holding)
+                        sell_quantity = _resolve_sell_quantity(holding_quantity, quantity)
+
                         if effective_limit_price:
-                            logger.info(f"[Async Sell API] {stock_code} executing sell all (holding: {holding_quantity} shares, limit: {effective_limit_price:,} KRW)")
+                            logger.info(f"[Async Sell API] {stock_code} executing sell (qty: {sell_quantity}/{holding_quantity} shares, limit: {effective_limit_price:,} KRW)")
                         else:
-                            logger.info(f"[Async Sell API] {stock_code} executing sell all (holding: {holding_quantity} shares, market)")
+                            logger.info(f"[Async Sell API] {stock_code} executing sell (qty: {sell_quantity}/{holding_quantity} shares, market)")
                         all_sell_result = await asyncio.to_thread(
-                            self.smart_sell_all, stock_code, effective_limit_price
+                            self.smart_sell_all, stock_code, effective_limit_price, sell_quantity
                         )
 
                         if all_sell_result['success']:
@@ -1576,7 +1618,7 @@ class MultiAccountDomesticStockTrading:
 
         return self._aggregate_results(stock_code, results, action="buy")
 
-    async def async_sell_stock(self, stock_code: str, timeout: float = 30.0, limit_price: Optional[int] = None) -> Dict[str, Any]:
+    async def async_sell_stock(self, stock_code: str, timeout: float = 30.0, limit_price: Optional[int] = None, quantity: Optional[int] = None) -> Dict[str, Any]:
         if not self.account_configs:
             return self._aggregate_results(stock_code, [], action="sell")
         results = []
@@ -1586,6 +1628,7 @@ class MultiAccountDomesticStockTrading:
                 stock_code=stock_code,
                 timeout=timeout,
                 limit_price=limit_price,
+                quantity=quantity,
             )
             result["account_name"] = account["name"]
             result["account_key"] = account["account_key"]


### PR DESCRIPTION
## 배경 & 설계 결정

이미 보유 중인 종목이 스크리닝에 다시 올라오면 기존엔 `"Already holding"`으로 **원천 차단**했습니다. #288은 **강세장에서 추세 좋은 보유 승자에 비중을 더 싣는(피라미딩)** 기회를 허용합니다 — O'Neil·Minervini·Livermore 추세추종 정통 교리(증명된 승자에 progressive하게 추가, 물타기 금지).

페르소나 패널(O'Neil/Minervini/Livermore/퀀트리스크/시장특성) + 운영서버 실데이터 진단을 거쳐 다음으로 확정:

**독립 행 모델** — 추가 진입마다 별도 `stock_holdings` 행(자기 시나리오·목표·손절), 슬롯 1개 소비 → **실제 포트폴리오 비중↑, 타종목 기회↓** (운영자 의도 반영).

**추가 허용 게이트** (보유종목 차단 해제 조건, 전부 충족):
- regime ∈ {strong_bull, parabolic} (약세/횡보장 비중확대 위험 회피)
- 기존 보유분 **≥ +5% 수익** (물타기 불가)
- 해당종목 행수 < 3 (추가 최대 2회)
- 매수에이전트가 독립적으로 Enter (점수·섹터·슬롯 게이트 그대로)

매수 시 KIS 1유닛 실제 주문 + `"📈 추가 진입 (N차)"` 전용 텔레그램(누적 평단·비중↑).

## 핵심 변경

- **스키마**: `stock_holdings`/`us_stock_holdings`의 `UNIQUE(account_key,ticker)` 제거 — 백업 기반 **idempotent 마이그레이션**(기존 rebuild 패턴 재사용, 운영 DB 안전)
- **매도 분할**: N행이면 `floor(총수량÷N)` 매도 + **id 기준** 행 삭제, 마지막 행이 잔량 일소. **단일행(비피라미딩) 종목은 기존 `sell_all`과 완전 동일 — 무회귀**
- **행별 id 스코핑**: scenario/목표/손절/삭제 전부 `WHERE id`(ticker fallback) → 형제 트랜치 안 건드림
- KIS 매도에 `quantity` 파라미터 추가(KR+US, None이면 전량=무변경)

## 리뷰에서 발견·수정한 위험

- 🔴 **US 예약주문 큐 desync**: 큐잉 창에서 분할매도 시 수량 유실 → 전량청산+유령행. → 큐잉 시 **일관된 전량 exit fallback**.
- 🔴 **다중행 동시매도 과매도 레이스**(운영자 지적): 한 패스에서 여러 행 매도 시 지정가 미체결이면 브로커 수량 재조회로 과매도. → **패스당 총수량 1회 스냅샷 후 분배**, 마지막 행도 스냅샷 잔량 매도(브로커 재조회 안 함). 무체결 worst-case에서도 합계==스냅샷 검증.
- regime 파싱 견고화(`:` 기준 정규화, fail-closed).

## 범위 & 무변경
- KR + US 미러. 매수 점수·min_score·MAX_SLOTS·MAX_SAME_SECTOR **무변경**.

## 검증
- `tests/test_issue_288_pyramiding.py` **101개 통과**: 마이그레이션 idempotency+데이터보존, 분할/과매도 산수(무체결 worst-case 포함), 큐잉→전량exit 분기, add-gate, regime 파싱, 단일행 회귀, 전 파일 ast.parse
- **import 의존성**: 모든 crontab 엔트리 스크립트(KR/US orchestrator·compress_trading_memory·performance_tracker·portfolio_telegram_reporter·us_pending_order_batch·weekly 등) 실제 import 성공. 파일 이동 0, 신규 파일은 테스트 1개뿐

🤖 Generated with [Claude Code](https://claude.com/claude-code)