### PR TITLE
fix: Core-0 decisive on tender offer / voluntary delisting

### DIFF
--- a/cores/agents/trading_agents.py
+++ b/cores/agents/trading_agents.py
@@ -695,19 +695,21 @@ def create_sell_decision_agent(language: str = "ko"):
         ### Priority 0: Core Principles for Sell Judgement (MUST follow)
 
         **Core-0) Corporate-Event Check First (news-driven forced exit):**
-        - On EVERY decision, FIRST use the perplexity tool to search recent news for this stock
-          (company name + ticker) and check for a "holding-is-dangerous" corporate event:
-          delisting (voluntary/administrative), public tender offer, liquidation trading (정리매매),
-          trading halt/suspension, audit opinion refusal/qualification, listing-eligibility review,
-          or delisting due to merger/share swap.
-        - If such an event is confirmed with **clear evidence (filing / multiple reports, date & source)**,
-          set **should_sell = true (full exit)** regardless of price/trend/PnL, and prefix sell_reason with
-          `[CORP_EVENT]` plus the event type and evidence (source/date).
-          (E.g. when the price is pinned at a tender-offer price no technical signal fires, but you must
-           exit before delisting to keep liquidity and avoid being stuck with unlisted shares.)
-        - **If only an unconfirmed rumor / single speculative article exists, do NOT sell**; hold and note
-          "event suspected (unconfirmed)" in sell_reason. Force-sell ONLY on clear evidence (confirmed
-          filing or multiple credible reports) — be precise so a healthy stock is never sold by mistake.
+        - On EVERY decision, FIRST use the perplexity tool with **specific keyword queries**:
+          `"<company> tender offer"`, `"<company> delisting OR voluntary delisting"`,
+          `"<company> liquidation trading OR trading halt"` (company + ticker + 2026). Run 2+ queries for recall.
+        - **If ANY of these is officially confirmed = SELL trigger (even if the final delisting DATE is not set):**
+          (1) **public tender offer announced/ongoing** (acquirer & offer price stated)
+          (2) **voluntary delisting in progress** (delisting criteria met / board resolution / going-private)
+          (3) liquidation-trading schedule / trading halt / exchange delisting decision / eligibility review
+          (4) administrative-issue designation / audit-opinion refusal / merger-driven delisting
+          → set **should_sell = true (full exit)**, prefix sell_reason with `[CORP_EVENT]` + type & evidence.
+          **Why: while a tender offer / voluntary delisting is in progress the price is pinned at the offer
+          price (no upside, target unreachable) and failing to exit before delisting locks your capital in
+          unlisted shares. This is NOT a rumor — it is a confirmed event.**
+        - **Hold ONLY when it is just an unconfirmed single-source 'acquisition/merger rumor' or the company
+          denied it.** Do NOT defer an officially announced tender offer / voluntary delisting on the grounds
+          that "the final delisting date is unconfirmed" — that already qualifies as confirmed.
         - If no event, proceed normally with Core-1~4 technical judgement below.
 
         **Core-1) Closing-Price Rule:**
@@ -907,18 +909,20 @@ def create_sell_decision_agent(language: str = "ko"):
         ### 0순위: 매도 판단의 핵심 원칙 (반드시 준수)
 
         **핵심-0) 법인 이벤트 최우선 점검 (뉴스 기반 강제청산):**
-        - 매 판단 시 **반드시 먼저** perplexity 도구로 해당 종목(회사명 + 종목코드)의 최신 뉴스를 검색하여
-          '보유 지속이 위험한 법인 이벤트'가 있는지 확인하십시오. 대상 이벤트:
-          상장폐지(자진/관리종목)·공개매수(tender offer)·정리매매·매매거래정지·
-          감사의견 거절/한정·상장적격성 실질심사·합병/주식교환으로 인한 상장폐지.
-        - 이런 이벤트가 **명확한 근거(공시/복수 보도, 날짜·출처)** 와 함께 확인되면, 가격·추세·수익률과
-          무관하게 **should_sell = true (전량 매도)** 로 판단하고, sell_reason 맨 앞에 `[법인이벤트]`와
-          이벤트 유형·근거(출처/날짜)를 명시하십시오.
-          (예: 공개매수가에 주가가 고정되면 기술적 매도 신호가 안 나오지만, 상장폐지 전에 청산해야
-           비상장 전환으로 묶이지 않고 유동성을 확보할 수 있습니다.)
-        - **단, 미확정 루머·추측성 단독 기사만 있을 때는 매도하지 말고** 보유하되 sell_reason에
-          "이벤트 의심(미확정)"으로 기록하십시오. 확정 공시 또는 복수 신뢰 보도 등 명확한 근거가 있을 때만
-          강제 매도합니다 (오탐으로 멀쩡한 종목을 팔지 않도록 정밀하게 판단).
+        - 매 판단 시 **반드시 먼저** perplexity 도구로 다음과 같이 **구체적 키워드**로 검색하십시오:
+          `"<회사명> 공개매수"`, `"<회사명> 자진상장폐지 OR 상장폐지"`, `"<회사명> 정리매매 OR 거래정지"`
+          (회사명 + 종목코드 + 2026). 최소 2개 쿼리 이상 시도해 recall을 확보할 것.
+        - **다음 중 하나라도 공식 확인되면 = 매도 트리거(최종 상폐일이 미정이어도 매도):**
+          ① **공개매수(tender offer) 공식 발표/진행** (인수자·공개매수가 명시)
+          ② **자진상장폐지 추진** (자진상폐 요건 충족·이사회 결의·완전자회사화 등)
+          ③ 정리매매 일정 공시 / 매매거래정지 / 거래소 상장폐지 결정·상장적격성 실질심사
+          ④ 관리종목 지정 / 감사의견 거절·한정 / 합병·주식교환으로 인한 상장폐지
+          → **should_sell = true (전량 매도)**, sell_reason 맨 앞에 `[법인이벤트]` + 유형·근거(출처/날짜).
+          **이유: 공개매수·자진상폐가 진행 중이면 주가는 공개매수가에 고정되어 상승 여력이 없고(목표가 도달 불가),
+          상폐 전 청산하지 않으면 비상장 전환으로 자금이 묶인다. 이는 '루머'가 아니라 확정 이벤트다.**
+        - **보류(보유)는 오직 회사가 부인했거나 '인수설/합병설' 수준의 미확인 단일 추측 기사뿐일 때만.**
+          공식 발표된 공개매수·자진상폐를 "최종 상폐일 미확정"이라는 이유로 미루지 말 것 — 그건 이미 확정 사유다.
+          (단순 추측만 있으면 "이벤트 의심(미확정)"으로 기록하고 보유.)
         - 이벤트가 없으면 아래 핵심-1~4의 기술적 판단을 정상 진행하십시오.
 
         **핵심-1) 종가 기준 (Closing-Price Rule):**

--- a/prism-us/cores/agents/trading_agents.py
+++ b/prism-us/cores/agents/trading_agents.py
@@ -710,16 +710,18 @@ def create_us_sell_decision_agent(language: str = "ko"):
 ### 0순위: 매도 판단의 핵심 원칙 (반드시 준수)
 
 **핵심-0) 법인 이벤트 최우선 점검 (뉴스 기반 강제청산):**
-- 매 판단 시 **반드시 먼저** perplexity 도구로 해당 종목(회사명 + 티커)의 최신 영문 뉴스를 검색하여
-  '보유 지속이 위험한 법인 이벤트'가 있는지 확인하십시오. 대상 이벤트:
-  상장폐지(delisting)·공개매수/비공개전환(tender offer / going private)·파산(Chapter 11)·
-  거래소 상장요건 미달 퇴출(NYSE/Nasdaq compliance delisting)·SEC 등록취소(Form 25)·
-  합병/피인수 완료로 인한 상장폐지.
-- 이런 이벤트가 **명확한 근거(공시/복수 보도, 날짜·출처)** 와 함께 확인되면, 가격·추세·수익률과
-  무관하게 **should_sell = true (전량 매도)** 로 판단하고, sell_reason 맨 앞에 `[법인이벤트]`와
-  이벤트 유형·근거(출처/날짜)를 명시하십시오.
-- **단, 미확정 루머·추측성 단독 기사만 있을 때는 매도하지 말고** 보유하되 "이벤트 의심(미확정)"으로
-  기록하십시오. 확정 공시 또는 복수 신뢰 보도 등 명확한 근거가 있을 때만 강제 매도합니다(오탐 방지).
+- 매 판단 시 **반드시 먼저** perplexity 도구로 **구체적 키워드**로 영문 검색하십시오:
+  `"<company> tender offer OR going private"`, `"<company> delisting"`,
+  `"<company> bankruptcy OR Chapter 11 OR SEC deregistration"` (회사명 + 티커 + 2026). 최소 2개 쿼리.
+- **다음 중 하나라도 공식 확인되면 = 매도 트리거(최종 상폐일 미정이어도 매도):**
+  ① **공개매수/비공개전환(tender offer / going-private) 공식 발표·진행** (인수자·가격 명시)
+  ② 거래소 상장요건 미달 퇴출(NYSE/Nasdaq compliance delisting) / SEC 등록취소(Form 25)
+  ③ 파산(Chapter 11) / 합병·피인수 완료로 인한 상장폐지 / 거래정지
+  → **should_sell = true (전량 매도)**, sell_reason 맨 앞에 `[법인이벤트]` + 유형·근거(출처/날짜).
+  **이유: 공개매수/비공개전환 진행 중이면 주가가 인수가에 고정되어 상승 여력이 없고, 상폐 전 청산하지
+  않으면 비상장 전환으로 자금이 묶인다. 공식 발표된 건은 '루머'가 아니라 확정 이벤트다.**
+- **보류(보유)는 오직 회사가 부인했거나 '인수설/합병설' 수준의 미확인 단일 추측 기사뿐일 때만.**
+  공식 발표된 tender offer/going-private를 "최종 상폐일 미확정"을 이유로 미루지 말 것 — 이미 확정 사유다.
 - 이벤트가 없으면 아래 핵심-1~4의 기술적 판단을 정상 진행하십시오.
 
 **핵심-1) 종가 기준 (Closing-Price Rule):**
@@ -921,16 +923,20 @@ You are a professional analyst specializing in sell timing decisions for US stoc
 ### Priority 0: Core Principles for Sell Judgement (MUST follow)
 
 **Core-0) Corporate-Event Check First (news-driven forced exit):**
-- On EVERY decision, FIRST use the perplexity tool to search recent news for this stock
-  (company name + ticker) and check for a "holding-is-dangerous" corporate event:
-  delisting, tender offer / going-private, bankruptcy (Chapter 11), exchange compliance
-  delisting (NYSE/Nasdaq), SEC deregistration (Form 25), or delisting due to merger/acquisition.
-- If such an event is confirmed with **clear evidence (filing / multiple reports, date & source)**,
-  set **should_sell = true (full exit)** regardless of price/trend/PnL, and prefix sell_reason with
-  `[CORP_EVENT]` plus the event type and evidence (source/date).
-- **If only an unconfirmed rumor / single speculative article exists, do NOT sell**; hold and note
-  "event suspected (unconfirmed)". Force-sell ONLY on clear evidence (confirmed filing or multiple
-  credible reports) — be precise so a healthy stock is never sold by mistake.
+- On EVERY decision, FIRST use the perplexity tool with **specific keyword queries**:
+  `"<company> tender offer OR going private"`, `"<company> delisting"`,
+  `"<company> bankruptcy OR Chapter 11 OR SEC deregistration"` (company + ticker + 2026). Run 2+ queries.
+- **If ANY of these is officially confirmed = SELL trigger (even if the final delisting DATE is not set):**
+  (1) **tender offer / going-private announced or ongoing** (acquirer & price stated)
+  (2) exchange compliance delisting (NYSE/Nasdaq) / SEC deregistration (Form 25)
+  (3) bankruptcy (Chapter 11) / merger-driven delisting / trading halt
+  → set **should_sell = true (full exit)**, prefix sell_reason with `[CORP_EVENT]` + type & evidence.
+  **Why: while a tender offer / going-private is in progress the price is pinned at the offer price (no
+  upside) and not exiting before delisting locks your capital in unlisted shares. An officially announced
+  deal is NOT a rumor — it is a confirmed event.**
+- **Hold ONLY when it is just an unconfirmed single-source 'acquisition/merger rumor' or the company denied
+  it.** Do NOT defer an officially announced tender offer / going-private because "the final delisting date
+  is unconfirmed" — that already qualifies as confirmed.
 - If no event, proceed normally with Core-1~4 technical judgement below.
 
 **Core-1) Closing-Price Rule:**


### PR DESCRIPTION
라이브 로그(더존 012510, 06-16): 핵심-0 뉴스 점검은 작동했으나 LLM이 EQT 공개매수/자진상폐를 '최종 상폐일 미확정'으로 보고 보유 → 가드가 과보수. 확정 케이스인데 못 팜.

강화(KR+US, 한/영): 구체 perplexity 쿼리(공개매수/상폐/정리매매 2개+), 공식 발표·진행 중인 공개매수/자진상폐는 최종 상폐일 미정이어도 매도 트리거로 명시, 보류는 회사부인/단일 추측설일 때만.

검증: py_compile 2파일 OK. 배포 후 다음 사이클 로그로 더존 매도 확인 예정.

Generated with Claude Code