### PR TITLE
fix(trading): O'Neil 추세추종 룰베이스 매도 fallback (KR+US) — 2026-06-04 quota 사고 대응

### DIFF
--- a/cores/oneil_fallback.py
+++ b/cores/oneil_fallback.py
@@ -1,0 +1,185 @@
+"""
+O'Neil(William O'Neil / CANSLIM) 추세추종 룰베이스 매도 알고리즘
+=================================================================
+KR / US 공용 — 시장 무관 순수 함수. 통화/표기만 호출측에서 포맷.
+
+KR: stock_tracking_agent._analyze_sell_decision 의 1차 룰 로직.
+US: us_stock_tracking_agent._fallback_sell_decision (AI 매도 실패 시 fallback).
+
+설계 철학 (O'Neil 철칙):
+  "손실은 빠르게 자른다(7~8%). 승자는 추세가 깨질 때까지 보유한다."
+  기존 크루드 룰의 치명적 버그였던
+    - profit >= 10% → 매도   (승자 조기 청산: 2026-06-04 MU +53%, ANET +24% 사례)
+    - 시간 기반 매도(30/60/90일)  (추세와 무관한 캘린더 청산)
+  를 전면 제거한다. 매도는 오직 '추세/가격' 신호로만 발생한다.
+
+가용 입력(스키마 확인됨): buy_price, current_price, stop_loss, target_price,
+  highest_price(진입 후 고점, 자동 갱신), live regime(매도 시점 계산값),
+  scenario.key_levels(지지/저항).  ※ 20MA·VIX·거래량·연속하락일은 매도경로에
+  직접 노출되지 않으므로 사용하지 않는다(과매도 방지).
+
+순수 stdlib 만 사용(dataclass/typing/json) — 외부 의존성 없음.
+"""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional, Tuple
+import json
+
+
+# ── 튜닝 상수 (O'Neil 교범 기준) ───────────────────────────────
+ABS_STOP_LOSS_PCT = -7.0        # 절대 손절: 진입가 대비 -7% (오닐 7~8% 룰)
+# 매도경로는 '종가'가 없고 last-trade(current_price)만 가짐.
+# O'Neil 손절은 '종가 기준' — 장중 wick 한 번의 터치로 팔지 않는다.
+# 종가 미가용 환경에서 이 규율을 근사하기 위해 스톱선에 작은 버퍼를 둔다.
+STOP_WICK_BUFFER = 0.005        # 스톱선 0.5% 아래로 '명확히' 이탈해야 매도
+TRAIL_ACTIVATION_PCT = 5.0      # 진입가 대비 +5% 도달 후에만 트레일링 활성화
+TRAIL_DROP_BULL = 0.92          # 강세장: 고점 대비 -8%
+TRAIL_DROP_WEAK = 0.95          # 약세/횡보: 고점 대비 -5% (더 타이트)
+TRAIL_DROP_UNKNOWN = 0.90       # regime 불명/stale: 고점 대비 -10% (불확실 시 과매도 방지)
+BULL_REGIMES = {"parabolic", "strong_bull", "moderate_bull"}
+WEAK_REGIMES = {"sideways", "moderate_bear", "strong_bear"}
+
+
+@dataclass
+class SellInputs:
+    buy_price: float
+    current_price: float
+    stop_loss: float = 0.0
+    target_price: float = 0.0
+    highest_price: float = 0.0          # 진입 후 고점 (없으면 current/buy로 보정)
+    market_condition: str = ""          # 레짐 문자열: '매도 시점의 LIVE 값'을 넣어야 함.
+    #   stock_data.scenario 의 market_condition 은 '매수 시점 동결값(stale)'이므로
+    #   그대로 쓰면 약세 전환을 못 잡는다. 호출측은 _compute_us_regime/_compute_kr_regime
+    #   으로 매 사이클 1회 계산한 LIVE regime 을 from_stock_data(live_regime=...) 로 주입할 것.
+    primary_support: float = 0.0        # key_levels.primary_support (선택)
+    regime_is_live: bool = False        # True 면 trailing 밴드를 신뢰, False(=stale)면 보수적
+
+
+def _normalize_regime(raw: str) -> str:
+    r = (raw or "").lower()
+    for k in ("parabolic", "strong_bull", "moderate_bull",
+              "strong_bear", "moderate_bear", "sideways"):
+        if k in r:
+            return k
+    # 한글/기타 표기 보정
+    if "강세" in r or "bull" in r:
+        return "moderate_bull"
+    if "약세" in r or "bear" in r:
+        return "moderate_bear"
+    if "횡보" in r or "side" in r:
+        return "sideways"
+    return "moderate_bull"   # 정보 없으면 보수적으로 보유 우선(강세 가정)
+
+
+def evaluate_oneil_sell(inp: SellInputs) -> Tuple[bool, str]:
+    """O'Neil 추세추종 룰 기반 매도 판단.
+
+    Returns: (should_sell, reason_key)
+      reason_key 는 호출측에서 통화/언어로 포맷할 수 있는 구조화 문자열.
+    매도 신호가 없으면 (False, "HOLD: ...").
+    """
+    bp, cp = inp.buy_price, inp.current_price
+    if bp <= 0 or cp <= 0:
+        return False, "HOLD: invalid price data"  # 데이터 불량 시 절대 매도 금지
+
+    profit = (cp - bp) / bp * 100.0
+    regime = _normalize_regime(inp.market_condition)
+    peak = inp.highest_price if inp.highest_price and inp.highest_price > 0 else max(cp, bp)
+
+    # ── TIER 1: 하드 스톱 (손실 차단, 예외 없음) ──────────────
+    # 1A. 시나리오 손절가 이탈 (종가 미가용 → wick 버퍼로 '명확한' 이탈만)
+    if inp.stop_loss > 0 and cp <= inp.stop_loss * (1.0 - STOP_WICK_BUFFER):
+        return True, f"TIER1_STOPLOSS: price<=stop_loss({inp.stop_loss:.4f})"
+    # 1B. 절대 손절 -7%
+    if profit <= ABS_STOP_LOSS_PCT:
+        return True, f"TIER1_ABS7: loss {profit:.2f}% <= {ABS_STOP_LOSS_PCT}%"
+
+    # ── TIER 2: 트레일링 스톱 (승자 보호, +5% 활성화 이후만) ───
+    activated = peak >= bp * (1.0 + TRAIL_ACTIVATION_PCT / 100.0)
+    if activated:
+        if not inp.regime_is_live:
+            drop = TRAIL_DROP_UNKNOWN                 # stale/불명 → 보수적(-10%)
+        elif regime in BULL_REGIMES:
+            drop = TRAIL_DROP_BULL                    # live 강세 → -8%
+        else:
+            drop = TRAIL_DROP_WEAK                    # live 약세/횡보 → -5%
+        # 트레일링도 종가 기준 → 동일 wick 버퍼로 '명확한' 이탈만 매도
+        trail_line = peak * drop * (1.0 - STOP_WICK_BUFFER)
+        if cp <= trail_line:
+            band = int(round((1 - drop) * 100))
+            return True, (f"TIER2_TRAIL: regime={regime} peak={peak:.4f} "
+                          f"trail(-{band}%)={trail_line:.4f} >= price")
+
+    # ── TIER 3: 목표가 = 매도 트리거 아님(강세) / 익절(약세만) ──
+    # O'Neil: 목표가는 강세장에서 '트레일링 전환 마일스톤'이지 자동매도 아님.
+    if inp.target_price > 0 and cp >= inp.target_price:
+        if regime in WEAK_REGIMES:
+            return True, f"TIER3_TARGET(weak): regime={regime} target reached"
+        # 강세: 목표 도달해도 보유(트레일링이 청산을 관리)
+        return False, f"HOLD: target hit but bull regime({regime}) -> let it run"
+
+    # ── 기본: 보유 (추세 유지) ───────────────────────────────
+    # 주의: profit>=10% 자동매도 / 시간기반 매도 전부 제거됨(안티-오닐).
+    return False, f"HOLD: trend intact (profit {profit:.2f}%, regime {regime})"
+
+
+# ── 호출측 어댑터 (stock_data dict → SellInputs) ────────────────
+def from_stock_data(stock_data: dict, live_regime: Optional[str] = None) -> SellInputs:
+    """KR/US 의 stock_data dict 에서 SellInputs 추출.
+    scenario 는 JSON 문자열 또는 dict 둘 다 허용.
+
+    live_regime: 매도 사이클 시작 시 _compute_us_regime/_compute_kr_regime 으로
+      계산한 '현재' 레짐 문자열. 주입되면 그것을 신뢰(regime_is_live=True).
+      None 이면 scenario 의 매수시점 동결값으로 폴백하되 regime_is_live=False
+      (→ trailing 밴드를 보수적 -10% 로 적용해 과매도 방지).
+    """
+    scen = stock_data.get("scenario", {}) or {}
+    if isinstance(scen, str):
+        try:
+            scen = json.loads(scen)
+        except Exception:
+            scen = {}
+    if not isinstance(scen, dict):
+        scen = {}
+    key_levels = (scen.get("trading_scenarios", {}) or {}).get("key_levels", {}) or {}
+    # highest_price 는 scenario 우선, 없으면 stock_data 레벨
+    highest = scen.get("highest_price") or stock_data.get("highest_price") or 0.0
+    is_live = bool(live_regime)
+    regime = live_regime if is_live else str(scen.get("market_condition", "") or "")
+
+    def _f(v):
+        try:
+            return float(v or 0)
+        except (TypeError, ValueError):
+            return 0.0
+
+    return SellInputs(
+        buy_price=_f(stock_data.get("buy_price", 0)),
+        current_price=_f(stock_data.get("current_price", 0)),
+        stop_loss=_f(stock_data.get("stop_loss", 0) or scen.get("stop_loss", 0)),
+        target_price=_f(stock_data.get("target_price", 0) or scen.get("target_price", 0)),
+        highest_price=_f(highest),
+        market_condition=str(regime or ""),
+        primary_support=_f(key_levels.get("primary_support", 0)),
+        regime_is_live=is_live,
+    )
+
+
+if __name__ == "__main__":
+    # 2026-06-04 사고 재현 검증: LIVE regime 이면 승자 4종목 보유, RL 만 정당한 트레일링 매도.
+    cases = [
+        ("VZ",  47.79, 46.51, 45.60, 51.58, 48.96, "moderate_bull"),
+        ("ANET",142.10,175.89,0,     176.0, 178.0,  "strong_bull"),
+        ("MU",  700.03,1071.21,955.82,741.85,1046.97,"strong_bull"),
+        ("RL",  362.24,358.78,359.27,0,     392.10, "moderate_bull"),
+        ("IBM", 241.86,307.19,297.67,277.68,330.84, "strong_bull"),
+    ]
+    print("--- LIVE regime ---")
+    for t, bp, cp, sl, tp, hi, rg in cases:
+        s, r = evaluate_oneil_sell(SellInputs(bp, cp, sl, tp, hi, rg, regime_is_live=True))
+        print(f"{t:5} sell={s!s:5} | {r}")
+    print("--- STALE regime (보수적 -10%) ---")
+    for t, bp, cp, sl, tp, hi, rg in cases:
+        s, r = evaluate_oneil_sell(SellInputs(bp, cp, sl, tp, hi, rg, regime_is_live=False))
+        print(f"{t:5} sell={s!s:5} | {r}")

--- a/prism-us/cores/oneil_fallback.py
+++ b/prism-us/cores/oneil_fallback.py
@@ -1,0 +1,185 @@
+"""
+O'Neil(William O'Neil / CANSLIM) 추세추종 룰베이스 매도 알고리즘
+=================================================================
+KR / US 공용 — 시장 무관 순수 함수. 통화/표기만 호출측에서 포맷.
+
+KR: stock_tracking_agent._analyze_sell_decision 의 1차 룰 로직.
+US: us_stock_tracking_agent._fallback_sell_decision (AI 매도 실패 시 fallback).
+
+설계 철학 (O'Neil 철칙):
+  "손실은 빠르게 자른다(7~8%). 승자는 추세가 깨질 때까지 보유한다."
+  기존 크루드 룰의 치명적 버그였던
+    - profit >= 10% → 매도   (승자 조기 청산: 2026-06-04 MU +53%, ANET +24% 사례)
+    - 시간 기반 매도(30/60/90일)  (추세와 무관한 캘린더 청산)
+  를 전면 제거한다. 매도는 오직 '추세/가격' 신호로만 발생한다.
+
+가용 입력(스키마 확인됨): buy_price, current_price, stop_loss, target_price,
+  highest_price(진입 후 고점, 자동 갱신), live regime(매도 시점 계산값),
+  scenario.key_levels(지지/저항).  ※ 20MA·VIX·거래량·연속하락일은 매도경로에
+  직접 노출되지 않으므로 사용하지 않는다(과매도 방지).
+
+순수 stdlib 만 사용(dataclass/typing/json) — 외부 의존성 없음.
+"""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional, Tuple
+import json
+
+
+# ── 튜닝 상수 (O'Neil 교범 기준) ───────────────────────────────
+ABS_STOP_LOSS_PCT = -7.0        # 절대 손절: 진입가 대비 -7% (오닐 7~8% 룰)
+# 매도경로는 '종가'가 없고 last-trade(current_price)만 가짐.
+# O'Neil 손절은 '종가 기준' — 장중 wick 한 번의 터치로 팔지 않는다.
+# 종가 미가용 환경에서 이 규율을 근사하기 위해 스톱선에 작은 버퍼를 둔다.
+STOP_WICK_BUFFER = 0.005        # 스톱선 0.5% 아래로 '명확히' 이탈해야 매도
+TRAIL_ACTIVATION_PCT = 5.0      # 진입가 대비 +5% 도달 후에만 트레일링 활성화
+TRAIL_DROP_BULL = 0.92          # 강세장: 고점 대비 -8%
+TRAIL_DROP_WEAK = 0.95          # 약세/횡보: 고점 대비 -5% (더 타이트)
+TRAIL_DROP_UNKNOWN = 0.90       # regime 불명/stale: 고점 대비 -10% (불확실 시 과매도 방지)
+BULL_REGIMES = {"parabolic", "strong_bull", "moderate_bull"}
+WEAK_REGIMES = {"sideways", "moderate_bear", "strong_bear"}
+
+
+@dataclass
+class SellInputs:
+    buy_price: float
+    current_price: float
+    stop_loss: float = 0.0
+    target_price: float = 0.0
+    highest_price: float = 0.0          # 진입 후 고점 (없으면 current/buy로 보정)
+    market_condition: str = ""          # 레짐 문자열: '매도 시점의 LIVE 값'을 넣어야 함.
+    #   stock_data.scenario 의 market_condition 은 '매수 시점 동결값(stale)'이므로
+    #   그대로 쓰면 약세 전환을 못 잡는다. 호출측은 _compute_us_regime/_compute_kr_regime
+    #   으로 매 사이클 1회 계산한 LIVE regime 을 from_stock_data(live_regime=...) 로 주입할 것.
+    primary_support: float = 0.0        # key_levels.primary_support (선택)
+    regime_is_live: bool = False        # True 면 trailing 밴드를 신뢰, False(=stale)면 보수적
+
+
+def _normalize_regime(raw: str) -> str:
+    r = (raw or "").lower()
+    for k in ("parabolic", "strong_bull", "moderate_bull",
+              "strong_bear", "moderate_bear", "sideways"):
+        if k in r:
+            return k
+    # 한글/기타 표기 보정
+    if "강세" in r or "bull" in r:
+        return "moderate_bull"
+    if "약세" in r or "bear" in r:
+        return "moderate_bear"
+    if "횡보" in r or "side" in r:
+        return "sideways"
+    return "moderate_bull"   # 정보 없으면 보수적으로 보유 우선(강세 가정)
+
+
+def evaluate_oneil_sell(inp: SellInputs) -> Tuple[bool, str]:
+    """O'Neil 추세추종 룰 기반 매도 판단.
+
+    Returns: (should_sell, reason_key)
+      reason_key 는 호출측에서 통화/언어로 포맷할 수 있는 구조화 문자열.
+    매도 신호가 없으면 (False, "HOLD: ...").
+    """
+    bp, cp = inp.buy_price, inp.current_price
+    if bp <= 0 or cp <= 0:
+        return False, "HOLD: invalid price data"  # 데이터 불량 시 절대 매도 금지
+
+    profit = (cp - bp) / bp * 100.0
+    regime = _normalize_regime(inp.market_condition)
+    peak = inp.highest_price if inp.highest_price and inp.highest_price > 0 else max(cp, bp)
+
+    # ── TIER 1: 하드 스톱 (손실 차단, 예외 없음) ──────────────
+    # 1A. 시나리오 손절가 이탈 (종가 미가용 → wick 버퍼로 '명확한' 이탈만)
+    if inp.stop_loss > 0 and cp <= inp.stop_loss * (1.0 - STOP_WICK_BUFFER):
+        return True, f"TIER1_STOPLOSS: price<=stop_loss({inp.stop_loss:.4f})"
+    # 1B. 절대 손절 -7%
+    if profit <= ABS_STOP_LOSS_PCT:
+        return True, f"TIER1_ABS7: loss {profit:.2f}% <= {ABS_STOP_LOSS_PCT}%"
+
+    # ── TIER 2: 트레일링 스톱 (승자 보호, +5% 활성화 이후만) ───
+    activated = peak >= bp * (1.0 + TRAIL_ACTIVATION_PCT / 100.0)
+    if activated:
+        if not inp.regime_is_live:
+            drop = TRAIL_DROP_UNKNOWN                 # stale/불명 → 보수적(-10%)
+        elif regime in BULL_REGIMES:
+            drop = TRAIL_DROP_BULL                    # live 강세 → -8%
+        else:
+            drop = TRAIL_DROP_WEAK                    # live 약세/횡보 → -5%
+        # 트레일링도 종가 기준 → 동일 wick 버퍼로 '명확한' 이탈만 매도
+        trail_line = peak * drop * (1.0 - STOP_WICK_BUFFER)
+        if cp <= trail_line:
+            band = int(round((1 - drop) * 100))
+            return True, (f"TIER2_TRAIL: regime={regime} peak={peak:.4f} "
+                          f"trail(-{band}%)={trail_line:.4f} >= price")
+
+    # ── TIER 3: 목표가 = 매도 트리거 아님(강세) / 익절(약세만) ──
+    # O'Neil: 목표가는 강세장에서 '트레일링 전환 마일스톤'이지 자동매도 아님.
+    if inp.target_price > 0 and cp >= inp.target_price:
+        if regime in WEAK_REGIMES:
+            return True, f"TIER3_TARGET(weak): regime={regime} target reached"
+        # 강세: 목표 도달해도 보유(트레일링이 청산을 관리)
+        return False, f"HOLD: target hit but bull regime({regime}) -> let it run"
+
+    # ── 기본: 보유 (추세 유지) ───────────────────────────────
+    # 주의: profit>=10% 자동매도 / 시간기반 매도 전부 제거됨(안티-오닐).
+    return False, f"HOLD: trend intact (profit {profit:.2f}%, regime {regime})"
+
+
+# ── 호출측 어댑터 (stock_data dict → SellInputs) ────────────────
+def from_stock_data(stock_data: dict, live_regime: Optional[str] = None) -> SellInputs:
+    """KR/US 의 stock_data dict 에서 SellInputs 추출.
+    scenario 는 JSON 문자열 또는 dict 둘 다 허용.
+
+    live_regime: 매도 사이클 시작 시 _compute_us_regime/_compute_kr_regime 으로
+      계산한 '현재' 레짐 문자열. 주입되면 그것을 신뢰(regime_is_live=True).
+      None 이면 scenario 의 매수시점 동결값으로 폴백하되 regime_is_live=False
+      (→ trailing 밴드를 보수적 -10% 로 적용해 과매도 방지).
+    """
+    scen = stock_data.get("scenario", {}) or {}
+    if isinstance(scen, str):
+        try:
+            scen = json.loads(scen)
+        except Exception:
+            scen = {}
+    if not isinstance(scen, dict):
+        scen = {}
+    key_levels = (scen.get("trading_scenarios", {}) or {}).get("key_levels", {}) or {}
+    # highest_price 는 scenario 우선, 없으면 stock_data 레벨
+    highest = scen.get("highest_price") or stock_data.get("highest_price") or 0.0
+    is_live = bool(live_regime)
+    regime = live_regime if is_live else str(scen.get("market_condition", "") or "")
+
+    def _f(v):
+        try:
+            return float(v or 0)
+        except (TypeError, ValueError):
+            return 0.0
+
+    return SellInputs(
+        buy_price=_f(stock_data.get("buy_price", 0)),
+        current_price=_f(stock_data.get("current_price", 0)),
+        stop_loss=_f(stock_data.get("stop_loss", 0) or scen.get("stop_loss", 0)),
+        target_price=_f(stock_data.get("target_price", 0) or scen.get("target_price", 0)),
+        highest_price=_f(highest),
+        market_condition=str(regime or ""),
+        primary_support=_f(key_levels.get("primary_support", 0)),
+        regime_is_live=is_live,
+    )
+
+
+if __name__ == "__main__":
+    # 2026-06-04 사고 재현 검증: LIVE regime 이면 승자 4종목 보유, RL 만 정당한 트레일링 매도.
+    cases = [
+        ("VZ",  47.79, 46.51, 45.60, 51.58, 48.96, "moderate_bull"),
+        ("ANET",142.10,175.89,0,     176.0, 178.0,  "strong_bull"),
+        ("MU",  700.03,1071.21,955.82,741.85,1046.97,"strong_bull"),
+        ("RL",  362.24,358.78,359.27,0,     392.10, "moderate_bull"),
+        ("IBM", 241.86,307.19,297.67,277.68,330.84, "strong_bull"),
+    ]
+    print("--- LIVE regime ---")
+    for t, bp, cp, sl, tp, hi, rg in cases:
+        s, r = evaluate_oneil_sell(SellInputs(bp, cp, sl, tp, hi, rg, regime_is_live=True))
+        print(f"{t:5} sell={s!s:5} | {r}")
+    print("--- STALE regime (보수적 -10%) ---")
+    for t, bp, cp, sl, tp, hi, rg in cases:
+        s, r = evaluate_oneil_sell(SellInputs(bp, cp, sl, tp, hi, rg, regime_is_live=False))
+        print(f"{t:5} sell={s!s:5} | {r}")

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -52,6 +52,18 @@ if _error_spec and _error_spec.loader:
 from telegram import Bot
 from telegram.error import TelegramError
 
+# O'Neil 룰베이스 매도 fallback (2026-06-04 quota 사고 대응).
+# prism-us/cores 가 sys.path 우선이라 prism-us/cores/oneil_fallback 로 해석됨.
+# 방어적 import: 실패 시 _ONEIL_FALLBACK_AVAILABLE=False 로 기존 레거시 룰 유지.
+try:
+    from cores.oneil_fallback import (
+        evaluate_oneil_sell as _oneil_eval,
+        from_stock_data as _oneil_from,
+    )
+    _ONEIL_FALLBACK_AVAILABLE = True
+except Exception:  # pragma: no cover - defensive
+    _ONEIL_FALLBACK_AVAILABLE = False
+
 # Logging configuration
 logging.basicConfig(
     level=logging.INFO,
@@ -1515,8 +1527,26 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
             logger.error(f"{ticker} AI sell analysis error: {e}, falling back to rule-based decision")
             return await self._fallback_sell_decision(stock_data)
 
+    def _get_live_regime_safe(self) -> Optional[str]:
+        """매도 사이클의 '현재' 시장 레짐을 yfinance(S&P500/VIX) 기반으로 1회 계산.
+        OpenAI 와 무관하므로 quota 사고 중에도 동작. 실패 시 None → stale 폴백.
+        """
+        try:
+            from cores.data_prefetch import prefetch_us_macro_intelligence_data
+            data = prefetch_us_macro_intelligence_data() or {}
+            regime = (data.get("computed_regime") or {}).get("market_regime")
+            if regime:
+                logger.info(f"[sell] live US market regime: {regime}")
+            return regime or None
+        except Exception as e:
+            logger.warning(f"[sell] live regime fetch failed, using stale market_condition: {e}")
+            return None
+
     async def _fallback_sell_decision(self, stock_data: Dict[str, Any]) -> Tuple[bool, str]:
         """Rule-based sell decision (fallback when AI unavailable).
+
+        1차: O'Neil 추세추종 룰(cores.oneil_fallback) — 승자 보유/손실 차단.
+        2차(안전망): 모듈 import 실패 등 예외 시에만 기존 레거시 룰.
 
         Args:
             stock_data: Stock information
@@ -1524,6 +1554,21 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
         Returns:
             Tuple[bool, str]: Whether to sell, sell reason
         """
+        # ── O'Neil 룰베이스 (live regime 주입) ───────────────────
+        if _ONEIL_FALLBACK_AVAILABLE:
+            try:
+                live_regime = getattr(self, "_live_regime_cache", None)
+                inp = _oneil_from(stock_data, live_regime=live_regime)
+                should_sell, reason = _oneil_eval(inp)
+                logger.info(
+                    f"{stock_data.get('ticker','')} O'Neil rule-based sell: "
+                    f"{'Sell' if should_sell else 'Hold'} | {reason}"
+                )
+                return should_sell, reason
+            except Exception as e:
+                logger.error(f"O'Neil fallback error, using legacy rules: {e}")
+
+        # ── 레거시 안전망 (O'Neil 모듈 불가/예외 시에만) ─────────
         try:
             ticker = stock_data.get('ticker', '')
             buy_price = stock_data.get('buy_price', 0)
@@ -2002,6 +2047,10 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
         """
         try:
             logger.info("Starting US holdings update")
+
+            # 매도 판단에 쓸 '현재' 시장 레짐을 사이클당 1회 계산(OpenAI 무관).
+            # _fallback_sell_decision 이 self._live_regime_cache 로 참조한다.
+            self._live_regime_cache = self._get_live_regime_safe()
 
             # Query holdings list
             # id included for pyramiding (#288): enables per-row delete and

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -51,6 +51,17 @@ from cores.openai_error_logging import log_openai_error
 from cores.agents.trading_agents import create_trading_scenario_agent
 from cores.utils import parse_llm_json
 
+# O'Neil 룰베이스 매도 (2026-06-04 US quota 사고 동일 룰 결함 KR에도 적용).
+# 방어적 import: 실패 시 _ONEIL_FALLBACK_AVAILABLE=False 로 기존 레거시 룰 유지.
+try:
+    from cores.oneil_fallback import (
+        evaluate_oneil_sell as _oneil_eval,
+        from_stock_data as _oneil_from,
+    )
+    _ONEIL_FALLBACK_AVAILABLE = True
+except Exception:  # pragma: no cover - defensive
+    _ONEIL_FALLBACK_AVAILABLE = False
+
 # Tracking package imports (refactored helpers)
 from tracking import (
     create_all_tables,
@@ -912,9 +923,26 @@ class StockTrackingAgent:
             logger.error(traceback.format_exc())
             return False
 
+    def _get_live_regime_safe(self) -> Optional[str]:
+        """매도 판단용 '현재' KOSPI 레짐을 1회 계산(OpenAI 무관). 실패 시 None → stale 폴백."""
+        try:
+            from cores.data_prefetch import prefetch_macro_intelligence_data
+            reference_date = datetime.now().strftime("%Y%m%d")
+            data = prefetch_macro_intelligence_data(reference_date) or {}
+            regime = (data.get("computed_regime") or {}).get("market_regime")
+            if regime:
+                logger.info(f"[sell] live KR market regime: {regime}")
+            return regime or None
+        except Exception as e:
+            logger.warning(f"[sell] live regime fetch failed, using stale market_condition: {e}")
+            return None
+
     async def _analyze_sell_decision(self, stock_data: Dict[str, Any]) -> Tuple[bool, str]:
         """
         Sell decision analysis
+
+        1차: O'Neil 추세추종 룰(cores.oneil_fallback) — 승자 보유/손실 차단.
+        2차(안전망): O'Neil 모듈 불가/예외 시에만 기존 레거시 룰.
 
         Args:
             stock_data: Stock information
@@ -922,6 +950,21 @@ class StockTrackingAgent:
         Returns:
             Tuple[bool, str]: Whether to sell, sell reason
         """
+        # ── O'Neil 룰베이스 (live regime 주입) ───────────────────
+        if _ONEIL_FALLBACK_AVAILABLE:
+            try:
+                live_regime = getattr(self, "_live_regime_cache", None)
+                inp = _oneil_from(stock_data, live_regime=live_regime)
+                should_sell, reason = _oneil_eval(inp)
+                logger.info(
+                    f"{stock_data.get('ticker','')} O'Neil rule-based sell: "
+                    f"{'Sell' if should_sell else 'Hold'} | {reason}"
+                )
+                return should_sell, reason
+            except Exception as e:
+                logger.error(f"O'Neil sell rule error, using legacy rules: {e}")
+
+        # ── 레거시 안전망 (O'Neil 모듈 불가/예외 시에만) ─────────
         try:
             ticker = stock_data.get('ticker', '')
             buy_price = stock_data.get('buy_price', 0)
@@ -1218,6 +1261,10 @@ class StockTrackingAgent:
         """
         try:
             logger.info("Starting holdings info update")
+
+            # 매도 판단에 쓸 '현재' 시장 레짐을 사이클당 1회 계산(OpenAI 무관).
+            # _analyze_sell_decision 이 self._live_regime_cache 로 참조한다.
+            self._live_regime_cache = self._get_live_regime_safe()
 
             # Query holdings list
             # id included for pyramiding (#288): enables per-row delete and


### PR DESCRIPTION
## 배경
2026-06-04 US afternoon 사이클에서 **OpenAI 429 (insufficient_quota)** 로 AI 매도분석이 전 종목 실패 → 기존 크루드 룰 fallback이 발동해 **5종목 무차별 청산** (MU +53%, ANET +24% 등 승자 포함).

근본 원인: fallback 룰의 **안티-오닐** 로직 — `profit>=10% 자동매도` + `30/60/90일 시간기반 매도`. "손실은 빨리, 승자는 끝까지"라는 오닐 철칙과 정반대.

## 변경
- **`cores/oneil_fallback.py`** (+ `prism-us/cores` 동일본): O'Neil/CANSLIM 룰베이스 매도 순수함수
  - TIER1 하드스톱: -7% 절대손절 / stop_loss 이탈 (종가 근사 wick 버퍼 0.5%)
  - TIER2 트레일링: +5% 활성화 후 강세 -8% / 약세 -5%
  - TIER3 목표가: 강세장은 자동매도 아님(트레일링이 관리), 약세장만 익절
  - `profit>=10%`·시간기반 매도 **전면 제거**
- **LIVE 시장 레짐 주입**: `scenario.market_condition`은 매수시점 동결값(stale)이라 약세 전환을 못 잡음 → `_compute_us_regime`/`_compute_kr_regime`(yfinance/KOSPI 기반, OpenAI 무관)으로 매도 사이클당 1회 LIVE 계산. 조회 실패 시 보수적 -10% 트레일링으로 과매도 방지.
- **US** `_fallback_sell_decision` → O'Neil 위임 (레거시는 import 실패 시 안전망 유지)
- **KR** `_analyze_sell_decision` → 동일 룰 결함 보유, 1차 O'Neil 위임
- **방어적 import** (try/except): 운영 의존성 에러 없이 graceful degrade

## 검증
2026-06-04 사고 5종목 재현: **승자 4종목(VZ·ANET·MU·IBM) 보유**, RL만 고점대비 -8.5% 정당한 트레일링 청산. 순수 stdlib, 외부 의존성 추가 없음. 4개 파일 py_compile 통과, KR/US 경로 import 해석 검증 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)