### PR TITLE
docs(env): .env.example에 누락된 운영 .env 키 8종 문서화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,3 +100,27 @@ TELEGRAM_CHANNEL_ID=your_channel_id
 # TELEGRAM_CHANNEL_USERNAME_JA=your_japanese_channel_username
 # TELEGRAM_CHANNEL_USERNAME_ZH=your_chinese_channel_username
 # TELEGRAM_CHANNEL_USERNAME_ES=your_spanish_channel_username
+
+# ============================================
+# Archive API (Optional - archive_api.py service)
+# ============================================
+# REST endpoint + key for the archive service. The key is also used by
+# telegram_ai_bot.py to authenticate archive lookups.
+# ARCHIVE_API_HOST=0.0.0.0
+# ARCHIVE_API_PORT=8000
+# ARCHIVE_API_KEY=your_archive_api_key
+
+# Daily per-user limit for on-demand insight generation (telegram_ai_bot.py)
+# INSIGHT_DAILY_LIMIT=10
+
+# Finnhub API key for US market data (https://finnhub.io)
+# FINNHUB_API_KEY=your_finnhub_api_key
+
+# ============================================
+# PRISM-BTC (Optional - BTC futures auto-trading module)
+# ============================================
+# Bybit DEMO trading credentials (prism-btc/live/demo.py)
+# BYBIT_DEMO_API_KEY=your_bybit_demo_api_key
+# BYBIT_DEMO_API_SECRET=your_bybit_demo_api_secret
+# Telegram channel for BTC ops/healthcheck alerts (prism-btc/live/healthcheck.py)
+# BTC_OPS_CHANNEL_ID=your_btc_ops_channel_id


### PR DESCRIPTION
운영 .env엔 있으나 .env.example에 없던 8키 추가(placeholder만, 실제값 없음): ARCHIVE_API_HOST/PORT/KEY, INSIGHT_DAILY_LIMIT, FINNHUB_API_KEY, BYBIT_DEMO_API_KEY/SECRET, BTC_OPS_CHANNEL_ID. 나머지 키는 이미 주석 예시로 존재. 유출검증: 실제 값 0.