### PR TITLE
fix(us): 18:00 포트폴리오 시즌수익 정산일관 총자산으로 계산

### DIFF
--- a/prism-us/tests/test_us_account_total_asset.py
+++ b/prism-us/tests/test_us_account_total_asset.py
@@ -1,0 +1,106 @@
+"""Unit tests for US get_account_summary settlement-coherent total asset.
+
+Regression guard for the 18:00 portfolio season-return bug: summing a real-time
+stock eval against the settlement-lagged USD deposit (frcr_dncl_amt_2) made the
+season return see-saw. get_account_summary must instead expose KIS-computed
+tot_asst_amt (KRW) as total_asset_usd = tot_asst_amt / exchange_rate.
+"""
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+_HERE = os.path.dirname(__file__)
+_ROOT = os.path.abspath(os.path.join(_HERE, "..", ".."))
+# kis_auth and shared modules live in the root trading/ dir (US runtime puts it on path).
+sys.path.insert(0, os.path.join(_ROOT, "trading"))
+sys.path.insert(0, os.path.join(_ROOT, "prism-us", "trading"))
+import us_stock_trading as ust  # noqa: E402
+
+
+class _FakeBody:
+    def __init__(self, output2, output3):
+        self.output2 = output2
+        self.output3 = output3
+
+
+class _FakeRes:
+    def __init__(self, output2, output3, ok=True):
+        self._body = _FakeBody(output2, output3)
+        self._ok = ok
+
+    def isOK(self):
+        return self._ok
+
+    def getBody(self):
+        return self._body
+
+    def getErrorCode(self):
+        return "ERR"
+
+    def getErrorMessage(self):
+        return "boom"
+
+
+def _make_trader(res, portfolio):
+    trader = ust.USStockTrading.__new__(ust.USStockTrading)
+    trader.trenv = SimpleNamespace(my_acct="123", my_prod="01")
+    trader._request = lambda *a, **k: res
+    trader.get_portfolio = lambda: portfolio
+    return trader
+
+
+_USD_ROW = {
+    "crcy_cd": "USD",
+    "frcr_dncl_amt_2": "2640.910000",   # settlement-lagged deposit
+    "frst_bltn_exrt": "1513.50000000",
+}
+_PORTFOLIO = [
+    {"eval_amount": 8709.0, "profit_amount": 342.0, "avg_price": 100.0, "quantity": 83},
+]
+
+
+def test_total_asset_usd_uses_kis_total_not_eval_plus_cash():
+    # KIS total asset (KRW) includes stock + USD cash + KRW deposit + unsettled.
+    output3 = {"tot_asst_amt": "20925371"}
+    trader = _make_trader(_FakeRes([_USD_ROW], output3), _PORTFOLIO)
+
+    summary = trader.get_account_summary()
+
+    assert summary is not None
+    # 20,925,371 / 1513.5 ~= 13825.95, NOT eval+cash (8709 + 2640.91 = 11349.91)
+    assert summary["total_asset_usd"] == pytest.approx(20925371 / 1513.5, abs=0.01)
+    assert summary["total_asset_usd"] > summary["total_eval_amount"] + summary["usd_cash"]
+    assert summary["usd_cash"] == pytest.approx(2640.91, abs=0.01)
+
+
+def test_total_asset_usd_handles_output3_as_list():
+    output3 = [{"tot_asst_amt": "20925371"}]
+    trader = _make_trader(_FakeRes([_USD_ROW], output3), _PORTFOLIO)
+
+    summary = trader.get_account_summary()
+
+    assert summary["total_asset_usd"] == pytest.approx(20925371 / 1513.5, abs=0.01)
+
+
+def test_total_asset_usd_falls_back_to_zero_when_missing():
+    # Missing tot_asst_amt -> total_asset_usd 0 so callers fall back to eval+cash.
+    trader = _make_trader(_FakeRes([_USD_ROW], {}), _PORTFOLIO)
+
+    summary = trader.get_account_summary()
+
+    assert summary["total_asset_usd"] == 0.0
+
+
+def test_total_asset_usd_zero_when_no_exchange_rate():
+    usd_row = {"crcy_cd": "USD", "frcr_dncl_amt_2": "2640.91", "frst_bltn_exrt": "0"}
+    trader = _make_trader(_FakeRes([usd_row], {"tot_asst_amt": "20925371"}), _PORTFOLIO)
+
+    summary = trader.get_account_summary()
+
+    assert summary["total_asset_usd"] == 0.0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/prism-us/trading/us_stock_trading.py
+++ b/prism-us/trading/us_stock_trading.py
@@ -1731,6 +1731,17 @@ class USStockTrading:
                             exchange_rate = _safe_float(item.get('frst_bltn_exrt'))
                             break
 
+                # KIS-computed total account asset (KRW). This is settlement-coherent:
+                # it already includes stock eval + USD cash + KRW deposit + net unsettled
+                # trade proceeds. Using it avoids the see-saw caused by summing a real-time
+                # stock eval against a settlement-lagged USD deposit (frcr_dncl_amt_2).
+                o3 = output3
+                if isinstance(o3, list):
+                    o3 = o3[0] if o3 else {}
+                o3 = o3 if isinstance(o3, dict) else {}
+                total_asset_krw = _safe_float(o3.get('tot_asst_amt'))
+                total_asset_usd = (total_asset_krw / exchange_rate) if exchange_rate > 0 else 0.0
+
                 # Calculate from portfolio for stock totals
                 portfolio = self.get_portfolio()
                 total_eval = sum(s['eval_amount'] for s in portfolio)
@@ -1744,12 +1755,16 @@ class USStockTrading:
                     'available_amount': usd_cash,  # USD cash available for trading
                     'usd_cash': usd_cash,
                     'exchange_rate': exchange_rate,
+                    'total_asset_krw': total_asset_krw,
+                    # Settlement-coherent total assets in USD; 0 if unavailable (callers fall back).
+                    'total_asset_usd': total_asset_usd,
                 }
 
                 logger.info(f"Account Summary: Stock Eval ${summary['total_eval_amount']:.2f}, "
                            f"P/L ${summary['total_profit_amount']:+.2f} "
                            f"({summary['total_profit_rate']:+.2f}%), "
-                           f"USD Cash ${summary['usd_cash']:.2f}")
+                           f"USD Cash ${summary['usd_cash']:.2f}, "
+                           f"Total Asset ${summary['total_asset_usd']:.2f}")
 
                 return summary
 

--- a/trading/portfolio_telegram_reporter.py
+++ b/trading/portfolio_telegram_reporter.py
@@ -230,8 +230,12 @@ class PortfolioTelegramReporter:
                 us_cash = us_account_summary.get('usd_cash', 0)
                 exchange_rate = us_account_summary.get('exchange_rate', 0)
 
-                # Total assets = stock evaluation + USD cash
-                us_total_assets = us_total_eval + us_cash
+                # Total assets: prefer KIS settlement-coherent total (stock + USD cash +
+                # KRW deposit + net unsettled trades). Summing real-time stock eval against
+                # the settlement-lagged USD deposit alone makes the season return see-saw
+                # day to day, so only fall back to that when the KIS total is unavailable.
+                us_total_asset_usd = us_account_summary.get('total_asset_usd', 0) or 0
+                us_total_assets = us_total_asset_usd if us_total_asset_usd > 0 else (us_total_eval + us_cash)
 
                 # Season profit measured from the US start amount
                 us_season_profit = us_total_assets - self.US_START_AMOUNT


### PR DESCRIPTION
## 문제
일일 18:00 텔레그램 포트폴리오 리포트의 **US 시즌수익률이 비정상적으로 출렁임** (06-15 +39.02% → 06-16 +18.92% → 06-17 +13.39%).

## 근본원인
`us_total_assets = total_eval + usd_cash` 공식이:
1. **실시간 주식평가**(`get_portfolio`)와 **정산지연 외화예수금**(`frcr_dncl_amt_2`)을 합산 → 매도 체결 시 주식은 즉시 빠지나 매도대금은 D+2 후 현금 반영 → see-saw.
2. **KRW예수금(≈$2,047)**과 **미결제 매도대금(net)**을 통째로 누락 → 상시 과소계상.

KIS `inquire-present-balance` output3 원본으로 검산 (06-17):
`tot_asst_amt` 20,925,371원 = 주식 13,181,566 + USD현금 3,997,017 + KRW예수금 3,098,556 + 미결제매도 648,232 (오차 0). 실제 총자산 ≈ $13,826 (+38.3%)로 안정적이며, 폭락은 허상.

## 수정
- `USStockTrading.get_account_summary`: `total_asset_usd = tot_asst_amt / exchange_rate` 노출 (정산·KRW현금·미결제 모두 일관 반영). output3 list/dict·환율0 graceful.
- `portfolio_telegram_reporter`: 시즌수익 계산을 `total_asset_usd` 기준으로 교체, 미가용 시 기존 `eval+cash`로 안전 fallback. 보유주식/현금 분해 표시는 그대로.
- 단위테스트 4건 (`test_us_account_total_asset.py`).

## 검증
- `pytest prism-us/tests/test_us_account_total_asset.py` → 4 passed
- db-server에서 present-balance output3 원본 덤프로 검산 완료 (오차 0)