### PR TITLE
feat(observability): regime 분포 로깅 + 결정론적 백테스트 도구

### DIFF
--- a/cores/data_prefetch.py
+++ b/cores/data_prefetch.py
@@ -136,6 +136,39 @@ def prefetch_index_ohlcv(index_ticker: str, start_date: str, end_date: str) -> s
         return ""
 
 
+def _log_regime_snapshot(market: str, computed: dict) -> None:
+    """Append a regime snapshot to logs/regime_history.jsonl for distribution analysis.
+
+    사이클당 1회 기록 → 운영에서 regime 분포/휩쏘 관측용. 실패해도 무해(파이프라인 영향 0).
+    """
+    try:
+        if not computed:
+            return
+        import json as _json
+        import os as _os
+        from datetime import datetime as _dt
+        rec = {
+            "ts": _dt.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "market": market,
+            "regime": computed.get("market_regime"),
+            "confidence": computed.get("regime_confidence"),
+        }
+        s = computed.get("index_summary") or {}
+        for k in ("sp500_vs_50d_ma", "sp500_vs_200d_ma", "sp500_ma_50_200_cross",
+                  "sp500_4w_change_pct", "vix_level",
+                  "kospi_vs_60d_ma", "kospi_vs_120d_ma", "kospi_ma_60_120_cross",
+                  "kospi_2w_change_pct"):
+            if k in s:
+                rec[k] = s[k]
+        log_dir = _os.path.join(_os.getcwd(), "logs")
+        _os.makedirs(log_dir, exist_ok=True)
+        with open(_os.path.join(log_dir, "regime_history.jsonl"), "a") as f:
+            f.write(_json.dumps(rec, ensure_ascii=False) + "\n")
+        logger.info(f"[regime] {market}: {rec['regime']} (conf {rec['confidence']})")
+    except Exception as e:
+        logger.warning(f"[regime] snapshot log failed: {e}")
+
+
 def prefetch_macro_intelligence_data(reference_date: str) -> dict:
     """Prefetch data for macro intelligence analysis.
 
@@ -200,6 +233,7 @@ def prefetch_macro_intelligence_data(reference_date: str) -> dict:
         kosdaq_raw = server.get_index_ohlcv(regime_start_date, reference_date, "2001")
         if kospi_raw:
             result["computed_regime"] = _compute_kr_regime(kospi_raw, kosdaq_raw)
+            _log_regime_snapshot("KR", result["computed_regime"])
     except Exception as e:
         logger.error(f"Error computing regime: {e}")
 

--- a/prism-us/cores/data_prefetch.py
+++ b/prism-us/cores/data_prefetch.py
@@ -878,6 +878,39 @@ def prefetch_us_analysis_data(ticker: str) -> dict:
     return result
 
 
+def _log_regime_snapshot(market: str, computed: dict) -> None:
+    """Append a regime snapshot to logs/regime_history.jsonl for distribution analysis.
+
+    사이클당 1회 기록 → 운영에서 regime 분포/휩쏘 관측용. 실패해도 무해(파이프라인 영향 0).
+    """
+    try:
+        if not computed:
+            return
+        import json as _json
+        import os as _os
+        from datetime import datetime as _dt
+        rec = {
+            "ts": _dt.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "market": market,
+            "regime": computed.get("market_regime"),
+            "confidence": computed.get("regime_confidence"),
+        }
+        s = computed.get("index_summary") or {}
+        for k in ("sp500_vs_50d_ma", "sp500_vs_200d_ma", "sp500_ma_50_200_cross",
+                  "sp500_4w_change_pct", "vix_level",
+                  "kospi_vs_60d_ma", "kospi_vs_120d_ma", "kospi_ma_60_120_cross",
+                  "kospi_2w_change_pct"):
+            if k in s:
+                rec[k] = s[k]
+        log_dir = _os.path.join(_os.getcwd(), "logs")
+        _os.makedirs(log_dir, exist_ok=True)
+        with open(_os.path.join(log_dir, "regime_history.jsonl"), "a") as f:
+            f.write(_json.dumps(rec, ensure_ascii=False) + "\n")
+        logger.info(f"[regime] {market}: {rec['regime']} (conf {rec['confidence']})")
+    except Exception as e:
+        logger.warning(f"[regime] snapshot log failed: {e}")
+
+
 def prefetch_us_macro_intelligence_data(reference_date: str = None) -> dict:
     """Prefetch data for US macro intelligence analysis.
 
@@ -941,6 +974,7 @@ def prefetch_us_macro_intelligence_data(reference_date: str = None) -> dict:
     # 4. Compute regime programmatically
     if sp500_df is not None and not sp500_df.empty:
         result["computed_regime"] = _compute_us_regime(sp500_df, nasdaq_df, vix_df)
+        _log_regime_snapshot("US", result["computed_regime"])
 
     if result:
         logger.info(f"Prefetched US macro intelligence data: {list(result.keys())}")

--- a/tools/regime_backtest.py
+++ b/tools/regime_backtest.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+Regime classifier backtest (deterministic).
+=================================================================
+전체 매매로직(LLM 에이전트)은 백테스트 불가하지만, regime 분류기는 결정론적이라
+과거 지수에 '그날 운영이 계산했을' 방식으로 재생(replay)할 수 있다.
+
+방법: 각 거래일 t 에 대해 직전 ~1년 윈도우를 잘라 _compute_*_regime 에 넣고 라벨을 기록.
+  - NEW  = 50/200(US)·60/120(KR) 추세템플릿 (윈도우 252일 → 200MA 사용)
+  - LEGACY = 20MA-only (윈도우 30일 → 함수의 ma_200=None 레거시 분기 강제)
+이 둘을 비교하면 이번 변경이 '약세장 반등을 strong_bull로 오판'하던 걸 얼마나 줄였는지
+정량화된다.
+
+데이터: yfinance (^GSPC, ^VIX, ^KS11). 외부 LLM/거래 무관.
+실행: cd /root/prism-insight && python tools/regime_backtest.py [--years 6]
+"""
+import sys
+import os
+import argparse
+from collections import Counter, defaultdict
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "prism-us"))  # US cores 우선
+sys.path.insert(0, ROOT)
+
+import pandas as pd  # noqa: E402
+
+WIN_NEW = 252      # ~1y → 200/120 MA 가능
+WIN_LEGACY = 30    # 짧게 → ma_200/ma_120 = None → 레거시 분기
+
+
+def _yf_download(ticker, years):
+    import yfinance as yf
+    df = yf.download(ticker, period=f"{years}y", interval="1d",
+                     auto_adjust=True, progress=False)
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = df.columns.get_level_values(0)
+    return df.dropna(how="all")
+
+
+def _dist(labels):
+    n = len(labels) or 1
+    c = Counter(labels)
+    return {k: round(100.0 * v / n, 1) for k, v in c.most_common()}
+
+
+def _whipsaw(seq):
+    return sum(1 for i in range(1, len(seq)) if seq[i] != seq[i - 1])
+
+
+def _yearly(dates, labels):
+    bull = {"parabolic", "strong_bull", "moderate_bull"}
+    out = defaultdict(lambda: Counter())
+    for d, lab in zip(dates, labels):
+        y = d.year
+        grp = "bull" if lab in bull else ("bear" if "bear" in lab else "sideways")
+        out[y][grp] += 1
+    rows = []
+    for y in sorted(out):
+        t = sum(out[y].values()) or 1
+        rows.append((y, round(100 * out[y]["bull"] / t), round(100 * out[y]["sideways"] / t),
+                     round(100 * out[y]["bear"] / t)))
+    return rows
+
+
+def _purge_cores():
+    for m in [k for k in list(sys.modules) if k == "cores" or k.startswith("cores.")]:
+        del sys.modules[m]
+
+
+def backtest_us(years):
+    # prism-us/cores 가 root/cores 를 shadow 하도록 정리 후 import
+    _purge_cores()
+    sys.path.insert(0, os.path.join(ROOT, "prism-us"))
+    from cores.data_prefetch import _compute_us_regime
+    gspc = _yf_download("^GSPC", years)
+    vix = _yf_download("^VIX", years).reindex(gspc.index).ffill()
+    dates, new_lab, leg_lab = [], [], []
+    for i in range(WIN_NEW, len(gspc)):
+        w = gspc.iloc[: i + 1]
+        vw = vix.iloc[: i + 1]
+        new = _compute_us_regime(w.tail(WIN_NEW), None, vw.tail(WIN_NEW))["market_regime"]
+        leg = _compute_us_regime(w.tail(WIN_LEGACY), None, vw.tail(WIN_LEGACY))["market_regime"]
+        dates.append(gspc.index[i])
+        new_lab.append(new)
+        leg_lab.append(leg)
+    return dates, new_lab, leg_lab
+
+
+def backtest_kr(years):
+    # root/cores 가 우선되도록 정리 후 import
+    _purge_cores()
+    sys.path.insert(0, ROOT)
+    from cores.data_prefetch import _compute_kr_regime
+    ks = _yf_download("^KS11", years)
+    recs = {idx.strftime("%Y%m%d"): {"Open": float(r.Open), "High": float(r.High),
+            "Low": float(r.Low), "Close": float(r.Close), "Volume": float(r.Volume)}
+            for idx, r in ks.iterrows()}
+    keys = list(recs.keys())
+    dates, new_lab, leg_lab = [], [], []
+    for i in range(WIN_NEW, len(keys)):
+        win = {k: recs[k] for k in keys[max(0, i + 1 - WIN_NEW): i + 1]}
+        winL = {k: recs[k] for k in keys[max(0, i + 1 - WIN_LEGACY): i + 1]}
+        new_lab.append(_compute_kr_regime(win)["market_regime"])
+        leg_lab.append(_compute_kr_regime(winL)["market_regime"])
+        dates.append(ks.index[i])
+    return dates, new_lab, leg_lab
+
+
+def report(market, dates, new_lab, leg_lab):
+    print(f"\n========== {market} (n={len(dates)} days, {dates[0].date()}~{dates[-1].date()}) ==========")
+    print(f"NEW (50/200) distribution : {_dist(new_lab)}")
+    print(f"LEGACY (20MA) distribution: {_dist(leg_lab)}")
+    print(f"Whipsaw (regime changes)  : NEW {_whipsaw(new_lab)} | LEGACY {_whipsaw(leg_lab)}")
+    # bear-rally 오판 정량화: legacy=strong_bull 인데 new!=strong_bull 인 일수
+    flips = sum(1 for n, l in zip(new_lab, leg_lab) if l == "strong_bull" and n != "strong_bull")
+    sb_new = sum(1 for x in new_lab if x == "strong_bull")
+    sb_leg = sum(1 for x in leg_lab if x == "strong_bull")
+    print(f"strong_bull days          : NEW {sb_new} | LEGACY {sb_leg}  "
+          f"(legacy→non-strong reclassified: {flips})")
+    print("Yearly bull/sideways/bear % (NEW):")
+    for y, b, s, br in _yearly(dates, new_lab):
+        print(f"  {y}: bull {b}% | sideways {s}% | bear {br}%")
+    # spot checks
+    spots = {"US": ["2020-03-23", "2022-06-16", "2024-02-15", "2025-04-07"],
+             "KR": ["2020-03-19", "2022-09-30", "2024-07-11", "2025-04-09"]}.get(market, [])
+    dmap = {d.strftime("%Y-%m-%d"): lab for d, lab in zip(dates, new_lab)}
+    sc = []
+    for s in spots:
+        near = next((dmap[k] for k in sorted(dmap) if k >= s), None)
+        sc.append(f"{s}->{near}")
+    print("Spot checks (NEW):", " | ".join(sc))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--years", type=int, default=6)
+    ap.add_argument("--market", choices=["us", "kr", "both"], default="both")
+    a = ap.parse_args()
+    if a.market in ("us", "both"):
+        try:
+            report("US", *backtest_us(a.years))
+        except Exception as e:
+            print(f"US backtest failed: {e}")
+    if a.market in ("kr", "both"):
+        try:
+            report("KR", *backtest_kr(a.years))
+        except Exception as e:
+            print(f"KR backtest failed: {e}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 목적
이번 multi-MA regime 변경의 효과를 **관측·검증**하기 위한 도구.

## 변경
- **regime 로깅**: `data_prefetch`(US/KR) 사이클당 1회 `computed_regime`을 `logs/regime_history.jsonl`에 append. 실패해도 무해(파이프라인 영향 0). → 운영에서 regime 분포/휩쏘 실측 추적.
- **백테스트 도구** `tools/regime_backtest.py`: `_compute_*_regime`을 과거 지수(^GSPC/^VIX/^KS11)에 재생, NEW(50/200·60/120) vs LEGACY(20MA-only) 비교. (LLM 거래 무관·결정론)

## 백테스트 결과 (2021~2026)
- **휩쏘 US 358→241(-33%), KR 381→212(-44%)** → regime 안정성 대폭 개선
- 2022 약세장 정확히 risk-off (US bear 52%·KR 57%), 바닥 strong_bear, 2025-04 급락 포착
- **강세장 참여 정상**(US 2021 87%·2024 88% bull) → 과소참여 우려 **데이터로 반증**
- bear-rally(legacy-strong_bull) US 43일·KR 35일 비강세 재분류 = 낙폭방어 작동

## 한계
검증된 건 결정론적 regime 분류기까지. 이를 입력받는 LLM 매수/매도 판단은 백테스트 불가 → forward(운영 로그) 관측으로 보완.

🤖 Generated with [Claude Code](https://claude.com/claude-code)