### PR TITLE
fix: harden sell final-check against transient empty portfolio reads

### DIFF
--- a/trading/domestic_stock_trading.py
+++ b/trading/domestic_stock_trading.py
@@ -1395,10 +1395,37 @@ class DomesticStockTrading:
                             result['current_price'] = current_price_info['current_price']
                             logger.info(f"[Async Sell API] {stock_code} current price: {current_price_info['current_price']:,} KRW")
 
-                        # Defensive logic 2: Check holding quantity once more before selling
-                        holding_quantity = await asyncio.to_thread(
-                            self.get_holding_quantity, stock_code
-                        )
+                        # Defensive logic 2: Re-confirm holding quantity once more before selling.
+                        # ⚠️ get_portfolio() returns [] on a transient balance-inquiry failure, so a
+                        # single re-check could read a FALSE 0 and abort a legitimate sell (sim already
+                        # deleted the row -> sim/real divergence). Distinguish "empty portfolio (likely
+                        # API failure)" from "ticker genuinely absent (sold)": retry on empty, and only
+                        # then fall back to the quantity confirmed by the FIRST portfolio read above.
+                        prev_confirmed_qty = int(target_stock.get('quantity', 0) or 0)
+                        holding_quantity = 0
+                        for _chk_attempt in range(3):
+                            portfolio_recheck = await asyncio.to_thread(self.get_portfolio)
+                            if portfolio_recheck:  # non-empty -> trustworthy snapshot
+                                _match = next(
+                                    (s for s in portfolio_recheck if s.get('stock_code') == stock_code),
+                                    None
+                                )
+                                holding_quantity = int(_match['quantity']) if _match else 0
+                                break
+                            # empty list -> almost certainly a transient API failure, NOT a real 0
+                            logger.warning(
+                                f"[Async Sell API] {stock_code} portfolio empty on final check "
+                                f"(attempt {_chk_attempt + 1}/3) — retrying"
+                            )
+                            await asyncio.sleep(1.0)
+                        else:
+                            # all retries returned empty -> treat as API failure, not 0 holdings;
+                            # fall back to the first-confirmed quantity so a valid sell is not dropped.
+                            holding_quantity = prev_confirmed_qty
+                            logger.warning(
+                                f"[Async Sell API] {stock_code} final check kept returning empty portfolio "
+                                f"— falling back to first-confirmed qty {prev_confirmed_qty}"
+                            )
 
                         if holding_quantity <= 0:
                             result['message'] = f'{stock_code} holding quantity is 0 at final check'


### PR DESCRIPTION
테크윙(089030) 06-16: 기계적 손절 발동·시뮬 매도됐으나 KIS는 'holding quantity is 0 at final check'로 주문 중단(직전엔 17주 확인) → 시뮬↔실 불일치.

원인: 방어로직2가 get_holding_quantity→get_portfolio 재호출, get_portfolio는 일시적 잔고조회 실패 시 [] 반환 → false 0으로 정상 매도 드롭.

수정(_execute_sell_stock): 최종 재확인에서 '빈 포트폴리오(API 실패 의심)'와 '종목 없음(매도됨)'을 구분. 빈 응답이면 3회 재시도, 그래도 비면 1차 확인 수량으로 진행. 비어있지 않은데 종목 없으면 기존대로 abort(과매도 방지).

검증: py_compile OK.

Generated with Claude Code