### PR TITLE
fix(us-trading): pyramiding adds bypass sector concentration limit

### DIFF
--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -643,8 +643,16 @@ class USStockTrackingAgent:
         account_key, _ = self._account_scope()
         return get_us_holdings_count(self.cursor, account_key=account_key)
 
-    async def _check_sector_diversity(self, sector: str) -> bool:
-        """Check for over-concentration in same sector."""
+    async def _check_sector_diversity(self, sector: str, is_pyramiding_add: bool = False) -> bool:
+        """Check for over-concentration in same sector.
+
+        Pyramiding adds (#288) target a ticker already held, so the name is
+        already counted toward the sector. Adding to it does not introduce a
+        new name into the sector, so the count-based concentration limit should
+        not block it — only brand-new positions are subject to the limit.
+        """
+        if is_pyramiding_add:
+            return True
         account_key, _ = self._account_scope()
         return check_sector_diversity(
             self.cursor, sector,
@@ -2460,7 +2468,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     # Evaluate sector / score / decision independently so the displayed
                     # rejection reason matches the rationale in the same message,
                     # rather than short-circuiting on whichever cause the code checked first.
-                    sector_diverse = await self._check_sector_diversity(sector)
+                    sector_diverse = await self._check_sector_diversity(sector, is_pyramiding_add=is_add)
 
                     buy_score = scenario.get("buy_score", 0)
                     min_score = scenario.get("min_score", 0)


### PR DESCRIPTION
## 문제
중복매수(피라미딩 추가매수)가 `Sector concentration` 사유로 Skip되는 경우 발생 (예: MU/Technology).

## 원인
`is_add`(이미 보유 중인 티커 추가매수) 플래그는 섹터 체크 전에 계산되지만, `_check_sector_diversity()`에 전달되지 않아 신규매수와 동일하게 차단됨. 섹터 집중도는 **보유 종목 개수** 기준인데, 중복매수 대상은 이미 그 개수에 포함돼 있어 추가매수해도 섹터 내 종목 수가 늘지 않음 → 차단할 다양성 근거가 없음.

## 변경
- `_check_sector_diversity(sector, is_pyramiding_add=False)`: 피라미딩 추가매수면 즉시 True 반환
- 호출부에서 기존 `is_add` 플래그 전달
- 신규 포지션은 그대로 `MAX_SAME_SECTOR`/집중도 비율 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)