### PR TITLE
feat: KR 스크리닝 RS+과열 소프트스코어 재설계 (#289)

### DIFF
--- a/docs/superpowers/specs/2026-05-29-kr-screening-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-29-kr-screening-redesign-design.md
@@ -1,0 +1,131 @@
+# KR 종목 스크리닝 재설계 (#289) — 설계 문서
+
+> **작성일**: 2026-05-29 | **이슈**: #289 한국시장 종목스크리닝 로직 수정
+> **상태**: 설계 승인 완료 → 구현 계획(writing-plans) 대기
+> **전제**: 이 시스템은 **백테스트 불가** → 점진적·되돌리기 쉬운 변경 + 라이브 관찰로 진행
+
+---
+
+## 1. 문제 정의
+
+운영 실데이터 진단(메모리 `project_screening_buyagent_mismatch`)과 페르소나 패널 5인 만장일치 결론:
+
+- **증상**: KR 폭등장에서 진입률이 낮음(4/10). 최근 30일 매수에이전트 score=2가 51건, 진입 2주째 0.
+- **오해**: "상승률 필터 20→15로 낮추면 됨" → **cosmetic**. 주력 트리거(갭상승·일일상승)는 v1.16.6에서 **이미 15%**.
+- **진짜 병목**: KR 스크리닝이 **"당일 raw 급등률"** 로만 거름. KR은 가격제한폭 ±30% + 개인 매수 광기 탓에 **같은 상승률이라도 US보다 훨씬 과열·climax(소진 급등) 종목**이 후보로 올라옴 → CAN SLIM 매수에이전트가 **정당하게 2/10**으로 거절. 매수에이전트는 정상이며 끄거나 min_score를 낮추면 안 됨.
+
+### 코드로 확정된 근본 원인
+1. **과열 가드 전무**: `trigger_batch.py:calculate_agent_fit_metrics`는 v1.16.6 이후 손절 고정 → `sl_score`가 **항상 1.0**, 목표가는 최근 N일 고가(min +15%). 따라서 이동평균에서 멀리 떨어진(extended) climax 종목도 `agent_fit_score` 만점.
+2. **선정이 순수 모멘텀**: `normalize_and_score`의 composite_score = 거래량/갭/금액 비율. 과열 여부 무관.
+3. **매수에이전트도 과열 보상**: `cores/agents/trading_agents.py:143` 모멘텀신호 #3 "52주 신고가 5% 이내"가 가점, 트리거 타입 자동 +1까지(`:147-148`).
+4. **RS 단일일·비활성**: `trigger_batch.py:910`의 RelativeStrength는 *하루치* 변동률−시장평균(노이즈). 다주 RS 없음. `trigger_macro_sector_leader`는 strong_bull에서 비활성(`:1338`).
+
+---
+
+## 2. 철학 정합성 점검 (윌리엄 오닐 / CAN SLIM 학파)
+
+본 시스템의 매매 철학은 **윌리엄 오닐 추세추종**(메모리 `user_trading_philosophy`). 수정 방향을 학파 원칙과 대조:
+
+| 오닐 학파 원칙 | 본 설계 | 정합성 |
+|---|---|---|
+| 상대강도(RS)가 핵심 — 다개월 가중으로 주도주 선별, RS Rating ≥80 | Stage 3: 다주 RS 가점 | ✅ (단일일 RS 폐기) |
+| 적정 피벗/베이스 돌파에서 매수, **extended 추격 금지** (피벗 +5% 초과 추격 금기) | Stage 2: extension 감점 | ✅✅ |
+| 거래량 동반 돌파 | 기존 트리거 유지 | ✅ |
+| 신고가 근접은 호재, 그러나 **climax top은 매도신호** | extension으로 climax 소진 구간 down-weight | ✅ |
+| 시장방향(M): 확인된 상승장엔 주도주 적극 매수, 단 상승장 *말기*에 climax 출현 | regime 차등(strong_bull RS↑, 과열 완화하되 **0 아님**) | ✅ |
+
+**ADR 정규화는 미너비니(오닐 학파) 정통** — 변동성/extension 평가에 ADR 배수를 명시 사용.
+
+### 매수에이전트(CAN SLIM 매트릭스) 궁합
+매수에이전트는 이미 오닐 로직 내장: Parabolic 활성(90일 ≥+30%, 30일 ≥+10%, `trading_agents.py:112-123`), Distribution Day Kill Switch(`:125-129`), CAN SLIM R/R·손절 매트릭스.
+
+**핵심 통찰**: 현재 스크리닝은 climax 종목을 매수에이전트에 보내고 에이전트가 거절하는 구조 — 스크리닝이 에이전트의 오닐 판단과 **싸우며 슬롯/관심을 낭비**. 본 설계는 새 철학 추가가 아니라 **매수에이전트가 이미 가진 오닐 판단을 스크리닝 상류로 전파**하는 것 = 구조적 정렬.
+
+### 설계에 박은 3가지 보정
+1. **RS = 다주/다개월 가중** (단일일 RS 폐기·격상).
+2. **Extension = MA/베이스 이격 + ADR 정규화** (52주 고가 기준 금지 → 매수에이전트 신호 #3과 **이중 평가 충돌 방지**, 상호보완). 건강한 돌파(신고가 근접·저extension)는 양쪽 통과, climax(신고가 근접·고extension)만 스크리닝에서 down-weight.
+3. **strong_bull에서도 climax/소진 보호 유지**, RS 비중만 상향 (오닐의 "상승장 말기 climax" 경고 반영).
+
+---
+
+## 3. 설계
+
+### 핵심 아이디어
+후보를 **자르지 않고**(soft) `final_score`에 **RS 가점 + 과열 감점**을 추가해 **국면별 가중치**로 재정렬한다. "시장보다 꾸준히 강하면서(고RS) 아직 너무 멀리 안 뜬(저extension)" 종목을 위로, "막판 불꽃(climax)"은 아래로.
+
+현재: `final_score = composite_norm·0.3 + agent_fit·0.7` (`trigger_batch.py:1183-1186`)
+신규:
+```
+final_score = w_comp·composite_norm + w_agent·agent_fit + w_rs·rs_score + w_ext·extension_score
+```
+
+### Stage 1 — 보조 트리거 임계 통일 (저위험, KR+US)
+`≤20%` → `≤15%`:
+- KR: `trigger_batch.py:403`, `:587`, `:725`
+- US: `prism-us/us_trigger_batch.py:272`, `:415`
+
+효과는 작지만 주력 트리거(이미 15%)와 일관성. 롤백 = 숫자 5개 되돌림.
+
+### Stage 2 — Extension(과열) soft score (KR only)
+종목별 지표:
+- `MA20` = 최근 20거래일 종가 평균
+- `ADR_pct` = 최근 20거래일 `(High/Low − 1)×100`의 평균 (미너비니 ADR)
+- `extension_in_adr = ((Close − MA20) / MA20 × 100) / ADR_pct`
+  → "현재가가 MA20에서 평소 하루 변동폭(ADR)의 몇 배만큼 떠 있나"
+- `extension_score`(0~1, 높을수록 건강): `T_low`(예 2 ADR) 이하=1.0(무감점), `T_high`(예 6 ADR) 이상=0.0(최대감점), 사이 선형. 임계는 모듈 상수로 튜닝 가능.
+
+데이터: 기존 `get_multi_day_ohlcv`(Open/High/Low/Close/Volume/Amount 반환)를 **lookback 10→20일**로 확대해 산출. 이미 `score_candidates_by_agent_criteria` 루프에서 종목별 호출 중 → 추가 네트워크 비용 최소.
+
+### Stage 3 — RS(다주) 가점 (KR only) + strong_bull 재활성화
+- `rs_relative = 종목 ~60거래일(약 3개월) 수익률 − 벤치마크 동기간 수익률`
+  벤치마크 = 해당 종목 시장 지수(코스피/코스닥 N일 수익률). `get_multi_day_ohlcv(days≈60)` + 지수 시계열 1회.
+- `rs_score` = 후보군 내 `rs_relative` 정규화(0~1).
+- `trigger_macro_sector_leader`:
+  - 단일일 RelativeStrength(`:910`) → 다주 `rs_relative`로 격상.
+  - strong_bull 비활성(`:1338`) 해제 — 단 과열점수도 함께 적용해 "안 뜬 섹터 주도주"를 surface.
+
+### 국면별 가중치 (모듈 상수 1곳, 재배포 없이 튜닝)
+| 국면 | w_comp(모멘텀) | w_agent(R/R) | w_rs(RS) | w_ext(과열) |
+|---|---|---|---|---|
+| strong_bull | 0.20 | 0.35 | **0.30** | **0.15** |
+| moderate_bull | 0.25 | 0.35 | 0.20 | 0.20 |
+| sideways | 0.20 | 0.35 | 0.15 | **0.30** |
+| moderate_bear / strong_bear | 0.15 | 0.35 | 0.15 | **0.35** |
+
+- 합 = 1.0. `agent_fit`(R/R) 비중 유지로 손익비 안전망 보존.
+- strong_bull: RS↑(주도주 선별)·과열 완화하되 **0 아님**(보정3, climax 보호).
+- 평온/하락장: 과열 감점 강화(추격이 가장 위험한 구간).
+- macro_context의 `market_regime`로 분기(기존 `_get_regime_slots` 패턴 재사용).
+
+---
+
+## 4. 범위 결정
+
+- **Stage 2·3는 KR 전용.** 진단상 US는 스크리닝이 건강(매수에이전트 avg 5~7점, 슬롯/섹터 캡에 막힘). 과열감점을 US에 넣으면 멀쩡한 파이프라인 훼손 위험.
+- **US 캡 완화는 #289와 별개** — 별도 이슈로 분리(out of scope).
+- **매수에이전트(`trading_agents.py`)는 미수정** — 구조적으로 호환되게 스크리닝만 정렬(스코프 최소). 보정2로 신호 #3과 충돌 없음.
+- **극단 climax 하드컷은 v1 제외** — soft 재정렬만으로 시작, 라이브 관찰 후 필요 시 도입(reversibility 우선).
+
+---
+
+## 5. 관측 (백테스트 대체)
+
+- 선정 JSON(`run_batch` 출력, `trigger_batch.py:1402` 부근)의 `stock_info`에 `extension_in_adr`, `rs_relative`, `rs_score`, `extension_score`, 각 sub-score 기록 → 매일 가시 확인.
+- #294 매매일지 영향추적 / 주간 리포트로 **KR 진입수·평균 buy_score** 변화를 2~4주 관찰.
+- 가중치·임계는 모듈 상수 → 재배포 없이 튜닝/롤백.
+
+## 6. 롤백 전략
+- Stage 1: 숫자 5개 되돌림.
+- Stage 2·3: 국면 가중치에서 `w_rs=w_ext=0`으로 두면 `final_score`가 composite·agent 재정렬로 환원(RS/과열 영향 제거). 즉 **킬 스위치 = 상수 0**. 완전한 기존 동작 복원이 필요하면 같은 상수 테이블에서 comp/agent를 0.3/0.7로 되돌림(가중치는 활성 항목 합으로 정규화).
+- `trigger_macro_sector_leader` strong_bull 재활성화는 `:1338` 한 줄 복원으로 되돌림.
+
+## 7. 리스크 / 미해결
+- **RS 벤치마크 선택**(코스피 vs 코스닥 vs 종목별 소속 지수): 구현 계획에서 종목 시장 구분 매핑 확인 필요.
+- **데이터 비용**: 후보 ~30-60종목 × 60일 OHLCV. 기존 루프에 흡수되나 RS용 추가 일수만큼 호출 비용 증가 — 캐싱/배치 검토.
+- **soft score 효과 검증**: 백테스트 불가 → 2~4주 라이브 관찰로만 판단. 효과 미미 시 가중치 상향 또는 하드컷 도입(2차).
+- **KR/US 미러 주의**: Stage 1만 양쪽, Stage 2·3 KR 전용 — US 파일에 과열/RS 로직 넣지 말 것.
+
+## 8. 작업 규약
+- 코드(.py) 변경 → feature 브랜치 + PR (예: `feat/issue-289-kr-screening-rs-extension`).
+- 커밋 끝: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- 파일 이동/생성 없음(기존 함수 확장 위주) → crontab import 깨짐 없음. 그래도 머지 전 `python -c "import trigger_batch"` 검증.

--- a/docs/superpowers/specs/2026-05-29-kr-screening-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-29-kr-screening-redesign-design.md
@@ -59,12 +59,13 @@
 final_score = w_comp·composite_norm + w_agent·agent_fit + w_rs·rs_score + w_ext·extension_score
 ```
 
-### Stage 1 — 보조 트리거 임계 통일 (저위험, KR+US)
+### Stage 1 — 보조 트리거 임계 통일 (저위험, **KR only**)
 `≤20%` → `≤15%`:
 - KR: `trigger_batch.py:403`, `:587`, `:725`
-- US: `prism-us/us_trigger_batch.py:272`, `:415`
 
-효과는 작지만 주력 트리거(이미 15%)와 일관성. 롤백 = 숫자 5개 되돌림.
+주력 트리거(이미 15%)와 일관성. 롤백 = 숫자 3개 되돌림.
+
+> **US 제외 결정 (2026-05-29)**: #289의 전제가 "KR과 US는 구조가 다르다"이다. US는 ±제한폭이 없고 개인 과열이 적어 15~20% 상승이 정당한 돌파일 때가 많으며, 진단상 US 병목은 스크리닝 품질이 아니라 슬롯/섹터 캡이다. US 보조 트리거를 조이면 멀쩡한 후보만 줄어듦 → **#289는 전 단계 KR 전용**, `us_trigger_batch.py` 미수정.
 
 ### Stage 2 — Extension(과열) soft score (KR only)
 종목별 지표:
@@ -81,8 +82,10 @@ final_score = w_comp·composite_norm + w_agent·agent_fit + w_rs·rs_score + w_e
   벤치마크 = 해당 종목 시장 지수(코스피/코스닥 N일 수익률). `get_multi_day_ohlcv(days≈60)` + 지수 시계열 1회.
 - `rs_score` = 후보군 내 `rs_relative` 정규화(0~1).
 - `trigger_macro_sector_leader`:
-  - 단일일 RelativeStrength(`:910`) → 다주 `rs_relative`로 격상.
-  - strong_bull 비활성(`:1338`) 해제 — 단 과열점수도 함께 적용해 "안 뜬 섹터 주도주"를 surface.
+  - strong_bull 비활성(`:1338`) 해제 — 폭등장에서도 섹터 주도주 후보 진입.
+  - **단일일 RelativeStrength(`:910`)는 섹터 shortlist용으로 유지**(top100 종목에 60일 fetch는 과비용). 실제 다주 RS 재정렬은 **downstream `final_score`(아래 통합)** 에서 모든 트리거 후보에 일괄 적용 — macro 트리거 후보도 여기서 60일 RS·과열점수로 재정렬됨.
+
+> **구현 정교화**: `calculate_agent_fit_metrics`의 target price는 10일 고가 기반이므로 그 lookback을 바꾸면 R/R(=agent_fit)이 변동(스코프 외). 따라서 MA20·ADR·60일수익률은 **별도 함수 `calculate_screening_signals`** 에서 60일 OHLCV 1회 fetch로 산출(에이전트 스코어 불변). 대상은 최종 후보군(~30-60종목)뿐.
 
 ### 국면별 가중치 (모듈 상수 1곳, 재배포 없이 튜닝)
 | 국면 | w_comp(모멘텀) | w_agent(R/R) | w_rs(RS) | w_ext(과열) |
@@ -101,7 +104,7 @@ final_score = w_comp·composite_norm + w_agent·agent_fit + w_rs·rs_score + w_e
 
 ## 4. 범위 결정
 
-- **Stage 2·3는 KR 전용.** 진단상 US는 스크리닝이 건강(매수에이전트 avg 5~7점, 슬롯/섹터 캡에 막힘). 과열감점을 US에 넣으면 멀쩡한 파이프라인 훼손 위험.
+- **전 단계(Stage 1·2·3) KR 전용.** 진단상 US는 스크리닝이 건강(매수에이전트 avg 5~7점, 슬롯/섹터 캡에 막힘). 과열감점을 US에 넣으면 멀쩡한 파이프라인 훼손 위험. Stage 1 임계 통일도 US에는 불필요(위 결정).
 - **US 캡 완화는 #289와 별개** — 별도 이슈로 분리(out of scope).
 - **매수에이전트(`trading_agents.py`)는 미수정** — 구조적으로 호환되게 스크리닝만 정렬(스코프 최소). 보정2로 신호 #3과 충돌 없음.
 - **극단 climax 하드컷은 v1 제외** — soft 재정렬만으로 시작, 라이브 관찰 후 필요 시 도입(reversibility 우선).

--- a/tests/test_issue_289_screening.py
+++ b/tests/test_issue_289_screening.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+#289 KR screening redesign — unit tests (no live data required).
+
+Validates pure logic of the O'Neil-style RS + extension soft-score redesign:
+  - extension_score mapping (ADR units above MA20 → 0~1)
+  - regime-aware blend weights (sum to 1.0, climax protection retained in strong_bull)
+  - RS cross-candidate normalization
+  - final_score blend range + kill-switch reduction
+  - Stage-1 threshold unification (no 20% caps remain in KR triggers)
+  - calculate_screening_signals safe defaults (no network for invalid price)
+  - file parses + module imports
+"""
+import os
+import sys
+import ast
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+passed = 0
+failed = 0
+
+
+def check(label, cond):
+    global passed, failed
+    if cond:
+        passed += 1
+        print(f"  PASS: {label}")
+    else:
+        failed += 1
+        print(f"  FAIL: {label}")
+
+
+import trigger_batch as t
+
+print("[Test 1] _compute_extension_score mapping")
+check("at T_low → 1.0", t._compute_extension_score(t.EXTENSION_ADR_T_LOW) == 1.0)
+check("below T_low → 1.0", t._compute_extension_score(0.0) == 1.0)
+check("at T_high → 0.0", t._compute_extension_score(t.EXTENSION_ADR_T_HIGH) == 0.0)
+check("above T_high → 0.0", t._compute_extension_score(99.0) == 0.0)
+_mid = (t.EXTENSION_ADR_T_LOW + t.EXTENSION_ADR_T_HIGH) / 2
+check("midpoint ≈ 0.5", abs(t._compute_extension_score(_mid) - 0.5) < 1e-9)
+# Monotonic non-increasing
+_xs = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+_ys = [t._compute_extension_score(x) for x in _xs]
+check("monotonic non-increasing", all(_ys[i] >= _ys[i + 1] for i in range(len(_ys) - 1)))
+check("all in [0,1]", all(0.0 <= y <= 1.0 for y in _ys))
+
+print("\n[Test 2] regime blend weights")
+_expected_regimes = {"strong_bull", "moderate_bull", "sideways", "moderate_bear", "strong_bear"}
+check("all 5 regimes present", set(t.REGIME_SCORE_WEIGHTS) == _expected_regimes)
+for _r, _w in t.REGIME_SCORE_WEIGHTS.items():
+    check(f"{_r} weights sum to 1.0", abs(sum(_w) - 1.0) < 1e-9)
+    check(f"{_r} has 4 components", len(_w) == 4)
+# strong_bull: RS emphasized but extension NOT zero (climax protection retained — correction 3)
+_sb = t.REGIME_SCORE_WEIGHTS["strong_bull"]
+_sw = t.REGIME_SCORE_WEIGHTS["sideways"]
+check("strong_bull extension weight > 0 (climax guard retained)", _sb[3] > 0)
+check("strong_bull RS weight > sideways RS weight", _sb[2] > _sw[2])
+check("sideways extension weight > strong_bull (heavier penalty when calm)", _sw[3] > _sb[3])
+check("agent R/R weight kept meaningful (>=0.3) in every regime",
+      all(_w[1] >= 0.3 for _w in t.REGIME_SCORE_WEIGHTS.values()))
+
+print("\n[Test 3] RS cross-candidate normalization")
+
+
+def _rs_norm(returns):
+    r_min, r_max = min(returns), max(returns)
+    r_range = r_max - r_min if r_max > r_min else 0.0
+    return [((x - r_min) / r_range) if r_range > 0 else 0.5 for x in returns]
+
+
+_n = _rs_norm([10.0, 20.0, 30.0])
+check("min → 0.0", abs(_n[0] - 0.0) < 1e-9)
+check("max → 1.0", abs(_n[2] - 1.0) < 1e-9)
+check("mid → 0.5", abs(_n[1] - 0.5) < 1e-9)
+check("all-equal returns → 0.5 each", _rs_norm([5.0, 5.0, 5.0]) == [0.5, 0.5, 0.5])
+
+print("\n[Test 4] final_score blend range + kill switch")
+
+
+def _blend(comp, agent, rs, ext, w):
+    return comp * w[0] + agent * w[1] + rs * w[2] + ext * w[3]
+
+
+# All components in [0,1] + weights sum 1 → final in [0,1]
+for _r, _w in t.REGIME_SCORE_WEIGHTS.items():
+    _hi = _blend(1, 1, 1, 1, _w)
+    _lo = _blend(0, 0, 0, 0, _w)
+    check(f"{_r} blend(1,1,1,1)=1.0", abs(_hi - 1.0) < 1e-9)
+    check(f"{_r} blend(0,0,0,0)=0.0", abs(_lo - 0.0) < 1e-9)
+# Kill switch: w_rs=w_ext=0 → final depends only on composite+agent
+_killed = (0.3, 0.7, 0.0, 0.0)
+check("kill switch ignores RS/ext (high vs low RS/ext identical)",
+      _blend(0.5, 0.5, 1.0, 1.0, _killed) == _blend(0.5, 0.5, 0.0, 0.0, _killed))
+# A non-extended leader should outscore a climax leader (same comp/agent/RS, different ext)
+_sw_w = t.REGIME_SCORE_WEIGHTS["sideways"]
+_leader = _blend(0.5, 0.8, 0.9, 1.0, _sw_w)   # ext_score 1.0 (healthy)
+_climax = _blend(0.5, 0.8, 0.9, 0.0, _sw_w)   # ext_score 0.0 (extended)
+check("non-extended leader > climax (same else)", _leader > _climax)
+
+print("\n[Test 5] Stage-1 threshold unification (KR, no 20% caps remain)")
+_src = open(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "trigger_batch.py")).read()
+check("no 'prev_day_change_rate'] <= 20.0' remains", 'prev_day_change_rate"] <= 20.0' not in _src)
+check("at least 3 '<= 15.0' change-rate caps present", _src.count('prev_day_change_rate"] <= 15.0') >= 3)
+
+print("\n[Test 6] calculate_screening_signals safe defaults (no network)")
+_sig = t.calculate_screening_signals("000000", 0.0, "20260529")  # current_price<=0 short-circuits
+check("invalid price → extension_score default 1.0", _sig["extension_score"] == 1.0)
+check("invalid price → extension_in_adr default 0.0", _sig["extension_in_adr"] == 0.0)
+check("invalid price → return_nd default 0.0", _sig["return_nd"] == 0.0)
+
+print("\n[Test 7] file parses + symbols exported")
+check("ast.parse OK", ast.parse(_src) is not None)
+for _sym in ("REGIME_SCORE_WEIGHTS", "EXTENSION_ADR_T_LOW", "EXTENSION_ADR_T_HIGH",
+             "SCREENING_SIGNAL_LOOKBACK_DAYS", "_compute_extension_score",
+             "calculate_screening_signals"):
+    check(f"exported: {_sym}", hasattr(t, _sym))
+
+print("\n[Test 8] select_final_tickers integration (mocked OHLCV, no network)")
+import pandas as pd
+import numpy as np
+
+
+def _fake_ohlcv(ticker, end_date, days=60):
+    """Synthetic OHLCV: LEADER = steady trend near base (low extension),
+    CLIMAX = late blow-off far above MA20 (high extension), higher raw return."""
+    idx = pd.date_range(end="2026-05-29", periods=days)
+    if ticker == "LEADER":
+        close = np.linspace(100.0, 120.0, days)          # steady uptrend
+        high = close * 1.01
+        low = close * 0.99                                # ADR ~2%
+    else:  # CLIMAX
+        close = np.array([100.0] * (days - 3) + [110.0, 130.0, 150.0])
+        high = close * 1.025
+        low = close * 0.975                               # ADR ~5%, huge late extension
+    return pd.DataFrame(
+        {"Open": close, "High": high, "Low": low, "Close": close,
+         "Volume": [1_000_000] * days, "Amount": [1e10] * days}, index=idx)
+
+
+_orig_ohlcv = t.get_multi_day_ohlcv
+try:
+    t.get_multi_day_ohlcv = _fake_ohlcv
+    df = pd.DataFrame(
+        {"Close": [120.0, 150.0], "composite_score": [0.5, 0.5],
+         "Amount": [1e10, 1e10], "Volume": [1_000_000, 1_000_000],
+         "stock_name": ["LEADER", "CLIMAX"]},
+        index=["LEADER", "CLIMAX"])
+    triggers = {"일중 상승률 상위주": df}
+    result = t.select_final_tickers(
+        triggers, trade_date="20260529", use_hybrid=True,
+        macro_context={"market_regime": "sideways"})
+
+    # Flatten selected rows
+    rows = {}
+    for _name, rdf in result.items():
+        for tk in rdf.index:
+            rows[tk] = rdf.loc[tk]
+    check("returns at least one selection", len(rows) >= 1)
+    _any = next(iter(rows.values()))
+    for col in ("rs_score", "rs_relative", "extension_score", "extension_in_adr", "final_score"):
+        check(f"selected row has '{col}'", col in _any.index)
+    # Both get selected (3 slots, 2 candidates), but the redesign must SCORE the
+    # non-extended LEADER above the higher-RS CLIMAX in sideways (extension weight 0.30).
+    check("both candidates present (spare slots)", "LEADER" in rows and "CLIMAX" in rows)
+    if "LEADER" in rows and "CLIMAX" in rows:
+        check("LEADER extension_score > CLIMAX (climax penalized)",
+              float(rows["LEADER"]["extension_score"]) > float(rows["CLIMAX"]["extension_score"]))
+        check("LEADER final_score > CLIMAX final_score (re-rank works despite lower RS)",
+              float(rows["LEADER"]["final_score"]) > float(rows["CLIMAX"]["final_score"]))
+        print(f"    [info] LEADER final={float(rows['LEADER']['final_score']):.3f} "
+              f"(ext={float(rows['LEADER']['extension_score']):.2f}, adr={float(rows['LEADER']['extension_in_adr']):.1f}, rs={float(rows['LEADER']['rs_score']):.2f}) | "
+              f"CLIMAX final={float(rows['CLIMAX']['final_score']):.3f} "
+              f"(ext={float(rows['CLIMAX']['extension_score']):.2f}, adr={float(rows['CLIMAX']['extension_in_adr']):.1f}, rs={float(rows['CLIMAX']['rs_score']):.2f})")
+finally:
+    t.get_multi_day_ohlcv = _orig_ohlcv
+
+print(f"\n===== RESULT: {passed} passed, {failed} failed =====")
+sys.exit(1 if failed else 0)

--- a/trigger_batch.py
+++ b/trigger_batch.py
@@ -356,6 +356,93 @@ def score_candidates_by_agent_criteria(candidates_df: pd.DataFrame, trade_date: 
     return result_df
 
 
+# === #289: KR screening signals (O'Neil-style RS + extension), regime-aware blend ===
+# Regime-aware weights for final_score: (composite/momentum, agent R/R, RS, extension).
+# Each component is 0~1 and weights sum to 1.0 → final_score stays in 0~1.
+# Kill switch / rollback: set RS and extension weights to 0 (then re-rank is composite+agent only).
+REGIME_SCORE_WEIGHTS = {
+    "strong_bull":   (0.20, 0.35, 0.30, 0.15),  # bull: emphasize RS (leaders), lighten extension (but not 0)
+    "moderate_bull": (0.25, 0.35, 0.20, 0.20),
+    "sideways":      (0.20, 0.35, 0.15, 0.30),  # calm: heavier extension penalty (chasing worst here)
+    "moderate_bear": (0.15, 0.35, 0.15, 0.35),
+    "strong_bear":   (0.15, 0.35, 0.15, 0.35),
+}
+_DEFAULT_SCORE_WEIGHTS = REGIME_SCORE_WEIGHTS["sideways"]
+
+# Extension (overheating) thresholds, measured in ADR units above MA20.
+EXTENSION_ADR_T_LOW = 2.0    # <= : healthy (near base) → no penalty (score 1.0)
+EXTENSION_ADR_T_HIGH = 6.0   # >= : climax / extended → full penalty (score 0.0)
+
+# Multi-week relative-strength lookback (trading days, ~3 months).
+SCREENING_SIGNAL_LOOKBACK_DAYS = 60
+
+
+def _compute_extension_score(extension_in_adr: float) -> float:
+    """#289: Map ADR-extension above MA20 to a 0~1 score.
+
+    1.0 = healthy (price near its 20-day mean, i.e. near a base/pivot),
+    0.0 = climax / extended (price far above the mean in volatility-normalized terms).
+    Linear taper between EXTENSION_ADR_T_LOW and EXTENSION_ADR_T_HIGH.
+    """
+    if extension_in_adr <= EXTENSION_ADR_T_LOW:
+        return 1.0
+    if extension_in_adr >= EXTENSION_ADR_T_HIGH:
+        return 0.0
+    span = EXTENSION_ADR_T_HIGH - EXTENSION_ADR_T_LOW
+    return float(max(0.0, min(1.0, 1.0 - (extension_in_adr - EXTENSION_ADR_T_LOW) / span)))
+
+
+def calculate_screening_signals(ticker: str, current_price: float, trade_date: str,
+                                lookback_days: int = SCREENING_SIGNAL_LOOKBACK_DAYS) -> dict:
+    """#289: Compute O'Neil-style screening signals from a single multi-week OHLCV fetch.
+
+    Intentionally independent of calculate_agent_fit_metrics so the agent's 10-day
+    target-price (resistance) lookback — and therefore agent_fit_score — is NOT perturbed.
+
+    Returns dict:
+        - extension_in_adr: (Close - MA20)/MA20 expressed in units of ADR% (overheating proxy)
+        - extension_score:  0~1 (1=healthy near base, 0=climax/extended)
+        - return_nd:        N-day price return % (raw multi-week relative-strength input;
+                            benchmark subtraction cancels under cross-candidate normalization)
+    """
+    result = {"extension_in_adr": 0.0, "extension_score": 1.0, "return_nd": 0.0}
+    if current_price <= 0:
+        return result
+
+    df = get_multi_day_ohlcv(ticker, trade_date, lookback_days)
+    if df.empty or len(df) < 5:
+        return result
+
+    high_col = "High" if "High" in df.columns else "고가"
+    low_col = "Low" if "Low" in df.columns else "저가"
+    close_col = "Close" if "Close" in df.columns else "종가"
+    if close_col not in df.columns:
+        return result
+
+    closes = df[close_col][df[close_col] > 0]
+    if closes.empty:
+        return result
+
+    # Multi-week return (relative-strength input).
+    first_close = float(closes.iloc[0])
+    if first_close > 0:
+        result["return_nd"] = (current_price - first_close) / first_close * 100
+
+    # MA20 + ADR(20d) extension.
+    recent_closes = closes.tail(20)
+    ma20 = float(recent_closes.mean()) if len(recent_closes) > 0 else 0.0
+    if ma20 > 0 and high_col in df.columns and low_col in df.columns:
+        hl = df.tail(20)
+        valid = hl[(hl[high_col] > 0) & (hl[low_col] > 0)]
+        if not valid.empty:
+            adr_pct = float(((valid[high_col] / valid[low_col] - 1.0) * 100).mean())
+            if adr_pct > 0:
+                ext = ((current_price - ma20) / ma20 * 100) / adr_pct
+                result["extension_in_adr"] = float(ext)
+                result["extension_score"] = _compute_extension_score(ext)
+    return result
+
+
 # --- Morning trigger functions (based on market open snapshot) ---
 def trigger_morning_volume_surge(trade_date: str, snapshot: pd.DataFrame, prev_snapshot: pd.DataFrame, cap_df: pd.DataFrame = None, top_n: int = 10) -> pd.DataFrame:
     """
@@ -399,8 +486,8 @@ def trigger_morning_volume_surge(trade_date: str, snapshot: pd.DataFrame, prev_s
     # Calculate change rate vs previous day - modified method
     snap["prev_day_change_rate"] = ((snap["Close"] - prev["Close"]) / prev["Close"]) * 100
 
-    # v1.16.6: Change rate upper limit (20% or less, surge stocks can enter with fixed stop-loss)
-    snap = snap[snap["prev_day_change_rate"] <= 20.0]
+    # #289: Change rate upper limit unified to 15% (was 20%) — align secondary triggers with primary
+    snap = snap[snap["prev_day_change_rate"] <= 15.0]
 
     # Debug calculation process for first 5 stocks' change rate vs previous day
     for ticker in snap.index[:5]:
@@ -583,8 +670,8 @@ def trigger_morning_value_to_cap_ratio(trade_date: str, snapshot: pd.DataFrame, 
         merged["prev_day_change_rate"] = ((merged["Close"] - prev["Close"]) / prev["Close"]) * 100  # Same as brokerage app
         merged["is_rising"] = merged["Close"] > merged["Open"]
 
-        # v1.16.6: Change rate upper limit (20% or less, surge stocks can enter with fixed stop-loss)
-        merged = merged[merged["prev_day_change_rate"] <= 20.0]
+        # #289: Change rate upper limit unified to 15% (was 20%) — align secondary triggers with primary
+        merged = merged[merged["prev_day_change_rate"] <= 15.0]
         if merged.empty:
             logger.warning("No stocks after change rate upper limit filtering")
             return pd.DataFrame()
@@ -721,8 +808,8 @@ def trigger_afternoon_closing_strength(trade_date: str, snapshot: pd.DataFrame, 
     snap["intraday_change_rate"] = (snap["Close"] / snap["Open"] - 1) * 100  # Current vs opening price
     snap["prev_day_change_rate"] = ((snap["Close"] - prev["Close"]) / prev["Close"]) * 100  # Same as brokerage app
 
-    # v1.16.7: Change rate upper limit (20% or less, exclude limit-up stocks)
-    snap = snap[snap["prev_day_change_rate"] <= 20.0]
+    # #289: Change rate upper limit unified to 15% (was 20%) — exclude limit-up / align with primary
+    snap = snap[snap["prev_day_change_rate"] <= 15.0]
     if snap.empty:
         logger.debug("trigger_afternoon_closing_strength: No stocks after change rate filtering")
         return pd.DataFrame()
@@ -1162,27 +1249,58 @@ def select_final_tickers(triggers: dict, trade_date: str = None, use_hybrid: boo
         logger.warning("No candidates from all triggers.")
         return final_result
 
-    # 2. Hybrid mode: Calculate agent scores
+    # 2. Hybrid mode: Calculate agent scores + #289 RS/extension signals
     if use_hybrid and trade_date:
         logger.info(f"Hybrid selection mode - Calculate agent scores with {lookback_days}-day data")
 
+        # #289: regime-aware blend weights (composite, agent R/R, RS, extension)
+        _regime = macro_context.get("market_regime", "sideways") if macro_context else "sideways"
+        w_comp, w_agent, w_rs, w_ext = REGIME_SCORE_WEIGHTS.get(_regime, _DEFAULT_SCORE_WEIGHTS)
+        logger.info(f"[#289] Blend weights for regime '{_regime}': "
+                    f"composite={w_comp}, agent={w_agent}, RS={w_rs}, extension={w_ext}")
+
+        # #289: pre-compute O'Neil-style signals across ALL unique candidates (cross-trigger),
+        # then normalize the multi-week return into a relative-strength score (0~1).
+        screening_signals = {}  # ticker -> {extension_in_adr, extension_score, return_nd}
+        for _name, _cdf in trigger_candidates.items():
+            for _ticker in _cdf.index:
+                if _ticker in screening_signals:
+                    continue
+                _cp = _cdf.loc[_ticker, "Close"] if "Close" in _cdf.columns else 0
+                screening_signals[_ticker] = calculate_screening_signals(_ticker, float(_cp), trade_date)
+
+        rs_score_map = {}
+        if screening_signals:
+            _returns = [s["return_nd"] for s in screening_signals.values()]
+            _r_min, _r_max = min(_returns), max(_returns)
+            _r_range = _r_max - _r_min if _r_max > _r_min else 0.0
+            for _ticker, s in screening_signals.items():
+                rs_score_map[_ticker] = ((s["return_nd"] - _r_min) / _r_range) if _r_range > 0 else 0.5
+
         for name, candidates_df in trigger_candidates.items():
-            # v1.16.6: Calculate agent scores by trigger type
+            # v1.16.6: Calculate agent scores by trigger type (agent_fit_score unchanged)
             scored_df = score_candidates_by_agent_criteria(candidates_df, trade_date, lookback_days, trigger_type=name)
 
-            # v1.16.6: Calculate final score: composite score (30%) + agent score (70%)
-            # Increase agent score weight to prioritize stocks likely to be approved by agents
+            # #289: final score = regime-weighted blend of composite + agent + RS + extension
             if "composite_score" in scored_df.columns and "agent_fit_score" in scored_df.columns:
-                # Normalize composite score (0~1)
+                # Normalize composite score (0~1) within trigger
                 cp_max = scored_df["composite_score"].max()
                 cp_min = scored_df["composite_score"].min()
                 cp_range = cp_max - cp_min if cp_max > cp_min else 1
                 scored_df["composite_score_norm"] = (scored_df["composite_score"] - cp_min) / cp_range
 
-                # Calculate final score (v1.16.6: adjusted weights)
+                # #289: attach RS + extension signals (cross-candidate)
+                scored_df["rs_score"] = [rs_score_map.get(t, 0.5) for t in scored_df.index]
+                scored_df["rs_relative"] = [screening_signals.get(t, {}).get("return_nd", 0.0) for t in scored_df.index]
+                scored_df["extension_score"] = [screening_signals.get(t, {}).get("extension_score", 1.0) for t in scored_df.index]
+                scored_df["extension_in_adr"] = [screening_signals.get(t, {}).get("extension_in_adr", 0.0) for t in scored_df.index]
+
+                # #289: regime-aware final score (was composite*0.3 + agent*0.7)
                 scored_df["final_score"] = (
-                    scored_df["composite_score_norm"] * 0.3 +
-                    scored_df["agent_fit_score"] * 0.7
+                    scored_df["composite_score_norm"] * w_comp +
+                    scored_df["agent_fit_score"] * w_agent +
+                    scored_df["rs_score"] * w_rs +
+                    scored_df["extension_score"] * w_ext
                 )
 
                 # Sort by final score
@@ -1194,9 +1312,10 @@ def select_final_tickers(triggers: dict, trade_date: str = None, use_hybrid: boo
                     logger.info(f"  - {ticker} ({scored_df.loc[ticker, 'stock_name'] if 'stock_name' in scored_df.columns else ''}): "
                                f"Composite={scored_df.loc[ticker, 'composite_score']:.3f}, "
                                f"Agent={scored_df.loc[ticker, 'agent_fit_score']:.3f}, "
+                               f"RS={scored_df.loc[ticker, 'rs_score']:.3f}, "
+                               f"Ext={scored_df.loc[ticker, 'extension_score']:.3f}(adr={scored_df.loc[ticker, 'extension_in_adr']:.1f}), "
                                f"Final={scored_df.loc[ticker, 'final_score']:.3f}, "
-                               f"Risk-reward={scored_df.loc[ticker, 'risk_reward_ratio']:.2f}, "
-                               f"Stop-loss={scored_df.loc[ticker, 'stop_loss_pct']*100:.1f}%")
+                               f"R/R={scored_df.loc[ticker, 'risk_reward_ratio']:.2f}")
 
             trigger_candidates[name] = scored_df
 
@@ -1334,12 +1453,13 @@ def run_batch(trigger_time: str, log_level: str = "INFO", output_file: str = Non
     # === New triggers: active based on market regime ===
     if macro_context:
         market_regime = macro_context.get("market_regime", "sideways")
-        # Macro sector trigger: active in all regimes except strong_bull
-        if market_regime not in ("strong_bull",):
-            res_macro = trigger_macro_sector_leader(trade_date, snapshot, prev_snapshot, cap_df, macro_context)
-            if not res_macro.empty:
-                triggers["매크로 섹터 리더"] = res_macro
-                logger.info(f"매크로 섹터 리더: {len(res_macro)} candidates")
+        # #289: Macro sector trigger now active in ALL regimes (incl. strong_bull) so that
+        # sector leaders surface even in surging markets; downstream RS/extension blend
+        # re-ranks them to favor non-extended leaders.
+        res_macro = trigger_macro_sector_leader(trade_date, snapshot, prev_snapshot, cap_df, macro_context)
+        if not res_macro.empty:
+            triggers["매크로 섹터 리더"] = res_macro
+            logger.info(f"매크로 섹터 리더: {len(res_macro)} candidates")
 
         # Contrarian value: active in sideways, moderate_bear, strong_bear
         if market_regime in ("sideways", "moderate_bear", "strong_bear"):
@@ -1407,6 +1527,14 @@ def run_batch(trigger_time: str, log_level: str = "INFO", output_file: str = Non
                         stock_info["target_price"] = float(stocks_df.loc[ticker, "target_price"]) if "target_price" in stocks_df.columns else 0
                     if "final_score" in stocks_df.columns:
                         stock_info["final_score"] = float(stocks_df.loc[ticker, "final_score"])
+
+                    # #289: observability — RS + extension signals
+                    if "rs_score" in stocks_df.columns:
+                        stock_info["rs_score"] = float(stocks_df.loc[ticker, "rs_score"])
+                        stock_info["rs_relative"] = float(stocks_df.loc[ticker, "rs_relative"]) if "rs_relative" in stocks_df.columns else 0
+                    if "extension_score" in stocks_df.columns:
+                        stock_info["extension_score"] = float(stocks_df.loc[ticker, "extension_score"])
+                        stock_info["extension_in_adr"] = float(stocks_df.loc[ticker, "extension_in_adr"]) if "extension_in_adr" in stocks_df.columns else 0
 
                     if "SelectionChannel" in stocks_df.columns:
                         stock_info["selection_channel"] = str(stocks_df.loc[ticker, "SelectionChannel"])


### PR DESCRIPTION
## 배경 (#289)
KR 스크리닝이 **당일 raw 급등률**로만 거름 → ±30% 제한+개인 과열 탓에 같은 %라도 US보다 훨씬 **climax(소진 급등)** 종목이 후보로 올라옴 → CAN SLIM 매수에이전트가 **정당하게 2/10**으로 거절(최근 30일 score=2 51건, 진입 0). 필터 20→15는 cosmetic이었음.

**진단**: 매수에이전트는 정상. 스크리닝이 에이전트의 오닐 판단과 싸우며 슬롯을 낭비. → 오닐/CAN SLIM의 **상대강도(RS)+extension(과열)** 판별을 스크리닝 상류로 전파(에이전트 미수정, 구조적 정렬).

## 변경 (전부 KR only)
- **Stage 1**: 보조 트리거 임계 `20→15` 통일 (`trigger_batch.py` 3곳)
- **Stage 2**: extension 과열점수 — `(Close−MA20)/MA20 / ADR%` 를 0~1 소프트 감점. **52주고가 아닌 MA20+ADR 기준** → 매수에이전트 모멘텀신호 #3(신고가 가점)과 이중평가 충돌 없이 상호보완
- **Stage 3**: 다주(60일) RS 가점 + `trigger_macro_sector_leader` strong_bull 재활성화
- **국면별 가중치** `REGIME_SCORE_WEIGHTS`: strong_bull은 RS↑·과열 완화(단 0 아님 — 상승장 말기 climax 보호), sideways/bear는 과열 페널티 강화. **후보 컷 없이 `final_score` 재정렬만**(soft)
- **관측**(백테스트 불가 대체): 선정 JSON에 `rs_score`/`rs_relative`/`extension_score`/`extension_in_adr` 기록
- **킬스위치/롤백**: RS·extension 가중치를 0으로 두면 composite+agent 재정렬로 환원

## 철학·궁합
오닐/CAN SLIM 정합 점검 + 매수에이전트(parabolic·distribution day·매트릭스) 궁합 점검을 설계 문서에 포함. 이상적 후보 = **고RS + 저extension**(지속 주도주의 돌파) vs **고RS + 고extension**(climax) 분리.

## 검증
`tests/test_issue_289_screening.py` **59개 통과**: extension 매핑, 국면가중 합=1, RS 정규화, final_score 블렌드/킬스위치, **통합 재정렬**(몽키패치 OHLCV — 저extension LEADER가 고RS CLIMAX를 final_score로 이김: `LEADER 0.650(ext1.0,adr1.4,rs0.0) > CLIMAX 0.500(ext0.0,adr8.5,rs1.0)`). syntax/import OK.
> 로컬 KRX 드라이런은 `data.krx.co.kr` 망 타임아웃으로 미수행 → 운영서버 cron 첫 실행에서 end-to-end 검증.

## 범위
- US 미적용 (시장 구조 상이, US 병목은 스크리닝 아닌 슬롯/섹터 캡 — 별개 이슈)
- 매수에이전트(`trading_agents.py`) 미수정
- 파일 이동/생성 없음 → crontab import 영향 없음

설계 문서: `docs/superpowers/specs/2026-05-29-kr-screening-redesign-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)