### PR TITLE
feat(us-sell): AI 매도 프롬프트에 LIVE 시장 레짐 주입

### DIFF
--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -1443,8 +1443,20 @@ class USStockTrackingAgent:
             # LLM call
             llm = await self.sell_decision_agent.attach_llm(OpenAIAugmentedLLM)
 
+            # 시스템이 사이클당 1회 계산한 LIVE 시장 레짐(S&P500/VIX 기반, OpenAI 무관).
+            # 매수시점 동결값(scenario.market_condition)이 아닌 '현재' 레짐을 권위값으로 주입.
+            live_regime_summary = getattr(self, "_live_regime_summary", None)
+            live_regime_block = (
+                live_regime_summary
+                if live_regime_summary
+                else "unavailable — verify via yahoo_finance (^GSPC 20MA, ^VIX)"
+            )
+
             prompt_message = f"""
 Please make a sell/hold decision for the following US stock holding.
+
+### Current Market Regime (LIVE, system-computed — authoritative):
+{live_regime_block}
 
 ### Stock Information:
 - Stock: {company_name} ({ticker})
@@ -1469,6 +1481,7 @@ Please make a sell/hold decision for the following US stock holding.
 
 ### Task:
 Use yahoo_finance and sqlite tools to check latest data, then decide whether to sell or continue holding.
+**Market regime**: Treat the "Current Market Regime (LIVE)" above as the authoritative market environment for step-0 분석 (강세장/약세장 판단). It is system-computed from S&P500/VIX this cycle; prefer it over the stored buy-time scenario. Only if it shows "unavailable", fall back to fetching ^GSPC/^VIX via yahoo_finance yourself.
 **Important**: If stop loss/target price adjustment is needed, return it via portfolio_adjustment JSON only. Do NOT directly UPDATE the DB.
 """
 
@@ -1530,13 +1543,33 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
     def _get_live_regime_safe(self) -> Optional[str]:
         """매도 사이클의 '현재' 시장 레짐을 yfinance(S&P500/VIX) 기반으로 1회 계산.
         OpenAI 와 무관하므로 quota 사고 중에도 동작. 실패 시 None → stale 폴백.
+
+        부수효과: self._live_regime_summary 에 AI 매도 프롬프트 주입용 사람-읽기 요약을
+        저장한다(S&P500 vs 20MA, 4주 변동, VIX). 실패 시 None.
         """
+        self._live_regime_summary = None
         try:
             from cores.data_prefetch import prefetch_us_macro_intelligence_data
             data = prefetch_us_macro_intelligence_data() or {}
-            regime = (data.get("computed_regime") or {}).get("market_regime")
+            cr = data.get("computed_regime") or {}
+            regime = cr.get("market_regime")
             if regime:
                 logger.info(f"[sell] live US market regime: {regime}")
+                s = cr.get("index_summary") or {}
+                conf = cr.get("regime_confidence")
+                parts = [regime]
+                if s.get("sp500_current") is not None and s.get("sp500_20d_ma") is not None:
+                    parts.append(
+                        f"S&P500 {s['sp500_current']} vs 20MA {s['sp500_20d_ma']} "
+                        f"({s.get('sp500_vs_20d_ma','?')})"
+                    )
+                if s.get("sp500_4w_change_pct") is not None:
+                    parts.append(f"4w {s['sp500_4w_change_pct']}%")
+                if s.get("vix_current") is not None:
+                    parts.append(f"VIX {s['vix_current']} ({s.get('vix_level','?')})")
+                if conf is not None:
+                    parts.append(f"confidence {conf}")
+                self._live_regime_summary = " | ".join(str(p) for p in parts)
             return regime or None
         except Exception as e:
             logger.warning(f"[sell] live regime fetch failed, using stale market_condition: {e}")


### PR DESCRIPTION
## 배경
기존 US AI 매도 프롬프트는 SYSTEM '0단계 시장환경 파악'에서 **모델이 yahoo_finance 툴로 직접 S&P500/VIX를 조회**해 강세/약세를 판단하도록 의존. 문제:
- 모델 재량에 의존 → 불안정
- 툴 라운드트립 비용/지연
- fallback(`_compute_us_regime`)과 **regime 소스 불일치**
- USER 프롬프트엔 매수시점 **동결값(stale)** scenario.market_condition만 간접 포함

## 변경 (US 전용)
- `_get_live_regime_safe`: 사이클당 1회 계산한 `computed_regime`에서 사람-읽기 요약(S&P500 vs 20MA, 4주 변동, VIX, confidence)을 `self._live_regime_summary`에 캐시
- `_analyze_sell_decision` USER 프롬프트에 **`### Current Market Regime (LIVE, system-computed — authoritative)`** 섹션 주입 + Task 문구로 권위값으로 사용 지시
- 조회 실패 시 `unavailable` → 기존 yahoo_finance 툴조회로 graceful fallback

## 효과
AI 매도판단이 **fallback과 동일한 LIVE regime 소스**를 사용 → 일관성/신뢰성 향상, regime 툴조회 의존 감소. 순수 프롬프트+캐시 변경(외부 의존성 0). 예시 주입값: `strong_bull | S&P500 6105.2 vs 20MA 5980.1 (above) | 4w 3.4% | VIX 15.8 (low) | confidence 0.9`.

KR 매도는 순수 룰(AI 프롬프트 없음)이라 대상 외 — 이미 rule 경로에서 live regime 사용 중.

py_compile 통과, 요약 포매팅 검증 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)