### PR TITLE
chore(prism-btc): market.db → btc_market.db 명칭 명확화

### DIFF
--- a/prism-btc/analysis/h1_signal_power.py
+++ b/prism-btc/analysis/h1_signal_power.py
@@ -24,7 +24,7 @@ from engine.regime import RegimeSnapshot
 from engine.config import ENTRY_SCORE_MIN
 from engine import config as cfg
 
-DB = Path(__file__).resolve().parents[1] / "state" / "market.db"
+DB = Path(__file__).resolve().parents[1] / "state" / "btc_market.db"
 ALL_TFS = ("30m", "1h", "4h", "12h", "1d", "1w")
 EVAL_TF = "4h"          # we evaluate the gate at each new confirmed 4h bar (live cadence)
 FWD_TF  = "1h"          # forward returns measured on 1h closes for resolution

--- a/prism-btc/analysis/h2_h3_truncation_cost.py
+++ b/prism-btc/analysis/h2_h3_truncation_cost.py
@@ -14,7 +14,7 @@ import pandas as pd
 import numpy as np
 
 ROOT = Path(__file__).resolve().parents[1]
-DB = ROOT / "state" / "market.db"
+DB = ROOT / "state" / "btc_market.db"
 RESULTS = ROOT / "backtest" / "results"
 # 3 clean periods (these CSVs are the authoritative round2/3 logs)
 CSVS = ["2022-01-01_to_2022-12-31_trades.csv",

--- a/prism-btc/collector/store.py
+++ b/prism-btc/collector/store.py
@@ -39,8 +39,9 @@ ON CONFLICT(timeframe, open_time) DO UPDATE SET
 def _get_db_path(db_path: str | Path | None = None) -> Path:
     if db_path is not None:
         return Path(db_path)
-    # Default: prism-btc/state/market.db relative to this file's package root
-    return Path(__file__).parent.parent / "state" / "market.db"
+    # Default: prism-btc/state/btc_market.db relative to this file's package root
+    # (비트코인 시세 원본 DB — 루트 stock_tracking_db.sqlite(거래/일지 장부)와 구분)
+    return Path(__file__).parent.parent / "state" / "btc_market.db"
 
 
 def get_connection(db_path: str | Path | None = None) -> sqlite3.Connection:

--- a/prism-btc/engine/config.py
+++ b/prism-btc/engine/config.py
@@ -78,4 +78,5 @@ BYBIT_SLEEP_BETWEEN_REQUESTS: float = 0.12  # seconds
 BACKFILL_START_MS: int = 1577836800000  # 2020-01-01 00:00:00 UTC
 
 # SQLite path (relative to prism-btc/ package root)
-DB_RELATIVE_PATH: str = "state/market.db"
+# 비트코인 시세 원본 DB (거래/일지 장부인 루트 stock_tracking_db.sqlite 와 구분).
+DB_RELATIVE_PATH: str = "state/btc_market.db"

--- a/prism-btc/tests/test_backtest.py
+++ b/prism-btc/tests/test_backtest.py
@@ -196,7 +196,7 @@ class TestNoLookaheadRealDB:
 
     def _db_path(self):
         from pathlib import Path
-        p = Path(__file__).resolve().parent.parent / "state" / "market.db"
+        p = Path(__file__).resolve().parent.parent / "state" / "btc_market.db"
         return p
 
     def test_no_unclosed_upper_tf_candle_in_snapshot(self):


### PR DESCRIPTION
비트코인 시세 DB를 btc_market.db 로 rename — 루트 거래장부 DB와 구분. 코드 5곳 갱신, tests 250 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)