### PR TITLE
feat(loops): Loop A 고빈도 하드스톱 루프 (SHADOW 기본, 비활성 배포)

### DIFF
--- a/cores/oneil_fallback.py
+++ b/cores/oneil_fallback.py
@@ -131,6 +131,31 @@ def evaluate_oneil_sell(inp: SellInputs) -> Tuple[bool, str]:
     return False, f"HOLD: trend intact (profit {profit:.2f}%, regime {regime})"
 
 
+def evaluate_tier1_hardstop(inp: SellInputs) -> Tuple[bool, str]:
+    """TIER1-only catastrophic hard stop for the high-frequency loop (Loop A).
+
+    Evaluates ONLY the two TIER1 rules from evaluate_oneil_sell — scenario
+    stop-loss breach (1A) and the absolute -7% stop (1B) — and nothing else.
+    Trailing (TIER2), 50MA (TIER1.5) and target (TIER3) are deliberately
+    excluded: Loop A runs every few minutes on raw last-trade prices, where
+    those slower trend signals would whipsaw on intraday noise. Uses the same
+    wick buffer and constants as evaluate_oneil_sell so the two never diverge.
+
+    Returns: (should_sell, reason_key). No trigger -> (False, "HOLD: ...").
+    """
+    bp, cp = inp.buy_price, inp.current_price
+    if bp <= 0 or cp <= 0:
+        return False, "HOLD: invalid price data"  # never sell on bad data
+    # 1A. scenario stop-loss breach (clear break below, wick buffer)
+    if inp.stop_loss > 0 and cp <= inp.stop_loss * (1.0 - STOP_WICK_BUFFER):
+        return True, f"TIER1_STOPLOSS: price<=stop_loss({inp.stop_loss:.4f})"
+    # 1B. absolute -7% stop
+    profit = (cp - bp) / bp * 100.0
+    if profit <= ABS_STOP_LOSS_PCT:
+        return True, f"TIER1_ABS7: loss {profit:.2f}% <= {ABS_STOP_LOSS_PCT}%"
+    return False, f"HOLD: above hard stop (profit {profit:.2f}%)"
+
+
 # ── 호출측 어댑터 (stock_data dict → SellInputs) ────────────────
 def from_stock_data(stock_data: dict, live_regime: Optional[str] = None,
                     ma_50: Optional[float] = None) -> SellInputs:

--- a/prism-us/cores/oneil_fallback.py
+++ b/prism-us/cores/oneil_fallback.py
@@ -131,6 +131,31 @@ def evaluate_oneil_sell(inp: SellInputs) -> Tuple[bool, str]:
     return False, f"HOLD: trend intact (profit {profit:.2f}%, regime {regime})"
 
 
+def evaluate_tier1_hardstop(inp: SellInputs) -> Tuple[bool, str]:
+    """TIER1-only catastrophic hard stop for the high-frequency loop (Loop A).
+
+    Evaluates ONLY the two TIER1 rules from evaluate_oneil_sell — scenario
+    stop-loss breach (1A) and the absolute -7% stop (1B) — and nothing else.
+    Trailing (TIER2), 50MA (TIER1.5) and target (TIER3) are deliberately
+    excluded: Loop A runs every few minutes on raw last-trade prices, where
+    those slower trend signals would whipsaw on intraday noise. Uses the same
+    wick buffer and constants as evaluate_oneil_sell so the two never diverge.
+
+    Returns: (should_sell, reason_key). No trigger -> (False, "HOLD: ...").
+    """
+    bp, cp = inp.buy_price, inp.current_price
+    if bp <= 0 or cp <= 0:
+        return False, "HOLD: invalid price data"  # never sell on bad data
+    # 1A. scenario stop-loss breach (clear break below, wick buffer)
+    if inp.stop_loss > 0 and cp <= inp.stop_loss * (1.0 - STOP_WICK_BUFFER):
+        return True, f"TIER1_STOPLOSS: price<=stop_loss({inp.stop_loss:.4f})"
+    # 1B. absolute -7% stop
+    profit = (cp - bp) / bp * 100.0
+    if profit <= ABS_STOP_LOSS_PCT:
+        return True, f"TIER1_ABS7: loss {profit:.2f}% <= {ABS_STOP_LOSS_PCT}%"
+    return False, f"HOLD: above hard stop (profit {profit:.2f}%)"
+
+
 # ── 호출측 어댑터 (stock_data dict → SellInputs) ────────────────
 def from_stock_data(stock_data: dict, live_regime: Optional[str] = None,
                     ma_50: Optional[float] = None) -> SellInputs:

--- a/tests/test_loop_a_hardstop.py
+++ b/tests/test_loop_a_hardstop.py
@@ -1,0 +1,176 @@
+"""Tests for Loop A high-frequency hard-stop loop (tools/loop_a_hardstop.py).
+
+Safety-critical guards covered:
+  - SHADOW mode (default) places NO real order, but logs an intended sell.
+  - LIVE mode places a market sell and reconciles qty against KIS first.
+  - owner_lock prevents two concurrent runs from double-selling.
+  - inflight guard prevents re-issuing a sell for a ticker already in flight.
+  - TIER1-only: trailing/target winners are NOT sold by Loop A.
+
+Run in the KR (root) pytest session.
+"""
+import asyncio
+import os
+import sys
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT))
+import tools.loop_a_hardstop as la  # noqa: E402
+
+
+# ── Fakes ──────────────────────────────────────────────────────────────────────
+class FakeTrader:
+    def __init__(self, portfolio, holding_qty=None, sell_result=None):
+        self._portfolio = portfolio
+        self._holding_qty = holding_qty or {}
+        self._sell_result = sell_result or {"success": True, "order_no": "ORD1", "message": "ok"}
+        self.sell_calls = []
+
+    def get_portfolio(self):
+        return self._portfolio
+
+    def get_holding_quantity(self, ticker):
+        return self._holding_qty.get(ticker, 0)
+
+    async def async_sell_stock(self, ticker, exchange=None, timeout=30.0,
+                               limit_price=None, use_moo=False, quantity=None):
+        self.sell_calls.append((ticker, quantity))
+        return self._sell_result
+
+
+class FakeCtx:
+    def __init__(self, trader):
+        self._trader = trader
+
+    async def __aenter__(self):
+        return self._trader
+
+    async def __aexit__(self, *a):
+        return False
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    db = tmp_path / "t.sqlite"
+    # seed holdings table so load_stop_map works
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE stock_holdings (ticker TEXT, stop_loss REAL)")
+    conn.execute("INSERT INTO stock_holdings VALUES ('005930', 0)")
+    conn.commit()
+    conn.close()
+    monkeypatch.setattr(la, "DB_PATH", str(db))
+    return str(db)
+
+
+def _patch_trader(monkeypatch, trader):
+    monkeypatch.setattr(la, "_open_context", lambda market: FakeCtx(trader))
+
+
+def _count_inflight(db, status=None):
+    conn = sqlite3.connect(db)
+    try:
+        if status:
+            return conn.execute(
+                "SELECT COUNT(*) FROM loop_a_inflight_orders WHERE status=?", (status,)
+            ).fetchone()[0]
+        return conn.execute("SELECT COUNT(*) FROM loop_a_inflight_orders").fetchone()[0]
+    finally:
+        conn.close()
+
+
+# a -8% loser (buy 100, now 92) -> TIER1 abs-7 fires
+_LOSER = [{"stock_code": "005930", "quantity": 10, "avg_price": 100.0, "current_price": 92.0}]
+
+
+def test_shadow_mode_places_no_order(tmp_db, monkeypatch):
+    monkeypatch.setattr(la, "LOOP_A_LIVE", False)
+    monkeypatch.setattr(la, "LOOP_A_ENABLED", True)
+    trader = FakeTrader(_LOSER)
+    _patch_trader(monkeypatch, trader)
+
+    summary = asyncio.run(la.run_market("KR", "run1"))
+
+    assert summary["triggered"] == 1
+    assert summary["shadow"] == 1
+    assert trader.sell_calls == []  # NO real order in shadow mode
+    assert _count_inflight(tmp_db, "SHADOW") == 1
+
+
+def test_live_mode_sells_and_reconciles(tmp_db, monkeypatch):
+    monkeypatch.setattr(la, "LOOP_A_LIVE", True)
+    monkeypatch.setattr(la, "LOOP_A_ENABLED", True)
+    trader = FakeTrader(_LOSER, holding_qty={"005930": 10})
+    _patch_trader(monkeypatch, trader)
+
+    summary = asyncio.run(la.run_market("KR", "run1"))
+
+    assert summary["sold"] == 1
+    assert trader.sell_calls == [("005930", 10)]  # market sell of full reconciled qty
+    assert _count_inflight(tmp_db, "FILLED") == 1
+
+
+def test_live_mode_skips_when_already_flat_at_kis(tmp_db, monkeypatch):
+    # KIS says qty 0 (batch already sold) -> Loop A must NOT sell.
+    monkeypatch.setattr(la, "LOOP_A_LIVE", True)
+    monkeypatch.setattr(la, "LOOP_A_ENABLED", True)
+    trader = FakeTrader(_LOSER, holding_qty={"005930": 0})
+    _patch_trader(monkeypatch, trader)
+
+    summary = asyncio.run(la.run_market("KR", "run1"))
+
+    assert trader.sell_calls == []
+    assert summary["sold"] == 0
+
+
+def test_inflight_guard_blocks_second_trigger(tmp_db, monkeypatch):
+    monkeypatch.setattr(la, "LOOP_A_LIVE", False)
+    monkeypatch.setattr(la, "LOOP_A_ENABLED", True)
+    trader = FakeTrader(_LOSER)
+    _patch_trader(monkeypatch, trader)
+
+    asyncio.run(la.run_market("KR", "run1"))      # creates SHADOW inflight
+    summary2 = asyncio.run(la.run_market("KR", "run2"))  # different run id
+
+    # second cycle sees the open SHADOW inflight and skips
+    assert summary2["skipped"] == 1
+    assert _count_inflight(tmp_db) == 1
+
+
+def test_owner_lock_is_exclusive(tmp_db, monkeypatch):
+    conn = la._connect()
+    la._ensure_schema(conn)
+    assert la.claim_lock(conn, "005930", "KR", "runA") is True
+    # second claimant cannot take a live lock
+    assert la.claim_lock(conn, "005930", "KR", "runB") is False
+    la.release_lock(conn, "005930", "KR", "runA")
+    assert la.claim_lock(conn, "005930", "KR", "runB") is True
+    conn.close()
+
+
+def test_winner_not_sold_tier1_only(tmp_db, monkeypatch):
+    # +20% winner well above a trailing peak: evaluate_oneil_sell might trail, but
+    # Loop A is TIER1-only and must HOLD.
+    monkeypatch.setattr(la, "LOOP_A_LIVE", False)
+    monkeypatch.setattr(la, "LOOP_A_ENABLED", True)
+    winner = [{"stock_code": "005930", "quantity": 10, "avg_price": 100.0, "current_price": 120.0}]
+    trader = FakeTrader(winner)
+    _patch_trader(monkeypatch, trader)
+
+    summary = asyncio.run(la.run_market("KR", "run1"))
+
+    assert summary["triggered"] == 0
+    assert trader.sell_calls == []
+
+
+def test_disabled_flag_is_noop(tmp_db, monkeypatch):
+    monkeypatch.setattr(la, "LOOP_A_ENABLED", False)
+    rc = asyncio.run(la.main_async(["KR"]))
+    assert rc == 0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tools/loop_a_hardstop.py
+++ b/tools/loop_a_hardstop.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Loop A — high-frequency catastrophic hard-stop loop (LLM-free).
+
+Runs as a standalone intraday cron, SEPARATE from the 2-3x/day batch sell cycle.
+For each real holding it fetches the live price and applies ONLY the O'Neil
+TIER1 hard stop (scenario stop-loss / absolute -7%). On a trigger it sells at
+market, so a stop that the slow batch cadence would only catch at -12~-15% is
+hit much closer to its intended level.
+
+SAFETY (read before enabling):
+  - Live selling is gated behind  LOOP_A_LIVE=true .  Default = SHADOW mode:
+    it logs exactly what it WOULD sell and places NO orders. Turn it on only
+    after reviewing the slippage backtest.
+  - LOOP_A_ENABLED=false  disables the loop entirely (kill switch).
+  - Loop A runs in its own process, so the batch's in-process asyncio locks do
+    NOT apply. We guard against double-selling with (a) a SQLite owner_lock
+    claimed via BEGIN IMMEDIATE, (b) an inflight-order uniqueness guard, and
+    (c) a fresh KIS holding-quantity reconcile immediately before every live
+    sell (KIS is the single source of truth; if the batch already sold, qty is
+    0 and we skip).
+
+Usage:
+    python tools/loop_a_hardstop.py [--market kr|us|both] [--once]
+
+Intended cron (SHADOW until reviewed), market hours only:
+    */7 * * * 1-5  cd /root/prism-insight && python tools/loop_a_hardstop.py --market both
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sqlite3
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+# ── Path bootstrap (mirror portfolio_telegram_reporter) ────────────────────────
+TOOLS_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = TOOLS_DIR.parent
+sys.path.insert(0, str(PROJECT_ROOT / "prism-us"))   # US modules
+sys.path.insert(0, str(PROJECT_ROOT))                # project root
+
+from cores.oneil_fallback import SellInputs, evaluate_tier1_hardstop  # noqa: E402
+
+logger = logging.getLogger("loop_a")
+
+# ── Configuration (env-driven) ────────────────────────────────────────────────
+def _env_bool(name: str, default: bool) -> bool:
+    return str(os.getenv(name, str(default))).strip().lower() in ("1", "true", "yes", "on")
+
+
+LOOP_A_ENABLED = _env_bool("LOOP_A_ENABLED", True)     # master kill switch
+LOOP_A_LIVE = _env_bool("LOOP_A_LIVE", False)          # False => SHADOW (no real orders)
+LOCK_TTL_SEC = int(os.getenv("LOOP_A_LOCK_TTL_SEC", "300"))
+DB_PATH = os.getenv("LOOP_A_DB") or os.getenv("STOCK_TRACKING_DB") \
+    or str(PROJECT_ROOT / "stock_tracking_db.sqlite")
+
+_HOLDINGS_TABLE = {"KR": "stock_holdings", "US": "us_stock_holdings"}
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+# ── SQLite state (loop_a_* tables only; never touches existing tables) ─────────
+def _connect() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH, timeout=30)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS loop_a_position_state (
+            ticker          TEXT NOT NULL,
+            market          TEXT NOT NULL,
+            state           TEXT NOT NULL DEFAULT 'HOLDING',  -- HOLDING/SELLING/SOLD
+            owner_lock      TEXT,
+            lock_expires_at TEXT,
+            last_eval_ts    TEXT,
+            PRIMARY KEY (ticker, market)
+        );
+        CREATE TABLE IF NOT EXISTS loop_a_inflight_orders (
+            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            ticker       TEXT NOT NULL,
+            market       TEXT NOT NULL,
+            side         TEXT NOT NULL DEFAULT 'SELL',
+            loop_run_id  TEXT NOT NULL,
+            order_no     TEXT,
+            qty          INTEGER,
+            status       TEXT NOT NULL,    -- SHADOW/OPEN/FILLED/REJECTED
+            reason       TEXT,
+            submitted_ts TEXT NOT NULL,
+            UNIQUE (ticker, market, side, loop_run_id)
+        );
+        """
+    )
+    conn.commit()
+
+
+def load_stop_map(conn: sqlite3.Connection, market: str) -> Dict[str, float]:
+    """ticker -> scenario stop_loss from the holdings table (any account)."""
+    table = _HOLDINGS_TABLE[market]
+    out: Dict[str, float] = {}
+    try:
+        for row in conn.execute(
+            f"SELECT ticker, MAX(COALESCE(stop_loss, 0)) AS sl FROM {table} GROUP BY ticker"
+        ):
+            try:
+                out[str(row["ticker"]).strip()] = float(row["sl"] or 0)
+            except (TypeError, ValueError):
+                continue
+    except sqlite3.Error as e:
+        logger.warning("stop_loss map load failed (%s): %s", market, e)
+    return out
+
+
+def has_open_inflight(conn: sqlite3.Connection, ticker: str, market: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM loop_a_inflight_orders "
+        "WHERE ticker=? AND market=? AND side='SELL' AND status IN ('OPEN','SHADOW') LIMIT 1",
+        (ticker, market),
+    ).fetchone()
+    return row is not None
+
+
+def claim_lock(conn: sqlite3.Connection, ticker: str, market: str, run_id: str) -> bool:
+    """Atomically claim the position owner_lock. Returns True if acquired.
+
+    BEGIN IMMEDIATE serialises competing writers (other loops/processes). A lock
+    older than LOCK_TTL_SEC is treated as stale and may be re-claimed.
+    """
+    now = _now()
+    expires = _iso(now + timedelta(seconds=LOCK_TTL_SEC))
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            "INSERT OR IGNORE INTO loop_a_position_state (ticker, market, state) VALUES (?,?, 'HOLDING')",
+            (ticker, market),
+        )
+        cur = conn.execute(
+            "UPDATE loop_a_position_state SET owner_lock=?, lock_expires_at=?, last_eval_ts=? "
+            "WHERE ticker=? AND market=? "
+            "AND (owner_lock IS NULL OR lock_expires_at IS NULL OR lock_expires_at < ?)",
+            (run_id, expires, _iso(now), ticker, market, _iso(now)),
+        )
+        conn.commit()
+        return cur.rowcount == 1
+    except sqlite3.Error as e:
+        conn.rollback()
+        logger.warning("lock claim failed %s/%s: %s", ticker, market, e)
+        return False
+
+
+def release_lock(conn: sqlite3.Connection, ticker: str, market: str, run_id: str,
+                 new_state: Optional[str] = None) -> None:
+    try:
+        if new_state:
+            conn.execute(
+                "UPDATE loop_a_position_state SET owner_lock=NULL, lock_expires_at=NULL, state=? "
+                "WHERE ticker=? AND market=? AND owner_lock=?",
+                (new_state, ticker, market, run_id),
+            )
+        else:
+            conn.execute(
+                "UPDATE loop_a_position_state SET owner_lock=NULL, lock_expires_at=NULL "
+                "WHERE ticker=? AND market=? AND owner_lock=?",
+                (ticker, market, run_id),
+            )
+        conn.commit()
+    except sqlite3.Error as e:
+        logger.warning("lock release failed %s/%s: %s", ticker, market, e)
+
+
+def record_inflight(conn: sqlite3.Connection, ticker: str, market: str, run_id: str,
+                    qty: int, status: str, reason: str, order_no: Optional[str]) -> None:
+    try:
+        conn.execute(
+            "INSERT OR IGNORE INTO loop_a_inflight_orders "
+            "(ticker, market, side, loop_run_id, order_no, qty, status, reason, submitted_ts) "
+            "VALUES (?,?, 'SELL', ?,?,?,?,?,?)",
+            (ticker, market, run_id, order_no, qty, status, reason, _iso(_now())),
+        )
+        conn.commit()
+    except sqlite3.Error as e:
+        logger.warning("inflight record failed %s/%s: %s", ticker, market, e)
+
+
+# ── Trader context factories (KR / US) ────────────────────────────────────────
+def _open_context(market: str):
+    if market == "KR":
+        from trading.domestic_stock_trading import AsyncTradingContext
+        return AsyncTradingContext()
+    from us_stock_trading import AsyncUSTradingContext
+    return AsyncUSTradingContext()
+
+
+def _ticker_of(holding: Dict[str, Any], market: str) -> str:
+    return str(holding.get("ticker") or holding.get("stock_code") or "").strip()
+
+
+# ── Core evaluation for one market ─────────────────────────────────────────────
+async def run_market(market: str, run_id: str) -> Dict[str, Any]:
+    """Evaluate TIER1 hard stop for every real holding in one market.
+
+    Never raises: any failure degrades to a no-op for that ticker/market.
+    """
+    summary = {"market": market, "checked": 0, "triggered": 0, "sold": 0, "shadow": 0, "skipped": 0}
+    conn = _connect()
+    try:
+        _ensure_schema(conn)
+        stop_map = load_stop_map(conn, market)
+        try:
+            async with _open_context(market) as trader:
+                try:
+                    portfolio: List[Dict[str, Any]] = await asyncio.to_thread(trader.get_portfolio)
+                except Exception as e:
+                    logger.warning("%s get_portfolio failed: %s", market, e)
+                    return summary
+                for h in (portfolio or []):
+                    ticker = _ticker_of(h, market)
+                    if not ticker:
+                        continue
+                    try:
+                        qty = int(h.get("quantity", 0) or 0)
+                        avg_price = float(h.get("avg_price", 0) or 0)
+                        cur_price = float(h.get("current_price", 0) or 0)
+                    except (TypeError, ValueError):
+                        continue
+                    if qty <= 0 or avg_price <= 0 or cur_price <= 0:
+                        continue
+                    summary["checked"] += 1
+                    inp = SellInputs(
+                        buy_price=avg_price,
+                        current_price=cur_price,
+                        stop_loss=stop_map.get(ticker, 0.0),
+                    )
+                    should_sell, reason = evaluate_tier1_hardstop(inp)
+                    if not should_sell:
+                        continue
+                    summary["triggered"] += 1
+                    await _act_on_trigger(conn, trader, market, ticker, qty, reason, run_id, summary)
+        except Exception as e:  # context/credential failure -> skip whole market safely
+            logger.warning("%s trading context failed: %s", market, e)
+    finally:
+        conn.close()
+    return summary
+
+
+async def _act_on_trigger(conn, trader, market: str, ticker: str, qty: int,
+                          reason: str, run_id: str, summary: Dict[str, Any]) -> None:
+    # Guard 1: an inflight SELL for this ticker already exists -> leave it alone.
+    if has_open_inflight(conn, ticker, market):
+        summary["skipped"] += 1
+        logger.info("[%s] %s trigger but inflight order exists -> skip (%s)", market, ticker, reason)
+        return
+    # Guard 2: claim the owner_lock (serialises against other loop processes).
+    if not claim_lock(conn, ticker, market, run_id):
+        summary["skipped"] += 1
+        logger.info("[%s] %s trigger but owner_lock held -> skip (%s)", market, ticker, reason)
+        return
+    try:
+        if not LOOP_A_LIVE:
+            # SHADOW: log intended sell, place no order.
+            summary["shadow"] += 1
+            logger.info("[SHADOW][%s] WOULD SELL %s qty=%d reason=%s", market, ticker, qty, reason)
+            record_inflight(conn, ticker, market, run_id, qty, "SHADOW", reason, None)
+            release_lock(conn, ticker, market, run_id, new_state="HOLDING")
+            return
+        # LIVE: reconcile against KIS (single source of truth) right before selling.
+        try:
+            live_qty = await asyncio.to_thread(trader.get_holding_quantity, ticker)
+        except Exception as e:
+            logger.warning("[%s] %s holding reconcile failed, aborting sell: %s", market, ticker, e)
+            release_lock(conn, ticker, market, run_id, new_state="HOLDING")
+            return
+        sell_qty = min(qty, int(live_qty or 0))
+        if sell_qty <= 0:
+            logger.info("[%s] %s already flat at KIS (qty=0) -> skip", market, ticker)
+            release_lock(conn, ticker, market, run_id, new_state="SOLD")
+            return
+        logger.warning("[LIVE][%s] SELLING %s qty=%d reason=%s", market, ticker, sell_qty, reason)
+        result = await trader.async_sell_stock(ticker, quantity=sell_qty)  # market order
+        ok = bool(result and result.get("success"))
+        order_no = (result or {}).get("order_no")
+        record_inflight(conn, ticker, market, run_id, sell_qty,
+                        "FILLED" if ok else "REJECTED", reason, str(order_no) if order_no else None)
+        release_lock(conn, ticker, market, run_id, new_state="SOLD" if ok else "HOLDING")
+        summary["sold"] += 1 if ok else 0
+        logger.warning("[LIVE][%s] %s sell result success=%s order_no=%s msg=%s",
+                       market, ticker, ok, order_no, (result or {}).get("message"))
+    except Exception as e:
+        logger.error("[%s] %s sell action failed: %s", market, ticker, e)
+        release_lock(conn, ticker, market, run_id, new_state="HOLDING")
+
+
+async def main_async(markets: List[str]) -> int:
+    if not LOOP_A_ENABLED:
+        logger.info("LOOP_A_ENABLED=false -> loop disabled, exiting.")
+        return 0
+    run_id = uuid.uuid4().hex[:12]
+    mode = "LIVE" if LOOP_A_LIVE else "SHADOW"
+    logger.info("Loop A start run_id=%s mode=%s markets=%s db=%s", run_id, mode, markets, DB_PATH)
+    totals = {"checked": 0, "triggered": 0, "sold": 0, "shadow": 0, "skipped": 0}
+    for market in markets:
+        s = await run_market(market, run_id)
+        for k in totals:
+            totals[k] += s.get(k, 0)
+        logger.info("Loop A %s summary: %s", market, s)
+    logger.info("Loop A done run_id=%s mode=%s totals=%s", run_id, mode, totals)
+    return 0
+
+
+def _setup_logging() -> None:
+    log_dir = PROJECT_ROOT / "logs"
+    log_dir.mkdir(exist_ok=True)
+    handlers = [logging.StreamHandler(sys.stdout)]
+    try:
+        handlers.append(logging.FileHandler(log_dir / "loop_a_hardstop.log"))
+    except OSError:
+        pass
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=handlers,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Loop A high-frequency hard-stop loop")
+    parser.add_argument("--market", choices=["kr", "us", "both"], default="both")
+    parser.add_argument("--once", action="store_true", help="(default) run a single cycle")
+    args = parser.parse_args()
+    _setup_logging()
+    markets = {"kr": ["KR"], "us": ["US"], "both": ["KR", "US"]}[args.market]
+    return asyncio.run(main_async(markets))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 목적 (handoff §3-1 최우선)
배치 cadence(KR 2회/US 3회) 사이 공백에서 −7% 손절이 −12~−15%로 밀리는 슬리피지를 LLM-free 고빈도 루프로 보완.

## 실데이터 백테스트 (회수 상한)
−7% 의도를 넘겨 청산된 거래: **KR 30건(평균 −10.06%, 최악 −16.31%, ≤−10% 12건) / US 6건(평균 −9.46%)**. −7% 초과분 합계 = **−106%p** (회수 상한). 상세·한계 = `tasks/loop_a_backtest.md`.

## 동작
- 보유종목별 live price → `oneil_fallback.evaluate_tier1_hardstop`(TIER1만: 시나리오 손절가/−7%) → 시장가 매도.
- `get_portfolio` 1회로 qty+avg+current 수집(쿼터 절약). stop_loss는 holdings DB join.

## 안전장치 (핵심)
- **실매도 = `LOOP_A_LIVE=true` 게이트. 기본 SHADOW**(의도 매도 로그만, 주문 0). `LOOP_A_ENABLED=false` 킬스위치.
- 별도 프로세스라 배치 asyncio 락 무효 → **SQLite owner_lock(BEGIN IMMEDIATE) + inflight 유니크 가드 + 매도 직전 KIS 수량 재조회(단일 진실원)**로 더블매도 차단.
- `loop_a_*` 신규 테이블만 사용, 기존 holdings 테이블 불변.

## 테스트
7건(KR 세션): shadow no-op·live reconcile·owner_lock 배타성·inflight 가드·TIER1 한정(승자 미매도)·kill switch. oneil TIER1 헬퍼 양쪽(KR/US) 동기.

## ⚠️ 미활성 (의도적)
- 반복 cron **미설치**. 이유: Loop A가 사이클마다 `AsyncTradingContext`를 열어 KIS 토큰을 발급 → 매 7분 실행 시 **토큰 발급 레이트리밋**으로 라이브봇 인증 간섭 우려(핸드오프 §0, PR #331이 같은 이유로 사이클당 1회 개방). cron 활성화 전 토큰 캐싱/재사용 검토 필요.
- 배포는 **코드 한정**. LIVE 전환·cron 설치는 사용자 확인 후.