### PR TITLE
feat(regime): O'Neil 분산일 결정론 카운트 → index_summary 정보 주입 (강등 없음)

### DIFF
--- a/cores/agents/trading_agents.py
+++ b/cores/agents/trading_agents.py
@@ -123,10 +123,16 @@ def create_trading_scenario_agent(language: str = "ko", sector_names: list = Non
         If any condition fails → fall back to the standard `strong_bull` row (R/R floor 1.0, stop -7%).
 
         **Distribution Day Kill Switch (overrides parabolic activation):**
-        If the report or analysis shows ≥ 4 distribution days (institutional selling sessions
-        with ≥ -0.2% close on rising volume) within the last 4 weeks → demote regime by ONE step
-        (parabolic → strong_bull, strong_bull → moderate_bull, moderate_bull → sideways).
-        State the demotion in `market_condition` field.
+        Distribution days (institutional selling sessions with ≥ -0.2% close on rising volume) are now
+        counted **deterministically** in `index_summary.distribution_days` (rolling 25-session window,
+        expiring on a +5% recovery). **The regime in `index_summary` is ALREADY demoted by one step when
+        distribution_days ≥ 6** — in that case `index_summary.distribution_demoted_from` is also supplied —
+        so do **NOT** demote again for the same reason (no double demotion).
+        - ONLY when distribution_days is absent (null, e.g. missing volume) fall back to manual judgment:
+          if the report/analysis shows ≥ 6 distribution days within the last 4 weeks, override parabolic
+          activation and demote regime by ONE step (parabolic → strong_bull, strong_bull → moderate_bull,
+          moderate_bull → sideways).
+        - State the demotion (automatic or manual) and the distribution_days value in the `market_condition` field.
 
         **Parabolic position management** (apply when parabolic row is active):
         - Active buying recommended: use the report-derived max_portfolio_size as-is. Do NOT reduce slots.
@@ -423,9 +429,10 @@ def create_trading_scenario_agent(language: str = "ko", sector_names: list = Non
         하나라도 미달 → 일반 `strong_bull` 행으로 fallback (R/R 1.0, 손절 -7%).
 
         **Distribution Day Kill Switch (parabolic 활성화를 무력화):**
-        보고서 또는 분석에서 최근 4주 내 분포일(거래량 동반 -0.2%↓ 마감) ≥ 4건이 확인되면
-        regime을 1단계 보수화하십시오 (parabolic → strong_bull, strong_bull → moderate_bull,
-        moderate_bull → sideways). 보수화 사실을 `market_condition` 필드에 명시하십시오.
+        분포일(거래량 동반 -0.2%↓ 마감)은 이제 `index_summary.distribution_days`로 **결정론적으로 자동 집계**됩니다
+        (최근 25거래일 윈도우, +5% 회복 시 만료). **`index_summary`의 regime은 distribution_days ≥ 6일 때 이미 1단계 강등이 반영된 값**이므로 — 이 경우 `index_summary.distribution_demoted_from`이 함께 제공됩니다 — 같은 사유로 **다시 강등하지 마십시오(이중 강등 금지)**.
+        - distribution_days가 주입되지 않은 경우(거래량 결측, null)에만, 보고서/분석에서 최근 4주 내 분포일 ≥ 6건이 확인되면 parabolic 활성화를 무력화하고 regime을 1단계 보수화하십시오 (parabolic → strong_bull, strong_bull → moderate_bull, moderate_bull → sideways).
+        - 강등(자동/수동 불문) 사실과 distribution_days 값을 `market_condition` 필드에 명시하십시오.
 
         **parabolic 포지션 운영** (parabolic 행이 활성화될 때):
         - 적극 매수 권장: max_portfolio_size를 보고서 기준값 그대로 사용하십시오. **슬롯 축소 금지**.

--- a/cores/agents/trading_agents.py
+++ b/cores/agents/trading_agents.py
@@ -122,17 +122,17 @@ def create_trading_scenario_agent(language: str = "ko", sector_names: list = Non
 
         If any condition fails → fall back to the standard `strong_bull` row (R/R floor 1.0, stop -7%).
 
-        **Distribution Day Kill Switch (overrides parabolic activation):**
-        Distribution days (institutional selling sessions with ≥ -0.2% close on rising volume) are now
+        **Distribution Day Kill Switch (new-buy defense only):**
+        Distribution days (institutional selling sessions with ≥ -0.2% close on rising volume) are
         counted **deterministically** in `index_summary.distribution_days` (rolling 25-session window,
-        expiring on a +5% recovery). **The regime in `index_summary` is ALREADY demoted by one step when
-        distribution_days ≥ 6** — in that case `index_summary.distribution_demoted_from` is also supplied —
-        so do **NOT** demote again for the same reason (no double demotion).
-        - ONLY when distribution_days is absent (null, e.g. missing volume) fall back to manual judgment:
-          if the report/analysis shows ≥ 6 distribution days within the last 4 weeks, override parabolic
-          activation and demote regime by ONE step (parabolic → strong_bull, strong_bull → moderate_bull,
-          moderate_bull → sideways).
-        - State the demotion (automatic or manual) and the distribution_days value in the `market_condition` field.
+        expiring on a +5% recovery; null when volume is missing → then judge from the report's last
+        4 weeks). The HIGHER this count of distribution days, the more institutional selling is underway.
+        - When it is elevated (≈5-6 or more), apply ONE step of caution to NEW BUYS ONLY
+          (parabolic → strong_bull, strong_bull → moderate_bull, moderate_bull → sideways): raise the bar
+          for new entries / parabolic sizing.
+        - Do NOT change sell or trailing-stop decisions for existing holdings — those keep the original
+          regime. Distribution days never force an early exit.
+        - State the distribution_days value and any new-buy caution in the `market_condition` field.
 
         **Parabolic position management** (apply when parabolic row is active):
         - Active buying recommended: use the report-derived max_portfolio_size as-is. Do NOT reduce slots.
@@ -428,11 +428,15 @@ def create_trading_scenario_agent(language: str = "ko", sector_names: list = Non
 
         하나라도 미달 → 일반 `strong_bull` 행으로 fallback (R/R 1.0, 손절 -7%).
 
-        **Distribution Day Kill Switch (parabolic 활성화를 무력화):**
-        분포일(거래량 동반 -0.2%↓ 마감)은 이제 `index_summary.distribution_days`로 **결정론적으로 자동 집계**됩니다
-        (최근 25거래일 윈도우, +5% 회복 시 만료). **`index_summary`의 regime은 distribution_days ≥ 6일 때 이미 1단계 강등이 반영된 값**이므로 — 이 경우 `index_summary.distribution_demoted_from`이 함께 제공됩니다 — 같은 사유로 **다시 강등하지 마십시오(이중 강등 금지)**.
-        - distribution_days가 주입되지 않은 경우(거래량 결측, null)에만, 보고서/분석에서 최근 4주 내 분포일 ≥ 6건이 확인되면 parabolic 활성화를 무력화하고 regime을 1단계 보수화하십시오 (parabolic → strong_bull, strong_bull → moderate_bull, moderate_bull → sideways).
-        - 강등(자동/수동 불문) 사실과 distribution_days 값을 `market_condition` 필드에 명시하십시오.
+        **Distribution Day Kill Switch (신규매수 방어 전용):**
+        분포일(거래량 동반 -0.2%↓ 마감)은 `index_summary.distribution_days`에 **결정론적으로 집계**됩니다
+        (최근 25거래일 윈도우, +5% 회복 시 만료; 거래량 결측이면 null → 보고서 최근 4주 내 분포일로 판단).
+        이 값이 높을수록 기관 분배가 진행 중이라는 천장 경고입니다.
+        - 값이 높으면(통상 5~6건 이상) **신규 매수에 한해** regime을 1단계 보수적으로 적용하십시오
+          (parabolic → strong_bull, strong_bull → moderate_bull, moderate_bull → sideways): 신규 진입·parabolic
+          사이징의 문턱만 높입니다.
+        - **보유 종목의 매도·trailing 판단은 원래 regime을 그대로 사용**하며, 분산일로 조기 청산하지 않습니다.
+        - distribution_days 값과 신규매수 보수화 여부를 `market_condition` 필드에 명시하십시오.
 
         **parabolic 포지션 운영** (parabolic 행이 활성화될 때):
         - 적극 매수 권장: max_portfolio_size를 보고서 기준값 그대로 사용하십시오. **슬롯 축소 금지**.

--- a/cores/data_prefetch.py
+++ b/cores/data_prefetch.py
@@ -256,9 +256,10 @@ _REGIME_DEMOTE = {
 DISTRIBUTION_WINDOW = 25
 DISTRIBUTION_DROP_PCT = 0.2
 DISTRIBUTION_RECOVERY_PCT = 5.0
-# ≥6 분산일 → regime 1단계 강등. 6은 O'Neil/IBD canonical(4~5주간 5~6개 = 천장/Market-in-Correction)
-# 이자, 백테스트로 검증된 판별 임계: thr=4는 강세장 포함 53~66%일 과발동, thr=6은 약세/천장 연도에
-# 집중(KR 2021-22 34~36%) & 강세장 저발동(KR 2025-26 0~4%). 시장별 동일.
+# ≥6 분산일 → regime 1단계 강등. KR 최적값(US는 7로 더 높음 — 시장 성격 차이).
+# 근거(장기 위험기반 백테스트, KOSPI 1996~2026, IMF·2008·2020·2022 포함): T=6 방어가
+# CAGR 8.67→9.84%, MaxDD -64.7→-51.8%, Sharpe 0.45→0.52 로 수익↑·낙폭↓·샤프↑ 강건한 개선.
+# KOSPI는 박스권/순환형이라 방어 신호의 상방손실이 작고 하락회피 이득이 커 미국보다 임계가 낮아도 유효.
 KR_DISTRIBUTION_THRESHOLD = 6
 
 

--- a/cores/data_prefetch.py
+++ b/cores/data_prefetch.py
@@ -243,24 +243,15 @@ def prefetch_macro_intelligence_data(reference_date: str) -> dict:
     return result
 
 
-# --- O'Neil Distribution Day (deterministic) -------------------------------
-# 1단계 강등 사다리(강세→약세). strong_bear는 클램프(더 강등 없음).
-_REGIME_DEMOTE = {
-    "strong_bull": "moderate_bull",
-    "moderate_bull": "sideways",
-    "sideways": "moderate_bear",
-    "moderate_bear": "strong_bear",
-    "strong_bear": "strong_bear",
-}
+# --- O'Neil Distribution Day (deterministic, 정보 주입 전용) ----------------
+# 설계 결정(tasks/distribution_day_design.md): 분산일은 결정론적으로 '계산'해 index_summary에
+# 정보로만 주입하고, regime의 기계적 강등은 하지 않는다. (강등은 매수+매도 양쪽을 뒤집어
+# US melt-up에서 조기청산 손실을 유발했고, 시장별 임계는 과최적화 위험이 컸다.) 분산일을
+# 어떻게 가중할지(신규매수 보수화 등)는 프롬프트에서 LLM이 판단한다 — O'Neil 본래의 재량적 용법.
 # 분산일 파라미터 (O'Neil/IBD). drop=-0.2% 종가, 거래량 전일 초과, 25거래일 윈도우, +5% 회복 만료.
 DISTRIBUTION_WINDOW = 25
 DISTRIBUTION_DROP_PCT = 0.2
 DISTRIBUTION_RECOVERY_PCT = 5.0
-# ≥6 분산일 → regime 1단계 강등. KR 최적값(US는 7로 더 높음 — 시장 성격 차이).
-# 근거(장기 위험기반 백테스트, KOSPI 1996~2026, IMF·2008·2020·2022 포함): T=6 방어가
-# CAGR 8.67→9.84%, MaxDD -64.7→-51.8%, Sharpe 0.45→0.52 로 수익↑·낙폭↓·샤프↑ 강건한 개선.
-# KOSPI는 박스권/순환형이라 방어 신호의 상방손실이 작고 하락회피 이득이 커 미국보다 임계가 낮아도 유효.
-KR_DISTRIBUTION_THRESHOLD = 6
 
 
 def _count_distribution_days(df, close_col, volume_col=None,
@@ -333,23 +324,14 @@ def _count_distribution_days(df, close_col, volume_col=None,
         return None
 
 
-def _apply_distribution_demotion(regime, confidence, index_summary, df, close_col,
-                                 threshold: int) -> tuple:
-    """분산일 카운트를 계산해 index_summary에 주입하고, 임계 초과 시 regime 1단계 강등."""
+def _inject_distribution_days(index_summary, df, close_col) -> None:
+    """분산일 카운트를 결정론적으로 계산해 index_summary에 정보로 주입(강등 없음).
+
+    거래량 결측/불가 시 distribution_days=None. regime/confidence는 변경하지 않는다.
+    """
     dist = _count_distribution_days(df, close_col)
     index_summary["distribution_window"] = DISTRIBUTION_WINDOW
-    index_summary["distribution_threshold"] = threshold
-    if dist is None:
-        index_summary["distribution_days"] = None
-        return regime, confidence
-    index_summary["distribution_days"] = dist["count"]
-    if dist["count"] >= threshold and regime in _REGIME_DEMOTE:
-        demoted = _REGIME_DEMOTE[regime]
-        if demoted != regime:
-            index_summary["distribution_demoted_from"] = regime
-            regime = demoted
-            confidence = min(confidence, 0.70)
-    return regime, confidence
+    index_summary["distribution_days"] = None if dist is None else dist["count"]
 
 
 def _compute_kr_regime(kospi_ohlcv: dict, kosdaq_ohlcv: dict = None) -> dict:
@@ -503,10 +485,8 @@ def _compute_kr_regime(kospi_ohlcv: dict, kosdaq_ohlcv: dict = None) -> dict:
     if golden is not None:
         index_summary["kospi_ma_60_120_cross"] = "golden" if golden else "dead"
 
-    # O'Neil 분산일 결정론 카운트 → 임계 초과 시 regime 1단계 강등 (KOSPI close+volume 사용)
-    regime, confidence = _apply_distribution_demotion(
-        regime, confidence, index_summary, df, close_col, KR_DISTRIBUTION_THRESHOLD
-    )
+    # O'Neil 분산일 결정론 카운트를 index_summary에 정보로 주입(강등 없음 — LLM이 프롬프트에서 판단)
+    _inject_distribution_days(index_summary, df, close_col)
 
     return {
         "market_regime": regime,

--- a/cores/data_prefetch.py
+++ b/cores/data_prefetch.py
@@ -243,6 +243,114 @@ def prefetch_macro_intelligence_data(reference_date: str) -> dict:
     return result
 
 
+# --- O'Neil Distribution Day (deterministic) -------------------------------
+# 1단계 강등 사다리(강세→약세). strong_bear는 클램프(더 강등 없음).
+_REGIME_DEMOTE = {
+    "strong_bull": "moderate_bull",
+    "moderate_bull": "sideways",
+    "sideways": "moderate_bear",
+    "moderate_bear": "strong_bear",
+    "strong_bear": "strong_bear",
+}
+# 분산일 파라미터 (O'Neil/IBD). drop=-0.2% 종가, 거래량 전일 초과, 25거래일 윈도우, +5% 회복 만료.
+DISTRIBUTION_WINDOW = 25
+DISTRIBUTION_DROP_PCT = 0.2
+DISTRIBUTION_RECOVERY_PCT = 5.0
+# ≥6 분산일 → regime 1단계 강등. 6은 O'Neil/IBD canonical(4~5주간 5~6개 = 천장/Market-in-Correction)
+# 이자, 백테스트로 검증된 판별 임계: thr=4는 강세장 포함 53~66%일 과발동, thr=6은 약세/천장 연도에
+# 집중(KR 2021-22 34~36%) & 강세장 저발동(KR 2025-26 0~4%). 시장별 동일.
+KR_DISTRIBUTION_THRESHOLD = 6
+
+
+def _count_distribution_days(df, close_col, volume_col=None,
+                             window: int = DISTRIBUTION_WINDOW,
+                             drop_threshold_pct: float = DISTRIBUTION_DROP_PCT,
+                             recovery_pct: float = DISTRIBUTION_RECOVERY_PCT):
+    """O'Neil 분산일 카운트 (결정론적).
+
+    분산일 = 지수가 전일 종가 대비 >= drop_threshold_pct% 하락 마감 AND 거래량이 전일 초과.
+    만료: (1) window 거래일 경과 시 윈도우 밖으로 자동 제외, (2) 분산일 이후 어떤 종가가
+    그 분산일 종가 대비 +recovery_pct% 이상 상승하면 카운트에서 제거.
+
+    Args:
+        df: 정렬 가능한 OHLCV DataFrame (인덱스=날짜).
+        close_col: 종가 컬럼명.
+        volume_col: 거래량 컬럼명. None이면 자동 탐지.
+
+    Returns:
+        {"count": int, "window": int, "raw_count": int} 또는 거래량 불가 시 None.
+    """
+    try:
+        d = df.sort_index()
+        if volume_col is None:
+            for c in ["Volume", "거래량", "volume"]:
+                if c in d.columns:
+                    volume_col = c
+                    break
+        if volume_col is None or close_col not in d.columns:
+            return None
+        closes = d[close_col].astype(float).values
+        vols = d[volume_col].astype(float).values
+        n = len(closes)
+        if n < 2:
+            return None
+        # 거래량이 전부 0/NaN이면 분산일 판정 불가 → graceful skip
+        import math as _math
+        valid_vol = [v for v in vols if not _math.isnan(v) and v > 0]
+        if not valid_vol:
+            return None
+        latest_max_after = closes[-1]  # i 이후 최대 종가를 뒤에서부터 누적
+        # 후보: 최근 window 거래일 (각 후보는 직전일 필요 → idx>=1)
+        start = max(1, n - window)
+        raw = 0
+        kept = 0
+        # 뒤에서 앞으로 스캔하며 'i 이후 최대 종가' 유지
+        running_max_after = -1.0
+        flags = []  # (idx, is_dist)
+        for i in range(n - 1, start - 1, -1):
+            prev_c = closes[i - 1]
+            cur_c = closes[i]
+            if prev_c <= 0:
+                flags.append((i, False, running_max_after))
+                running_max_after = max(running_max_after, cur_c)
+                continue
+            pct = (cur_c - prev_c) / prev_c * 100.0
+            vol_up = vols[i] > vols[i - 1]
+            is_dist = (pct <= -drop_threshold_pct) and vol_up
+            flags.append((i, is_dist, running_max_after))
+            running_max_after = max(running_max_after, cur_c)
+        for (i, is_dist, max_after) in flags:
+            if not is_dist:
+                continue
+            raw += 1
+            # 회복 만료: 이후 종가가 분산일 종가 +recovery_pct% 이상이면 제외
+            if max_after >= closes[i] * (1 + recovery_pct / 100.0):
+                continue
+            kept += 1
+        return {"count": kept, "window": window, "raw_count": raw}
+    except Exception:
+        return None
+
+
+def _apply_distribution_demotion(regime, confidence, index_summary, df, close_col,
+                                 threshold: int) -> tuple:
+    """분산일 카운트를 계산해 index_summary에 주입하고, 임계 초과 시 regime 1단계 강등."""
+    dist = _count_distribution_days(df, close_col)
+    index_summary["distribution_window"] = DISTRIBUTION_WINDOW
+    index_summary["distribution_threshold"] = threshold
+    if dist is None:
+        index_summary["distribution_days"] = None
+        return regime, confidence
+    index_summary["distribution_days"] = dist["count"]
+    if dist["count"] >= threshold and regime in _REGIME_DEMOTE:
+        demoted = _REGIME_DEMOTE[regime]
+        if demoted != regime:
+            index_summary["distribution_demoted_from"] = regime
+            regime = demoted
+            confidence = min(confidence, 0.70)
+    return regime, confidence
+
+
 def _compute_kr_regime(kospi_ohlcv: dict, kosdaq_ohlcv: dict = None) -> dict:
     """Compute KR market regime programmatically from KOSPI OHLCV data.
 
@@ -393,6 +501,11 @@ def _compute_kr_regime(kospi_ohlcv: dict, kosdaq_ohlcv: dict = None) -> dict:
         index_summary["kospi_vs_120d_ma"] = "above" if above_120 else "below"
     if golden is not None:
         index_summary["kospi_ma_60_120_cross"] = "golden" if golden else "dead"
+
+    # O'Neil 분산일 결정론 카운트 → 임계 초과 시 regime 1단계 강등 (KOSPI close+volume 사용)
+    regime, confidence = _apply_distribution_demotion(
+        regime, confidence, index_summary, df, close_col, KR_DISTRIBUTION_THRESHOLD
+    )
 
     return {
         "market_regime": regime,

--- a/prism-us/cores/agents/trading_agents.py
+++ b/prism-us/cores/agents/trading_agents.py
@@ -124,11 +124,14 @@ B) 없으면 S&P 500 (^GSPC) + VIX 최근 20일 데이터(yahoo_finance-get_hist
 
 하나라도 미달 → 일반 `strong_bull` 행으로 fallback (R/R 1.0, 손절 -7%).
 
-**Distribution Day Kill Switch (parabolic 활성화를 무력화):**
-분포일(거래량 동반 -0.2%↓ 마감)은 이제 `index_summary.distribution_days`로 **결정론적으로 자동 집계**됩니다
-(최근 25거래일 윈도우, +5% 회복 시 만료). **`index_summary`의 regime은 distribution_days ≥ 7일 때 이미 1단계 강등이 반영된 값**이므로 — 이 경우 `index_summary.distribution_demoted_from`이 함께 제공됩니다 — 같은 사유로 **다시 강등하지 마십시오(이중 강등 금지)**.
-- distribution_days가 주입되지 않은 경우(거래량 결측, null)에만, 보고서/분석에서 최근 4주 내 분포일 ≥ 7건이 확인되면 parabolic 활성화를 무력화하고 regime을 1단계 보수화하십시오 (parabolic → strong_bull, strong_bull → moderate_bull, moderate_bull → sideways).
-- 강등(자동/수동 불문) 사실과 distribution_days 값을 `market_condition` 필드에 명시하십시오.
+**Distribution Day Kill Switch (신규매수 방어 전용):**
+분포일(거래량 동반 -0.2%↓ 마감)은 `index_summary.distribution_days`에 **결정론적으로 집계**됩니다
+(최근 25거래일 윈도우, +5% 회복 시 만료; 거래량 결측이면 null → 보고서 최근 4주 내 분포일로 판단).
+이 값이 높을수록 기관 분배가 진행 중이라는 천장 경고입니다.
+- 값이 높으면(통상 5~6건 이상) **신규 매수에 한해** regime을 1단계 보수적으로 적용하십시오
+  (parabolic → strong_bull, strong_bull → moderate_bull, moderate_bull → sideways): 신규 진입·parabolic 사이징의 문턱만 높입니다.
+- **보유 종목의 매도·trailing 판단은 원래 regime을 그대로 사용**하며, 분산일로 조기 청산하지 않습니다.
+- distribution_days 값과 신규매수 보수화 여부를 `market_condition` 필드에 명시하십시오.
 
 **parabolic 포지션 운영** (parabolic 행이 활성화될 때):
 - 적극 매수 권장: max_portfolio_size를 보고서 기준값 그대로 사용하십시오. **슬롯 축소 금지**.
@@ -428,17 +431,17 @@ Apply the **parabolic** row ONLY when ALL of the following hold:
 
 If any condition fails → fall back to the standard `strong_bull` row (R/R floor 1.0, stop -7%).
 
-**Distribution Day Kill Switch (overrides parabolic activation):**
-Distribution days (institutional selling sessions with ≥ -0.2% close on rising volume) are now
+**Distribution Day Kill Switch (new-buy defense only):**
+Distribution days (institutional selling sessions with ≥ -0.2% close on rising volume) are
 counted **deterministically** in `index_summary.distribution_days` (rolling 25-session window,
-expiring on a +5% recovery). **The regime in `index_summary` is ALREADY demoted by one step when
-distribution_days ≥ 7** — in that case `index_summary.distribution_demoted_from` is also supplied —
-so do **NOT** demote again for the same reason (no double demotion).
-- ONLY when distribution_days is absent (null, e.g. missing volume) fall back to manual judgment:
-  if the report/analysis shows ≥ 7 distribution days within the last 4 weeks, override parabolic
-  activation and demote regime by ONE step (parabolic → strong_bull, strong_bull → moderate_bull,
-  moderate_bull → sideways).
-- State the demotion (automatic or manual) and the distribution_days value in the `market_condition` field.
+expiring on a +5% recovery; null when volume is missing → then judge from the report's last
+4 weeks). The HIGHER this count of distribution days, the more institutional selling is underway.
+- When it is elevated (≈5-6 or more), apply ONE step of caution to NEW BUYS ONLY
+  (parabolic → strong_bull, strong_bull → moderate_bull, moderate_bull → sideways): raise the bar
+  for new entries / parabolic sizing.
+- Do NOT change sell or trailing-stop decisions for existing holdings — those keep the original
+  regime. Distribution days never force an early exit.
+- State the distribution_days value and any new-buy caution in the `market_condition` field.
 
 **Parabolic position management** (apply when parabolic row is active):
 - Active buying recommended: use the report-derived max_portfolio_size as-is. Do NOT reduce slots.

--- a/prism-us/cores/agents/trading_agents.py
+++ b/prism-us/cores/agents/trading_agents.py
@@ -126,8 +126,8 @@ B) 없으면 S&P 500 (^GSPC) + VIX 최근 20일 데이터(yahoo_finance-get_hist
 
 **Distribution Day Kill Switch (parabolic 활성화를 무력화):**
 분포일(거래량 동반 -0.2%↓ 마감)은 이제 `index_summary.distribution_days`로 **결정론적으로 자동 집계**됩니다
-(최근 25거래일 윈도우, +5% 회복 시 만료). **`index_summary`의 regime은 distribution_days ≥ 6일 때 이미 1단계 강등이 반영된 값**이므로 — 이 경우 `index_summary.distribution_demoted_from`이 함께 제공됩니다 — 같은 사유로 **다시 강등하지 마십시오(이중 강등 금지)**.
-- distribution_days가 주입되지 않은 경우(거래량 결측, null)에만, 보고서/분석에서 최근 4주 내 분포일 ≥ 6건이 확인되면 parabolic 활성화를 무력화하고 regime을 1단계 보수화하십시오 (parabolic → strong_bull, strong_bull → moderate_bull, moderate_bull → sideways).
+(최근 25거래일 윈도우, +5% 회복 시 만료). **`index_summary`의 regime은 distribution_days ≥ 7일 때 이미 1단계 강등이 반영된 값**이므로 — 이 경우 `index_summary.distribution_demoted_from`이 함께 제공됩니다 — 같은 사유로 **다시 강등하지 마십시오(이중 강등 금지)**.
+- distribution_days가 주입되지 않은 경우(거래량 결측, null)에만, 보고서/분석에서 최근 4주 내 분포일 ≥ 7건이 확인되면 parabolic 활성화를 무력화하고 regime을 1단계 보수화하십시오 (parabolic → strong_bull, strong_bull → moderate_bull, moderate_bull → sideways).
 - 강등(자동/수동 불문) 사실과 distribution_days 값을 `market_condition` 필드에 명시하십시오.
 
 **parabolic 포지션 운영** (parabolic 행이 활성화될 때):
@@ -432,10 +432,10 @@ If any condition fails → fall back to the standard `strong_bull` row (R/R floo
 Distribution days (institutional selling sessions with ≥ -0.2% close on rising volume) are now
 counted **deterministically** in `index_summary.distribution_days` (rolling 25-session window,
 expiring on a +5% recovery). **The regime in `index_summary` is ALREADY demoted by one step when
-distribution_days ≥ 6** — in that case `index_summary.distribution_demoted_from` is also supplied —
+distribution_days ≥ 7** — in that case `index_summary.distribution_demoted_from` is also supplied —
 so do **NOT** demote again for the same reason (no double demotion).
 - ONLY when distribution_days is absent (null, e.g. missing volume) fall back to manual judgment:
-  if the report/analysis shows ≥ 6 distribution days within the last 4 weeks, override parabolic
+  if the report/analysis shows ≥ 7 distribution days within the last 4 weeks, override parabolic
   activation and demote regime by ONE step (parabolic → strong_bull, strong_bull → moderate_bull,
   moderate_bull → sideways).
 - State the demotion (automatic or manual) and the distribution_days value in the `market_condition` field.

--- a/prism-us/cores/agents/trading_agents.py
+++ b/prism-us/cores/agents/trading_agents.py
@@ -125,9 +125,10 @@ B) 없으면 S&P 500 (^GSPC) + VIX 최근 20일 데이터(yahoo_finance-get_hist
 하나라도 미달 → 일반 `strong_bull` 행으로 fallback (R/R 1.0, 손절 -7%).
 
 **Distribution Day Kill Switch (parabolic 활성화를 무력화):**
-보고서 또는 분석에서 최근 4주 내 분포일(거래량 동반 -0.2%↓ 마감) ≥ 4건이 확인되면
-regime을 1단계 보수화하십시오 (parabolic → strong_bull, strong_bull → moderate_bull,
-moderate_bull → sideways). 보수화 사실을 `market_condition` 필드에 명시하십시오.
+분포일(거래량 동반 -0.2%↓ 마감)은 이제 `index_summary.distribution_days`로 **결정론적으로 자동 집계**됩니다
+(최근 25거래일 윈도우, +5% 회복 시 만료). **`index_summary`의 regime은 distribution_days ≥ 6일 때 이미 1단계 강등이 반영된 값**이므로 — 이 경우 `index_summary.distribution_demoted_from`이 함께 제공됩니다 — 같은 사유로 **다시 강등하지 마십시오(이중 강등 금지)**.
+- distribution_days가 주입되지 않은 경우(거래량 결측, null)에만, 보고서/분석에서 최근 4주 내 분포일 ≥ 6건이 확인되면 parabolic 활성화를 무력화하고 regime을 1단계 보수화하십시오 (parabolic → strong_bull, strong_bull → moderate_bull, moderate_bull → sideways).
+- 강등(자동/수동 불문) 사실과 distribution_days 값을 `market_condition` 필드에 명시하십시오.
 
 **parabolic 포지션 운영** (parabolic 행이 활성화될 때):
 - 적극 매수 권장: max_portfolio_size를 보고서 기준값 그대로 사용하십시오. **슬롯 축소 금지**.
@@ -428,10 +429,16 @@ Apply the **parabolic** row ONLY when ALL of the following hold:
 If any condition fails → fall back to the standard `strong_bull` row (R/R floor 1.0, stop -7%).
 
 **Distribution Day Kill Switch (overrides parabolic activation):**
-If the report or analysis shows ≥ 4 distribution days (institutional selling sessions
-with ≥ -0.2% close on rising volume) within the last 4 weeks → demote regime by ONE step
-(parabolic → strong_bull, strong_bull → moderate_bull, moderate_bull → sideways).
-State the demotion in `market_condition` field.
+Distribution days (institutional selling sessions with ≥ -0.2% close on rising volume) are now
+counted **deterministically** in `index_summary.distribution_days` (rolling 25-session window,
+expiring on a +5% recovery). **The regime in `index_summary` is ALREADY demoted by one step when
+distribution_days ≥ 6** — in that case `index_summary.distribution_demoted_from` is also supplied —
+so do **NOT** demote again for the same reason (no double demotion).
+- ONLY when distribution_days is absent (null, e.g. missing volume) fall back to manual judgment:
+  if the report/analysis shows ≥ 6 distribution days within the last 4 weeks, override parabolic
+  activation and demote regime by ONE step (parabolic → strong_bull, strong_bull → moderate_bull,
+  moderate_bull → sideways).
+- State the demotion (automatic or manual) and the distribution_days value in the `market_condition` field.
 
 **Parabolic position management** (apply when parabolic row is active):
 - Active buying recommended: use the report-derived max_portfolio_size as-is. Do NOT reduce slots.

--- a/prism-us/cores/data_prefetch.py
+++ b/prism-us/cores/data_prefetch.py
@@ -982,24 +982,15 @@ def prefetch_us_macro_intelligence_data(reference_date: str = None) -> dict:
     return result
 
 
-# --- O'Neil Distribution Day (deterministic) -------------------------------
-# 1단계 강등 사다리(강세→약세). strong_bear는 클램프(더 강등 없음).
-_REGIME_DEMOTE = {
-    "strong_bull": "moderate_bull",
-    "moderate_bull": "sideways",
-    "sideways": "moderate_bear",
-    "moderate_bear": "strong_bear",
-    "strong_bear": "strong_bear",
-}
+# --- O'Neil Distribution Day (deterministic, 정보 주입 전용) ----------------
+# 설계 결정(tasks/distribution_day_design.md): 분산일은 결정론적으로 '계산'해 index_summary에
+# 정보로만 주입하고, regime의 기계적 강등은 하지 않는다. (강등은 매수+매도 양쪽을 뒤집어
+# US melt-up에서 조기청산 손실을 유발했고, 시장별 임계는 과최적화 위험이 컸다.) 분산일을
+# 어떻게 가중할지(신규매수 보수화 등)는 프롬프트에서 LLM이 판단한다 — O'Neil 본래의 재량적 용법.
 # 분산일 파라미터 (O'Neil/IBD). drop=-0.2% 종가, 거래량 전일 초과, 25거래일 윈도우, +5% 회복 만료.
 DISTRIBUTION_WINDOW = 25
 DISTRIBUTION_DROP_PCT = 0.2
 DISTRIBUTION_RECOVERY_PCT = 5.0
-# ≥7 분산일 → regime 1단계 강등. US는 KR(=6)보다 높게 설정.
-# 근거(장기 위험기반 백테스트, S&P500 1990~2026, 닷컴·GFC 포함): S&P는 장기 강우상향이라 방어가
-# 복리손실로 과금됨 → 전 구간(1990/2000/2007)에서 T=7이 T=6보다 우월. T=7(부분축소 효과)만이
-# buy&hold Sharpe(0.55)를 상회(0.57)하고 MaxDD를 -56.8%→-51.3%로 완화. T=5/6 강한 방어는 역효과.
-US_DISTRIBUTION_THRESHOLD = 7
 
 
 def _count_distribution_days(df, close_col, volume_col=None,
@@ -1062,23 +1053,14 @@ def _count_distribution_days(df, close_col, volume_col=None,
         return None
 
 
-def _apply_distribution_demotion(regime, confidence, index_summary, df, close_col,
-                                 threshold: int) -> tuple:
-    """분산일 카운트를 계산해 index_summary에 주입하고, 임계 초과 시 regime 1단계 강등."""
+def _inject_distribution_days(index_summary, df, close_col) -> None:
+    """분산일 카운트를 결정론적으로 계산해 index_summary에 정보로 주입(강등 없음).
+
+    거래량 결측/불가 시 distribution_days=None. regime/confidence는 변경하지 않는다.
+    """
     dist = _count_distribution_days(df, close_col)
     index_summary["distribution_window"] = DISTRIBUTION_WINDOW
-    index_summary["distribution_threshold"] = threshold
-    if dist is None:
-        index_summary["distribution_days"] = None
-        return regime, confidence
-    index_summary["distribution_days"] = dist["count"]
-    if dist["count"] >= threshold and regime in _REGIME_DEMOTE:
-        demoted = _REGIME_DEMOTE[regime]
-        if demoted != regime:
-            index_summary["distribution_demoted_from"] = regime
-            regime = demoted
-            confidence = min(confidence, 0.70)
-    return regime, confidence
+    index_summary["distribution_days"] = None if dist is None else dist["count"]
 
 
 def _compute_us_regime(sp500_df: pd.DataFrame, nasdaq_df: pd.DataFrame = None, vix_df: pd.DataFrame = None) -> dict:
@@ -1255,10 +1237,8 @@ def _compute_us_regime(sp500_df: pd.DataFrame, nasdaq_df: pd.DataFrame = None, v
         index_summary["vix_current"] = round(vix_current, 2)
         index_summary["vix_level"] = vix_level
 
-    # O'Neil 분산일 결정론 카운트 → 임계 초과 시 regime 1단계 강등 (S&P 500 close+volume 사용)
-    regime, confidence = _apply_distribution_demotion(
-        regime, confidence, index_summary, sp500_df, close_col, US_DISTRIBUTION_THRESHOLD
-    )
+    # O'Neil 분산일 결정론 카운트를 index_summary에 정보로 주입(강등 없음 — LLM이 프롬프트에서 판단)
+    _inject_distribution_days(index_summary, sp500_df, close_col)
 
     return {
         "market_regime": regime,

--- a/prism-us/cores/data_prefetch.py
+++ b/prism-us/cores/data_prefetch.py
@@ -982,6 +982,104 @@ def prefetch_us_macro_intelligence_data(reference_date: str = None) -> dict:
     return result
 
 
+# --- O'Neil Distribution Day (deterministic) -------------------------------
+# 1단계 강등 사다리(강세→약세). strong_bear는 클램프(더 강등 없음).
+_REGIME_DEMOTE = {
+    "strong_bull": "moderate_bull",
+    "moderate_bull": "sideways",
+    "sideways": "moderate_bear",
+    "moderate_bear": "strong_bear",
+    "strong_bear": "strong_bear",
+}
+# 분산일 파라미터 (O'Neil/IBD). drop=-0.2% 종가, 거래량 전일 초과, 25거래일 윈도우, +5% 회복 만료.
+DISTRIBUTION_WINDOW = 25
+DISTRIBUTION_DROP_PCT = 0.2
+DISTRIBUTION_RECOVERY_PCT = 5.0
+# ≥6 분산일 → regime 1단계 강등. 6은 O'Neil/IBD canonical(4~5주간 5~6개 = 천장/Market-in-Correction)
+# 이자, 백테스트로 검증된 판별 임계: thr=4는 강세장 포함 53~66%일 과발동, thr=6은 약세/천장 연도에
+# 집중(US 2022 39%) & 강세장 저발동(US 2024 19%). 시장별 동일.
+US_DISTRIBUTION_THRESHOLD = 6
+
+
+def _count_distribution_days(df, close_col, volume_col=None,
+                             window: int = DISTRIBUTION_WINDOW,
+                             drop_threshold_pct: float = DISTRIBUTION_DROP_PCT,
+                             recovery_pct: float = DISTRIBUTION_RECOVERY_PCT):
+    """O'Neil 분산일 카운트 (결정론적).
+
+    분산일 = 지수가 전일 종가 대비 >= drop_threshold_pct% 하락 마감 AND 거래량이 전일 초과.
+    만료: (1) window 거래일 경과 시 윈도우 밖으로 자동 제외, (2) 분산일 이후 어떤 종가가
+    그 분산일 종가 대비 +recovery_pct% 이상 상승하면 카운트에서 제거.
+
+    Returns:
+        {"count": int, "window": int, "raw_count": int} 또는 거래량 불가 시 None.
+    """
+    try:
+        d = df.sort_index()
+        if volume_col is None:
+            for c in ["Volume", "거래량", "volume"]:
+                if c in d.columns:
+                    volume_col = c
+                    break
+        if volume_col is None or close_col not in d.columns:
+            return None
+        closes = d[close_col].astype(float).values
+        vols = d[volume_col].astype(float).values
+        n = len(closes)
+        if n < 2:
+            return None
+        import math as _math
+        valid_vol = [v for v in vols if not _math.isnan(v) and v > 0]
+        if not valid_vol:
+            return None
+        start = max(1, n - window)
+        raw = 0
+        kept = 0
+        running_max_after = -1.0
+        flags = []
+        for i in range(n - 1, start - 1, -1):
+            prev_c = closes[i - 1]
+            cur_c = closes[i]
+            if prev_c <= 0:
+                flags.append((i, False, running_max_after))
+                running_max_after = max(running_max_after, cur_c)
+                continue
+            pct = (cur_c - prev_c) / prev_c * 100.0
+            vol_up = vols[i] > vols[i - 1]
+            is_dist = (pct <= -drop_threshold_pct) and vol_up
+            flags.append((i, is_dist, running_max_after))
+            running_max_after = max(running_max_after, cur_c)
+        for (i, is_dist, max_after) in flags:
+            if not is_dist:
+                continue
+            raw += 1
+            if max_after >= closes[i] * (1 + recovery_pct / 100.0):
+                continue
+            kept += 1
+        return {"count": kept, "window": window, "raw_count": raw}
+    except Exception:
+        return None
+
+
+def _apply_distribution_demotion(regime, confidence, index_summary, df, close_col,
+                                 threshold: int) -> tuple:
+    """분산일 카운트를 계산해 index_summary에 주입하고, 임계 초과 시 regime 1단계 강등."""
+    dist = _count_distribution_days(df, close_col)
+    index_summary["distribution_window"] = DISTRIBUTION_WINDOW
+    index_summary["distribution_threshold"] = threshold
+    if dist is None:
+        index_summary["distribution_days"] = None
+        return regime, confidence
+    index_summary["distribution_days"] = dist["count"]
+    if dist["count"] >= threshold and regime in _REGIME_DEMOTE:
+        demoted = _REGIME_DEMOTE[regime]
+        if demoted != regime:
+            index_summary["distribution_demoted_from"] = regime
+            regime = demoted
+            confidence = min(confidence, 0.70)
+    return regime, confidence
+
+
 def _compute_us_regime(sp500_df: pd.DataFrame, nasdaq_df: pd.DataFrame = None, vix_df: pd.DataFrame = None) -> dict:
     """Compute US market regime programmatically from index data.
 
@@ -1155,6 +1253,11 @@ def _compute_us_regime(sp500_df: pd.DataFrame, nasdaq_df: pd.DataFrame = None, v
     if vix_current is not None:
         index_summary["vix_current"] = round(vix_current, 2)
         index_summary["vix_level"] = vix_level
+
+    # O'Neil 분산일 결정론 카운트 → 임계 초과 시 regime 1단계 강등 (S&P 500 close+volume 사용)
+    regime, confidence = _apply_distribution_demotion(
+        regime, confidence, index_summary, sp500_df, close_col, US_DISTRIBUTION_THRESHOLD
+    )
 
     return {
         "market_regime": regime,

--- a/prism-us/cores/data_prefetch.py
+++ b/prism-us/cores/data_prefetch.py
@@ -995,10 +995,11 @@ _REGIME_DEMOTE = {
 DISTRIBUTION_WINDOW = 25
 DISTRIBUTION_DROP_PCT = 0.2
 DISTRIBUTION_RECOVERY_PCT = 5.0
-# ≥6 분산일 → regime 1단계 강등. 6은 O'Neil/IBD canonical(4~5주간 5~6개 = 천장/Market-in-Correction)
-# 이자, 백테스트로 검증된 판별 임계: thr=4는 강세장 포함 53~66%일 과발동, thr=6은 약세/천장 연도에
-# 집중(US 2022 39%) & 강세장 저발동(US 2024 19%). 시장별 동일.
-US_DISTRIBUTION_THRESHOLD = 6
+# ≥7 분산일 → regime 1단계 강등. US는 KR(=6)보다 높게 설정.
+# 근거(장기 위험기반 백테스트, S&P500 1990~2026, 닷컴·GFC 포함): S&P는 장기 강우상향이라 방어가
+# 복리손실로 과금됨 → 전 구간(1990/2000/2007)에서 T=7이 T=6보다 우월. T=7(부분축소 효과)만이
+# buy&hold Sharpe(0.55)를 상회(0.57)하고 MaxDD를 -56.8%→-51.3%로 완화. T=5/6 강한 방어는 역효과.
+US_DISTRIBUTION_THRESHOLD = 7
 
 
 def _count_distribution_days(df, close_col, volume_col=None,

--- a/prism-us/tests/test_distribution_days.py
+++ b/prism-us/tests/test_distribution_days.py
@@ -1,8 +1,8 @@
 """US cores 분산일 헬퍼 스모크 테스트.
 
 알고리즘 자체는 KR(tests/test_distribution_days.py)에서 전수 검증한다.
-여기서는 prism-us/cores.data_prefetch 의 동일 구현이 import 되고 동작하는지,
-그리고 US 임계(US_DISTRIBUTION_THRESHOLD) 강등이 적용되는지만 확인한다.
+여기서는 prism-us/cores.data_prefetch 의 동일 구현이 import 되고, 카운트/정보 주입이
+동작하는지(regime 강등 없음)만 확인한다.
 """
 import os
 import sys
@@ -15,8 +15,8 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from cores.data_prefetch import (  # noqa: E402
     _count_distribution_days,
-    _apply_distribution_demotion,
-    US_DISTRIBUTION_THRESHOLD,
+    _inject_distribution_days,
+    DISTRIBUTION_WINDOW,
 )
 
 
@@ -30,15 +30,12 @@ def test_us_counts_distribution_days():
     assert r["count"] == 4
 
 
-def test_us_demotion_applies_at_threshold():
-    closes = [100] + [round(100 * (0.99 ** k), 4) for k in range(1, US_DISTRIBUTION_THRESHOLD + 1)]
-    vols = [10 + k for k in range(len(closes))]
+def test_us_inject_sets_count_no_demotion():
     summary = {}
-    regime, conf = _apply_distribution_demotion(
-        "strong_bull", 0.9, summary, _mk(closes, vols), "Close", US_DISTRIBUTION_THRESHOLD,
-    )
-    assert regime == "moderate_bull"
-    assert summary["distribution_days"] >= US_DISTRIBUTION_THRESHOLD
+    _inject_distribution_days(summary, _mk([100, 99, 98, 97, 96], [10, 11, 12, 13, 14]), "Close")
+    assert summary["distribution_days"] == 4
+    assert summary["distribution_window"] == DISTRIBUTION_WINDOW
+    assert "distribution_demoted_from" not in summary
 
 
 def test_us_missing_volume_none():

--- a/prism-us/tests/test_distribution_days.py
+++ b/prism-us/tests/test_distribution_days.py
@@ -1,0 +1,50 @@
+"""US cores 분산일 헬퍼 스모크 테스트.
+
+알고리즘 자체는 KR(tests/test_distribution_days.py)에서 전수 검증한다.
+여기서는 prism-us/cores.data_prefetch 의 동일 구현이 import 되고 동작하는지,
+그리고 US 임계(US_DISTRIBUTION_THRESHOLD) 강등이 적용되는지만 확인한다.
+"""
+import os
+import sys
+
+import pandas as pd
+import pytest
+
+# prism-us 디렉터리를 우선 경로에 둬 cores=prism-us/cores 로 해석되게 함
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cores.data_prefetch import (  # noqa: E402
+    _count_distribution_days,
+    _apply_distribution_demotion,
+    US_DISTRIBUTION_THRESHOLD,
+)
+
+
+def _mk(closes, vols):
+    idx = pd.date_range("2024-01-01", periods=len(closes), freq="D")
+    return pd.DataFrame({"Close": closes, "Volume": vols}, index=idx)
+
+
+def test_us_counts_distribution_days():
+    r = _count_distribution_days(_mk([100, 99, 98, 97, 96], [10, 11, 12, 13, 14]), "Close")
+    assert r["count"] == 4
+
+
+def test_us_demotion_applies_at_threshold():
+    closes = [100] + [round(100 * (0.99 ** k), 4) for k in range(1, US_DISTRIBUTION_THRESHOLD + 1)]
+    vols = [10 + k for k in range(len(closes))]
+    summary = {}
+    regime, conf = _apply_distribution_demotion(
+        "strong_bull", 0.9, summary, _mk(closes, vols), "Close", US_DISTRIBUTION_THRESHOLD,
+    )
+    assert regime == "moderate_bull"
+    assert summary["distribution_days"] >= US_DISTRIBUTION_THRESHOLD
+
+
+def test_us_missing_volume_none():
+    df = pd.DataFrame({"Close": [100, 99, 98]}, index=pd.date_range("2024-01-01", periods=3))
+    assert _count_distribution_days(df, "Close") is None
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_distribution_days.py
+++ b/tests/test_distribution_days.py
@@ -1,0 +1,153 @@
+"""O'Neil 분산일(Distribution Day) 결정론 카운트 단위테스트 (KR cores).
+
+분산일 정의(-0.2% 종가/거래량↑), 회복 만료(+5%), 윈도우 경과 만료,
+거래량 결측 graceful, regime 강등 사다리·클램프·임계 경계를 합성데이터로 검증.
+US cores(prism-us)의 헬퍼는 동일 구현이므로 prism-us/tests에 스모크 테스트만 둔다.
+"""
+import os
+import sys
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cores.data_prefetch import (  # noqa: E402
+    _count_distribution_days,
+    _apply_distribution_demotion,
+    KR_DISTRIBUTION_THRESHOLD,
+    DISTRIBUTION_WINDOW,
+)
+
+
+def _mk(closes, vols):
+    idx = pd.date_range("2024-01-01", periods=len(closes), freq="D")
+    return pd.DataFrame({"Close": closes, "Volume": vols}, index=idx)
+
+
+def test_clear_distribution_days_counted():
+    # 4 consecutive ~-1% down days on rising volume → 4 distribution days
+    r = _count_distribution_days(_mk([100, 99, 98, 97, 96], [10, 11, 12, 13, 14]), "Close")
+    assert r["count"] == 4
+    assert r["raw_count"] == 4
+
+
+def test_down_but_volume_not_rising_is_not_distribution():
+    # price down but volume falling → not institutional distribution
+    r = _count_distribution_days(_mk([100, 99, 98, 97, 96], [14, 13, 12, 11, 10]), "Close")
+    assert r["count"] == 0
+
+
+def test_drop_below_threshold_not_counted():
+    # -0.05% drops are below the -0.2% threshold → ignored
+    r = _count_distribution_days(_mk([100, 99.95, 99.9, 99.85], [10, 11, 12, 13]), "Close")
+    assert r["count"] == 0
+
+
+def test_recovery_5pct_expires_distribution_day():
+    # day1 -2% on rising vol = distribution; day2 closes +12% (> 98*1.05) → expires it
+    r = _count_distribution_days(_mk([100, 98, 110], [10, 11, 12]), "Close")
+    assert r["raw_count"] == 1
+    assert r["count"] == 0
+
+
+def test_recovery_just_below_5pct_keeps_distribution_day():
+    # day1 -2% (close 98) on rising vol; later max close 102 < 98*1.05(=102.9) → kept
+    r = _count_distribution_days(_mk([100, 98, 102], [10, 11, 12]), "Close")
+    assert r["count"] == 1
+
+
+def test_missing_volume_returns_none():
+    df = pd.DataFrame({"Close": [100, 99, 98]}, index=pd.date_range("2024-01-01", periods=3))
+    assert _count_distribution_days(df, "Close") is None
+
+
+def test_all_zero_volume_returns_none():
+    r = _count_distribution_days(_mk([100, 99, 98], [0, 0, 0]), "Close")
+    assert r is None
+
+
+def test_window_caps_old_distribution_days():
+    # 40 down-on-rising-volume days; recovery disabled → only last `window` counted
+    closes, vols = [100], [10]
+    for _ in range(40):
+        closes.append(round(closes[-1] * 0.99, 4))
+        vols.append(vols[-1] + 1)
+    r = _count_distribution_days(_mk(closes, vols), "Close", recovery_pct=1e9)
+    assert r["count"] == DISTRIBUTION_WINDOW
+
+
+def test_korean_volume_column_detected():
+    idx = pd.date_range("2024-01-01", periods=5, freq="D")
+    df = pd.DataFrame({"종가": [100, 99, 98, 97, 96], "거래량": [10, 11, 12, 13, 14]}, index=idx)
+    r = _count_distribution_days(df, "종가")
+    assert r["count"] == 4
+
+
+# --- demotion ladder --------------------------------------------------------
+
+def _n_distribution_days(n):
+    """정확히 n개의 분산일을 만드는 (단조 하락+거래량 증가) 시계열."""
+    closes = [100.0] + [round(100 * (0.99 ** k), 4) for k in range(1, n + 1)]
+    vols = [10 + k for k in range(len(closes))]
+    return _mk(closes, vols)
+
+
+def test_demotion_one_step_when_threshold_met():
+    summary = {}
+    regime, conf = _apply_distribution_demotion(
+        "strong_bull", 0.9, summary, _n_distribution_days(KR_DISTRIBUTION_THRESHOLD),
+        "Close", KR_DISTRIBUTION_THRESHOLD,
+    )
+    assert regime == "moderate_bull"
+    assert conf == 0.70
+    assert summary["distribution_demoted_from"] == "strong_bull"
+    assert summary["distribution_days"] >= KR_DISTRIBUTION_THRESHOLD
+
+
+def test_strong_bear_clamps_no_further_demotion():
+    summary = {}
+    regime, _ = _apply_distribution_demotion(
+        "strong_bear", 0.9, summary, _n_distribution_days(KR_DISTRIBUTION_THRESHOLD),
+        "Close", KR_DISTRIBUTION_THRESHOLD,
+    )
+    assert regime == "strong_bear"
+    assert "distribution_demoted_from" not in summary
+
+
+def test_no_demotion_in_up_market():
+    summary = {}
+    regime, conf = _apply_distribution_demotion(
+        "strong_bull", 0.9, summary, _mk([100, 100.5, 101, 101.5], [10, 11, 12, 13]),
+        "Close", KR_DISTRIBUTION_THRESHOLD,
+    )
+    assert regime == "strong_bull"
+    assert conf == 0.9
+    assert summary["distribution_days"] == 0
+
+
+def test_threshold_boundary_one_below_no_demotion():
+    # exactly threshold-1 distribution days → no demotion
+    n = KR_DISTRIBUTION_THRESHOLD - 1
+    closes = [100] + [round(100 * (0.99 ** k), 4) for k in range(1, n + 1)]
+    vols = [10 + k for k in range(len(closes))]
+    summary = {}
+    regime, _ = _apply_distribution_demotion(
+        "strong_bull", 0.9, summary, _mk(closes, vols), "Close", KR_DISTRIBUTION_THRESHOLD,
+    )
+    assert summary["distribution_days"] == n
+    assert regime == "strong_bull"
+
+
+def test_missing_volume_skips_demotion():
+    summary = {}
+    df = pd.DataFrame({"Close": [100, 99, 98, 97, 96]}, index=pd.date_range("2024-01-01", periods=5))
+    regime, conf = _apply_distribution_demotion(
+        "strong_bull", 0.9, summary, df, "Close", KR_DISTRIBUTION_THRESHOLD,
+    )
+    assert regime == "strong_bull"
+    assert summary["distribution_days"] is None
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_distribution_days.py
+++ b/tests/test_distribution_days.py
@@ -1,8 +1,8 @@
 """O'Neil 분산일(Distribution Day) 결정론 카운트 단위테스트 (KR cores).
 
-분산일 정의(-0.2% 종가/거래량↑), 회복 만료(+5%), 윈도우 경과 만료,
-거래량 결측 graceful, regime 강등 사다리·클램프·임계 경계를 합성데이터로 검증.
-US cores(prism-us)의 헬퍼는 동일 구현이므로 prism-us/tests에 스모크 테스트만 둔다.
+분산일 정의(-0.2% 종가/거래량↑), 회복 만료(+5%), 윈도우 경과 만료, 거래량 결측 graceful,
+그리고 index_summary 정보 주입(_inject_distribution_days; regime 강등 없음)을 합성데이터로 검증.
+US cores(prism-us) 헬퍼는 동일 구현이므로 prism-us/tests에 스모크 테스트만 둔다.
 """
 import os
 import sys
@@ -14,8 +14,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from cores.data_prefetch import (  # noqa: E402
     _count_distribution_days,
-    _apply_distribution_demotion,
-    KR_DISTRIBUTION_THRESHOLD,
+    _inject_distribution_days,
     DISTRIBUTION_WINDOW,
 )
 
@@ -33,7 +32,6 @@ def test_clear_distribution_days_counted():
 
 
 def test_down_but_volume_not_rising_is_not_distribution():
-    # price down but volume falling → not institutional distribution
     r = _count_distribution_days(_mk([100, 99, 98, 97, 96], [14, 13, 12, 11, 10]), "Close")
     assert r["count"] == 0
 
@@ -84,69 +82,29 @@ def test_korean_volume_column_detected():
     assert r["count"] == 4
 
 
-# --- demotion ladder --------------------------------------------------------
+# --- information injection (no regime demotion) -----------------------------
 
-def _n_distribution_days(n):
-    """정확히 n개의 분산일을 만드는 (단조 하락+거래량 증가) 시계열."""
-    closes = [100.0] + [round(100 * (0.99 ** k), 4) for k in range(1, n + 1)]
-    vols = [10 + k for k in range(len(closes))]
-    return _mk(closes, vols)
-
-
-def test_demotion_one_step_when_threshold_met():
+def test_inject_sets_distribution_days_and_window():
     summary = {}
-    regime, conf = _apply_distribution_demotion(
-        "strong_bull", 0.9, summary, _n_distribution_days(KR_DISTRIBUTION_THRESHOLD),
-        "Close", KR_DISTRIBUTION_THRESHOLD,
-    )
-    assert regime == "moderate_bull"
-    assert conf == 0.70
-    assert summary["distribution_demoted_from"] == "strong_bull"
-    assert summary["distribution_days"] >= KR_DISTRIBUTION_THRESHOLD
+    _inject_distribution_days(summary, _mk([100, 99, 98, 97, 96], [10, 11, 12, 13, 14]), "Close")
+    assert summary["distribution_days"] == 4
+    assert summary["distribution_window"] == DISTRIBUTION_WINDOW
 
 
-def test_strong_bear_clamps_no_further_demotion():
+def test_inject_missing_volume_sets_none():
     summary = {}
-    regime, _ = _apply_distribution_demotion(
-        "strong_bear", 0.9, summary, _n_distribution_days(KR_DISTRIBUTION_THRESHOLD),
-        "Close", KR_DISTRIBUTION_THRESHOLD,
-    )
-    assert regime == "strong_bear"
-    assert "distribution_demoted_from" not in summary
-
-
-def test_no_demotion_in_up_market():
-    summary = {}
-    regime, conf = _apply_distribution_demotion(
-        "strong_bull", 0.9, summary, _mk([100, 100.5, 101, 101.5], [10, 11, 12, 13]),
-        "Close", KR_DISTRIBUTION_THRESHOLD,
-    )
-    assert regime == "strong_bull"
-    assert conf == 0.9
-    assert summary["distribution_days"] == 0
-
-
-def test_threshold_boundary_one_below_no_demotion():
-    # exactly threshold-1 distribution days → no demotion
-    n = KR_DISTRIBUTION_THRESHOLD - 1
-    closes = [100] + [round(100 * (0.99 ** k), 4) for k in range(1, n + 1)]
-    vols = [10 + k for k in range(len(closes))]
-    summary = {}
-    regime, _ = _apply_distribution_demotion(
-        "strong_bull", 0.9, summary, _mk(closes, vols), "Close", KR_DISTRIBUTION_THRESHOLD,
-    )
-    assert summary["distribution_days"] == n
-    assert regime == "strong_bull"
-
-
-def test_missing_volume_skips_demotion():
-    summary = {}
-    df = pd.DataFrame({"Close": [100, 99, 98, 97, 96]}, index=pd.date_range("2024-01-01", periods=5))
-    regime, conf = _apply_distribution_demotion(
-        "strong_bull", 0.9, summary, df, "Close", KR_DISTRIBUTION_THRESHOLD,
-    )
-    assert regime == "strong_bull"
+    df = pd.DataFrame({"Close": [100, 99, 98]}, index=pd.date_range("2024-01-01", periods=3))
+    _inject_distribution_days(summary, df, "Close")
     assert summary["distribution_days"] is None
+    assert summary["distribution_window"] == DISTRIBUTION_WINDOW
+
+
+def test_inject_does_not_add_demotion_fields():
+    # 결정론 강등은 제거됨 → demotion/threshold 관련 필드를 절대 만들지 않는다
+    summary = {}
+    _inject_distribution_days(summary, _mk([100, 99, 98, 97, 96], [10, 11, 12, 13, 14]), "Close")
+    assert "distribution_demoted_from" not in summary
+    assert "distribution_threshold" not in summary
 
 
 if __name__ == "__main__":

--- a/tools/regime_backtest.py
+++ b/tools/regime_backtest.py
@@ -139,13 +139,13 @@ def report(market, dates, new_lab, leg_lab, dist=None):
         print(f"  {y}: bull {b}% | sideways {s}% | bear {br}%")
     # 분산일 카운트 재생 (O'Neil): 천장/급락 직전 급증해야 정상
     if dist and any(c is not None for c in dist):
-        thr = {"US": 6, "KR": 6}.get(market, 6)
-        print(f"Distribution-day count (window=25, demote≥{thr}) — yearly max | avg:")
+        ref = 6  # 참고선(정보용): O'Neil/IBD 천장 경고대(5~6). 강등 트리거 아님 — LLM 판단용 정보.
+        print(f"Distribution-day count (window=25, informational ref≥{ref}) — yearly max | avg:")
         for y, mx, av in _dist_yearly_max(dates, dist):
-            flag = "  <== tops/distribution" if mx >= thr else ""
+            flag = "  <== elevated (tops/distribution)" if mx >= ref else ""
             print(f"  {y}: max {mx} | avg {av}{flag}")
-        trig = sum(1 for c in dist if c is not None and c >= thr)
-        print(f"Days at/over demote threshold: {trig} / {sum(1 for c in dist if c is not None)}")
+        hi = sum(1 for c in dist if c is not None and c >= ref)
+        print(f"Days at/over ref {ref}: {hi} / {sum(1 for c in dist if c is not None)} (info only)")
     # spot checks
     spots = {"US": ["2020-03-23", "2022-06-16", "2024-02-15", "2025-04-07"],
              "KR": ["2020-03-19", "2022-09-30", "2024-07-11", "2025-04-09"]}.get(market, [])

--- a/tools/regime_backtest.py
+++ b/tools/regime_backtest.py
@@ -75,16 +75,17 @@ def backtest_us(years):
     from cores.data_prefetch import _compute_us_regime
     gspc = _yf_download("^GSPC", years)
     vix = _yf_download("^VIX", years).reindex(gspc.index).ffill()
-    dates, new_lab, leg_lab = [], [], []
+    dates, new_lab, leg_lab, dist = [], [], [], []
     for i in range(WIN_NEW, len(gspc)):
         w = gspc.iloc[: i + 1]
         vw = vix.iloc[: i + 1]
-        new = _compute_us_regime(w.tail(WIN_NEW), None, vw.tail(WIN_NEW))["market_regime"]
+        res = _compute_us_regime(w.tail(WIN_NEW), None, vw.tail(WIN_NEW))
         leg = _compute_us_regime(w.tail(WIN_LEGACY), None, vw.tail(WIN_LEGACY))["market_regime"]
         dates.append(gspc.index[i])
-        new_lab.append(new)
+        new_lab.append(res["market_regime"])
         leg_lab.append(leg)
-    return dates, new_lab, leg_lab
+        dist.append(res.get("index_summary", {}).get("distribution_days"))
+    return dates, new_lab, leg_lab, dist
 
 
 def backtest_kr(years):
@@ -97,17 +98,32 @@ def backtest_kr(years):
             "Low": float(r.Low), "Close": float(r.Close), "Volume": float(r.Volume)}
             for idx, r in ks.iterrows()}
     keys = list(recs.keys())
-    dates, new_lab, leg_lab = [], [], []
+    dates, new_lab, leg_lab, dist = [], [], [], []
     for i in range(WIN_NEW, len(keys)):
         win = {k: recs[k] for k in keys[max(0, i + 1 - WIN_NEW): i + 1]}
         winL = {k: recs[k] for k in keys[max(0, i + 1 - WIN_LEGACY): i + 1]}
-        new_lab.append(_compute_kr_regime(win)["market_regime"])
+        res = _compute_kr_regime(win)
+        new_lab.append(res["market_regime"])
         leg_lab.append(_compute_kr_regime(winL)["market_regime"])
+        dist.append(res.get("index_summary", {}).get("distribution_days"))
         dates.append(ks.index[i])
-    return dates, new_lab, leg_lab
+    return dates, new_lab, leg_lab, dist
 
 
-def report(market, dates, new_lab, leg_lab):
+def _dist_yearly_max(dates, dist):
+    """연도별 분산일 카운트 최대/평균 (None 제외)."""
+    by = defaultdict(list)
+    for d, c in zip(dates, dist or []):
+        if c is not None:
+            by[d.year].append(c)
+    rows = []
+    for y in sorted(by):
+        vals = by[y]
+        rows.append((y, max(vals), round(sum(vals) / len(vals), 1)))
+    return rows
+
+
+def report(market, dates, new_lab, leg_lab, dist=None):
     print(f"\n========== {market} (n={len(dates)} days, {dates[0].date()}~{dates[-1].date()}) ==========")
     print(f"NEW (50/200) distribution : {_dist(new_lab)}")
     print(f"LEGACY (20MA) distribution: {_dist(leg_lab)}")
@@ -121,15 +137,27 @@ def report(market, dates, new_lab, leg_lab):
     print("Yearly bull/sideways/bear % (NEW):")
     for y, b, s, br in _yearly(dates, new_lab):
         print(f"  {y}: bull {b}% | sideways {s}% | bear {br}%")
+    # 분산일 카운트 재생 (O'Neil): 천장/급락 직전 급증해야 정상
+    if dist and any(c is not None for c in dist):
+        thr = {"US": 6, "KR": 6}.get(market, 6)
+        print(f"Distribution-day count (window=25, demote≥{thr}) — yearly max | avg:")
+        for y, mx, av in _dist_yearly_max(dates, dist):
+            flag = "  <== tops/distribution" if mx >= thr else ""
+            print(f"  {y}: max {mx} | avg {av}{flag}")
+        trig = sum(1 for c in dist if c is not None and c >= thr)
+        print(f"Days at/over demote threshold: {trig} / {sum(1 for c in dist if c is not None)}")
     # spot checks
     spots = {"US": ["2020-03-23", "2022-06-16", "2024-02-15", "2025-04-07"],
              "KR": ["2020-03-19", "2022-09-30", "2024-07-11", "2025-04-09"]}.get(market, [])
     dmap = {d.strftime("%Y-%m-%d"): lab for d, lab in zip(dates, new_lab)}
+    cmap = {d.strftime("%Y-%m-%d"): c for d, c in zip(dates, dist or [])}
     sc = []
     for s in spots:
-        near = next((dmap[k] for k in sorted(dmap) if k >= s), None)
-        sc.append(f"{s}->{near}")
-    print("Spot checks (NEW):", " | ".join(sc))
+        near = next((k for k in sorted(dmap) if k >= s), None)
+        lab = dmap.get(near)
+        dd = cmap.get(near)
+        sc.append(f"{s}->{lab}(dd={dd})")
+    print("Spot checks (NEW, regime+distribution_days):", " | ".join(sc))
 
 
 def main():


### PR DESCRIPTION
## 요약
분산일(Distribution Day)을 **결정론적으로 계산해 `index_summary.distribution_days`에 정보로 주입**한다. LLM이 더는 분산일을 환각 추정하지 않는다(= handoff 원래 목표). **regime의 기계적 강등은 하지 않는다.**

## 왜 강등을 안 하나 (검증 경과)
1. **forward-return 테스트**: bull 상태 강등일의 이후 수익률 — KR은 언더퍼폼(신호 유효), **US는 오히려 아웃퍼폼(역효과)**.
2. **장기 위험기반(MaxDD/Sharpe, 1990~2026)**: KR T=6은 이득이나 **임계 6에서만 뾰족 = 과최적화 신호**. US는 secular 강세라 방어가 복리손실로 과금.
3. 무엇보다 regime 강등은 **매수뿐 아니라 매도(익절·trailing)까지 뒤집어 보유 종목 조기청산**을 유발 → US melt-up 손실의 실체.
4. 분산일은 본래 O'Neil의 **재량적 방어 포스처**이지 기계적 현금화 룰이 아님.

→ 과최적화·조기청산·US 손해·복잡도를 모두 제거하고, 결정론 카운트의 이득(LLM 환각 제거)만 취한다.

## 변경
- `_count_distribution_days`: -0.2%↓ 마감 + 거래량 전일 초과 = 분산일. 25거래일 윈도우, +5% 회복 만료, 거래량 결측 graceful(None).
- `_inject_distribution_days`: `distribution_days`/`distribution_window`만 index_summary에 주입. **regime/confidence 불변.**
- 기계적 강등(`_apply_distribution_demotion`/`_REGIME_DEMOTE`/`*_DISTRIBUTION_THRESHOLD`) 전면 삭제.
- 프롬프트(KR/US × KO/EN): "분산일 높으면(≈5~6+) **신규매수에 한해** 보수화, **보유 매도·trailing은 원래 regime 유지(조기청산 금지)**"로 advisory화.
- `tools/regime_backtest.py`: 분산일 카운트는 정보용 참고선(ref≥6)으로만 출력.

## 검증
- 단위테스트 KR 12 + US 3 통과(정의·거래량조건·임계미달·회복만료·윈도우캡·한글컬럼·결측graceful·정보주입·강등필드 미생성).
- 합성 호출 확인: distribution_days=6 주입되되 regime moderate_bull 불변, demoted_from/threshold 필드 없음.
- 프롬프트-rule 테스트 단언 문자열 보존(로컬 mcp_agent 미설치 → db-server 실행).

🤖 Generated with [Claude Code](https://claude.com/claude-code)