### PR TITLE
fix(us): 18:00 시즌수익을 달러자산−원금 기준으로 (see-saw 제거)

### DIFF
--- a/prism-us/tests/test_us_account_total_asset.py
+++ b/prism-us/tests/test_us_account_total_asset.py
@@ -1,9 +1,14 @@
-"""Unit tests for US get_account_summary settlement-coherent total asset.
+"""Unit tests for US get_account_summary USD-denominated total asset.
 
-Regression guard for the 18:00 portfolio season-return bug: summing a real-time
-stock eval against the settlement-lagged USD deposit (frcr_dncl_amt_2) made the
-season return see-saw. get_account_summary must instead expose KIS-computed
-tot_asst_amt (KRW) as total_asset_usd = tot_asst_amt / exchange_rate.
+Regression guard for the 18:00 portfolio season-return bug. The season return is
+measured as USD-denominated assets minus start capital, so total_asset_usd must be:
+
+    total_eval + usd_cash + (unsettled_sell - unsettled_buy)
+
+- It must EXCLUDE KRW cash (dollar-basis metric).
+- The net-unsettled term puts cash on the same trade-date basis as the real-time
+  eval, removing the see-saw caused by the settlement-lagged USD deposit
+  (frcr_dncl_amt_2).
 """
 import os
 import sys
@@ -51,55 +56,70 @@ def _make_trader(res, portfolio):
     return trader
 
 
-_USD_ROW = {
-    "crcy_cd": "USD",
-    "frcr_dncl_amt_2": "2640.910000",   # settlement-lagged deposit
-    "frst_bltn_exrt": "1513.50000000",
-}
+def _usd_row(cash="2640.91", sell="1023.69", buy="595.39", rate="1513.50"):
+    return {
+        "crcy_cd": "USD",
+        "frcr_dncl_amt_2": cash,
+        "frcr_sll_amt_smtl": sell,
+        "frcr_buy_amt_smtl": buy,
+        "frst_bltn_exrt": rate,
+    }
+
+
 _PORTFOLIO = [
     {"eval_amount": 8709.0, "profit_amount": 342.0, "avg_price": 100.0, "quantity": 83},
 ]
+# KRW deposit in output3 must NOT leak into total_asset_usd.
+_OUTPUT3_WITH_KRW = {"tot_asst_amt": "20925371", "tot_dncl_amt": "3098556"}
 
 
-def test_total_asset_usd_uses_kis_total_not_eval_plus_cash():
-    # KIS total asset (KRW) includes stock + USD cash + KRW deposit + unsettled.
-    output3 = {"tot_asst_amt": "20925371"}
-    trader = _make_trader(_FakeRes([_USD_ROW], output3), _PORTFOLIO)
+def test_total_asset_usd_is_eval_plus_cash_plus_net_unsettled():
+    trader = _make_trader(_FakeRes([_usd_row()], _OUTPUT3_WITH_KRW), _PORTFOLIO)
 
     summary = trader.get_account_summary()
 
+    expected = 8709.0 + 2640.91 + (1023.69 - 595.39)  # = 11778.21
     assert summary is not None
-    # 20,925,371 / 1513.5 ~= 13825.95, NOT eval+cash (8709 + 2640.91 = 11349.91)
-    assert summary["total_asset_usd"] == pytest.approx(20925371 / 1513.5, abs=0.01)
-    assert summary["total_asset_usd"] > summary["total_eval_amount"] + summary["usd_cash"]
-    assert summary["usd_cash"] == pytest.approx(2640.91, abs=0.01)
+    assert summary["total_asset_usd"] == pytest.approx(expected, abs=0.01)
+    assert summary["net_unsettled_usd"] == pytest.approx(428.30, abs=0.01)
 
 
-def test_total_asset_usd_handles_output3_as_list():
-    output3 = [{"tot_asst_amt": "20925371"}]
-    trader = _make_trader(_FakeRes([_USD_ROW], output3), _PORTFOLIO)
-
-    summary = trader.get_account_summary()
-
-    assert summary["total_asset_usd"] == pytest.approx(20925371 / 1513.5, abs=0.01)
-
-
-def test_total_asset_usd_falls_back_to_zero_when_missing():
-    # Missing tot_asst_amt -> total_asset_usd 0 so callers fall back to eval+cash.
-    trader = _make_trader(_FakeRes([_USD_ROW], {}), _PORTFOLIO)
+def test_total_asset_usd_excludes_krw_cash():
+    # KRW deposit (~$2,047) is large; if it leaked in, total would jump well above
+    # eval+cash+unsettled. Guard that the dollar metric stays KRW-free.
+    trader = _make_trader(_FakeRes([_usd_row()], _OUTPUT3_WITH_KRW), _PORTFOLIO)
 
     summary = trader.get_account_summary()
 
-    assert summary["total_asset_usd"] == 0.0
+    assert summary["total_asset_usd"] < 12000  # not the ~$13,800 KRW-inclusive total
 
 
-def test_total_asset_usd_zero_when_no_exchange_rate():
-    usd_row = {"crcy_cd": "USD", "frcr_dncl_amt_2": "2640.91", "frst_bltn_exrt": "0"}
-    trader = _make_trader(_FakeRes([usd_row], {"tot_asst_amt": "20925371"}), _PORTFOLIO)
+def test_no_unsettled_reduces_to_eval_plus_cash():
+    trader = _make_trader(_FakeRes([_usd_row(sell="0", buy="0")], {}), _PORTFOLIO)
 
     summary = trader.get_account_summary()
 
-    assert summary["total_asset_usd"] == 0.0
+    assert summary["net_unsettled_usd"] == pytest.approx(0.0, abs=0.01)
+    assert summary["total_asset_usd"] == pytest.approx(8709.0 + 2640.91, abs=0.01)
+
+
+def test_net_unsettled_can_be_negative():
+    # More buys than sells in transit -> cash is overstated, net unsettled negative.
+    trader = _make_trader(_FakeRes([_usd_row(sell="100", buy="700")], {}), _PORTFOLIO)
+
+    summary = trader.get_account_summary()
+
+    assert summary["net_unsettled_usd"] == pytest.approx(-600.0, abs=0.01)
+    assert summary["total_asset_usd"] == pytest.approx(8709.0 + 2640.91 - 600.0, abs=0.01)
+
+
+def test_missing_usd_row_degrades_to_eval_only():
+    trader = _make_trader(_FakeRes([], {}), _PORTFOLIO)
+
+    summary = trader.get_account_summary()
+
+    assert summary["usd_cash"] == 0.0
+    assert summary["total_asset_usd"] == pytest.approx(8709.0, abs=0.01)
 
 
 if __name__ == "__main__":

--- a/prism-us/trading/us_stock_trading.py
+++ b/prism-us/trading/us_stock_trading.py
@@ -1720,33 +1720,37 @@ class USStockTrading:
                 output2 = body.output2 if hasattr(body, 'output2') else []
                 output3 = body.output3 if hasattr(body, 'output3') else {}
 
-                # Extract USD info from output2
+                # Extract USD info from output2. unsettled buy/sell amounts let us put cash
+                # on a trade-date basis (see total_asset_usd below).
                 usd_cash = 0.0
                 exchange_rate = 0.0
+                unsettled_buy = 0.0   # executed buys not yet settled (cash not yet debited)
+                unsettled_sell = 0.0  # executed sells not yet settled (proceeds not yet credited)
 
                 if output2 and isinstance(output2, list):
                     for item in output2:
                         if item.get('crcy_cd') == 'USD':
                             usd_cash = _safe_float(item.get('frcr_dncl_amt_2'))
                             exchange_rate = _safe_float(item.get('frst_bltn_exrt'))
+                            unsettled_buy = _safe_float(item.get('frcr_buy_amt_smtl'))
+                            unsettled_sell = _safe_float(item.get('frcr_sll_amt_smtl'))
                             break
-
-                # KIS-computed total account asset (KRW). This is settlement-coherent:
-                # it already includes stock eval + USD cash + KRW deposit + net unsettled
-                # trade proceeds. Using it avoids the see-saw caused by summing a real-time
-                # stock eval against a settlement-lagged USD deposit (frcr_dncl_amt_2).
-                o3 = output3
-                if isinstance(o3, list):
-                    o3 = o3[0] if o3 else {}
-                o3 = o3 if isinstance(o3, dict) else {}
-                total_asset_krw = _safe_float(o3.get('tot_asst_amt'))
-                total_asset_usd = (total_asset_krw / exchange_rate) if exchange_rate > 0 else 0.0
 
                 # Calculate from portfolio for stock totals
                 portfolio = self.get_portfolio()
                 total_eval = sum(s['eval_amount'] for s in portfolio)
                 total_profit = sum(s['profit_amount'] for s in portfolio)
                 total_cost = sum(s['avg_price'] * s['quantity'] for s in portfolio)
+
+                # USD-denominated total assets on a trade-date basis (excludes KRW cash).
+                # frcr_dncl_amt_2 is settlement-based (D+2), so summing it against a
+                # real-time stock eval makes the season return see-saw: a sell drops eval
+                # immediately but its proceeds reach the deposit days later. Adding net
+                # unsettled trades (sells in transit minus buys in transit) realigns cash to
+                # the same trade-date basis as the eval, removing the see-saw. Dividends are
+                # already reflected in usd_cash, so they are captured here too.
+                net_unsettled = unsettled_sell - unsettled_buy
+                total_asset_usd = total_eval + usd_cash + net_unsettled
 
                 summary = {
                     'total_eval_amount': total_eval,
@@ -1755,8 +1759,10 @@ class USStockTrading:
                     'available_amount': usd_cash,  # USD cash available for trading
                     'usd_cash': usd_cash,
                     'exchange_rate': exchange_rate,
-                    'total_asset_krw': total_asset_krw,
-                    # Settlement-coherent total assets in USD; 0 if unavailable (callers fall back).
+                    'unsettled_buy_usd': unsettled_buy,
+                    'unsettled_sell_usd': unsettled_sell,
+                    'net_unsettled_usd': net_unsettled,
+                    # USD-denominated trade-date total assets (stock + USD cash + net unsettled).
                     'total_asset_usd': total_asset_usd,
                 }
 
@@ -1764,7 +1770,8 @@ class USStockTrading:
                            f"P/L ${summary['total_profit_amount']:+.2f} "
                            f"({summary['total_profit_rate']:+.2f}%), "
                            f"USD Cash ${summary['usd_cash']:.2f}, "
-                           f"Total Asset ${summary['total_asset_usd']:.2f}")
+                           f"Net Unsettled ${net_unsettled:+.2f}, "
+                           f"Total Asset(USD) ${summary['total_asset_usd']:.2f}")
 
                 return summary
 

--- a/trading/portfolio_telegram_reporter.py
+++ b/trading/portfolio_telegram_reporter.py
@@ -229,11 +229,12 @@ class PortfolioTelegramReporter:
                 us_total_profit_rate = us_account_summary.get('total_profit_rate', 0)
                 us_cash = us_account_summary.get('usd_cash', 0)
                 exchange_rate = us_account_summary.get('exchange_rate', 0)
+                us_net_unsettled = us_account_summary.get('net_unsettled_usd', 0)
 
-                # Total assets: prefer KIS settlement-coherent total (stock + USD cash +
-                # KRW deposit + net unsettled trades). Summing real-time stock eval against
-                # the settlement-lagged USD deposit alone makes the season return see-saw
-                # day to day, so only fall back to that when the KIS total is unavailable.
+                # USD-denominated total assets = stock eval + USD cash + net unsettled trades
+                # (excludes KRW cash). The net-unsettled term keeps cash on the same
+                # trade-date basis as the eval so the season return does not see-saw with
+                # D+2 settlement; falls back to eval+cash if the field is unavailable.
                 us_total_asset_usd = us_account_summary.get('total_asset_usd', 0) or 0
                 us_total_assets = us_total_asset_usd if us_total_asset_usd > 0 else (us_total_eval + us_cash)
 
@@ -261,6 +262,10 @@ class PortfolioTelegramReporter:
                     message += f"📈 환율: `{exchange_rate:,.2f}원/USD`\n"
                 else:
                     message += "\n"
+
+                # In-transit settlement so 총자산 reconciles with 보유주식 + USD현금
+                if abs(us_net_unsettled) >= 0.01:
+                    message += f"🔄 정산중(미결제): `{self.format_currency_with_sign(us_net_unsettled, 'USD')}`\n"
             else:
                 message += "❌ 계좌 정보를 가져올 수 없습니다\n"
 


### PR DESCRIPTION
## 배경
PR #338에서 `tot_asst_amt`(KIS 총자산)로 바꿨으나, 여기엔 **KRW예수금(~$2,047)+환율**이 섞여 시즌수익이 ~38%로 과대계상됐음(전수검사로 확인). 사용자 결정: **달러자산−원금** 기준.

## 수정
- `get_account_summary`: `total_asset_usd = total_eval + usd_cash + (frcr_sll_amt_smtl − frcr_buy_amt_smtl)`.
  - **달러전용**(KRW현금 제외), **배당 자동포함**(USD현금에 반영됨).
  - **미결제 정산분(net)** 가산 → 실시간 eval과 cash를 동일 trade-date 기준으로 정렬 → 정산지연(D+2) see-saw 제거. (단순 eval+usd_cash로 되돌리면 see-saw 재발하므로 이 항이 필수.)
- 리포터: `총자산`을 달러자산 기준으로, `🔄 정산중(미결제)` 라인 추가로 보유주식+USD현금과 정합. 주석 갱신.
- 단위테스트 5건 재작성.

## 검증
- pytest 5 passed, py_compile OK
- db-server 라이브 렌더(전송X)로 사후 검증 예정