### PR TITLE
fix: 횡보주 트리거 MA20 하락추세 게이트 (#289 follow-up)

### DIFF
--- a/prism-us/us_trigger_batch.py
+++ b/prism-us/us_trigger_batch.py
@@ -563,6 +563,25 @@ def trigger_afternoon_closing_strength(trade_date: str, snapshot: pd.DataFrame,
     return enhance_dataframe(result.sort_values("CompositeScore", ascending=False).head(10))
 
 
+# Sideways trigger downtrend gate (#289 follow-up, mirrors KR trigger_batch.py):
+# a genuine consolidation base forms at/above the 20-day mean; a stock below MA20
+# on a quiet day is a downtrend, not a base. Allow a support test within -3% of MA20.
+SIDEWAYS_MA20_SUPPORT_TOLERANCE = 0.97
+
+
+def _compute_ma20(ticker: str, trade_date: str, lookback_days: int = 20) -> float:
+    """20-day moving average of close for the sideways downtrend gate.
+    Returns 0.0 when data is unavailable (gate treats 0 as 'unknown → pass')."""
+    df = get_multi_day_ohlcv(ticker, trade_date, lookback_days)
+    if df.empty:
+        return 0.0
+    close_col = "Close" if "Close" in df.columns else "종가"
+    if close_col not in df.columns:
+        return 0.0
+    closes = df[close_col][df[close_col] > 0].tail(20)
+    return float(closes.mean()) if len(closes) > 0 else 0.0
+
+
 def trigger_afternoon_volume_surge_flat(trade_date: str, snapshot: pd.DataFrame,
                                         prev_snapshot: pd.DataFrame, cap_df: pd.DataFrame = None,
                                         top_n: int = 20) -> pd.DataFrame:
@@ -614,6 +633,24 @@ def trigger_afternoon_volume_surge_flat(trade_date: str, snapshot: pd.DataFrame,
 
     if result.empty:
         logger.debug("trigger_afternoon_volume_surge_flat: No sideways stocks")
+        return pd.DataFrame()
+
+    # #289 follow-up: downtrend gate. IsSideways only checks |today's move| <= 5%,
+    # mislabeling a downtrending stock (below MA20) as "sideways". A real base sits
+    # at/above the 20-day mean — exclude names clearly below MA20.
+    kept_mask = []
+    for ticker in result.index:
+        ma20 = _compute_ma20(ticker, trade_date)
+        close_price = float(result.loc[ticker, "Close"])
+        kept_mask.append(ma20 <= 0 or close_price >= ma20 * SIDEWAYS_MA20_SUPPORT_TOLERANCE)
+    excluded = len(result) - sum(kept_mask)
+    result = result[pd.Series(kept_mask, index=result.index)].copy()
+    if excluded:
+        logger.debug(f"trigger_afternoon_volume_surge_flat: downtrend gate excluded "
+                     f"{excluded} stock(s) below MA20")
+
+    if result.empty:
+        logger.debug("trigger_afternoon_volume_surge_flat: No stocks after downtrend gate")
         return pd.DataFrame()
 
     logger.debug(f"Volume surge sideways detected: {len(result)} stocks")

--- a/tests/test_sideways_downtrend_gate.py
+++ b/tests/test_sideways_downtrend_gate.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+횡보주 트리거 하락추세 게이트 테스트 (#289 follow-up).
+
+is_sideways(당일 ±5%)만으로 "횡보" 판정하던 맹점 — MA20 하회 하락추세 종목
+(예: 이노션 2026-05-29)이 횡보로 오분류되던 것 — 을 MA20 추세 게이트로
+거르는지 검증. get_multi_day_ohlcv를 몽키패치해 망 없이 실행.
+"""
+import os
+import sys
+import pandas as pd
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+passed = 0
+failed = 0
+
+
+def check(label, cond):
+    global passed, failed
+    if cond:
+        passed += 1
+        print(f"  PASS: {label}")
+    else:
+        failed += 1
+        print(f"  FAIL: {label}")
+
+
+import trigger_batch as t
+
+print("[Test 1] _compute_ma20 — mock OHLCV로 평균 계산")
+_orig = t.get_multi_day_ohlcv
+
+
+def _mk(closes):
+    n = len(closes)
+    return pd.DataFrame({
+        "Open": closes, "High": [c * 1.01 for c in closes],
+        "Low": [c * 0.99 for c in closes], "Close": closes,
+        "Volume": [1_000_000] * n, "Amount": [1e10] * n,
+    })
+
+
+try:
+    t.get_multi_day_ohlcv = lambda tk, td, days=20: _mk([100.0] * 20)
+    check("MA20 of flat 100 = 100", abs(t._compute_ma20("X", "20260529") - 100.0) < 1e-9)
+    t.get_multi_day_ohlcv = lambda tk, td, days=20: pd.DataFrame()
+    check("데이터 없으면 0.0 (게이트 통과 처리)", t._compute_ma20("X", "20260529") == 0.0)
+
+    print("\n[Test 2] 게이트 경계 — SIDEWAYS_MA20_SUPPORT_TOLERANCE=0.97")
+    tol = t.SIDEWAYS_MA20_SUPPORT_TOLERANCE
+    check("tolerance = 0.97", tol == 0.97)
+    # MA20=100. 게이트 통과 조건: close >= 100*0.97 = 97
+    ma20 = 100.0
+    cases = [
+        ("MA20 위(105) 통과", 105.0, True),
+        ("MA20 정확(100) 통과", 100.0, True),
+        ("지지 테스트(-2%, 98) 통과", 98.0, True),
+        ("경계(-3%, 97) 통과", 97.0, True),
+        ("명백한 하회(-5%, 95) 제외", 95.0, False),
+        ("이노션류(-10%, 90) 제외", 90.0, False),
+    ]
+    for label, close, expected in cases:
+        gate_pass = (ma20 <= 0) or (close >= ma20 * tol)
+        check(label, gate_pass == expected)
+
+    print("\n[Test 3] 데이터 불명(ma20=0)이면 항상 통과 (데이터 blip에 종목 안 버림)")
+    check("ma20=0 → 통과", (0.0 <= 0) or (50.0 >= 0.0 * tol))
+
+    print("\n[Test 4] 이노션 시나리오 재현 — 하락추세는 제외, 지지횡보는 통과")
+    # 이노션: 종가 19850, MA20 위? 하락추세라 MA20 아래로 가정
+    inno_ma20 = 21000.0  # 최근 하락으로 MA20이 현재가보다 위
+    inno_close = 19850.0
+    inno_pass = (inno_ma20 <= 0) or (inno_close >= inno_ma20 * tol)  # 19850 >= 20370? No
+    check("이노션(하락추세, MA20 -5.5%) 제외됨", inno_pass is False)
+    # 진짜 지지 횡보주: MA20 근처에서 다지기
+    base_ma20 = 20000.0
+    base_close = 19900.0  # -0.5%, 지지 중
+    base_pass = (base_ma20 <= 0) or (base_close >= base_ma20 * tol)
+    check("지지 횡보주(MA20 -0.5%) 통과", base_pass is True)
+
+finally:
+    t.get_multi_day_ohlcv = _orig
+
+print(f"\n===== RESULT: {passed} passed, {failed} failed =====")
+sys.exit(1 if failed else 0)

--- a/trigger_batch.py
+++ b/trigger_batch.py
@@ -373,6 +373,12 @@ _DEFAULT_SCORE_WEIGHTS = REGIME_SCORE_WEIGHTS["sideways"]
 EXTENSION_ADR_T_LOW = 2.0    # <= : healthy (near base) → no penalty (score 1.0)
 EXTENSION_ADR_T_HIGH = 6.0   # >= : climax / extended → full penalty (score 0.0)
 
+# Sideways trigger downtrend gate (#289 follow-up): a genuine consolidation base
+# forms at/above the 20-day mean. A stock drifting BELOW MA20 on a quiet day is a
+# downtrend, not a base, and must not be treated as a buyable "sideways" stock.
+# Allow a support test within this fraction of MA20 (0.97 = down to -3% of MA20).
+SIDEWAYS_MA20_SUPPORT_TOLERANCE = 0.97
+
 # Multi-week relative-strength lookback (trading days, ~3 months).
 SCREENING_SIGNAL_LOOKBACK_DAYS = 60
 
@@ -441,6 +447,20 @@ def calculate_screening_signals(ticker: str, current_price: float, trade_date: s
                 result["extension_in_adr"] = float(ext)
                 result["extension_score"] = _compute_extension_score(ext)
     return result
+
+
+def _compute_ma20(ticker: str, trade_date: str, lookback_days: int = 20) -> float:
+    """#289 follow-up: 20-day moving average of close, for the sideways-trigger
+    downtrend gate. Returns 0.0 when data is unavailable (the gate treats 0 as
+    'unknown → pass' so a data blip never silently drops candidates)."""
+    df = get_multi_day_ohlcv(ticker, trade_date, lookback_days)
+    if df.empty:
+        return 0.0
+    close_col = "Close" if "Close" in df.columns else "종가"
+    if close_col not in df.columns:
+        return 0.0
+    closes = df[close_col][df[close_col] > 0].tail(20)
+    return float(closes.mean()) if len(closes) > 0 else 0.0
 
 
 # --- Morning trigger functions (based on market open snapshot) ---
@@ -903,6 +923,26 @@ def trigger_afternoon_volume_surge_flat(trade_date: str, snapshot: pd.DataFrame,
 
     if result.empty:
         logger.debug("trigger_afternoon_volume_surge_flat: No stocks meeting criteria")
+        return pd.DataFrame()
+
+    # #289 follow-up: downtrend gate. is_sideways only checks |today's move| <= 5%,
+    # which mislabels a downtrending stock (below MA20, weak RS) as "sideways"
+    # (e.g. 이노션 2026-05-29: -2.2%, below MA20). A real consolidation base sits
+    # at/above the 20-day mean — exclude names clearly below MA20.
+    kept_mask = []
+    for ticker in result.index:
+        ma20 = _compute_ma20(ticker, trade_date)
+        close_price = float(result.loc[ticker, "Close"])
+        # ma20 <= 0 means data unavailable → keep (don't drop on a data blip)
+        kept_mask.append(ma20 <= 0 or close_price >= ma20 * SIDEWAYS_MA20_SUPPORT_TOLERANCE)
+    excluded = len(result) - sum(kept_mask)
+    result = result[pd.Series(kept_mask, index=result.index)].copy()
+    if excluded:
+        logger.debug(f"trigger_afternoon_volume_surge_flat: downtrend gate excluded "
+                     f"{excluded} stock(s) below MA20")
+
+    if result.empty:
+        logger.debug("trigger_afternoon_volume_surge_flat: No stocks after downtrend gate")
         return pd.DataFrame()
 
     # Add debugging logs


### PR DESCRIPTION
## 배경 (운영 진단)
2026-05-29 오후 매매에서 **이노션(214320)** 이 매수됨 — 당일 **-2.2%**, MA20 하회, RS 후보 중 최하위(+6.9%). 폭등장(strong_bull)에 명백한 하락추세 종목이 "거래량 증가 상위 횡보주"로 진입.

## 근본 원인
`is_sideways`가 **당일 등락 ±5%만** 보고 추세 방향을 안 봄 (`trigger_batch.py`):
```python
is_sideways = (prev_day_change_rate.abs() <= 5)   # 방향 무시
```
→ 하락추세 중 조용한 날(-2.2%)을 "횡보"로 오분류.

## 전수 점검 결과
| 트리거 | 방향 필터 | 맹점 |
|---|---|---|
| 거래량급증·갭상승·시총유입·일중상승·마감강도 (5개) | is_rising(당일 양봉) 또는 상승률 하한 | 하락일 1차 차단됨 |
| **거래량 횡보주** | **±5%만, 방향 무관** | ❌ 유일한 직접 맹점 |

## 수정
횡보 후보에 **MA20 추세 게이트**:
- 종가 < `MA20 × 0.97`(−3% 이내 지지는 허용) → 하락추세로 보고 제외
- MA20 데이터 불명 시 통과(데이터 blip에 종목 안 버림)
- 헬퍼 `_compute_ma20` + 상수 `SIDEWAYS_MA20_SUPPORT_TOLERANCE`(튜닝 쉽게)
- **KR + US 미러**

**오닐 철학 정합**: 진짜 횡보(베이스 다지기)는 MA20 위/근처에서 형성. MA20 명백 하회는 하락추세이므로 매수 대상 아님. 사용자 기준 "지지선 지지 횡보=OK, 명백한 하락추세=NO"를 코드화.

## 검증
`tests/test_sideways_downtrend_gate.py` **12개 통과**(경계값 97/95, 이노션 재현, 데이터 blip 방어). 기존 #289·retry 테스트 회귀 없음. KR/US syntax·import OK.

> 이번 릴리즈(#289)의 후속. requirements/DB 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)