### PR TITLE
feat: auto-inject KIS status code for event-driven exit (TIER0)

### DIFF
--- a/cores/corporate_status.py
+++ b/cores/corporate_status.py
@@ -105,3 +105,34 @@ def check_event_exit(
             return True, reason
 
     return False, ""
+
+
+async def fetch_status_codes(tickers, account_name: Optional[str] = None) -> dict:
+    """보유종목들의 KIS 종목상태코드(iscd_stat_cls_code)를 일괄 조회.
+
+    KIS 토큰 발급 레이트리밋을 피하려고 **AsyncTradingContext를 1회만** 열고
+    종목별 시세조회(quotation, 계좌 무관)로 상태코드만 수집한다.
+    어떤 단계가 실패해도(자격증명 없음/네트워크/레이트리밋) 절대 예외를 올리지
+    않고, 가능한 만큼만 채운 dict를 반환한다(override 경로는 독립적으로 동작).
+
+    Returns: { ticker: "iscd_stat_cls_code" }  (조회 실패 종목은 누락)
+    """
+    import asyncio
+
+    out: dict = {}
+    uniq = [str(t).strip() for t in (tickers or []) if str(t or "").strip()]
+    if not uniq:
+        return out
+    try:
+        from trading.domestic_stock_trading import AsyncTradingContext
+        async with AsyncTradingContext(account_name=account_name) as trading:
+            for t in uniq:
+                try:
+                    info = await asyncio.to_thread(trading.get_current_price, t)
+                    if info:
+                        out[t] = str(info.get("iscd_stat_cls_code", "") or "")
+                except Exception as e:  # 개별 종목 실패는 건너뜀
+                    logger.warning(f"{t} KIS 상태코드 조회 실패: {e}")
+    except Exception as e:  # 컨텍스트/자격증명 실패 → 전체 스킵(안전)
+        logger.warning(f"KIS 상태코드 prefetch 스킵: {e}")
+    return out

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -1304,6 +1304,19 @@ class StockTrackingAgent:
 
             sold_stocks = []
 
+            # 이벤트 강제청산 자동탐지: 사이클당 1회 KIS 종목상태코드 일괄 prefetch.
+            # (관리종목/투자위험/거래정지 자동 포착 → _analyze_sell_decision의 TIER0.)
+            # 실패해도 override 경로는 독립 동작하므로 빈 dict로 안전 폴백.
+            kis_status_map: Dict[str, str] = {}
+            try:
+                from cores.corporate_status import fetch_status_codes
+                kis_status_map = await fetch_status_codes(
+                    [h.get("ticker") for h in holdings],
+                    account_name=holdings[0].get("account_name") if holdings else None,
+                )
+            except Exception as e:
+                logger.warning(f"KIS status prefetch skipped: {e}")
+
             # Pyramiding (#288) FIX 2 — in-pass over-sell guard:
             # When several rows of the SAME ticker sell within one update pass,
             # limit/reserved orders may not have filled yet, so re-reading the
@@ -1329,6 +1342,9 @@ class StockTrackingAgent:
 
                 # Update stock price information
                 stock['current_price'] = current_price
+
+                # 이벤트 자동탐지용 KIS 종목상태코드 주입(TIER0가 _analyze_sell_decision에서 사용)
+                stock['_kis_stat_code'] = kis_status_map.get(ticker)
 
                 # Check scenario JSON string
                 scenario_str = stock.get('scenario', '{}')

--- a/tests/test_corporate_status.py
+++ b/tests/test_corporate_status.py
@@ -63,3 +63,71 @@ def test_missing_file_is_safe(tmp_path, monkeypatch):
 def test_empty_ticker():
     ok, _ = cs.check_event_exit("", market="KR")
     assert ok is False
+
+
+# ── fetch_status_codes (KIS 상태코드 일괄 prefetch) ─────────────────
+import asyncio
+import sys
+import types
+
+
+class _FakeTrader:
+    def __init__(self, mapping):
+        self._m = mapping
+
+    def get_current_price(self, ticker):
+        if ticker in self._m:
+            return {"current_price": 1, "iscd_stat_cls_code": self._m[ticker]}
+        return None
+
+
+class _FakeCtx:
+    def __init__(self, mapping):
+        self._t = _FakeTrader(mapping)
+
+    async def __aenter__(self):
+        return self._t
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _BoomCtx:
+    async def __aenter__(self):
+        raise RuntimeError("no credentials")
+
+    async def __aexit__(self, *a):
+        return False
+
+
+def _install_fake_trading(monkeypatch, mapping=None, boom=False):
+    parent = types.ModuleType("trading")
+    sub = types.ModuleType("trading.domestic_stock_trading")
+    sub.AsyncTradingContext = (lambda *a, **k: _BoomCtx()) if boom else (lambda *a, **k: _FakeCtx(mapping or {}))
+    parent.domestic_stock_trading = sub
+    monkeypatch.setitem(sys.modules, "trading", parent)
+    monkeypatch.setitem(sys.modules, "trading.domestic_stock_trading", sub)
+
+
+def test_fetch_status_codes_ok(monkeypatch):
+    _install_fake_trading(monkeypatch, {"012510": "58", "000660": "00"})
+    out = asyncio.run(cs.fetch_status_codes(["012510", "000660", "  ", ""]))
+    assert out == {"012510": "58", "000660": "00"}
+
+
+def test_fetch_status_codes_context_failure_safe(monkeypatch):
+    _install_fake_trading(monkeypatch, boom=True)
+    out = asyncio.run(cs.fetch_status_codes(["012510"]))
+    assert out == {}  # 예외 없이 빈 dict
+
+
+def test_fetch_status_codes_empty_input():
+    assert asyncio.run(cs.fetch_status_codes([])) == {}
+
+
+def test_fetch_then_classify_integration(monkeypatch):
+    # prefetch로 받은 코드를 check_event_exit에 주입하면 자동 강제청산
+    _install_fake_trading(monkeypatch, {"000660": "58"})  # 거래정지
+    out = asyncio.run(cs.fetch_status_codes(["000660"]))
+    ok, reason = cs.check_event_exit("000660", kis_status_code=out.get("000660"), market="KR")
+    assert ok is True and "KIS_STATUS" in reason

--- a/trading/domestic_stock_trading.py
+++ b/trading/domestic_stock_trading.py
@@ -268,7 +268,11 @@ class DomesticStockTrading:
                     'stock_name': data.get('rprs_mrkt_kor_name', ''),
                     'current_price': int(data.get('stck_prpr', 0)),  # Current price
                     'change_rate': float(data.get('prdy_ctrt', 0)),  # Change rate from previous day
-                    'volume': int(data.get('acml_vol', 0))  # Cumulative volume
+                    'volume': int(data.get('acml_vol', 0)),  # Cumulative volume
+                    # 종목상태/시장경고 (이벤트 강제청산 자동탐지용 — cores.corporate_status)
+                    # iscd_stat_cls_code: 00/55 정상, 51 관리종목, 52 투자위험, 53 투자경고, 58 거래정지
+                    'iscd_stat_cls_code': data.get('iscd_stat_cls_code', ''),
+                    'mrkt_warn_cls_code': data.get('mrkt_warn_cls_code', ''),  # 00 없음/01 주의/02 경고/03 위험
                 }
 
                 logger.info(f"[{stock_code}] Current price: {result['current_price']:,} KRW ({result['change_rate']:+.2f}%)")


### PR DESCRIPTION
## 목적
이벤트 강제청산(TIER0, PR #330)의 **자동탐지**를 켠다. 매 매도평가 사이클이 보유종목의 KIS 종목상태코드(`iscd_stat_cls_code`)를 자동 수집해, 관리종목(51)·투자위험(52)·거래정지(58)면 사람 개입 없이 강제청산. override 목록(`event_force_exit.json`)은 KIS가 안 잡는 자진상폐·공개매수용으로 계속 병행.

## 변경 (KIS 주문/시그널/구독자 무수정)
- `get_current_price`: `iscd_stat_cls_code`/`mrkt_warn_cls_code` 가산 반환(무파괴)
- `cores/corporate_status.fetch_status_codes`: **AsyncTradingContext 1회만** 열어 전 종목 시세조회로 상태코드 일괄 수집. 토큰 레이트리밋 회피. 모든 실패를 흡수해 `{}` 반환(override 경로 독립, 안전 degrade)
- `update_holdings`: 사이클당 1회 prefetch → 종목별 `_kis_stat_code` 주입 → 기존 TIER0가 자동 사용

## 안전성
- KIS 자격증명/네트워크/필드명 문제 시 → 빈 dict로 degrade(자동탐지만 비활성, override·기존 매도로직 정상). false-trigger 없음(정상코드 00/55는 미발동).

## 검증
- 단위테스트 11건 통과(override/KIS분류/fetch 정상·실패·빈입력·통합). py_compile OK(3파일).
- 배포 후 db-server 실계좌로 `fetch_status_codes` 라이브 확인 예정.

## 범위
KR 한정. US 동형/거래정지 재시도 일관성/매수 게이트는 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)