### PR TITLE
fix(loops): Loop A .env 로드 (TELEGRAM_CHANNEL_ID/LOOP_A_* 인식)

### DIFF
--- a/tools/loop_a_hardstop.py
+++ b/tools/loop_a_hardstop.py
@@ -71,6 +71,14 @@ def _bootstrap_path(market: str) -> None:
 
 logger = logging.getLogger("loop_a")
 
+# Load .env so env-driven config below (TELEGRAM_CHANNEL_ID, LOOP_A_*, journal flag)
+# is visible — a fresh cron process does not inherit .env otherwise.
+try:
+    from dotenv import load_dotenv
+    load_dotenv(PROJECT_ROOT / ".env")
+except Exception:
+    pass
+
 
 # ── Configuration (env-driven) ────────────────────────────────────────────────
 def _env_bool(name: str, default: bool) -> bool:


### PR DESCRIPTION
cron 프로세스는 .env를 상속받지 않아 os.getenv가 None → LIVE 매도 시 텔레그램·저널이 조용히 누락됨. 코드베이스 패턴대로 load_dotenv(PROJECT_ROOT/.env) 추가.