### PR TITLE
fix(memory): 직관 생성 중단 보완 (누적 코퍼스 refresh_intuitions)

### DIFF
--- a/compress_trading_memory.py
+++ b/compress_trading_memory.py
@@ -267,6 +267,15 @@ async def run_compression(
         logger.info(f"  Layer 2 → 3: {results.get('layer2_to_layer3', {}).get('compressed', 0)} entries compressed")
         logger.info(f"  Intuitions Generated: {results.get('intuitions_generated', 0)}")
 
+        # 누적 코퍼스 기반 직관 재추출(#intuition-stall): 압축 배치가 소량이라 직관이
+        # 2026-02 이후 0건이던 문제 보완. 압축과 별개·격리(실패해도 압축 영향 없음).
+        try:
+            refresh = await agent.compression_manager.refresh_intuitions()
+            logger.info(f"  Intuitions Refreshed (corpus): generated={refresh.get('intuitions_generated', 0)} "
+                        f"corpus={refresh.get('corpus', 0)} extracted={refresh.get('extracted', 0)}")
+        except Exception as _re:
+            logger.warning(f"Intuition refresh skipped: {_re}")
+
         logger.info("\n📊 Updated Status:")
         logger.info(f"  Layer 1 (Detailed): {stats_after.get('entries_by_layer', {}).get('layer1_detailed', 0)}")
         logger.info(f"  Layer 2 (Summarized): {stats_after.get('entries_by_layer', {}).get('layer2_summarized', 0)}")

--- a/tracking/compression.py
+++ b/tracking/compression.py
@@ -225,6 +225,66 @@ class CompressionManager:
             logger.error(f"Error in Layer 3 compression: {e}")
             return {"processed": len(entries), "compressed": 0, "intuitions_generated": 0, "errors": [str(e)]}
 
+    async def refresh_intuitions(self, window_days: int = 90, limit: int = 40,
+                                 min_entries: int = 5) -> Dict[str, Any]:
+        """누적 코퍼스 기반 직관 재추출.
+
+        기존 layer2→3 압축은 '30일 지난 소량 배치(주당 2~7건)'만 LLM에 먹여
+        '2회 이상 반복 패턴' 조건이 거의 안 맞아 직관 생성이 2026-02 이후 멈췄다.
+        이 메서드는 압축과 별개로 최근 window_days 저널을 한 번에 LLM에 먹여 직관을
+        생성/갱신한다(_save_intuition 이 condition+insight 로 dedup). compression_layer
+        는 건드리지 않으며, 실패해도 압축 결과에 영향이 없도록 호출측에서 격리한다.
+        """
+        results = {"intuitions_generated": 0, "corpus": 0, "extracted": 0, "errors": []}
+        if not self.enable_journal:
+            results["skipped"] = True
+            return results
+        try:
+            from cores.agents.memory_compressor_agent import create_memory_compressor_agent
+            from mcp_agent.workflows.llm.augmented_llm import RequestParams
+            from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
+
+            cutoff = (datetime.now() - timedelta(days=window_days)).strftime("%Y-%m-%d")
+            self.cursor.execute("""
+                SELECT id, ticker, company_name, trade_date, profit_rate,
+                       COALESCE(compressed_summary, one_line_summary) AS compressed_summary,
+                       pattern_tags, buy_scenario
+                FROM trading_journal
+                WHERE trade_date >= ?
+                ORDER BY trade_date DESC
+                LIMIT ?
+            """, (cutoff, limit))
+            entries = [dict(zip([d[0] for d in self.cursor.description], row))
+                       for row in self.cursor.fetchall()]
+            results["corpus"] = len(entries)
+            if len(entries) < min_entries:
+                results["reason"] = "insufficient_corpus"
+                return results
+
+            compressor_agent = create_memory_compressor_agent(self.language)
+            async with compressor_agent:
+                llm = await compressor_agent.attach_llm(OpenAIAugmentedLLM)
+                entries_text = self._format_entries_for_intuition(entries)
+                prompt = self._build_layer3_prompt(entries_text, len(entries))
+                response = await llm.generate_str(
+                    message=prompt,
+                    request_params=RequestParams(model="gpt-5.4", reasoning_effort="none", maxTokens=8000)
+                )
+            data = self._parse_response(response)
+            new_intuitions = data.get('new_intuitions', [])
+            results["extracted"] = len(new_intuitions)
+            source_ids = [e['id'] for e in entries]
+            for intuition in new_intuitions:
+                if self._save_intuition(intuition, source_ids):
+                    results["intuitions_generated"] += 1
+            self.conn.commit()
+            return results
+        except Exception as e:
+            log_openai_error(logger, e, "intuition refresh")
+            logger.error(f"Error in intuition refresh: {e}")
+            results["errors"].append(str(e))
+            return results
+
     def _fetch_hindsight_prices(self, entries: List[Dict[str, Any]]) -> Dict[str, float]:
         """Fetch current prices for tickers to add hindsight context during compression.
 


### PR DESCRIPTION
## 문제
`trading_intuitions`가 2026-02-22 이후 신규 0건(주간 배치 5회 연속 'Intuitions Generated: 0'). parse 실패 0회 → 크래시 아님.

## 원인
layer2→3 압축이 '30일 지난 소량 배치(주당 2~7건)'만 LLM에 먹여 '2회 이상 반복 패턴' 조건이 거의 안 맞음 → 빈 직관. 2월 11건은 초기 대량 백로그 압축 산물.

## 수정
`CompressionManager.refresh_intuitions(window_days=90, limit=40)` 추가: 압축과 별개로 최근 누적 저널을 한 번에 LLM에 먹여 직관 생성/갱신(dedup: condition+insight). compression_layer 불변. compress_trading_memory.py에서 압축 직후 try/except로 격리 호출 → 실패해도 기존 압축 영향 0. 기존 프롬프트/파서/세이브 재사용.

py_compile OK. 운영 1회 실행으로 직관 생성 검증 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)