### PR TITLE
fix(us-journal): trading_journal_agent market 인자 지원 (US=yahoo_finance)

### DIFF
--- a/cores/agents/trading_journal_agent.py
+++ b/cores/agents/trading_journal_agent.py
@@ -14,7 +14,7 @@ Key Features:
 from mcp_agent.agents.agent import Agent
 
 
-def create_trading_journal_agent(language: str = "ko"):
+def create_trading_journal_agent(language: str = "ko", market: str = "KR"):
     """
     Create trading journal retrospective agent.
 
@@ -218,10 +218,18 @@ def create_trading_journal_agent(language: str = "ko"):
            - **low**: 종목 특화 관찰
         """
 
+    # US 시장은 kospi_kosdaq 대신 yahoo_finance 데이터 서버를 사용한다.
+    # (그동안 US 저널이 market 인자 미지원으로 TypeError 나며 미동작했던 버그 수정)
+    if market == "US":
+        instruction = instruction.replace("kospi_kosdaq", "yahoo_finance")
+        data_servers = ["yahoo_finance", "sqlite", "time"]
+    else:
+        data_servers = ["kospi_kosdaq", "sqlite", "time"]
+
     return Agent(
         name="trading_journal_agent",
         instruction=instruction,
-        server_names=["kospi_kosdaq", "sqlite", "time"]
+        server_names=data_servers
     )
 
 


### PR DESCRIPTION
## 문제
US 매매일지 활성화(#312) 후에도 매도 저널 기록이 매번 실패. 원인: `prism-us/tracking/journal.py`가 `create_trading_journal_agent(language, market="US")`로 호출하지만 함수가 `market` 인자를 안 받아 **TypeError** → create_entry가 False 반환하며 저널 미기록. (여태 enable_journal=False라 잠복)

## 수정
`create_trading_journal_agent(language, market="KR")` — market 파라미터 추가. `market="US"`면 server_names를 **yahoo_finance**로 전환(KR=kospi_kosdaq), 프롬프트 도구 안내도 치환. → US 매도 시 라이브 저널 기록 정상 동작.

## 검증
py_compile OK, 시그니처 `[language, market]` 확인. KR 경로 무변(기본 KR). 백필(과거 거래 소급)은 MCPApp 컨텍스트 필요로 별도 경량 처리 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)