### PR TITLE
fix: use KST for domestic trading windows

### DIFF
--- a/tests/test_domestic_trading_time_windows.py
+++ b/tests/test_domestic_trading_time_windows.py
@@ -1,0 +1,99 @@
+import datetime
+import sys
+import types
+from typing import Any, cast
+
+# domestic_stock_trading imports kis_auth at module import time. These tests only
+# exercise pure time-window routing, so stub heavyweight optional dependencies
+# that may be absent in lightweight CI/local environments.
+sys.modules.setdefault("pandas", types.ModuleType("pandas"))
+crypto = sys.modules.setdefault("Crypto", types.ModuleType("Crypto"))
+cipher = sys.modules.setdefault("Crypto.Cipher", types.ModuleType("Crypto.Cipher"))
+aes = sys.modules.setdefault("Crypto.Cipher.AES", types.ModuleType("Crypto.Cipher.AES"))
+util = sys.modules.setdefault("Crypto.Util", types.ModuleType("Crypto.Util"))
+padding = sys.modules.setdefault("Crypto.Util.Padding", types.ModuleType("Crypto.Util.Padding"))
+setattr(cipher, "AES", aes)
+setattr(crypto, "Cipher", cipher)
+setattr(crypto, "Util", util)
+setattr(util, "Padding", padding)
+setattr(padding, "unpad", lambda data, block_size: data)
+
+from trading import domestic_stock_trading as domestic
+
+
+class _DummyDomesticTrader:
+    auto_trading = True
+
+    def __init__(self):
+        self.called = None
+
+    def buy_market_price(self, stock_code, buy_amount=None):
+        self.called = ("buy_market_price", stock_code, buy_amount)
+        return {"success": True, "method": "market"}
+
+    def buy_closing_price(self, stock_code, buy_amount=None):
+        self.called = ("buy_closing_price", stock_code, buy_amount)
+        return {"success": True, "method": "closing"}
+
+    def buy_reserved_order(self, stock_code, buy_amount=None, limit_price=None):
+        self.called = ("buy_reserved_order", stock_code, buy_amount, limit_price)
+        return {"success": True, "method": "reserved"}
+
+    def sell_all_market_price(self, stock_code, quantity=None):
+        self.called = ("sell_all_market_price", stock_code, quantity)
+        return {"success": True, "method": "market"}
+
+    def sell_all_closing_price(self, stock_code, quantity=None):
+        self.called = ("sell_all_closing_price", stock_code, quantity)
+        return {"success": True, "method": "closing"}
+
+    def sell_all_reserved_order(self, stock_code, limit_price=None, quantity=None):
+        self.called = ("sell_all_reserved_order", stock_code, limit_price, quantity)
+        return {"success": True, "method": "reserved"}
+
+
+def _dt(hour, minute):
+    return datetime.datetime(2026, 6, 1, hour, minute, tzinfo=domestic.KST)
+
+
+def test_domestic_order_window_uses_kst_regular_market():
+    assert domestic._domestic_order_window(_dt(15, 15)) == "regular"
+
+
+def test_domestic_order_window_blocks_0730_to_0900_reserved_gap():
+    assert domestic._domestic_order_window(_dt(8, 15)) == "unavailable"
+
+
+def test_domestic_order_window_blocks_reserved_maintenance_gap():
+    assert domestic._domestic_order_window(_dt(23, 50)) == "unavailable"
+
+
+def test_smart_buy_uses_market_order_at_1515_kst(monkeypatch):
+    trader = _DummyDomesticTrader()
+    monkeypatch.setattr(domestic, "_now_kst", lambda: _dt(15, 15))
+
+    result = domestic.DomesticStockTrading.smart_buy(cast(Any, trader), "005935", buy_amount=100000, limit_price=50000)
+
+    assert result["method"] == "market"
+    assert trader.called == ("buy_market_price", "005935", 100000)
+
+
+def test_smart_buy_does_not_submit_reserved_order_in_0815_kst_gap(monkeypatch):
+    trader = _DummyDomesticTrader()
+    monkeypatch.setattr(domestic, "_now_kst", lambda: _dt(8, 15))
+
+    result = domestic.DomesticStockTrading.smart_buy(cast(Any, trader), "005935", buy_amount=100000, limit_price=50000)
+
+    assert result["success"] is False
+    assert "Order window unavailable" in result["message"]
+    assert trader.called is None
+
+
+def test_smart_sell_uses_market_order_at_1515_kst(monkeypatch):
+    trader = _DummyDomesticTrader()
+    monkeypatch.setattr(domestic, "_now_kst", lambda: _dt(15, 15))
+
+    result = domestic.DomesticStockTrading.smart_sell_all(cast(Any, trader), "005935", limit_price=50000, quantity=3)
+
+    assert result["method"] == "market"
+    assert trader.called == ("sell_all_market_price", "005935", 3)

--- a/trading/domestic_stock_trading.py
+++ b/trading/domestic_stock_trading.py
@@ -12,6 +12,7 @@ import math
 import time
 from pathlib import Path
 from typing import Optional, Dict, List, Any
+from zoneinfo import ZoneInfo
 
 import yaml
 
@@ -32,6 +33,36 @@ from kis_auth import (
 # Logging setup
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
+
+KST = ZoneInfo("Asia/Seoul")
+
+
+def _now_kst() -> datetime.datetime:
+    """Return timezone-aware current time in Korea Standard Time."""
+    return datetime.datetime.now(KST)
+
+
+def _domestic_order_window(now: Optional[datetime.datetime] = None) -> str:
+    """Classify the Korean domestic stock order window using KST.
+
+    Returns one of:
+    - regular: 09:00~15:30 market orders
+    - closing: 15:40~16:00 after-hours closing-price orders
+    - reserved: KIS reserved-order window, excluding 23:40~00:10
+    - unavailable: gaps where neither regular/closing nor reserved orders are accepted
+    """
+    now = now or _now_kst()
+    current_time = now.astimezone(KST).time() if now.tzinfo else now.time()
+
+    if datetime.time(9, 0) <= current_time <= datetime.time(15, 30):
+        return "regular"
+    if datetime.time(15, 40) <= current_time <= datetime.time(16, 0):
+        return "closing"
+    if datetime.time(16, 0) < current_time <= datetime.time(23, 40):
+        return "reserved"
+    if datetime.time(0, 10) <= current_time <= datetime.time(7, 30):
+        return "reserved"
+    return "unavailable"
 
 # Load configuration file
 CONFIG_FILE = TRADING_DIR / "config" / "kis_devlp.yaml"
@@ -530,27 +561,34 @@ class DomesticStockTrading:
                 'message': 'Auto trading is disabled. Cannot execute buy order. (AUTO_TRADING=False)'
             }
 
-        now = datetime.datetime.now()
-        current_time = now.time()
+        now = _now_kst()
+        order_window = _domestic_order_window(now)
 
-        # Branch by time period
-        if datetime.time(9, 0) <= current_time <= datetime.time(15, 30):
-            # Regular trading hours
-            logger.info(f"[{stock_code}] Regular trading hours - executing market buy")
+        # Branch by Korean market time (KST), regardless of server/local timezone.
+        if order_window == "regular":
+            logger.info(f"[{stock_code}] Regular trading hours (KST) - executing market buy")
             return self.buy_market_price(stock_code, buy_amount)
 
-        elif datetime.time(15, 40) <= current_time <= datetime.time(16, 0):
-            # After-hours closing price trading
-            logger.info(f"[{stock_code}] After-hours closing price time - executing closing price buy")
+        if order_window == "closing":
+            logger.info(f"[{stock_code}] After-hours closing price time (KST) - executing closing price buy")
             return self.buy_closing_price(stock_code, buy_amount)
 
-        else:
-            # Reserved order (limit or market price)
+        if order_window == "reserved":
             if limit_price:
-                logger.info(f"[{stock_code}] Outside trading hours - executing reserved order (limit: {limit_price:,} KRW)")
+                logger.info(f"[{stock_code}] Reserved order window (KST) - executing reserved order (limit: {limit_price:,} KRW)")
             else:
-                logger.info(f"[{stock_code}] Outside trading hours - executing reserved order (market)")
+                logger.info(f"[{stock_code}] Reserved order window (KST) - executing reserved order (market)")
             return self.buy_reserved_order(stock_code, buy_amount, limit_price=limit_price)
+
+        message = "Order window unavailable in KST (reserved orders are accepted 16:00~23:40 and 00:10~07:30)"
+        logger.warning(f"[{stock_code}] {message}")
+        return {
+            'success': False,
+            'order_no': None,
+            'stock_code': stock_code,
+            'quantity': 0,
+            'message': message
+        }
 
     def buy_closing_price(self, stock_code: str, buy_amount: int = None) -> Dict[str, Any]:
         """
@@ -893,27 +931,34 @@ class DomesticStockTrading:
                 'message': 'Auto trading is disabled. Cannot execute sell order. (AUTO_TRADING=False)'
             }
 
-        now = datetime.datetime.now()
-        current_time = now.time()
+        now = _now_kst()
+        order_window = _domestic_order_window(now)
 
-        # Branch by time period
-        if datetime.time(9, 0) <= current_time <= datetime.time(15, 30):
-            # Regular trading hours - market sell
-            logger.info(f"[{stock_code}] Regular trading hours - executing market sell")
+        # Branch by Korean market time (KST), regardless of server/local timezone.
+        if order_window == "regular":
+            logger.info(f"[{stock_code}] Regular trading hours (KST) - executing market sell")
             return self.sell_all_market_price(stock_code, quantity=quantity)
 
-        elif datetime.time(15, 40) <= current_time <= datetime.time(16, 0):
-            # After-hours closing price trading
-            logger.info(f"[{stock_code}] After-hours closing price time - executing closing price sell")
+        if order_window == "closing":
+            logger.info(f"[{stock_code}] After-hours closing price time (KST) - executing closing price sell")
             return self.sell_all_closing_price(stock_code, quantity=quantity)
 
-        else:
-            # Reserved order (limit or market price)
+        if order_window == "reserved":
             if limit_price:
-                logger.info(f"[{stock_code}] Outside trading hours - executing reserved order (limit: {limit_price:,} KRW)")
+                logger.info(f"[{stock_code}] Reserved order window (KST) - executing reserved order (limit: {limit_price:,} KRW)")
             else:
-                logger.info(f"[{stock_code}] Outside trading hours - executing reserved order (market)")
+                logger.info(f"[{stock_code}] Reserved order window (KST) - executing reserved order (market)")
             return self.sell_all_reserved_order(stock_code, limit_price=limit_price, quantity=quantity)
+
+        message = "Order window unavailable in KST (reserved orders are accepted 16:00~23:40 and 00:10~07:30)"
+        logger.warning(f"[{stock_code}] {message}")
+        return {
+            'success': False,
+            'order_no': None,
+            'stock_code': stock_code,
+            'quantity': 0,
+            'message': message
+        }
 
     def sell_all_closing_price(self, stock_code: str, quantity: int = None) -> Dict[str, Any]:
         """
@@ -1163,7 +1208,7 @@ class DomesticStockTrading:
                 'total_amount': 0,
                 'order_no': None,
                 'message': f'Buy request timeout ({timeout}s)',
-                'timestamp': datetime.datetime.now().isoformat()
+                'timestamp': _now_kst().isoformat()
             }
 
     async def _execute_buy_stock(self, stock_code: str, buy_amount: int = None, limit_price: int = None) -> Dict[str, Any]:
@@ -1178,7 +1223,7 @@ class DomesticStockTrading:
             'total_amount': 0,
             'order_no': None,
             'message': '',
-            'timestamp': datetime.datetime.now().isoformat()
+            'timestamp': _now_kst().isoformat()
         }
 
         # 3-level protection: per-stock lock + semaphore + global lock
@@ -1286,7 +1331,7 @@ class DomesticStockTrading:
                 'estimated_amount': 0,
                 'order_no': None,
                 'message': f'Sell request timeout ({timeout}s)',
-                'timestamp': datetime.datetime.now().isoformat()
+                'timestamp': _now_kst().isoformat()
             }
 
     async def _execute_sell_stock(self, stock_code: str, limit_price: int = None, quantity: int = None) -> Dict[str, Any]:
@@ -1302,7 +1347,7 @@ class DomesticStockTrading:
             'estimated_amount': 0,
             'order_no': None,
             'message': '',
-            'timestamp': datetime.datetime.now().isoformat()
+            'timestamp': _now_kst().isoformat()
         }
 
         # 3-level protection: per-stock lock + semaphore + global lock


### PR DESCRIPTION
## Summary
- Use timezone-aware Asia/Seoul time for domestic smart buy/sell routing
- Avoid submitting reserved orders during KIS unavailable gaps such as 07:30~09:00 and 23:40~00:10
- Add unit coverage for 15:15 KST market routing and reserved-order gaps

## Test Plan
- /opt/homebrew/bin/python3 -m py_compile trading/domestic_stock_trading.py tests/test_domestic_trading_time_windows.py
- /opt/homebrew/bin/python3 -m pytest tests/test_domestic_trading_time_windows.py -q