### PR TITLE
fix(loops): Loop A 기존 TELEGRAM_CHANNEL_ID 채널 재사용

### DIFF
--- a/tools/loop_a_hardstop.py
+++ b/tools/loop_a_hardstop.py
@@ -82,7 +82,9 @@ LOOP_A_LIVE = _env_bool("LOOP_A_LIVE", False)          # False => SHADOW (no rea
 LOCK_TTL_SEC = int(os.getenv("LOOP_A_LOCK_TTL_SEC", "300"))
 DB_PATH = os.getenv("LOOP_A_DB") or os.getenv("STOCK_TRACKING_DB") \
     or str(PROJECT_ROOT / "stock_tracking_db.sqlite")
-CHAT_ID = os.getenv("LOOP_A_CHAT_ID") or os.getenv("TELEGRAM_CHAT_ID") or None
+# Reuse the same channel the batch/system already broadcasts to (TELEGRAM_CHANNEL_ID).
+# LOOP_A_CHAT_ID is only an optional override.
+CHAT_ID = os.getenv("LOOP_A_CHAT_ID") or os.getenv("TELEGRAM_CHANNEL_ID") or None
 
 _HOLDINGS_TABLE = {"KR": "stock_holdings", "US": "us_stock_holdings"}
 


### PR DESCRIPTION
Loop A가 없는 env(TELEGRAM_CHAT_ID)를 읽고 있었음. 시스템 전체가 쓰는 **TELEGRAM_CHANNEL_ID**(배치와 동일 채널)로 변경(LOOP_A_CHAT_ID는 선택 override). 참고: KIS 토큰 캐싱은 이미 존재(kis_auth.read_token, 1일 유효, auth()가 재사용) → 7분 주기 컨텍스트 오픈이 캐시 토큰 재사용해 발급 rate limit 안 걸림, 추가작업 불필요.