### PR TITLE
feat(loops): Loop A 시뮬+실계좌+텔레그램 일관성 (배치 매도경로 재사용)

### DIFF
--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -524,13 +524,19 @@ class USStockTrackingAgent:
         if self.telegram_token:
             self.telegram_bot = Bot(token=self.telegram_token)
 
-    async def initialize(self, language: str = "ko", sector_names: list = None):
+    async def initialize(self, language: str = "ko", sector_names: list = None,
+                         skip_llm_agent: bool = False):
         """
         Create necessary tables and initialize.
 
         Args:
             language: Language code for agents (default: "ko")
             sector_names: List of valid sector names for trading agent (optional)
+            skip_llm_agent: When True, skip creating the LLM trading-scenario agent.
+                The sell path (sell_stock / send_telegram_message) does NOT use
+                self.trading_agent, so the LLM-free Loop A hard-stop loop can reuse
+                the sell/journal/telegram plumbing without the heavy LLM agent.
+                Default False keeps batch behaviour byte-for-byte unchanged.
         """
         logger.info("Starting US tracking agent initialization")
 
@@ -541,8 +547,9 @@ class USStockTrackingAgent:
         self.conn.row_factory = sqlite3.Row
         self.cursor = self.conn.cursor()
 
-        # Initialize trading scenario agent for US
-        self.trading_agent = create_us_trading_scenario_agent(language=language, sector_names=sector_names)
+        # Initialize trading scenario agent for US (skipped for lightweight consumers).
+        self.trading_agent = None if skip_llm_agent else \
+            create_us_trading_scenario_agent(language=language, sector_names=sector_names)
 
         # Initialize sell decision agent for US
         self.sell_decision_agent = create_us_sell_decision_agent(language=language)

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -146,13 +146,20 @@ class StockTrackingAgent:
         if self.telegram_token:
             self.telegram_bot = Bot(token=self.telegram_token)
 
-    async def initialize(self, language: str = "ko", sector_names: list = None):
+    async def initialize(self, language: str = "ko", sector_names: list = None,
+                         skip_llm_agent: bool = False):
         """
         Create necessary tables and initialize
 
         Args:
             language: Language code for agents (default: "ko")
             sector_names: List of valid sector names for trading agent (optional)
+            skip_llm_agent: When True, skip creating the LLM trading-scenario agent.
+                The sell path (sell_stock / send_telegram_message) does NOT use
+                self.trading_agent, so lightweight consumers (e.g. the LLM-free
+                Loop A hard-stop loop) can reuse the sell/journal/telegram plumbing
+                without pulling in the heavy LLM agent. Default False keeps the
+                batch behaviour byte-for-byte unchanged.
         """
         logger.info("Starting tracking agent initialization")
         logger.info(f"Trading journal feature: {'enabled' if self.enable_journal else 'disabled'}")
@@ -165,8 +172,10 @@ class StockTrackingAgent:
         self.conn.row_factory = sqlite3.Row  # Return results as dictionary
         self.cursor = self.conn.cursor()
 
-        # Initialize trading scenario generation agent with language and sector names
-        self.trading_agent = create_trading_scenario_agent(language=language, sector_names=sector_names)
+        # Initialize trading scenario generation agent with language and sector names.
+        # Skipped for lightweight sell-only consumers (see skip_llm_agent docstring).
+        self.trading_agent = None if skip_llm_agent else \
+            create_trading_scenario_agent(language=language, sector_names=sector_names)
 
         # Create database tables
         await self._create_tables()

--- a/tests/test_loop_a_hardstop.py
+++ b/tests/test_loop_a_hardstop.py
@@ -1,16 +1,17 @@
 """Tests for Loop A high-frequency hard-stop loop (tools/loop_a_hardstop.py).
 
-Safety-critical guards covered:
-  - SHADOW mode (default) places NO real order, but logs an intended sell.
-  - LIVE mode places a market sell and reconciles qty against KIS first.
-  - owner_lock prevents two concurrent runs from double-selling.
-  - inflight guard prevents re-issuing a sell for a ticker already in flight.
-  - TIER1-only: trailing/target winners are NOT sold by Loop A.
+Loop A reuses the batch's sell path so the simulator, the real KIS account and
+Telegram stay consistent. Safety-critical guards covered:
+  - SHADOW (default): touches NO agent and places NO order, only logs.
+  - LIVE: runs sell_stock (sim) -> async_sell_stock (KIS) -> send_telegram_message
+    (telegram), in that order; reconciles qty against KIS first.
+  - Pyramided tickers (>1 row) are skipped (batch owns fractional sells).
+  - owner_lock exclusivity + inflight guard prevent double-selling.
+  - TIER1-only: a winner is never sold by Loop A.
 
 Run in the KR (root) pytest session.
 """
 import asyncio
-import os
 import sys
 import sqlite3
 from pathlib import Path
@@ -24,21 +25,21 @@ import tools.loop_a_hardstop as la  # noqa: E402
 
 # ── Fakes ──────────────────────────────────────────────────────────────────────
 class FakeTrader:
-    def __init__(self, portfolio, holding_qty=None, sell_result=None):
-        self._portfolio = portfolio
+    def __init__(self, prices, holding_qty=None, sell_result=None, calls=None):
+        self._prices = prices
         self._holding_qty = holding_qty or {}
         self._sell_result = sell_result or {"success": True, "order_no": "ORD1", "message": "ok"}
-        self.sell_calls = []
+        self.calls = calls if calls is not None else []
 
-    def get_portfolio(self):
-        return self._portfolio
+    def get_current_price(self, ticker, exchange=None):
+        return {"current_price": self._prices.get(ticker, 0)}
 
     def get_holding_quantity(self, ticker):
         return self._holding_qty.get(ticker, 0)
 
     async def async_sell_stock(self, ticker, exchange=None, timeout=30.0,
                                limit_price=None, use_moo=False, quantity=None):
-        self.sell_calls.append((ticker, quantity))
+        self.calls.append(f"kis:{ticker}:{quantity}")
         return self._sell_result
 
 
@@ -53,24 +54,63 @@ class FakeCtx:
         return False
 
 
+class FakeAgent:
+    def __init__(self, calls):
+        self.calls = calls
+        self.conn = None
+
+    async def sell_stock(self, stock_data, sell_reason):
+        self.calls.append(f"sim:{stock_data.get('ticker')}")
+        return True
+
+    async def send_telegram_message(self, chat_id, language="ko"):
+        self.calls.append("tg")
+        return True
+
+
 @pytest.fixture
 def tmp_db(tmp_path, monkeypatch):
     db = tmp_path / "t.sqlite"
-    # seed holdings table so load_stop_map works
     conn = sqlite3.connect(db)
-    conn.execute("CREATE TABLE stock_holdings (ticker TEXT, stop_loss REAL)")
-    conn.execute("INSERT INTO stock_holdings VALUES ('005930', 0)")
+    conn.execute(
+        "CREATE TABLE stock_holdings (id INTEGER PRIMARY KEY, ticker TEXT, company_name TEXT, "
+        "buy_price REAL, buy_date TEXT, scenario TEXT, target_price REAL, stop_loss REAL, "
+        "account_key TEXT, account_name TEXT)"
+    )
     conn.commit()
     conn.close()
     monkeypatch.setattr(la, "DB_PATH", str(db))
     return str(db)
 
 
-def _patch_trader(monkeypatch, trader):
-    monkeypatch.setattr(la, "_open_context", lambda market: FakeCtx(trader))
+def _seed(db, rows):
+    conn = sqlite3.connect(db)
+    conn.executemany(
+        "INSERT INTO stock_holdings (id, ticker, company_name, buy_price, buy_date, scenario, "
+        "target_price, stop_loss, account_key, account_name) VALUES (?,?,?,?,?,?,?,?,?,?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
 
 
-def _count_inflight(db, status=None):
+def _row(id_, ticker, buy_price, stop_loss=0.0):
+    return (id_, ticker, ticker, buy_price, "2026-06-01 10:00:00", "{}", 0.0,
+            stop_loss, "acc1", "primary")
+
+
+def _patch(monkeypatch, trader, agent_holder=None, make_agent_counter=None):
+    monkeypatch.setattr(la, "_open_context", lambda market, account_name=None: FakeCtx(trader))
+
+    async def _fake_make_agent(market):
+        if make_agent_counter is not None:
+            make_agent_counter.append(1)
+        return agent_holder
+
+    monkeypatch.setattr(la, "_make_agent", _fake_make_agent)
+
+
+def _inflight(db, status=None):
     conn = sqlite3.connect(db)
     try:
         if status:
@@ -82,69 +122,88 @@ def _count_inflight(db, status=None):
         conn.close()
 
 
-# a -8% loser (buy 100, now 92) -> TIER1 abs-7 fires
-_LOSER = [{"stock_code": "005930", "quantity": 10, "avg_price": 100.0, "current_price": 92.0}]
-
-
-def test_shadow_mode_places_no_order(tmp_db, monkeypatch):
+def test_shadow_touches_no_agent_and_no_order(tmp_db, monkeypatch):
     monkeypatch.setattr(la, "LOOP_A_LIVE", False)
     monkeypatch.setattr(la, "LOOP_A_ENABLED", True)
-    trader = FakeTrader(_LOSER)
-    _patch_trader(monkeypatch, trader)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])  # buy 100, price 92 => -8% TIER1
+    calls = []
+    trader = FakeTrader({"005930": 92.0}, calls=calls)
+    made = []
+    _patch(monkeypatch, trader, agent_holder=FakeAgent(calls), make_agent_counter=made)
 
     summary = asyncio.run(la.run_market("KR", "run1"))
 
-    assert summary["triggered"] == 1
-    assert summary["shadow"] == 1
-    assert trader.sell_calls == []  # NO real order in shadow mode
-    assert _count_inflight(tmp_db, "SHADOW") == 1
+    assert summary["triggered"] == 1 and summary["shadow"] == 1
+    assert made == []                 # agent NEVER created in shadow
+    assert calls == []                # no sim, no kis, no telegram
+    assert _inflight(tmp_db, "SHADOW") == 1
 
 
-def test_live_mode_sells_and_reconciles(tmp_db, monkeypatch):
+def test_live_order_is_sim_then_kis_then_telegram(tmp_db, monkeypatch):
     monkeypatch.setattr(la, "LOOP_A_LIVE", True)
     monkeypatch.setattr(la, "LOOP_A_ENABLED", True)
-    trader = FakeTrader(_LOSER, holding_qty={"005930": 10})
-    _patch_trader(monkeypatch, trader)
+    monkeypatch.setattr(la, "CHAT_ID", "chat1")
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader({"005930": 92.0}, holding_qty={"005930": 10}, calls=calls)
+    _patch(monkeypatch, trader, agent_holder=FakeAgent(calls))
 
     summary = asyncio.run(la.run_market("KR", "run1"))
 
     assert summary["sold"] == 1
-    assert trader.sell_calls == [("005930", 10)]  # market sell of full reconciled qty
-    assert _count_inflight(tmp_db, "FILLED") == 1
+    assert calls == ["sim:005930", "kis:005930:10", "tg"]   # exact order
+    assert _inflight(tmp_db, "FILLED") == 1
 
 
-def test_live_mode_skips_when_already_flat_at_kis(tmp_db, monkeypatch):
-    # KIS says qty 0 (batch already sold) -> Loop A must NOT sell.
+def test_live_skips_kis_when_flat_but_still_closes_sim(tmp_db, monkeypatch):
+    # KIS says qty 0 (batch already sold real) -> no KIS order, sim still closed.
     monkeypatch.setattr(la, "LOOP_A_LIVE", True)
     monkeypatch.setattr(la, "LOOP_A_ENABLED", True)
-    trader = FakeTrader(_LOSER, holding_qty={"005930": 0})
-    _patch_trader(monkeypatch, trader)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader({"005930": 92.0}, holding_qty={"005930": 0}, calls=calls)
+    _patch(monkeypatch, trader, agent_holder=FakeAgent(calls))
+
+    asyncio.run(la.run_market("KR", "run1"))
+
+    assert "sim:005930" in calls
+    assert not any(c.startswith("kis:") for c in calls)   # no real order placed
+
+
+def test_pyramided_ticker_is_skipped(tmp_db, monkeypatch):
+    monkeypatch.setattr(la, "LOOP_A_LIVE", False)
+    monkeypatch.setattr(la, "LOOP_A_ENABLED", True)
+    _seed(tmp_db, [_row(1, "005930", 100.0), _row(2, "005930", 110.0)])  # 2 rows = pyramided
+    calls = []
+    trader = FakeTrader({"005930": 80.0}, calls=calls)  # deep loss, but must be skipped
+    _patch(monkeypatch, trader, agent_holder=FakeAgent(calls))
 
     summary = asyncio.run(la.run_market("KR", "run1"))
 
-    assert trader.sell_calls == []
-    assert summary["sold"] == 0
+    assert summary["pyramided_skipped"] == 1
+    assert summary["checked"] == 0 and summary["triggered"] == 0
+    assert calls == []
 
 
 def test_inflight_guard_blocks_second_trigger(tmp_db, monkeypatch):
     monkeypatch.setattr(la, "LOOP_A_LIVE", False)
     monkeypatch.setattr(la, "LOOP_A_ENABLED", True)
-    trader = FakeTrader(_LOSER)
-    _patch_trader(monkeypatch, trader)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader({"005930": 92.0}, calls=calls)
+    _patch(monkeypatch, trader, agent_holder=FakeAgent(calls))
 
-    asyncio.run(la.run_market("KR", "run1"))      # creates SHADOW inflight
-    summary2 = asyncio.run(la.run_market("KR", "run2"))  # different run id
+    asyncio.run(la.run_market("KR", "run1"))
+    summary2 = asyncio.run(la.run_market("KR", "run2"))
 
-    # second cycle sees the open SHADOW inflight and skips
     assert summary2["skipped"] == 1
-    assert _count_inflight(tmp_db) == 1
+    assert _inflight(tmp_db) == 1
 
 
-def test_owner_lock_is_exclusive(tmp_db, monkeypatch):
+def test_owner_lock_is_exclusive(tmp_db):
     conn = la._connect()
     la._ensure_schema(conn)
     assert la.claim_lock(conn, "005930", "KR", "runA") is True
-    # second claimant cannot take a live lock
     assert la.claim_lock(conn, "005930", "KR", "runB") is False
     la.release_lock(conn, "005930", "KR", "runA")
     assert la.claim_lock(conn, "005930", "KR", "runB") is True
@@ -152,18 +211,17 @@ def test_owner_lock_is_exclusive(tmp_db, monkeypatch):
 
 
 def test_winner_not_sold_tier1_only(tmp_db, monkeypatch):
-    # +20% winner well above a trailing peak: evaluate_oneil_sell might trail, but
-    # Loop A is TIER1-only and must HOLD.
     monkeypatch.setattr(la, "LOOP_A_LIVE", False)
     monkeypatch.setattr(la, "LOOP_A_ENABLED", True)
-    winner = [{"stock_code": "005930", "quantity": 10, "avg_price": 100.0, "current_price": 120.0}]
-    trader = FakeTrader(winner)
-    _patch_trader(monkeypatch, trader)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader({"005930": 120.0}, calls=calls)  # +20% winner
+    _patch(monkeypatch, trader, agent_holder=FakeAgent(calls))
 
     summary = asyncio.run(la.run_market("KR", "run1"))
 
     assert summary["triggered"] == 0
-    assert trader.sell_calls == []
+    assert calls == []
 
 
 def test_disabled_flag_is_noop(tmp_db, monkeypatch):

--- a/tools/loop_a_hardstop.py
+++ b/tools/loop_a_hardstop.py
@@ -2,22 +2,29 @@
 """Loop A — high-frequency catastrophic hard-stop loop (LLM-free).
 
 Runs as a standalone intraday cron, SEPARATE from the 2-3x/day batch sell cycle.
-For each real holding it fetches the live price and applies ONLY the O'Neil
-TIER1 hard stop (scenario stop-loss / absolute -7%). On a trigger it sells at
-market, so a stop that the slow batch cadence would only catch at -12~-15% is
-hit much closer to its intended level.
+For each tracked holding it fetches the live price and applies ONLY the O'Neil
+TIER1 hard stop (scenario stop-loss / absolute -7%). On a trigger it closes the
+position the SAME way the batch does — so the simulator, the real KIS account
+and the Telegram channel all stay consistent:
+
+    1. agent.sell_stock(stock_data, reason)   # simulator close + journal + queue msg
+    2. trading.async_sell_stock(ticker)       # real KIS market order
+    3. agent.send_telegram_message(chat_id)   # flush the queued sell message
+
+This is exactly the batch's sequence (stock_tracking_agent.py ~1380-1452),
+reused rather than re-implemented, so there is one source of truth. Loop A only
+adds the high-frequency TIER1 decision in front of it.
 
 SAFETY (read before enabling):
-  - Live selling is gated behind  LOOP_A_LIVE=true .  Default = SHADOW mode:
-    it logs exactly what it WOULD sell and places NO orders. Turn it on only
-    after reviewing the slippage backtest.
-  - LOOP_A_ENABLED=false  disables the loop entirely (kill switch).
-  - Loop A runs in its own process, so the batch's in-process asyncio locks do
-    NOT apply. We guard against double-selling with (a) a SQLite owner_lock
-    claimed via BEGIN IMMEDIATE, (b) an inflight-order uniqueness guard, and
-    (c) a fresh KIS holding-quantity reconcile immediately before every live
-    sell (KIS is the single source of truth; if the batch already sold, qty is
-    0 and we skip).
+  - Live selling is gated behind  LOOP_A_LIVE=true . Default = SHADOW: it logs
+    what it WOULD sell, touches NO agent and places NO order. The heavy agent is
+    only imported/instantiated on an actual LIVE sell.
+  - LOOP_A_ENABLED=false disables the loop entirely (kill switch).
+  - Separate process, so the batch's in-process asyncio locks do NOT apply:
+    guards via a SQLite owner_lock (BEGIN IMMEDIATE), an inflight-order
+    uniqueness guard, and a fresh KIS holding-qty reconcile before every sell.
+  - Pyramided tickers (>1 holding row) are SKIPPED — the batch owns the
+    fractional-sell logic; Loop A only handles clean single-row positions.
 
 Usage:
     python tools/loop_a_hardstop.py [--market kr|us|both] [--once]
@@ -38,32 +45,32 @@ import sys
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 TOOLS_DIR = Path(__file__).resolve().parent
 PROJECT_ROOT = TOOLS_DIR.parent
+
 
 # ── Market-aware path bootstrap (cores-shadowing safety) ──────────────────────
 # The `cores` package is imported once per process and cached, and the US runtime
 # resolves `from cores.X` to prism-us/cores while KR resolves to the root cores.
 # A single process therefore CANNOT serve both markets without cross-wiring KR/US
-# modules. Each market runs in its own process (see main(): `both` spawns two
+# modules. Each market runs in its own process (main(): `both` spawns two
 # subprocesses), and we set sys.path so the active market's modules win.
 def _bootstrap_path(market: str) -> None:
     root = str(PROJECT_ROOT)
     us = str(PROJECT_ROOT / "prism-us")
     us_trading = str(PROJECT_ROOT / "prism-us" / "trading")
     if market == "US":
-        # prism-us must be highest priority so `cores` == prism-us/cores and the
-        # bare `import kis_auth` inside us_stock_trading resolves to prism-us/trading.
         for p in (root, us_trading, us):
             sys.path.insert(0, p)
-    else:  # KR: root highest priority so `cores`/`trading` == repo root.
+    else:  # KR
         for p in (us, root):
             sys.path.insert(0, p)
 
 
 logger = logging.getLogger("loop_a")
+
 
 # ── Configuration (env-driven) ────────────────────────────────────────────────
 def _env_bool(name: str, default: bool) -> bool:
@@ -75,6 +82,7 @@ LOOP_A_LIVE = _env_bool("LOOP_A_LIVE", False)          # False => SHADOW (no rea
 LOCK_TTL_SEC = int(os.getenv("LOOP_A_LOCK_TTL_SEC", "300"))
 DB_PATH = os.getenv("LOOP_A_DB") or os.getenv("STOCK_TRACKING_DB") \
     or str(PROJECT_ROOT / "stock_tracking_db.sqlite")
+CHAT_ID = os.getenv("LOOP_A_CHAT_ID") or os.getenv("TELEGRAM_CHAT_ID") or None
 
 _HOLDINGS_TABLE = {"KR": "stock_holdings", "US": "us_stock_holdings"}
 
@@ -124,20 +132,18 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
-def load_stop_map(conn: sqlite3.Connection, market: str) -> Dict[str, float]:
-    """ticker -> scenario stop_loss from the holdings table (any account)."""
+def load_holdings_by_ticker(conn: sqlite3.Connection, market: str) -> Dict[str, List[Dict[str, Any]]]:
+    """All holding rows (full dicts) grouped by ticker. Empty on error."""
     table = _HOLDINGS_TABLE[market]
-    out: Dict[str, float] = {}
+    out: Dict[str, List[Dict[str, Any]]] = {}
     try:
-        for row in conn.execute(
-            f"SELECT ticker, MAX(COALESCE(stop_loss, 0)) AS sl FROM {table} GROUP BY ticker"
-        ):
-            try:
-                out[str(row["ticker"]).strip()] = float(row["sl"] or 0)
-            except (TypeError, ValueError):
-                continue
+        for row in conn.execute(f"SELECT * FROM {table}"):
+            d = dict(row)
+            ticker = str(d.get("ticker") or "").strip()
+            if ticker:
+                out.setdefault(ticker, []).append(d)
     except sqlite3.Error as e:
-        logger.warning("stop_loss map load failed (%s): %s", market, e)
+        logger.warning("holdings load failed (%s): %s", market, e)
     return out
 
 
@@ -151,11 +157,7 @@ def has_open_inflight(conn: sqlite3.Connection, ticker: str, market: str) -> boo
 
 
 def claim_lock(conn: sqlite3.Connection, ticker: str, market: str, run_id: str) -> bool:
-    """Atomically claim the position owner_lock. Returns True if acquired.
-
-    BEGIN IMMEDIATE serialises competing writers (other loops/processes). A lock
-    older than LOCK_TTL_SEC is treated as stale and may be re-claimed.
-    """
+    """Atomically claim the position owner_lock. Returns True if acquired."""
     now = _now()
     expires = _iso(now + timedelta(seconds=LOCK_TTL_SEC))
     try:
@@ -212,71 +214,98 @@ def record_inflight(conn: sqlite3.Connection, ticker: str, market: str, run_id: 
         logger.warning("inflight record failed %s/%s: %s", ticker, market, e)
 
 
-# ── Trader context factories (KR / US) ────────────────────────────────────────
-def _open_context(market: str):
+# ── Trader context + agent factories (KR / US) ────────────────────────────────
+def _open_context(market: str, account_name: Optional[str] = None):
     if market == "KR":
         from trading.domestic_stock_trading import AsyncTradingContext
-        return AsyncTradingContext()
+        return AsyncTradingContext(account_name=account_name)
     from us_stock_trading import AsyncUSTradingContext
-    return AsyncUSTradingContext()
+    return AsyncUSTradingContext(account_name=account_name)
 
 
-def _ticker_of(holding: Dict[str, Any], market: str) -> str:
-    return str(holding.get("ticker") or holding.get("stock_code") or "").strip()
+async def _make_agent(market: str):
+    """Instantiate + lightweight-init the tracking agent (LLM agent skipped).
+
+    Only called for a LIVE sell, so SHADOW runs never pull in the agent deps.
+    """
+    if market == "KR":
+        from stock_tracking_agent import StockTrackingAgent
+        agent = StockTrackingAgent(db_path=DB_PATH)
+    else:
+        from us_stock_tracking_agent import USStockTrackingAgent
+        agent = USStockTrackingAgent(db_path=DB_PATH)
+    await agent.initialize(skip_llm_agent=True)
+    return agent
 
 
 # ── Core evaluation for one market ─────────────────────────────────────────────
 async def run_market(market: str, run_id: str) -> Dict[str, Any]:
-    """Evaluate TIER1 hard stop for every real holding in one market.
+    """Evaluate the TIER1 hard stop for every clean single-row holding.
 
     Never raises: any failure degrades to a no-op for that ticker/market.
     """
-    summary = {"market": market, "checked": 0, "triggered": 0, "sold": 0, "shadow": 0, "skipped": 0}
-    # Lazy import after path bootstrap so the correct (KR vs US) cores wins.
+    summary = {"market": market, "checked": 0, "triggered": 0, "sold": 0,
+               "shadow": 0, "skipped": 0, "pyramided_skipped": 0}
     from cores.oneil_fallback import SellInputs, evaluate_tier1_hardstop
     conn = _connect()
+    agent = {"ref": None}  # lazily created on first LIVE sell
     try:
         _ensure_schema(conn)
-        stop_map = load_stop_map(conn, market)
+        by_ticker = load_holdings_by_ticker(conn, market)
+        if not by_ticker:
+            return summary
         try:
-            async with _open_context(market) as trader:
-                try:
-                    portfolio: List[Dict[str, Any]] = await asyncio.to_thread(trader.get_portfolio)
-                except Exception as e:
-                    logger.warning("%s get_portfolio failed: %s", market, e)
-                    return summary
-                for h in (portfolio or []):
-                    ticker = _ticker_of(h, market)
-                    if not ticker:
+            async with _open_context(market) as trader:  # primary ctx, prices only (account-agnostic)
+                for ticker, rows in by_ticker.items():
+                    if len(rows) > 1:
+                        # Pyramided position -> leave to the batch's fractional logic.
+                        summary["pyramided_skipped"] += 1
+                        logger.info("[%s] %s pyramided (%d rows) -> skip (batch handles)",
+                                    market, ticker, len(rows))
                         continue
+                    h = rows[0]
                     try:
-                        qty = int(h.get("quantity", 0) or 0)
-                        avg_price = float(h.get("avg_price", 0) or 0)
-                        cur_price = float(h.get("current_price", 0) or 0)
+                        buy_price = float(h.get("buy_price", 0) or 0)
+                        stop_loss = float(h.get("stop_loss", 0) or 0)
                     except (TypeError, ValueError):
                         continue
-                    if qty <= 0 or avg_price <= 0 or cur_price <= 0:
+                    if buy_price <= 0:
+                        continue
+                    try:
+                        info = await asyncio.to_thread(trader.get_current_price, ticker)
+                        cur_price = float((info or {}).get("current_price", 0) or 0)
+                    except Exception as e:
+                        logger.warning("[%s] %s price fetch failed: %s", market, ticker, e)
+                        continue
+                    if cur_price <= 0:
                         continue
                     summary["checked"] += 1
-                    inp = SellInputs(
-                        buy_price=avg_price,
-                        current_price=cur_price,
-                        stop_loss=stop_map.get(ticker, 0.0),
+                    should_sell, reason = evaluate_tier1_hardstop(
+                        SellInputs(buy_price=buy_price, current_price=cur_price, stop_loss=stop_loss)
                     )
-                    should_sell, reason = evaluate_tier1_hardstop(inp)
                     if not should_sell:
                         continue
                     summary["triggered"] += 1
-                    await _act_on_trigger(conn, trader, market, ticker, qty, reason, run_id, summary)
+                    h = dict(h)
+                    h["current_price"] = cur_price
+                    await _act_on_trigger(conn, market, ticker, h, reason, run_id, agent, summary)
         except Exception as e:  # context/credential failure -> skip whole market safely
             logger.warning("%s trading context failed: %s", market, e)
     finally:
         conn.close()
+        if agent["ref"] is not None:
+            try:
+                if getattr(agent["ref"], "conn", None):
+                    agent["ref"].conn.close()
+            except Exception:
+                pass
     return summary
 
 
-async def _act_on_trigger(conn, trader, market: str, ticker: str, qty: int,
-                          reason: str, run_id: str, summary: Dict[str, Any]) -> None:
+async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, Any],
+                          reason: str, run_id: str, agent: Dict[str, Any],
+                          summary: Dict[str, Any]) -> None:
+    qty_hint = 0
     # Guard 1: an inflight SELL for this ticker already exists -> leave it alone.
     if has_open_inflight(conn, ticker, market):
         summary["skipped"] += 1
@@ -289,34 +318,54 @@ async def _act_on_trigger(conn, trader, market: str, ticker: str, qty: int,
         return
     try:
         if not LOOP_A_LIVE:
-            # SHADOW: log intended sell, place no order.
+            # SHADOW: log intended sell; touch no agent, place no order.
             summary["shadow"] += 1
-            logger.info("[SHADOW][%s] WOULD SELL %s qty=%d reason=%s", market, ticker, qty, reason)
-            record_inflight(conn, ticker, market, run_id, qty, "SHADOW", reason, None)
+            logger.info("[SHADOW][%s] WOULD SELL %s reason=%s (buy=%.4f cur=%.4f)",
+                        market, ticker, reason, stock_data.get("buy_price", 0),
+                        stock_data.get("current_price", 0))
+            record_inflight(conn, ticker, market, run_id, 0, "SHADOW", reason, None)
             release_lock(conn, ticker, market, run_id, new_state="HOLDING")
             return
-        # LIVE: reconcile against KIS (single source of truth) right before selling.
+
+        # LIVE: 1) simulator close (+journal +telegram queue) via the SAME path as batch.
+        if agent["ref"] is None:
+            agent["ref"] = await _make_agent(market)
+        ag = agent["ref"]
+        logger.warning("[LIVE][%s] SELLING %s reason=%s", market, ticker, reason)
+        sim_ok = await ag.sell_stock(stock_data, reason)
+        if not sim_ok:
+            logger.error("[%s] %s sell_stock (sim) failed -> aborting, no KIS order", market, ticker)
+            release_lock(conn, ticker, market, run_id, new_state="HOLDING")
+            return
+
+        # 2) real KIS market order on the holding's own account; reconcile qty first.
+        order_no, ok, sold_qty = None, False, 0
         try:
-            live_qty = await asyncio.to_thread(trader.get_holding_quantity, ticker)
+            async with _open_context(market, account_name=stock_data.get("account_name")) as seller:
+                live_qty = await asyncio.to_thread(seller.get_holding_quantity, ticker)
+                sold_qty = int(live_qty or 0)
+                if sold_qty <= 0:
+                    logger.info("[%s] %s already flat at KIS (qty=0); sim closed", market, ticker)
+                else:
+                    result = await seller.async_sell_stock(ticker, quantity=sold_qty)
+                    ok = bool(result and result.get("success"))
+                    order_no = (result or {}).get("order_no")
+                    logger.warning("[LIVE][%s] %s KIS sell success=%s order_no=%s msg=%s",
+                                   market, ticker, ok, order_no, (result or {}).get("message"))
         except Exception as e:
-            logger.warning("[%s] %s holding reconcile failed, aborting sell: %s", market, ticker, e)
-            release_lock(conn, ticker, market, run_id, new_state="HOLDING")
-            return
-        sell_qty = min(qty, int(live_qty or 0))
-        if sell_qty <= 0:
-            logger.info("[%s] %s already flat at KIS (qty=0) -> skip", market, ticker)
-            release_lock(conn, ticker, market, run_id, new_state="SOLD")
-            return
-        logger.warning("[LIVE][%s] SELLING %s qty=%d reason=%s", market, ticker, sell_qty, reason)
-        result = await trader.async_sell_stock(ticker, quantity=sell_qty)  # market order
-        ok = bool(result and result.get("success"))
-        order_no = (result or {}).get("order_no")
-        record_inflight(conn, ticker, market, run_id, sell_qty,
-                        "FILLED" if ok else "REJECTED", reason, str(order_no) if order_no else None)
-        release_lock(conn, ticker, market, run_id, new_state="SOLD" if ok else "HOLDING")
-        summary["sold"] += 1 if ok else 0
-        logger.warning("[LIVE][%s] %s sell result success=%s order_no=%s msg=%s",
-                       market, ticker, ok, order_no, (result or {}).get("message"))
+            logger.error("[%s] %s KIS sell failed after sim close: %s", market, ticker, e)
+
+        # 3) flush the queued telegram message (instant notification).
+        try:
+            await ag.send_telegram_message(CHAT_ID)
+        except Exception as e:
+            logger.warning("[%s] %s telegram flush failed: %s", market, ticker, e)
+
+        record_inflight(conn, ticker, market, run_id, sold_qty,
+                        "FILLED" if (ok or sold_qty == 0) else "REJECTED",
+                        reason, str(order_no) if order_no else None)
+        release_lock(conn, ticker, market, run_id, new_state="SOLD")
+        summary["sold"] += 1
     except Exception as e:
         logger.error("[%s] %s sell action failed: %s", market, ticker, e)
         release_lock(conn, ticker, market, run_id, new_state="HOLDING")
@@ -329,11 +378,12 @@ async def main_async(markets: List[str]) -> int:
     run_id = uuid.uuid4().hex[:12]
     mode = "LIVE" if LOOP_A_LIVE else "SHADOW"
     logger.info("Loop A start run_id=%s mode=%s markets=%s db=%s", run_id, mode, markets, DB_PATH)
-    totals = {"checked": 0, "triggered": 0, "sold": 0, "shadow": 0, "skipped": 0}
+    totals: Dict[str, int] = {}
     for market in markets:
         s = await run_market(market, run_id)
-        for k in totals:
-            totals[k] += s.get(k, 0)
+        for k, v in s.items():
+            if isinstance(v, int):
+                totals[k] = totals.get(k, 0) + v
         logger.info("Loop A %s summary: %s", market, s)
     logger.info("Loop A done run_id=%s mode=%s totals=%s", run_id, mode, totals)
     return 0
@@ -342,7 +392,7 @@ async def main_async(markets: List[str]) -> int:
 def _setup_logging() -> None:
     log_dir = PROJECT_ROOT / "logs"
     log_dir.mkdir(exist_ok=True)
-    handlers = [logging.StreamHandler(sys.stdout)]
+    handlers: List[logging.Handler] = [logging.StreamHandler(sys.stdout)]
     try:
         handlers.append(logging.FileHandler(log_dir / "loop_a_hardstop.log"))
     except OSError:
@@ -375,7 +425,6 @@ def main() -> int:
     args = parser.parse_args()
     _setup_logging()
     if args.market == "both":
-        # Cannot serve both markets in one process (cores package is cached) -> fan out.
         return _run_both_isolated()
     market = {"kr": "KR", "us": "US"}[args.market]
     _bootstrap_path(market)


### PR DESCRIPTION
## 배경
Loop A가 KIS만 직접 매도 → 시뮬레이터 미반영(시뮬↔실 불일치)·텔레그램 누락. 사용자 지적대로 **배치 매도 시퀀스를 재사용**하도록 변경.

## 변경
트리거 시 배치와 동일 순서:
1. `agent.sell_stock(stock_data, reason)` — 시뮬 청산 + 매매일지 + 텔레그램 큐
2. `trading.async_sell_stock(ticker)` — 실 KIS (수량 재조회 후)
3. `agent.send_telegram_message(chat_id)` — 텔레그램 즉시 flush

## 의존성 주의(사용자 당부 반영)
- 양쪽 agent `initialize()`에 **additive `skip_llm_agent`**(기본 False=배치 무변경). Loop A만 True → 무거운 LLM 시나리오 에이전트 생성 회피. `sell_stock`은 `trading_agent` 미사용이라 안전.
- **배치 매도 루프 자체는 무변경**(회귀 표면 0).
- **SHADOW는 agent 자체를 안 건드림**(무거운 의존성은 실매도 시에만 로드).
- 피라미딩(>1행) 종목은 **skip**(배치가 분할매도 담당).

## 테스트 (8건)
shadow=agent미생성·주문0 / live 순서 정확히 sim→kis→telegram / KIS flat이어도 시뮬 청산 / 피라미딩 skip / owner_lock / inflight 가드 / TIER1한정 승자미매도.

## 배포 후 검증 예정 (db-server)
- 배치 무변경 회귀: `initialize(skip_llm_agent=False)`가 여전히 trading_agent 생성 / True면 None
- SHADOW dry-run 주문 0