### PR TITLE
feat: wire US weekly compression into compress_trading_memory (#321)

### DIFF
--- a/compress_trading_memory.py
+++ b/compress_trading_memory.py
@@ -362,6 +362,138 @@ async def run_compression(
         return {"status": "error", "error": str(e)}
 
 
+def _load_us_compression_manager():
+    """Load USCompressionManager directly from prism-us/tracking/compression.py.
+
+    Loaded via importlib from the file path so we bypass prism-us/tracking/__init__.py
+    (which imports db_schema/journal and would risk the documented KR/US 'cores'
+    shadowing when run from the root context). compression.py itself only depends on
+    the stdlib, so a standalone file load is safe.
+    """
+    import importlib.util
+
+    comp_path = Path(__file__).parent / "prism-us" / "tracking" / "compression.py"
+    spec = importlib.util.spec_from_file_location("us_compression_standalone", comp_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.USCompressionManager
+
+
+async def run_us_compression(
+    db_path: str = "stock_tracking_db.sqlite",
+    layer1_age_days: int = 7,
+    layer2_age_days: int = 30,
+    min_entries: int = 3,
+    dry_run: bool = False,
+    force: bool = False,
+    skip_cleanup: bool = False,
+    max_principles: int = 50,
+    max_intuitions: int = 50,
+    stale_days: int = 90,
+    archive_layer3_days: int = 365,
+) -> dict:
+    """Run US-market compression/cleanup on the same shared SQLite database.
+
+    US trades live in the same DB as KR (distinguished by the ``market`` column),
+    but the weekly job previously only ran the KR ``StockTrackingAgent`` pass, so US
+    intuitions were never derived from compression. This decoupled pass runs the
+    standalone ``USCompressionManager`` (deterministic, no LLM) over its own
+    connection, independent of the KR control flow.
+    """
+    import sqlite3
+
+    logger.info("=" * 60)
+    logger.info("US Trading Memory Compression Started")
+    logger.info(f"Database: {db_path}")
+    logger.info("=" * 60)
+
+    try:
+        USCompressionManager = _load_us_compression_manager()
+    except Exception as e:
+        logger.error(f"Could not load USCompressionManager (skipping US pass): {e}")
+        return {"status": "error", "error": f"load failed: {e}"}
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+
+    try:
+        manager = USCompressionManager(cursor, conn)
+
+        stats_before = manager.get_compression_stats()
+        layers = stats_before.get("entries_by_layer", {})
+        logger.info("\n📊 US Current Status:")
+        logger.info(f"  Layer 1 (Detailed): {layers.get('layer1_detailed', 0)}")
+        logger.info(f"  Layer 2 (Summarized): {layers.get('layer2_summarized', 0)}")
+        logger.info(f"  Layer 3 (Compressed): {layers.get('layer3_compressed', 0)}")
+        logger.info(f"  Active Intuitions: {stats_before.get('active_intuitions', 0)}")
+        logger.info(f"  Active Principles: {stats_before.get('active_principles', 0)}")
+
+        if dry_run:
+            logger.info("\n🔍 US DRY RUN - showing cleanup preview only (compression not simulated)")
+            cleanup_preview = manager.cleanup_stale_data(
+                max_principles=max_principles,
+                max_intuitions=max_intuitions,
+                stale_days=stale_days,
+                archive_layer3_days=archive_layer3_days,
+                dry_run=True,
+            )
+            return {
+                "status": "dry_run",
+                "stats_before": stats_before,
+                "cleanup_preview": cleanup_preview,
+            }
+
+        effective_min = 1 if force else min_entries
+
+        logger.info("\n🔄 Running US compression...")
+        results = await manager.compress_old_journal_entries(
+            layer1_age_days=layer1_age_days,
+            layer2_age_days=layer2_age_days,
+            min_entries_for_compression=effective_min,
+        )
+        logger.info(f"  US Layer 1 → 2: {results['layer1_to_layer2']['compressed']} compressed")
+        logger.info(f"  US Layer 2 → 3: {results['layer2_to_layer3']['compressed']} compressed")
+        logger.info(f"  US Intuitions generated: {results['intuitions_generated']}")
+
+        cleanup_results = {}
+        if not skip_cleanup:
+            logger.info("\n🧹 Running US Cleanup...")
+            cleanup_results = manager.cleanup_stale_data(
+                max_principles=max_principles,
+                max_intuitions=max_intuitions,
+                stale_days=stale_days,
+                archive_layer3_days=archive_layer3_days,
+                dry_run=False,
+            )
+            logger.info(f"  US Principles deactivated: {cleanup_results.get('principles_deactivated', 0)}")
+            logger.info(f"  US Intuitions deactivated: {cleanup_results.get('intuitions_deactivated', 0)}")
+            logger.info(f"  US Journal entries archived: {cleanup_results.get('journal_entries_archived', 0)}")
+        else:
+            logger.info("\n⏭️  US Cleanup skipped (--skip-cleanup)")
+
+        stats_after = manager.get_compression_stats()
+        logger.info("\n📊 US Final Active Counts:")
+        logger.info(f"  Active Intuitions: {stats_after.get('active_intuitions', 0)}")
+        logger.info(f"  Active Principles: {stats_after.get('active_principles', 0)}")
+
+        return {
+            "status": "success",
+            "results": results,
+            "cleanup_results": cleanup_results,
+            "stats_before": stats_before,
+            "stats_after": stats_after,
+        }
+
+    except Exception as e:
+        logger.error(f"US compression failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return {"status": "error", "error": str(e)}
+    finally:
+        conn.close()
+
+
 def main():
     """Main entry point."""
     parser = argparse.ArgumentParser(
@@ -465,15 +597,32 @@ Examples:
         archive_layer3_days=args.archive_days
     ))
 
+    # Run US-market compression/cleanup on the same shared DB (decoupled from KR).
+    # Previously only the KR pass ran, so US intuitions were never derived (#321).
+    us_result = asyncio.run(run_us_compression(
+        db_path=args.db_path,
+        layer1_age_days=args.layer1_age,
+        layer2_age_days=args.layer2_age,
+        min_entries=args.min_entries,
+        dry_run=args.dry_run,
+        force=args.force,
+        skip_cleanup=args.skip_cleanup,
+        max_principles=args.max_principles,
+        max_intuitions=args.max_intuitions,
+        stale_days=args.stale_days,
+        archive_layer3_days=args.archive_days
+    ))
+
     # Print final summary
     logger.info("\n" + "=" * 60)
-    logger.info(f"Final Status: {result.get('status', 'unknown')}")
+    logger.info(f"Final Status (KR): {result.get('status', 'unknown')}")
+    logger.info(f"Final Status (US): {us_result.get('status', 'unknown')}")
     logger.info("=" * 60)
 
-    if result.get('status') == 'error':
+    if result.get('status') == 'error' or us_result.get('status') == 'error':
         sys.exit(1)
 
-    return result
+    return {"kr": result, "us": us_result}
 
 
 if __name__ == "__main__":

--- a/tests/test_us_compression_wiring.py
+++ b/tests/test_us_compression_wiring.py
@@ -1,0 +1,177 @@
+"""Tests for the US-market compression pass wired into compress_trading_memory.
+
+Regression guard for #321: the weekly compression job previously only ran the KR
+``StockTrackingAgent`` pass, so US intuitions were never derived from compression.
+``run_us_compression`` now runs ``USCompressionManager`` over the same shared DB.
+
+These tests build a minimal self-contained SQLite schema (only the columns the
+compression code touches) so they run in the root pytest session WITHOUT importing
+any prism-us package modules — avoiding the documented KR/US ``cores`` shadowing.
+"""
+
+import asyncio
+import sqlite3
+from datetime import datetime, timedelta
+
+import compress_trading_memory as ctm
+
+
+def _create_minimal_schema(db_path: str) -> None:
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE trading_journal (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ticker TEXT,
+            company_name TEXT,
+            profit_rate REAL,
+            holding_days INTEGER,
+            one_line_summary TEXT,
+            lessons TEXT,
+            pattern_tags TEXT,
+            sell_price REAL,
+            buy_scenario TEXT,
+            compressed_summary TEXT,
+            trade_date TEXT,
+            compression_layer INTEGER DEFAULT 1,
+            market TEXT DEFAULT 'KR'
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE trading_intuitions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            category TEXT,
+            condition TEXT,
+            insight TEXT,
+            confidence REAL,
+            success_rate REAL,
+            supporting_count INTEGER,
+            created_at TEXT,
+            last_validated_at TEXT,
+            is_active INTEGER DEFAULT 1,
+            market TEXT DEFAULT 'KR'
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE trading_principles (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            confidence REAL,
+            created_at TEXT,
+            last_validated_at TEXT,
+            is_active INTEGER DEFAULT 1,
+            market TEXT DEFAULT 'KR'
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _insert_layer2_entry(db_path, ticker, profit_rate, pattern_tags, market, days_ago=40):
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    trade_date = (datetime.now() - timedelta(days=days_ago)).strftime("%Y-%m-%d")
+    cur.execute(
+        """
+        INSERT INTO trading_journal
+            (ticker, company_name, profit_rate, holding_days, one_line_summary,
+             lessons, pattern_tags, sell_price, buy_scenario, trade_date,
+             compression_layer, market)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 2, ?)
+        """,
+        (
+            ticker, f"{ticker} Inc", profit_rate, 10, f"{ticker} summary",
+            "[]", pattern_tags, 100.0, "{}", trade_date, market,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_us_compression_derives_us_intuitions(tmp_path):
+    """3 US layer-2 entries sharing a pattern → one market='US' intuition is created."""
+    db = str(tmp_path / "shared.sqlite")
+    _create_minimal_schema(db)
+
+    _insert_layer2_entry(db, "AAPL", 5.0, '["breakout"]', "US")
+    _insert_layer2_entry(db, "MSFT", -2.0, '["breakout"]', "US")
+    _insert_layer2_entry(db, "NVDA", 3.0, '["breakout"]', "US")
+
+    result = asyncio.run(
+        ctm.run_us_compression(db_path=db, min_entries=3, skip_cleanup=True)
+    )
+
+    assert result["status"] == "success"
+    assert result["results"]["intuitions_generated"] >= 1
+
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("SELECT category, market FROM trading_intuitions WHERE market = 'US'")
+    rows = cur.fetchall()
+    conn.close()
+
+    assert len(rows) == 1
+    assert rows[0][0] == "breakout"
+    assert rows[0][1] == "US"
+
+
+def test_us_compression_does_not_touch_kr_rows(tmp_path):
+    """KR layer-2 rows must remain untouched (no compression, no KR intuition)."""
+    db = str(tmp_path / "shared.sqlite")
+    _create_minimal_schema(db)
+
+    # KR rows with the same pattern — US pass must ignore them (market filter).
+    _insert_layer2_entry(db, "005930", 4.0, '["breakout"]', "KR")
+    _insert_layer2_entry(db, "000660", 6.0, '["breakout"]', "KR")
+    _insert_layer2_entry(db, "035420", 2.0, '["breakout"]', "KR")
+
+    result = asyncio.run(
+        ctm.run_us_compression(db_path=db, min_entries=3, skip_cleanup=True)
+    )
+
+    assert result["status"] == "success"
+    # No US intuitions generated from KR rows.
+    assert result["results"]["intuitions_generated"] == 0
+
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM trading_intuitions")
+    intuition_count = cur.fetchone()[0]
+    cur.execute("SELECT COUNT(*) FROM trading_journal WHERE compression_layer = 2 AND market = 'KR'")
+    kr_layer2_remaining = cur.fetchone()[0]
+    conn.close()
+
+    assert intuition_count == 0
+    assert kr_layer2_remaining == 3
+
+
+def test_us_compression_dry_run_makes_no_changes(tmp_path):
+    """Dry run returns a preview and creates no intuitions."""
+    db = str(tmp_path / "shared.sqlite")
+    _create_minimal_schema(db)
+
+    _insert_layer2_entry(db, "AAPL", 5.0, '["breakout"]', "US")
+    _insert_layer2_entry(db, "MSFT", -2.0, '["breakout"]', "US")
+    _insert_layer2_entry(db, "NVDA", 3.0, '["breakout"]', "US")
+
+    result = asyncio.run(
+        ctm.run_us_compression(db_path=db, min_entries=3, dry_run=True)
+    )
+
+    assert result["status"] == "dry_run"
+
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM trading_intuitions")
+    intuition_count = cur.fetchone()[0]
+    cur.execute("SELECT COUNT(*) FROM trading_journal WHERE compression_layer = 3")
+    layer3_count = cur.fetchone()[0]
+    conn.close()
+
+    assert intuition_count == 0
+    assert layer3_count == 0


### PR DESCRIPTION
## Problem
The weekly `compress_trading_memory.py` job only instantiated the KR `StockTrackingAgent`, so **US intuitions were never derived from compression**. `USCompressionManager` existed (`prism-us/tracking/compression.py`) but was only invoked inside the live US agent — never by the weekly cron.

## Fix
Add a decoupled `run_us_compression()` pass that runs `USCompressionManager` over the **same shared SQLite DB** after the KR pass, called from `main()`.

- **No cores shadowing**: the manager is loaded via `importlib` from the file path, bypassing `prism-us/tracking/__init__.py` (which pulls in db_schema/journal). `compression.py` only depends on the stdlib.
- **Independent control flow**: own sqlite connection, so KR skip/dry-run no longer suppresses the US pass; US self-gates via its own `min_entries`.
- **No KR/US mixing**: US `_save_intuition` already writes `market='US'`; all US queries filter `market = 'US'`.

## Tests
`tests/test_us_compression_wiring.py` (3 cases, all pass locally on `.venv`):
1. US layer-2 entries → `market='US'` intuition derived
2. KR rows untouched (no compression, no KR intuition)
3. dry-run makes no changes

Self-contained minimal schema → runs in the root pytest session without importing prism-us packages.

## Deploy
After merge: db-server `git pull --ff-only origin main`, then verify next weekly compression run derives US intuitions.