### PR TITLE
feat(prism-btc): 실시간 매매 시그널 텔레그램 알림

### DIFF
--- a/prism-btc/live/notifier.py
+++ b/prism-btc/live/notifier.py
@@ -1,0 +1,178 @@
+# live/notifier.py — 실시간 매매 이벤트 텔레그램 알림 (진입/추가/청산 즉시 발송)
+#
+# telegram_reporter 는 하루 1회 "현황 스냅샷"을 보낸다. 이 모듈은 그 사이사이의
+# 실제 사건(새 진입/비중 추가/포지션 정리)이 발생할 때마다 즉시 1건씩 알린다.
+#
+# 멱등 감지 (btc_meta 마커 기반):
+#   - 진입/추가진입: btc_positions 의 autoincrement id 가 마커보다 큰 신규 행.
+#     id 는 단조증가하며 삭제된 행 id 는 재등장하지 않으므로, "마지막으로 알린 id"
+#     보다 큰 행만 보면 중복 없이 정확히 한 번씩 감지된다.
+#   - 청산: btc_trading_history 는 불변(append-only) 이므로 같은 마커 전략을 쓴다.
+#
+# 콜드스타트 가드: 마커가 없으면(첫 실행) 과거 행을 폭주 전송하지 않고 현재 max(id)
+# 로 마커만 세팅한다. 이후부터 실제 신규 사건만 알린다.
+#
+# 안전 원칙: 모든 SQL/전송 실패를 흡수한다. 어떤 예외도 밖으로 던지지 않는다
+# (데몬 tick 비중단). 토큰/채널 미설정 시 stdout 폴백 (크래시 금지).
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from live import tracking
+from live.telegram_reporter import (
+    _send,
+    _load_env,
+    _resolve_channel,
+    _side_kr,
+    _reason_kr,
+)
+
+log = logging.getLogger("live.notifier")
+
+# btc_meta 마커 키 (mode 별로 독립).
+_MARK_ENTRY = "last_notified_entry_id"
+_MARK_EXIT = "last_notified_exit_id"
+
+
+# ---------------------------------------------------------------------------
+# 메시지 빌드 — 한국어, 일반인 친화, 시범운용 명시.
+# ---------------------------------------------------------------------------
+
+def _disclaimer() -> str:
+    return "_가상자금 모의투자입니다_"
+
+
+def _mode_tag(mode: str) -> str:
+    # demo = 시범운용(모의투자), live = 실전.
+    return "시범운용" if mode == "demo" else "실전"
+
+
+def _build_entry_message(row, mode: str) -> str:
+    """진입/추가진입 알림 1건. tranche_index 로 신규 vs 비중 추가 구분."""
+    tag = _mode_tag(mode)
+    side = _side_kr(row["side"])
+    entry = float(row["entry_price"])
+    sl = float(row["sl_price"])
+    lev = float(row["leverage"])
+    tranche = int(row["tranche_index"])
+
+    if tranche <= 0:
+        # 신규 진입 (tranche 0).
+        head = f"🟢 [{tag}] 새 진입 — {side}"
+        body = (f"진입가 {entry:,.0f}달러 · 손절 {sl:,.0f}달러 · "
+                f"{lev:.0f}배율")
+    else:
+        # 비중 추가 (피라미딩). 사람이 읽는 N/3 표기.
+        head = f"🟢 [{tag}] 비중 추가 ({tranche + 1}/3) — {side}"
+        body = f"진입가 {entry:,.0f}달러"
+
+    return f"{head}\n{body}\n{_disclaimer()}"
+
+
+def _build_exit_message(row, mode: str) -> str:
+    """청산 알림 1건. r_multiple 로 이익/손실, exit_reason 한글화."""
+    tag = _mode_tag(mode)
+    r = float(row["r_multiple"])
+    reason = _reason_kr(row["exit_reason"])
+    if r > 0:
+        outcome = f"✅ 이익 {r:+.1f}배"
+    else:
+        outcome = f"❌ 손실 {r:+.1f}배"
+    head = f"🔵 [{tag}] 포지션 정리 — {outcome} ({reason})"
+    return f"{head}\n{_disclaimer()}"
+
+
+# ---------------------------------------------------------------------------
+# 전송 — telegram_reporter._send 재사용 (asyncio.run). 실패 흡수.
+# ---------------------------------------------------------------------------
+
+def _dispatch(messages: list[str]) -> None:
+    """메시지들을 순서대로 전송. 토큰/채널 없으면 _send 가 stdout 폴백한다."""
+    if not messages:
+        return
+    try:
+        _load_env()
+    except Exception:  # noqa: BLE001 — env 로드 실패해도 환경에 이미 있을 수 있음
+        pass
+    token = os.environ.get("TELEGRAM_BOT_TOKEN")
+    channel = _resolve_channel(None)
+    for msg in messages:
+        try:
+            asyncio.run(_send(token, channel, msg))
+        except Exception as exc:  # noqa: BLE001 — 전송 실패 절대 비전파
+            log.warning("notifier 전송 실패 (흡수): %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# 핵심 진입점 — 신규 이벤트 감지 후 알림.
+# ---------------------------------------------------------------------------
+
+def _max_id(conn, table: str, mode: str):
+    """해당 mode 의 max(id). 행이 없으면 None."""
+    r = conn.execute(
+        f"SELECT MAX(id) AS m FROM {table} WHERE mode=?", (mode,)
+    ).fetchone()
+    return None if r is None or r["m"] is None else int(r["m"])
+
+
+def notify_new_events(conn, mode: str = "demo") -> dict:
+    """신규 진입/추가/청산 이벤트를 감지해 즉시 텔레그램 알림.
+
+    멱등: btc_meta 마커(last_notified_*_id) 보다 큰 id 만 처리하고, 전송 후 마커를
+    max(id) 로 갱신한다. 콜드스타트(마커 없음)는 전송 없이 마커만 세팅한다.
+
+    어떤 예외도 밖으로 던지지 않는다. 반환은 {"entries", "exits"} 카운트 (디버그용).
+    """
+    result = {"entries": 0, "exits": 0}
+    try:
+        # --- 진입/추가진입 (btc_positions) ---
+        entry_marker = tracking.get_meta(conn, _MARK_ENTRY, mode)
+        if entry_marker is None:
+            # 콜드스타트: 현재 max(id) 로 마커만 세팅 (과거 폭주 전송 안 함).
+            cur_max = _max_id(conn, "btc_positions", mode)
+            tracking.set_meta(conn, _MARK_ENTRY, cur_max if cur_max is not None else 0, mode)
+        else:
+            rows = conn.execute(
+                "SELECT * FROM btc_positions WHERE mode=? AND id > ? ORDER BY id ASC",
+                (mode, int(entry_marker)),
+            ).fetchall()
+            if rows:
+                msgs = []
+                for row in rows:
+                    try:
+                        msgs.append(_build_entry_message(row, mode))
+                    except Exception as exc:  # noqa: BLE001 — 1건 실패가 전체를 못 막음
+                        log.warning("진입 메시지 빌드 실패 (흡수): %s", exc)
+                _dispatch(msgs)
+                tracking.set_meta(conn, _MARK_ENTRY, int(rows[-1]["id"]), mode)
+                result["entries"] = len(rows)
+    except Exception as exc:  # noqa: BLE001 — 진입 알림 실패 절대 비전파
+        log.warning("notify entries 실패 (흡수): %s", exc)
+
+    try:
+        # --- 청산 (btc_trading_history, 불변 행) ---
+        exit_marker = tracking.get_meta(conn, _MARK_EXIT, mode)
+        if exit_marker is None:
+            cur_max = _max_id(conn, "btc_trading_history", mode)
+            tracking.set_meta(conn, _MARK_EXIT, cur_max if cur_max is not None else 0, mode)
+        else:
+            rows = conn.execute(
+                "SELECT * FROM btc_trading_history WHERE mode=? AND id > ? ORDER BY id ASC",
+                (mode, int(exit_marker)),
+            ).fetchall()
+            if rows:
+                msgs = []
+                for row in rows:
+                    try:
+                        msgs.append(_build_exit_message(row, mode))
+                    except Exception as exc:  # noqa: BLE001
+                        log.warning("청산 메시지 빌드 실패 (흡수): %s", exc)
+                _dispatch(msgs)
+                tracking.set_meta(conn, _MARK_EXIT, int(rows[-1]["id"]), mode)
+                result["exits"] = len(rows)
+    except Exception as exc:  # noqa: BLE001 — 청산 알림 실패 절대 비전파
+        log.warning("notify exits 실패 (흡수): %s", exc)
+
+    return result

--- a/prism-btc/live/runner.py
+++ b/prism-btc/live/runner.py
@@ -170,6 +170,17 @@ def tick(mode: str = "shadow", market_db_path=None, root_db_path=None) -> dict:
         tracking.log_event(root_conn, "error", f"journal pipeline: {exc}",
                            level="error", mode=mode)
 
+    # --- 3b. 실시간 매매 이벤트 알림 (데모/실모드만 — shadow 는 가상 시뮬이라 미발송) ---
+    # 새 진입/비중 추가/포지션 정리를 즉시 텔레그램으로 알린다 (멱등). 어떤 예외도
+    # 데몬을 멈출 수 없다 (notify_new_events 가 내부 흡수하지만 여기서도 한 겹 더 방어).
+    if mode in ("demo", "live"):
+        try:
+            from live import notifier
+            notifier.notify_new_events(root_conn, mode)
+        except Exception as exc:  # noqa: BLE001 — 알림 실패는 트레이딩과 무관
+            tracking.log_event(root_conn, "error", f"notifier: {exc}",
+                               level="error", mode=mode)
+
     tracking.log_event(root_conn, "heartbeat",
         f"tick ok: processed {processed} new 30m bar(s); "
         f"last={result['ts']}", mode=mode)

--- a/prism-btc/tests/test_notifier.py
+++ b/prism-btc/tests/test_notifier.py
@@ -1,0 +1,228 @@
+# tests/test_notifier.py — 실시간 매매 이벤트 알림 (notifier) 단위 테스트 (오프라인).
+#
+# 원칙: 네트워크 0. 텔레그램 전송은 monkeypatch 로 캡처한다.
+#   - 콜드스타트: 마커만 세팅, 전송 0
+#   - 신규 진입 1건 감지·전송
+#   - 추가 트랜치(2/3) 문구
+#   - 청산 이익·손실 문구
+#   - 멱등: 재호출 시 중복 전송 0
+#   - 토큰 없을 때 stdout 폴백·크래시 없음
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from live import notifier, tracking
+from live.tracking import PositionRow, TradeRow, ensure_schema
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+def _root_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    ensure_schema(conn)
+    return conn
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    """notifier._dispatch 내부의 _send 호출을 캡처 (네트워크 0). 보낸 메시지 리스트."""
+    sent: list[str] = []
+
+    async def _fake_send(token, channel, message):
+        sent.append(message)
+        return True
+
+    monkeypatch.setattr(notifier, "_send", _fake_send)
+    return sent
+
+
+def _mk_position(side="long", entry=50000.0, sl=49000.0, lev=3.0, tranche=0,
+                 mode="demo") -> PositionRow:
+    return PositionRow(
+        side=side, entry_price=entry, qty=0.01, leverage=lev, sl_price=sl,
+        tp1_price=entry * 1.02, tp2_price=entry * 1.04, tp3_price=entry * 1.06,
+        liq_price=entry * 0.9, entry_time="2026-06-15T00:00:00+00:00",
+        tranche_index=tranche, entry_bar_idx=1, initial_risk=10.0, mode=mode,
+    )
+
+
+def _mk_trade(side="long", r=2.3, reason="trail", mode="demo") -> TradeRow:
+    return TradeRow(
+        trade_id=1, side=side, entry_time="2026-06-15T00:00:00+00:00",
+        entry_price=50000.0, exit_time="2026-06-15T04:00:00+00:00",
+        exit_price=51000.0, qty=0.01, leverage=3.0, sl_price=49000.0,
+        exit_reason=reason, r_multiple=r, fee_paid=0.1, funding_paid=0.0,
+        tranche_index=0, liq_price=45000.0, net_pnl=23.0, mode=mode,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 콜드스타트 가드
+# ---------------------------------------------------------------------------
+
+def test_cold_start_sets_markers_no_send(captured):
+    """마커 없음 + 기존 행 존재 → 전송 0, 마커만 현재 max(id) 로 세팅."""
+    conn = _root_conn()
+    # 과거 행이 이미 쌓여있는 상태.
+    tracking.save_position(conn, _mk_position(tranche=0))
+    tracking.record_trade(conn, _mk_trade())
+
+    res = notifier.notify_new_events(conn, mode="demo")
+
+    assert captured == []  # 과거 폭주 전송 안 함.
+    assert res == {"entries": 0, "exits": 0}
+    # 마커가 현재 max(id) 로 세팅됨.
+    assert tracking.get_meta(conn, "last_notified_entry_id", "demo") == 1
+    assert tracking.get_meta(conn, "last_notified_exit_id", "demo") == 1
+
+
+def test_cold_start_empty_tables(captured):
+    """행이 전혀 없을 때 콜드스타트 → 마커 0, 전송 0, 크래시 없음."""
+    conn = _root_conn()
+    res = notifier.notify_new_events(conn, mode="demo")
+    assert captured == []
+    assert res == {"entries": 0, "exits": 0}
+    assert tracking.get_meta(conn, "last_notified_entry_id", "demo") == 0
+    assert tracking.get_meta(conn, "last_notified_exit_id", "demo") == 0
+
+
+# ---------------------------------------------------------------------------
+# 신규 진입 감지·전송
+# ---------------------------------------------------------------------------
+
+def test_new_entry_detected_and_sent(captured):
+    """콜드스타트 후 신규 진입 1건 → 전송 1건, '새 진입' 문구."""
+    conn = _root_conn()
+    notifier.notify_new_events(conn, mode="demo")  # 콜드스타트 (마커 세팅).
+    assert captured == []
+
+    tracking.save_position(conn, _mk_position(tranche=0, entry=50000.0, sl=49000.0))
+    res = notifier.notify_new_events(conn, mode="demo")
+
+    assert res["entries"] == 1
+    assert len(captured) == 1
+    msg = captured[0]
+    assert "새 진입" in msg
+    assert "📈 상승 베팅" in msg
+    assert "50,000달러" in msg
+    assert "49,000달러" in msg
+    assert "가상자금 모의투자입니다" in msg
+
+
+def test_add_tranche_message(captured):
+    """추가 트랜치(tranche_index=1) → '비중 추가 (2/3)' 문구."""
+    conn = _root_conn()
+    notifier.notify_new_events(conn, mode="demo")  # 콜드스타트.
+
+    tracking.save_position(conn, _mk_position(tranche=1, side="long"))
+    res = notifier.notify_new_events(conn, mode="demo")
+
+    assert res["entries"] == 1
+    assert len(captured) == 1
+    assert "비중 추가 (2/3)" in captured[0]
+    assert "📈 상승 베팅" in captured[0]
+
+
+# ---------------------------------------------------------------------------
+# 청산 이익/손실 문구
+# ---------------------------------------------------------------------------
+
+def test_exit_profit_message(captured):
+    """청산 이익(r>0) → '✅ 이익' + 한글화된 사유."""
+    conn = _root_conn()
+    notifier.notify_new_events(conn, mode="demo")  # 콜드스타트.
+
+    tracking.record_trade(conn, _mk_trade(r=2.3, reason="trail"))
+    res = notifier.notify_new_events(conn, mode="demo")
+
+    assert res["exits"] == 1
+    assert len(captured) == 1
+    msg = captured[0]
+    assert "포지션 정리" in msg
+    assert "✅ 이익 +2.3배" in msg
+    assert "추세 꺾여 익절 마감" in msg  # _reason_kr("trail")
+    assert "가상자금 모의투자입니다" in msg
+
+
+def test_exit_loss_message(captured):
+    """청산 손실(r<0) → '❌ 손실' + 손절 사유."""
+    conn = _root_conn()
+    notifier.notify_new_events(conn, mode="demo")  # 콜드스타트.
+
+    tracking.record_trade(conn, _mk_trade(r=-1.0, reason="sl"))
+    res = notifier.notify_new_events(conn, mode="demo")
+
+    assert res["exits"] == 1
+    assert len(captured) == 1
+    msg = captured[0]
+    assert "❌ 손실 -1.0배" in msg
+    assert "손절" in msg  # _reason_kr("sl")
+
+
+# ---------------------------------------------------------------------------
+# 멱등성
+# ---------------------------------------------------------------------------
+
+def test_idempotent_no_duplicate_send(captured):
+    """같은 이벤트로 재호출 → 두 번째는 전송 0 (마커 갱신됨)."""
+    conn = _root_conn()
+    notifier.notify_new_events(conn, mode="demo")  # 콜드스타트.
+
+    tracking.save_position(conn, _mk_position(tranche=0))
+    tracking.record_trade(conn, _mk_trade())
+
+    res1 = notifier.notify_new_events(conn, mode="demo")
+    assert res1 == {"entries": 1, "exits": 1}
+    assert len(captured) == 2
+
+    captured.clear()
+    res2 = notifier.notify_new_events(conn, mode="demo")
+    assert res2 == {"entries": 0, "exits": 0}
+    assert captured == []  # 중복 전송 0.
+
+
+# ---------------------------------------------------------------------------
+# 토큰 없을 때 stdout 폴백 — 크래시 없음 (실제 _send 사용, monkeypatch 없음)
+# ---------------------------------------------------------------------------
+
+def test_no_token_stdout_fallback_no_crash(monkeypatch, capsys):
+    """토큰/채널 미설정 → _send 가 stdout 폴백. 예외 없이 완료."""
+    # 환경에서 토큰/채널 제거.
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("BTC_TELEGRAM_CHANNEL_ID", raising=False)
+    monkeypatch.delenv("TELEGRAM_CHANNEL_ID", raising=False)
+    # _load_env 가 .env 를 읽어 토큰을 주입하지 못하도록 무력화.
+    monkeypatch.setattr(notifier, "_load_env", lambda: None)
+
+    conn = _root_conn()
+    notifier.notify_new_events(conn, mode="demo")  # 콜드스타트.
+    tracking.save_position(conn, _mk_position(tranche=0))
+
+    # 크래시 없이 완료해야 한다.
+    res = notifier.notify_new_events(conn, mode="demo")
+    assert res["entries"] == 1
+
+    out = capsys.readouterr().out
+    assert "새 진입" in out  # stdout 폴백으로 메시지가 출력됨.
+
+
+# ---------------------------------------------------------------------------
+# shadow 격리 — notifier 는 mode 인자대로만 동작 (runner 가 shadow 를 안 부름)
+# ---------------------------------------------------------------------------
+
+def test_mode_isolation_demo_only_reads_demo(captured):
+    """demo 마커 세팅 후 shadow 행을 넣어도 demo 알림에 안 섞인다."""
+    conn = _root_conn()
+    notifier.notify_new_events(conn, mode="demo")  # demo 콜드스타트.
+
+    # shadow 모드 포지션 — demo 알림과 무관해야 함.
+    tracking.save_position(conn, _mk_position(tranche=0, mode="shadow"))
+    res = notifier.notify_new_events(conn, mode="demo")
+
+    assert res["entries"] == 0
+    assert captured == []


### PR DESCRIPTION
진입/비중추가/청산 발생 시 즉시 텔레그램 알림. ID 마커 멱등, 콜드스타트 가드, 기존 발송 인프라 재사용. tests 250 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)