### PR TITLE
fix(us-journal): US 매매일지 활성화 (ENABLE_TRADING_JOURNAL env 존중)

### DIFF
--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -482,7 +482,7 @@ class USStockTrackingAgent:
         self,
         db_path: str = "stock_tracking_db.sqlite",
         telegram_token: str = None,
-        enable_journal: bool = False
+        enable_journal: bool = None
     ):
         """
         Initialize US Stock Tracking Agent.
@@ -490,7 +490,9 @@ class USStockTrackingAgent:
         Args:
             db_path: SQLite database file path
             telegram_token: Telegram bot token
-            enable_journal: Whether to enable trading journal feature
+            enable_journal: Enable trading journal feature.
+                Priority: parameter > ENABLE_TRADING_JOURNAL env > default(False).
+                (KR 에이전트와 동일 토글 — 기존엔 US가 env 무시하고 False 하드코딩이라 일지 미동작)
         """
         self.max_slots = self.MAX_SLOTS
         self.message_queue = []
@@ -502,7 +504,13 @@ class USStockTrackingAgent:
         self.conn = None
         self.cursor = None
         self.language = "en"  # Default to English for US
-        self.enable_journal = enable_journal
+        # Trading journal feature flag — Priority: parameter > env > default(False).
+        # KR 에이전트와 동일하게 ENABLE_TRADING_JOURNAL env 를 존중한다.
+        if enable_journal is not None:
+            self.enable_journal = enable_journal
+        else:
+            env_value = os.environ.get("ENABLE_TRADING_JOURNAL", "false").lower()
+            self.enable_journal = env_value in ("true", "1", "yes")
         self.account_configs: list[dict[str, Any]] = []
         self.active_account: dict[str, Any] | None = None
 


### PR DESCRIPTION
## 문제
US 거래(MU·SNDK 등)가 변동성 횡보장에서 같은 종목을 손절당하고도 며칠 뒤 재진입해 반복 손절(MU/SNDK 1주새 각 2회 손절, -8~10%). 매매일지 피드백이 안 먹힘.

## 근본 원인
US 에이전트는 매매일지 인프라(매도 journal write `:2056`, 매수 journal context 주입 `:3043`/점수조정 `:3059`, 텔레그램 ⚠️/📒/📊 메시지 `:1039-1046`)를 **완비**했지만, **KR과 달리 `ENABLE_TRADING_JOURNAL` env(.env=true)를 무시하고 `enable_journal=False` 하드코딩**(`__init__`). → `trading_journal`(103)·`intuitions`(11)·`principles`(388) 전부 **KR만**, US 0행.

## 수정 (1파일)
US `__init__` 의 `enable_journal` 기본값 `False`→`None`, KR과 동일하게 `parameter > ENABLE_TRADING_JOURNAL env > default(False)` 우선순위로 읽음. 배포 즉시(env=true) US 매도가 일지 기록 → 다음 동일 종목 매수 후보 시 "최근 손절, 추격 재진입 신중"이 시나리오 + 텔레그램 메시지에 노출.

## 검증
py_compile OK, env 파싱 로직(true/1/yes→True) 단위확인. 저위험(인프라는 KR에서 검증됨, 실패시 거래 영향 없게 gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)