### PR TITLE
feat: news-aware sell decision (autonomous corporate-event exit)

### DIFF
--- a/cores/agents/trading_agents.py
+++ b/cores/agents/trading_agents.py
@@ -694,6 +694,22 @@ def create_sell_decision_agent(language: str = "ko"):
 
         ### Priority 0: Core Principles for Sell Judgement (MUST follow)
 
+        **Core-0) Corporate-Event Check First (news-driven forced exit):**
+        - On EVERY decision, FIRST use the perplexity tool to search recent news for this stock
+          (company name + ticker) and check for a "holding-is-dangerous" corporate event:
+          delisting (voluntary/administrative), public tender offer, liquidation trading (정리매매),
+          trading halt/suspension, audit opinion refusal/qualification, listing-eligibility review,
+          or delisting due to merger/share swap.
+        - If such an event is confirmed with **clear evidence (filing / multiple reports, date & source)**,
+          set **should_sell = true (full exit)** regardless of price/trend/PnL, and prefix sell_reason with
+          `[CORP_EVENT]` plus the event type and evidence (source/date).
+          (E.g. when the price is pinned at a tender-offer price no technical signal fires, but you must
+           exit before delisting to keep liquidity and avoid being stuck with unlisted shares.)
+        - **If only an unconfirmed rumor / single speculative article exists, do NOT sell**; hold and note
+          "event suspected (unconfirmed)" in sell_reason. Force-sell ONLY on clear evidence (confirmed
+          filing or multiple credible reports) — be precise so a healthy stock is never sold by mistake.
+        - If no event, proceed normally with Core-1~4 technical judgement below.
+
         **Core-1) Closing-Price Rule:**
         - All stop_loss and trailing-stop judgements are based on the **closing price**.
         - An intraday low that briefly touches stop_loss (intraday wick) is NEVER a sell reason on its own.
@@ -889,6 +905,21 @@ def create_sell_decision_agent(language: str = "ko"):
         → **약세장/횡보장**: 위 조건 미충족
 
         ### 0순위: 매도 판단의 핵심 원칙 (반드시 준수)
+
+        **핵심-0) 법인 이벤트 최우선 점검 (뉴스 기반 강제청산):**
+        - 매 판단 시 **반드시 먼저** perplexity 도구로 해당 종목(회사명 + 종목코드)의 최신 뉴스를 검색하여
+          '보유 지속이 위험한 법인 이벤트'가 있는지 확인하십시오. 대상 이벤트:
+          상장폐지(자진/관리종목)·공개매수(tender offer)·정리매매·매매거래정지·
+          감사의견 거절/한정·상장적격성 실질심사·합병/주식교환으로 인한 상장폐지.
+        - 이런 이벤트가 **명확한 근거(공시/복수 보도, 날짜·출처)** 와 함께 확인되면, 가격·추세·수익률과
+          무관하게 **should_sell = true (전량 매도)** 로 판단하고, sell_reason 맨 앞에 `[법인이벤트]`와
+          이벤트 유형·근거(출처/날짜)를 명시하십시오.
+          (예: 공개매수가에 주가가 고정되면 기술적 매도 신호가 안 나오지만, 상장폐지 전에 청산해야
+           비상장 전환으로 묶이지 않고 유동성을 확보할 수 있습니다.)
+        - **단, 미확정 루머·추측성 단독 기사만 있을 때는 매도하지 말고** 보유하되 sell_reason에
+          "이벤트 의심(미확정)"으로 기록하십시오. 확정 공시 또는 복수 신뢰 보도 등 명확한 근거가 있을 때만
+          강제 매도합니다 (오탐으로 멀쩡한 종목을 팔지 않도록 정밀하게 판단).
+        - 이벤트가 없으면 아래 핵심-1~4의 기술적 판단을 정상 진행하십시오.
 
         **핵심-1) 종가 기준 (Closing-Price Rule):**
         - 모든 손절가·trailing stop 판단은 **종가(closing price)** 기준입니다.

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -796,6 +796,23 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
             target_price = stock_data.get('target_price', 0)
             stop_loss = stock_data.get('stop_loss', 0)
 
+            # ── TIER0: 법인 이벤트 강제청산 (AI 판단 이전, 결정론 안전망) ──────
+            # KIS 관리종목(51) 자동탐지 + (선택)override 목록. AI 매도 프롬프트의
+            # 핵심-0 뉴스 판단이 놓쳐도 명백한 부실/등록 건은 여기서 확정 청산한다.
+            # _kis_stat_code는 update_holdings가 사이클당 주입 → 운영자 개입 불필요.
+            try:
+                from cores.corporate_status import check_event_exit
+                ev_sell, ev_reason = check_event_exit(
+                    ticker,
+                    kis_status_code=stock_data.get("_kis_stat_code"),
+                    market="KR",
+                )
+                if ev_sell:
+                    logger.warning(f"{ticker} TIER0 event force-exit: {ev_reason}")
+                    return True, ev_reason
+            except Exception as e:
+                logger.warning(f"{ticker} TIER0 event check skipped: {e}")
+
             # Calculate profit rate
             profit_rate = ((current_price - buy_price) / buy_price) * 100
 


### PR DESCRIPTION
## 목적
override(수동 리스트) 의존 제거. **프로덕션 LLM 매도 에이전트가 perplexity로 뉴스를 자율 판단**해 상폐/공개매수류 이벤트를 사람 개입 없이 매도.

## 변경
- **매도 프롬프트(ko+en) 핵심-0 추가**: 매 판단 시 perplexity로 보유종목 뉴스 점검 → 상장폐지/공개매수/정리매매/거래정지/감사의견거절/합병상폐가 **명확한 근거(공시·복수보도)** 와 함께 확인되면 가격·추세 무관 `should_sell=true`([법인이벤트]). 미확정 루머는 매도 금지(오탐 방지).
- **결정론 TIER0를 실제 프로덕션 메서드(`EnhancedStockTrackingAgent._analyze_sell_decision`)로 이전**: 기존 TIER0는 부모클래스에 있어 오버라이드로 **무력화**돼 있었음(버그). KIS 관리종목(51)+override를 AI 판단 이전 안전망으로. 전부 자동, 수동 리스트 불필요.

## 효과
더존(012510) 자진상폐(KIS코드 57로 자동탐지 안 됨)를 **운영자 리스트 없이 뉴스로 자율 포착**.

## 검증
corporate_status 단위테스트 11건 통과, py_compile OK(3파일). prompt-rule는 db-server(mcp_agent)에서 스모크 검증 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)