### PR TITLE
fix: add perplexity tool to sell_decision_agent (Core-0 news check)

### DIFF
--- a/cores/agents/trading_agents.py
+++ b/cores/agents/trading_agents.py
@@ -1098,5 +1098,6 @@ def create_sell_decision_agent(language: str = "ko"):
     return Agent(
         name="sell_decision_agent",
         instruction=instruction,
-        server_names=["kospi_kosdaq", "sqlite", "time"]
+        # perplexity: 핵심-0 법인 이벤트(상폐/공개매수 등) 뉴스 자율 점검에 필요
+        server_names=["kospi_kosdaq", "sqlite", "time", "perplexity"]
     )


### PR DESCRIPTION
핵심-0 뉴스 점검이 작동하려면 매도 에이전트에 perplexity 도구가 필요한데 누락돼 있었음(server_names에 없음). 추가. perplexity MCP는 매수 에이전트가 이미 db-server에서 사용 중이라 안전.

🤖 Generated with [Claude Code](https://claude.com/claude-code)