### PR TITLE
feat(regime): multi-MA 추세템플릿 (KR 5/20/60/120, US 10/20/50/200) — 투자 안정성

### DIFF
--- a/cores/agents/macro_intelligence_agent.py
+++ b/cores/agents/macro_intelligence_agent.py
@@ -40,9 +40,16 @@ The following regime was computed programmatically from KOSPI price data:
 - **KOSPI 2-week change**: {idx.get('kospi_2w_change_pct', 'N/A')}%
 - **KOSPI current**: {idx.get('kospi_current', 'N/A')}
 - **KOSPI 20d MA**: {idx.get('kospi_20d_ma', 'N/A')}
+- **KOSPI 60d MA**: {idx.get('kospi_60d_ma', 'N/A')}
+- **KOSPI vs 60d MA**: {idx.get('kospi_vs_60d_ma', 'N/A')}
+- **KOSPI 120d MA**: {idx.get('kospi_120d_ma', 'N/A')}
+- **KOSPI vs 120d MA**: {idx.get('kospi_vs_120d_ma', 'N/A')}
+- **KOSPI 60/120 MA cross**: {idx.get('kospi_ma_60_120_cross', 'N/A')} (golden = bull trend, dead = bear trend)
 - **KOSDAQ 20d trend**: {idx.get('kosdaq_20d_trend', 'N/A')}
 
 You MUST use these pre-computed values for market_regime, regime_confidence, simple_ma_regime, and index_summary.
+Treat the KOSPI 60/120 MA cross (golden/dead) together with the index position vs its 60-day and 120-day MAs
+as the PRIMARY bull/bear trend signal, and report it explicitly in your analysis.
 You may adjust regime_confidence (±0.1) based on perplexity analysis, but DO NOT change market_regime unless
 perplexity data provides overwhelming contradictory evidence.
 """

--- a/cores/agents/stock_price_agents.py
+++ b/cores/agents/stock_price_agents.py
@@ -24,7 +24,8 @@ def create_price_volume_analysis_agent(company_name, company_code, reference_dat
 
                         ## Analysis Elements
                         1. Stock Price Trend and Pattern Analysis (uptrend/downtrend/sideways, chart patterns)
-                        2. Moving Average Analysis (short/medium/long-term moving average golden cross/dead cross)
+                        2. Moving Average Analysis (golden cross/dead cross)
+                           - 5-day, 20-day, 60-day, 120-day moving averages (KR market standard)
                         3. Identification and explanation of major support and resistance levels
                         4. Trading Volume Analysis (relationship between volume change patterns and price movements)
                         5. **Technical Indicators - MUST CALCULATE from OHLCV data:**
@@ -84,7 +85,8 @@ def create_price_volume_analysis_agent(company_name, company_code, reference_dat
 
                         ## 분석 요소
                         1. 주가 추세 및 패턴 분석 (상승/하락/횡보, 차트 패턴)
-                        2. 이동평균선 분석 (단기/중기/장기 이평선 골든크로스/데드크로스)
+                        2. 이동평균선 분석 (골든크로스/데드크로스)
+                           - 5일/20일/60일/120일 이동평균 (KR 시장 표준)
                         3. 주요 지지선과 저항선 식별 및 설명
                         4. 거래량 분석 (거래량 증감 패턴과 주가 움직임 관계)
                         5. **기술적 지표 - OHLCV 데이터에서 반드시 직접 계산:**

--- a/cores/data_prefetch.py
+++ b/cores/data_prefetch.py
@@ -162,6 +162,8 @@ def prefetch_macro_intelligence_data(reference_date: str) -> dict:
 
     ref_dt = datetime.strptime(reference_date, "%Y%m%d")
     start_date = (ref_dt - timedelta(days=45)).strftime("%Y%m%d")
+    # regime 계산용 별도 장기 구간(60/120일선 필요). 마크다운(start_date, 45일)은 불변.
+    regime_start_date = (ref_dt - timedelta(days=250)).strftime("%Y%m%d")
 
     # 1. KOSPI index OHLCV
     kospi_md = prefetch_index_ohlcv("1001", start_date, reference_date)
@@ -194,8 +196,8 @@ def prefetch_macro_intelligence_data(reference_date: str) -> dict:
 
     # 4. Compute regime from raw KOSPI data
     try:
-        kospi_raw = server.get_index_ohlcv(start_date, reference_date, "1001")
-        kosdaq_raw = server.get_index_ohlcv(start_date, reference_date, "2001")
+        kospi_raw = server.get_index_ohlcv(regime_start_date, reference_date, "1001")
+        kosdaq_raw = server.get_index_ohlcv(regime_start_date, reference_date, "2001")
         if kospi_raw:
             result["computed_regime"] = _compute_kr_regime(kospi_raw, kosdaq_raw)
     except Exception as e:
@@ -242,9 +244,19 @@ def _compute_kr_regime(kospi_ohlcv: dict, kosdaq_ohlcv: dict = None) -> dict:
         price_2w_ago = float(df_20d[close_col].iloc[0])
     change_2w_pct = ((current_price - price_2w_ago) / price_2w_ago) * 100
 
-    # MA position
+    # MA position (short-term, 20-day = 생명선)
     ma_diff_pct = ((current_price - ma_20d) / ma_20d) * 100
     above_ma = current_price > ma_20d
+
+    # Trend MAs (60/120) from FULL history — needs ~250d fetch.
+    # KR 관례: 60일선=수급선(중기), 120일선=경기선(중장기 추세 분기).
+    closes_full = df[close_col].dropna()
+    ma_60 = float(closes_full.tail(60).mean()) if len(closes_full) >= 60 else None
+    ma_120 = float(closes_full.tail(120).mean()) if len(closes_full) >= 120 else None
+    above_60 = (current_price > ma_60) if ma_60 is not None else None
+    above_120 = (current_price > ma_120) if ma_120 is not None else None
+    # golden = 60일선 > 120일선 (정배열 경향); False = 데드크로스
+    golden = (ma_60 > ma_120) if (ma_60 is not None and ma_120 is not None) else None
 
     # simple_ma_regime (pure index-based)
     if abs(ma_diff_pct) <= 0.5:
@@ -262,22 +274,50 @@ def _compute_kr_regime(kospi_ohlcv: dict, kosdaq_ohlcv: dict = None) -> dict:
     else:
         kospi_trend = "sideways"
 
-    # Market regime classification (KR uses 2-week / ±5% thresholds)
-    if above_ma and change_2w_pct > 5:
-        regime = "strong_bull"
-        confidence = 0.85
-    elif above_ma and change_2w_pct >= 0:
-        regime = "moderate_bull"
-        confidence = 0.75
-    elif abs(ma_diff_pct) <= 1 and abs(change_2w_pct) < 2:
-        regime = "sideways"
-        confidence = 0.65
-    elif not above_ma and change_2w_pct < -5:
-        regime = "strong_bear"
-        confidence = 0.85
+    # Market regime classification.
+    # Trend-template (120일선 primary divider) when 120MA available; else legacy 20MA logic.
+    # Output strings unchanged (6 regimes) so downstream buy-matrix/prompts stay compatible.
+    if ma_120 is not None:
+        if above_120:
+            # 중장기 상승추세 (가격 > 120일선)
+            if above_60 and golden and change_2w_pct > 5:
+                regime = "strong_bull"
+                confidence = 0.90
+            elif above_60 or change_2w_pct >= 0:
+                regime = "moderate_bull"
+                confidence = 0.78
+            else:
+                regime = "sideways"
+                confidence = 0.62
+        else:
+            # 120일선 아래 = 중장기 하락추세 → 'bull' 금지. 약세장 반등 방어:
+            # 120선 아래에서의 단기 급반등은 strong_bull 이 아니라 sideways(보수)로 분류.
+            if golden is False and change_2w_pct < -5:
+                regime = "strong_bear"
+                confidence = 0.90
+            elif change_2w_pct < 0:
+                regime = "moderate_bear"
+                confidence = 0.78
+            else:
+                regime = "sideways"
+                confidence = 0.55
     else:
-        regime = "moderate_bear"
-        confidence = 0.75
+        # Legacy 20MA logic (insufficient history for 120MA) — backward compatible
+        if above_ma and change_2w_pct > 5:
+            regime = "strong_bull"
+            confidence = 0.85
+        elif above_ma and change_2w_pct >= 0:
+            regime = "moderate_bull"
+            confidence = 0.75
+        elif abs(ma_diff_pct) <= 1 and abs(change_2w_pct) < 2:
+            regime = "sideways"
+            confidence = 0.65
+        elif not above_ma and change_2w_pct < -5:
+            regime = "strong_bear"
+            confidence = 0.85
+        else:
+            regime = "moderate_bear"
+            confidence = 0.75
 
     # KOSDAQ trend (if available)
     kosdaq_trend = "sideways"
@@ -302,18 +342,29 @@ def _compute_kr_regime(kospi_ohlcv: dict, kosdaq_ohlcv: dict = None) -> dict:
         except Exception:
             pass
 
+    index_summary = {
+        "kospi_20d_trend": kospi_trend,
+        "kospi_vs_20d_ma": "above" if above_ma else "below",
+        "kospi_2w_change_pct": round(change_2w_pct, 2),
+        "kospi_current": round(current_price, 2),
+        "kospi_20d_ma": round(ma_20d, 2),
+        "kosdaq_20d_trend": kosdaq_trend,
+    }
+    # Trend MA fields (additive — present only when enough history)
+    if ma_60 is not None:
+        index_summary["kospi_60d_ma"] = round(ma_60, 2)
+        index_summary["kospi_vs_60d_ma"] = "above" if above_60 else "below"
+    if ma_120 is not None:
+        index_summary["kospi_120d_ma"] = round(ma_120, 2)
+        index_summary["kospi_vs_120d_ma"] = "above" if above_120 else "below"
+    if golden is not None:
+        index_summary["kospi_ma_60_120_cross"] = "golden" if golden else "dead"
+
     return {
         "market_regime": regime,
         "regime_confidence": confidence,
         "simple_ma_regime": simple_ma_regime,
-        "index_summary": {
-            "kospi_20d_trend": kospi_trend,
-            "kospi_vs_20d_ma": "above" if above_ma else "below",
-            "kospi_2w_change_pct": round(change_2w_pct, 2),
-            "kospi_current": round(current_price, 2),
-            "kospi_20d_ma": round(ma_20d, 2),
-            "kosdaq_20d_trend": kosdaq_trend,
-        }
+        "index_summary": index_summary,
     }
 
 

--- a/cores/oneil_fallback.py
+++ b/cores/oneil_fallback.py
@@ -54,6 +54,7 @@ class SellInputs:
     #   으로 매 사이클 1회 계산한 LIVE regime 을 from_stock_data(live_regime=...) 로 주입할 것.
     primary_support: float = 0.0        # key_levels.primary_support (선택)
     regime_is_live: bool = False        # True 면 trailing 밴드를 신뢰, False(=stale)면 보수적
+    ma_50: float = 0.0                  # 개별종목 50일선(주입 시에만 TIER1.5 작동, 0이면 dormant)
 
 
 def _normalize_regime(raw: str) -> str:
@@ -95,6 +96,12 @@ def evaluate_oneil_sell(inp: SellInputs) -> Tuple[bool, str]:
     if profit <= ABS_STOP_LOSS_PCT:
         return True, f"TIER1_ABS7: loss {profit:.2f}% <= {ABS_STOP_LOSS_PCT}%"
 
+    # ── TIER 1.5: 50일선 이탈 + 손실 (보수적 손실차단) ─────────
+    # 오닐 '기관 방어선(50일선)' 이탈을 손실 포지션에 한해 적용 → 승자는 절대 안 팔림.
+    # ma_50 이 주입되지 않으면(0) 비활성(dormant) — 라이브 배선 전까지 동작 변화 없음.
+    if inp.ma_50 and inp.ma_50 > 0 and profit < 0 and cp <= inp.ma_50 * (1.0 - STOP_WICK_BUFFER):
+        return True, f"TIER1.5_MA50: below 50MA({inp.ma_50:.4f}) while losing ({profit:.2f}%)"
+
     # ── TIER 2: 트레일링 스톱 (승자 보호, +5% 활성화 이후만) ───
     activated = peak >= bp * (1.0 + TRAIL_ACTIVATION_PCT / 100.0)
     if activated:
@@ -125,7 +132,8 @@ def evaluate_oneil_sell(inp: SellInputs) -> Tuple[bool, str]:
 
 
 # ── 호출측 어댑터 (stock_data dict → SellInputs) ────────────────
-def from_stock_data(stock_data: dict, live_regime: Optional[str] = None) -> SellInputs:
+def from_stock_data(stock_data: dict, live_regime: Optional[str] = None,
+                    ma_50: Optional[float] = None) -> SellInputs:
     """KR/US 의 stock_data dict 에서 SellInputs 추출.
     scenario 는 JSON 문자열 또는 dict 둘 다 허용.
 
@@ -163,6 +171,7 @@ def from_stock_data(stock_data: dict, live_regime: Optional[str] = None) -> Sell
         market_condition=str(regime or ""),
         primary_support=_f(key_levels.get("primary_support", 0)),
         regime_is_live=is_live,
+        ma_50=_f(ma_50),
     )
 
 

--- a/cores/stock_chart.py
+++ b/cores/stock_chart.py
@@ -510,6 +510,7 @@ def create_price_chart(ticker, company_name=None, days=730, save_path=None, adju
     df = df.sort_index()
 
     # Calculate moving averages (krx_data_client returns English column names)
+    df['MA5'] = df['Close'].rolling(window=5).mean()  # 5-day moving average
     df['MA20'] = df['Close'].rolling(window=20).mean()  # 20-day moving average
     df['MA60'] = df['Close'].rolling(window=60).mean()  # 60-day moving average
     df['MA120'] = df['Close'].rolling(window=120).mean()  # 120-day moving average
@@ -525,6 +526,7 @@ def create_price_chart(ticker, company_name=None, days=730, save_path=None, adju
 
     # Configure moving average overlay plots
     additional_plots = [
+        mpf.make_addplot(df['MA5'], color='#00aa44', width=1),  # 5-day MA (green)
         mpf.make_addplot(df['MA20'], color='#ff9500', width=1),  # 20-day MA (orange)
         mpf.make_addplot(df['MA60'], color='#0066cc', width=1.5),  # 60-day MA (blue)
         mpf.make_addplot(df['MA120'], color='#cc3300', width=1.5, linestyle='--'),  # 120-day MA (red, dashed)
@@ -564,7 +566,7 @@ def create_price_chart(ticker, company_name=None, days=730, save_path=None, adju
     ax1, ax2 = axes[0], axes[2]
 
     # Add legend for moving averages
-    ax1.legend(['MA20', 'MA60', 'MA120'], loc='upper left')
+    ax1.legend(['MA5', 'MA20', 'MA60', 'MA120'], loc='upper left')
 
     # Identify key price points for annotation
     max_point = df['Close'].idxmax()  # Highest closing price date

--- a/prism-us/cores/agents/macro_intelligence_agent.py
+++ b/prism-us/cores/agents/macro_intelligence_agent.py
@@ -40,11 +40,18 @@ The following regime was computed programmatically from S&P 500 / VIX price data
 - **S&P 500 4-week change**: {idx.get('sp500_4w_change_pct', 'N/A')}%
 - **S&P 500 current**: {idx.get('sp500_current', 'N/A')}
 - **S&P 500 20d MA**: {idx.get('sp500_20d_ma', 'N/A')}
+- **S&P 500 50d MA**: {idx.get('sp500_50d_ma', 'N/A')}
+- **S&P 500 vs 50d MA**: {idx.get('sp500_vs_50d_ma', 'N/A')}
+- **S&P 500 200d MA**: {idx.get('sp500_200d_ma', 'N/A')}
+- **S&P 500 vs 200d MA**: {idx.get('sp500_vs_200d_ma', 'N/A')}
+- **S&P 500 50/200 MA cross**: {idx.get('sp500_ma_50_200_cross', 'N/A')} (golden = bull trend, dead = bear trend)
 - **NASDAQ 20d trend**: {idx.get('nasdaq_20d_trend', 'N/A')}
 - **VIX current**: {idx.get('vix_current', 'N/A')}
 - **VIX level**: {idx.get('vix_level', 'N/A')}
 
 You MUST use these pre-computed values for market_regime, regime_confidence, simple_ma_regime, and index_summary.
+Treat the S&P 500 50/200 MA cross (golden/dead) together with the index position vs its 50-day and 200-day MAs
+as the PRIMARY bull/bear trend signal, and report it explicitly in your analysis.
 You may adjust regime_confidence (±0.1) based on perplexity analysis, but DO NOT change market_regime unless
 perplexity data provides overwhelming contradictory evidence.
 """

--- a/prism-us/cores/agents/stock_price_agents.py
+++ b/prism-us/cores/agents/stock_price_agents.py
@@ -109,7 +109,7 @@ def create_us_price_volume_analysis_agent(
 ## Analysis Elements
 1. Stock Price Trend and Pattern Analysis (uptrend/downtrend/sideways, chart patterns)
 2. Moving Average Analysis (short/medium/long-term moving average golden cross/dead cross)
-   - 20-day, 50-day, 200-day moving averages (US market standard)
+   - 10-day, 20-day, 50-day, 200-day moving averages (US O'Neil standard)
 3. Identification and explanation of major support and resistance levels
 4. Trading Volume Analysis (relationship between volume change patterns and price movements)
 5. **Technical Indicators - MUST CALCULATE from OHLCV data:**

--- a/prism-us/cores/data_prefetch.py
+++ b/prism-us/cores/data_prefetch.py
@@ -905,7 +905,7 @@ def prefetch_us_macro_intelligence_data(reference_date: str = None) -> dict:
     # 1. S&P 500
     sp500_df = None
     try:
-        sp500_df = client.get_ohlcv("^GSPC", period="3mo", interval="1d")
+        sp500_df = client.get_ohlcv("^GSPC", period="1y", interval="1d")
         if sp500_df is not None and not sp500_df.empty:
             sp500_20d = sp500_df.tail(20)
             sp500_20d.columns = [col.title().replace("_", " ") for col in sp500_20d.columns]
@@ -917,7 +917,7 @@ def prefetch_us_macro_intelligence_data(reference_date: str = None) -> dict:
     # 2. NASDAQ
     nasdaq_df = None
     try:
-        nasdaq_df = client.get_ohlcv("^IXIC", period="3mo", interval="1d")
+        nasdaq_df = client.get_ohlcv("^IXIC", period="1y", interval="1d")
         if nasdaq_df is not None and not nasdaq_df.empty:
             nasdaq_20d = nasdaq_df.tail(20)
             nasdaq_20d.columns = [col.title().replace("_", " ") for col in nasdaq_20d.columns]
@@ -929,7 +929,7 @@ def prefetch_us_macro_intelligence_data(reference_date: str = None) -> dict:
     # 3. VIX
     vix_df = None
     try:
-        vix_df = client.get_ohlcv("^VIX", period="3mo", interval="1d")
+        vix_df = client.get_ohlcv("^VIX", period="1y", interval="1d")
         if vix_df is not None and not vix_df.empty:
             vix_20d = vix_df.tail(20)
             vix_20d.columns = [col.title().replace("_", " ") for col in vix_20d.columns]
@@ -983,9 +983,19 @@ def _compute_us_regime(sp500_df: pd.DataFrame, nasdaq_df: pd.DataFrame = None, v
         price_4w_ago = float(df_20d[close_col].iloc[0])
     change_4w_pct = ((current_price - price_4w_ago) / price_4w_ago) * 100
 
-    # MA position
+    # MA position (short-term, 20-day)
     ma_diff_pct = ((current_price - ma_20d) / ma_20d) * 100
     above_ma = current_price > ma_20d
+
+    # Trend MAs (50/200) from FULL history — needs ~1y fetch.
+    # O'Neil/Minervini trend template: 200MA = primary bull/bear divider, 50MA = intermediate.
+    closes_full = sp500_df[close_col].dropna()
+    ma_50 = float(closes_full.tail(50).mean()) if len(closes_full) >= 50 else None
+    ma_200 = float(closes_full.tail(200).mean()) if len(closes_full) >= 200 else None
+    above_50 = (current_price > ma_50) if ma_50 is not None else None
+    above_200 = (current_price > ma_200) if ma_200 is not None else None
+    # golden = 50MA above 200MA (bullish alignment); False = dead cross
+    golden = (ma_50 > ma_200) if (ma_50 is not None and ma_200 is not None) else None
 
     # VIX level
     vix_current = None
@@ -1045,22 +1055,51 @@ def _compute_us_regime(sp500_df: pd.DataFrame, nasdaq_df: pd.DataFrame = None, v
         except Exception:
             pass
 
-    # Market regime classification (US uses 4-week / ±3%/±5% thresholds + VIX)
-    if above_ma and change_4w_pct > 3 and vix_level in ("low", "moderate"):
-        regime = "strong_bull"
-        confidence = 0.85
-    elif above_ma and change_4w_pct >= 0:
-        regime = "moderate_bull"
-        confidence = 0.75
-    elif abs(ma_diff_pct) <= 1 and abs(change_4w_pct) < 2:
-        regime = "sideways"
-        confidence = 0.65
-    elif not above_ma and change_4w_pct < -5 and vix_level in ("elevated", "high"):
-        regime = "strong_bear"
-        confidence = 0.85
+    # Market regime classification.
+    # Trend-template (200MA primary divider) when 200MA available; else legacy 20MA logic.
+    # Output strings unchanged (6 regimes) so downstream buy-matrix/prompts stay compatible.
+    if ma_200 is not None:
+        if above_200:
+            # Primary uptrend (price above 200MA)
+            if above_50 and golden and change_4w_pct > 3 and vix_level in ("low", "moderate"):
+                regime = "strong_bull"
+                confidence = 0.90
+            elif above_50 or change_4w_pct >= 0:
+                regime = "moderate_bull"
+                confidence = 0.78
+            else:
+                # above primary trend but short-term pullback below 50MA
+                regime = "sideways"
+                confidence = 0.62
+        else:
+            # Primary downtrend (price below 200MA) → never 'bull'. Bear-rally protection:
+            # a sharp 4w bounce here is classified cautious (sideways), not strong_bull.
+            if golden is False and change_4w_pct < -5 and vix_level in ("elevated", "high"):
+                regime = "strong_bear"
+                confidence = 0.90
+            elif change_4w_pct < 0:
+                regime = "moderate_bear"
+                confidence = 0.78
+            else:
+                regime = "sideways"
+                confidence = 0.55
     else:
-        regime = "moderate_bear"
-        confidence = 0.75
+        # Legacy 20MA logic (insufficient history for 200MA) — backward compatible
+        if above_ma and change_4w_pct > 3 and vix_level in ("low", "moderate"):
+            regime = "strong_bull"
+            confidence = 0.85
+        elif above_ma and change_4w_pct >= 0:
+            regime = "moderate_bull"
+            confidence = 0.75
+        elif abs(ma_diff_pct) <= 1 and abs(change_4w_pct) < 2:
+            regime = "sideways"
+            confidence = 0.65
+        elif not above_ma and change_4w_pct < -5 and vix_level in ("elevated", "high"):
+            regime = "strong_bear"
+            confidence = 0.85
+        else:
+            regime = "moderate_bear"
+            confidence = 0.75
 
     index_summary = {
         "sp500_20d_trend": sp500_trend,
@@ -1070,6 +1109,15 @@ def _compute_us_regime(sp500_df: pd.DataFrame, nasdaq_df: pd.DataFrame = None, v
         "sp500_20d_ma": round(ma_20d, 2),
         "nasdaq_20d_trend": nasdaq_trend,
     }
+    # Trend MA fields (additive — present only when enough history)
+    if ma_50 is not None:
+        index_summary["sp500_50d_ma"] = round(ma_50, 2)
+        index_summary["sp500_vs_50d_ma"] = "above" if above_50 else "below"
+    if ma_200 is not None:
+        index_summary["sp500_200d_ma"] = round(ma_200, 2)
+        index_summary["sp500_vs_200d_ma"] = "above" if above_200 else "below"
+    if golden is not None:
+        index_summary["sp500_ma_50_200_cross"] = "golden" if golden else "dead"
     if vix_current is not None:
         index_summary["vix_current"] = round(vix_current, 2)
         index_summary["vix_level"] = vix_level

--- a/prism-us/cores/oneil_fallback.py
+++ b/prism-us/cores/oneil_fallback.py
@@ -54,6 +54,7 @@ class SellInputs:
     #   으로 매 사이클 1회 계산한 LIVE regime 을 from_stock_data(live_regime=...) 로 주입할 것.
     primary_support: float = 0.0        # key_levels.primary_support (선택)
     regime_is_live: bool = False        # True 면 trailing 밴드를 신뢰, False(=stale)면 보수적
+    ma_50: float = 0.0                  # 개별종목 50일선(주입 시에만 TIER1.5 작동, 0이면 dormant)
 
 
 def _normalize_regime(raw: str) -> str:
@@ -95,6 +96,12 @@ def evaluate_oneil_sell(inp: SellInputs) -> Tuple[bool, str]:
     if profit <= ABS_STOP_LOSS_PCT:
         return True, f"TIER1_ABS7: loss {profit:.2f}% <= {ABS_STOP_LOSS_PCT}%"
 
+    # ── TIER 1.5: 50일선 이탈 + 손실 (보수적 손실차단) ─────────
+    # 오닐 '기관 방어선(50일선)' 이탈을 손실 포지션에 한해 적용 → 승자는 절대 안 팔림.
+    # ma_50 이 주입되지 않으면(0) 비활성(dormant) — 라이브 배선 전까지 동작 변화 없음.
+    if inp.ma_50 and inp.ma_50 > 0 and profit < 0 and cp <= inp.ma_50 * (1.0 - STOP_WICK_BUFFER):
+        return True, f"TIER1.5_MA50: below 50MA({inp.ma_50:.4f}) while losing ({profit:.2f}%)"
+
     # ── TIER 2: 트레일링 스톱 (승자 보호, +5% 활성화 이후만) ───
     activated = peak >= bp * (1.0 + TRAIL_ACTIVATION_PCT / 100.0)
     if activated:
@@ -125,7 +132,8 @@ def evaluate_oneil_sell(inp: SellInputs) -> Tuple[bool, str]:
 
 
 # ── 호출측 어댑터 (stock_data dict → SellInputs) ────────────────
-def from_stock_data(stock_data: dict, live_regime: Optional[str] = None) -> SellInputs:
+def from_stock_data(stock_data: dict, live_regime: Optional[str] = None,
+                    ma_50: Optional[float] = None) -> SellInputs:
     """KR/US 의 stock_data dict 에서 SellInputs 추출.
     scenario 는 JSON 문자열 또는 dict 둘 다 허용.
 
@@ -163,6 +171,7 @@ def from_stock_data(stock_data: dict, live_regime: Optional[str] = None) -> Sell
         market_condition=str(regime or ""),
         primary_support=_f(key_levels.get("primary_support", 0)),
         regime_is_live=is_live,
+        ma_50=_f(ma_50),
     )
 
 

--- a/prism-us/cores/us_stock_chart.py
+++ b/prism-us/cores/us_stock_chart.py
@@ -203,10 +203,11 @@ def create_us_price_chart(
             df.index = pd.to_datetime(df.index)
         df = df.sort_index()
 
-        # Calculate moving averages
+        # Calculate moving averages (US O'Neil standard: 10/20/50/200)
+        df['MA10'] = df['Close'].rolling(window=10).mean()
         df['MA20'] = df['Close'].rolling(window=20).mean()
-        df['MA60'] = df['Close'].rolling(window=60).mean()
-        df['MA120'] = df['Close'].rolling(window=120).mean()
+        df['MA50'] = df['Close'].rolling(window=50).mean()
+        df['MA200'] = df['Close'].rolling(window=200).mean()
 
         # Create OHLCV DataFrame
         ohlc_df = df[['Open', 'High', 'Low', 'Close', 'Volume']].copy()
@@ -225,19 +226,24 @@ def create_us_price_chart(
             gridcolor='#e0e0e0'
         )
 
-        # Moving average plots
+        # Moving average plots (10/20/50/200)
+        # MA200 requires >=200 rows; guard so a mostly-NaN series doesn't crash the plot
         additional_plots = []
+        if not df['MA10'].isna().all():
+            additional_plots.append(
+                mpf.make_addplot(df['MA10'], color='#9933cc', width=1)
+            )
         if not df['MA20'].isna().all():
             additional_plots.append(
                 mpf.make_addplot(df['MA20'], color='#ff9500', width=1)
             )
-        if not df['MA60'].isna().all():
+        if not df['MA50'].isna().all():
             additional_plots.append(
-                mpf.make_addplot(df['MA60'], color='#0066cc', width=1.5)
+                mpf.make_addplot(df['MA50'], color='#0066cc', width=1.5)
             )
-        if not df['MA120'].isna().all():
+        if df['MA200'].notna().any():
             additional_plots.append(
-                mpf.make_addplot(df['MA120'], color='#cc3300', width=1.5, linestyle='--')
+                mpf.make_addplot(df['MA200'], color='#cc3300', width=1.5, linestyle='--')
             )
 
         # Create chart
@@ -302,12 +308,14 @@ def create_us_price_chart(
         # Legend
         if additional_plots:
             legend_labels = []
+            if not df['MA10'].isna().all():
+                legend_labels.append('MA10')
             if not df['MA20'].isna().all():
                 legend_labels.append('MA20')
-            if not df['MA60'].isna().all():
-                legend_labels.append('MA60')
-            if not df['MA120'].isna().all():
-                legend_labels.append('MA120')
+            if not df['MA50'].isna().all():
+                legend_labels.append('MA50')
+            if df['MA200'].notna().any():
+                legend_labels.append('MA200')
             if legend_labels:
                 ax1.legend(legend_labels, loc='upper left', fontsize=8)
 
@@ -542,10 +550,19 @@ def create_us_technical_indicators_chart(
         ax1.plot(df.index, df['Close'], color=PRIMARY_COLORS[0], linewidth=1.5, label='Close Price')
         ax1.fill_between(df.index, df['Close'], alpha=0.1, color=PRIMARY_COLORS[0])
 
-        # Add moving averages
+        # Add moving averages (US standard: 10/20/50/200)
+        if len(df) >= 10:
+            ma10 = df['Close'].rolling(window=10).mean()
+            ax1.plot(df.index, ma10, color='#9933cc', linewidth=1, linestyle='--', label='MA10', alpha=0.7)
         if len(df) >= 20:
             ma20 = df['Close'].rolling(window=20).mean()
             ax1.plot(df.index, ma20, color='#ff9500', linewidth=1, linestyle='--', label='MA20', alpha=0.7)
+        if len(df) >= 50:
+            ma50 = df['Close'].rolling(window=50).mean()
+            ax1.plot(df.index, ma50, color='#0066cc', linewidth=1, linestyle='--', label='MA50', alpha=0.7)
+        if len(df) >= 200:
+            ma200 = df['Close'].rolling(window=200).mean()
+            ax1.plot(df.index, ma200, color='#cc3300', linewidth=1, linestyle='--', label='MA200', alpha=0.7)
 
         ax1.set_ylabel('Price ($)', fontsize=10)
         ax1.set_title('Price', fontsize=11, loc='left')


### PR DESCRIPTION
## 목적
투자 안정성(낙폭 축소). regime이 **매수 매트릭스 + 매도 트레일링 밴드를 동시에 좌우**하므로 regime 고도화가 핵심 레버리지. raw 수익률보다 **리스크조정 수익/낙폭** 개선이 목표.

## Phase 1 — regime multi-MA (load-bearing, 검증완료)
- **US** `_compute_us_regime`: 지수 fetch `3mo→1y`, **50/200일선 + 골든/데드크로스** 계산, **200일선=강세/약세 1차 분기선**. 출력 문자열 6종 유지(downstream 호환), 200MA 미가용 시 레거시 20MA 폴백. `index_summary`에 50/200 필드 additive.
- **KR** `_compute_kr_regime`: regime 전용 fetch `45d→250d`(마크다운 불변, **추가 호출 0**), **60/120일선 + 골든/데드**, 120일선=중장기 분기선.
- **핵심 효과 검증**: 약세장 반등(200/120선 아래 단기 급반등)을 `strong_bull`로 오판하지 않고 `sideways`로 분류 → **bear-rally 과매수 차단**.

## Phase 2 — 시장별 MA셋 정렬
- US 차트 20/60/120(한국식 오류)→**10/20/50/200 교정**, KR 차트 **MA5 추가**.
- 보고서 tech 프롬프트: US 10/20/50/200, KR 5/20/60/120 명시.
- 매크로 에이전트: 50/200(US)·60/120(KR) MA·크로스를 1차 추세신호로 참조.

## Phase 3 — 50일선 이탈 매도 TIER (보수적, **기본 dormant**)
- `oneil_fallback` TIER1.5: 종목 50일선 이탈 + **손실 포지션에 한해** 매도(**승자 절대 보호**). `ma_50` 주입 시에만 작동 → **라이브 미배선이라 운영 동작 변화 0**.
- per-holding 50MA 배치 fetch 라이브 배선 + 상수 중앙화 → **백테스트 후 별도 PR**.

## 검증
- 합성데이터 단위테스트: US/KR regime 분류(추세/약세반등/하락/레거시폴백), oneil dormant·active·승자보호 모두 통과.
- 10개 파일 py_compile OK. RSI(14) 유지, 외부 의존성 추가 0.
- ⚠️ 권장: 머지 후 2022 약세장 백테스트로 20MA-only vs 50/200-blend 낙폭 비교 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)