### PR TITLE
feat(llm): mcp-agent → openai-agents migration foundation (Phase 1-3, flag-gated)

### DIFF
--- a/cores/chatgpt_proxy/api_translator.py
+++ b/cores/chatgpt_proxy/api_translator.py
@@ -26,6 +26,46 @@ def _map_model(model: str) -> str:
     return _MODEL_MAP.get(model, model)
 
 
+def prepare_responses_passthrough(body: dict) -> dict:
+    """Prepare a Responses API request for passthrough to the Codex backend.
+
+    The openai-agents Runner already produces a Responses-shaped body (with
+    ``input``, ``instructions``, ``tools`` flat, ``text.format``, etc.), so
+    this function must NOT re-translate the payload.  It only:
+
+    - Maps the model name via ``_map_model`` (e.g. gpt-4o -> gpt-5.4-mini).
+    - Forces ``store=False`` and ``stream=True`` (mandatory for Codex backend).
+    - Injects a default ``instructions`` value when the caller omitted it
+      (Codex requires the field to be present and non-empty).
+
+    All other Responses API fields (``input``, ``tools``, ``tool_choice``,
+    ``text``, ``reasoning``, ``max_output_tokens``, ``temperature``,
+    ``top_p``) are left untouched.
+
+    Does not mutate the caller's dict.
+    """
+    out = dict(body)
+    out["model"] = _map_model(body.get("model", "gpt-5.4-mini"))
+    out["store"] = False   # MANDATORY: store:true returns 400
+    out["stream"] = True   # MANDATORY: always stream upstream
+    if not out.get("instructions"):
+        out["instructions"] = "You are a helpful assistant."
+    # Codex backend requires `input` to be a LIST of items; the openai SDK may
+    # send a bare string for simple text input -> normalize to a user message.
+    inp = out.get("input")
+    if isinstance(inp, str):
+        out["input"] = [{"role": "user", "content": inp}]
+    # The Codex backend rejects several Responses parameters the openai-agents
+    # Runner adds by default (observed: "Unsupported parameter: max_output_tokens").
+    # Strip them so subscription requests succeed.
+    for unsupported in ("max_output_tokens", "include"):
+        out.pop(unsupported, None)
+    # Drop empty tool list (Codex dislikes an empty `tools: []`).
+    if out.get("tools") == []:
+        out.pop("tools", None)
+    return out
+
+
 def translate_request(body: dict) -> dict:
     """Translate Chat Completions request to Responses API format.
 

--- a/cores/chatgpt_proxy/proxy_server.py
+++ b/cores/chatgpt_proxy/proxy_server.py
@@ -26,6 +26,7 @@ def create_app(token_manager: TokenManager) -> web.Application:
 
     app = web.Application()
     app.router.add_post("/v1/chat/completions", handle_chat_completions)
+    app.router.add_post("/v1/responses", handle_responses)
     app.router.add_get("/health", handle_health)
     return app
 
@@ -41,6 +42,99 @@ async def handle_health(request: web.Request) -> web.Response:
             pass
 
     return web.json_response({"status": "ok", "token_valid": token_valid})
+
+
+async def _forward_to_codex(
+    translated_request: dict,
+) -> "tuple[dict | None, web.Response | None]":
+    """Forward a pre-translated Responses API request to the Codex upstream.
+
+    Handles token retrieval, HTTP POST, SSE/JSON parsing, and error translation.
+
+    Returns:
+        (api_response, None)  on success — api_response is a Responses API dict.
+        (None, error_response) on any failure — error_response is a web.Response.
+    """
+    if not _token_manager:
+        return None, web.json_response(
+            {"error": {"message": "Token manager not initialized", "type": "server_error"}},
+            status=500,
+        )
+
+    # Get OAuth token
+    try:
+        token = await _token_manager.get_token()
+        account_id = await _token_manager.get_account_id()
+    except Exception as e:
+        logger.error("Token retrieval failed: %s", e)
+        return None, web.json_response(
+            {"error": {"message": str(e), "type": "authentication_error"}},
+            status=401,
+        )
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "OpenAI-Beta": "responses=experimental",
+        "accept": "text/event-stream",
+    }
+    if account_id:
+        headers["chatgpt-account-id"] = account_id
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                CHATGPT_RESPONSES_URL,
+                json=translated_request,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=300),
+            ) as resp:
+                raw_body = await resp.text()
+
+                if resp.status != 200:
+                    try:
+                        error_body = json.loads(raw_body)
+                    except json.JSONDecodeError:
+                        error_body = {"error": {"message": raw_body}}
+
+                    translated_error, status = api_translator.translate_error(error_body, resp.status)
+                    logger.warning("ChatGPT API error (%d): %s", resp.status, raw_body[:200])
+                    return None, web.json_response(translated_error, status=status)
+
+                # Parse response (may be SSE or JSON)
+                # Always request stream=true, so check both Content-Type and body format
+                content_type = resp.headers.get("Content-Type", "")
+                is_sse = "text/event-stream" in content_type or raw_body.lstrip().startswith("event:")
+                if is_sse:
+                    try:
+                        api_response = api_translator.collect_sse_to_response(raw_body)
+                        logger.debug("SSE parsed: output_items=%s status=%s",
+                                     [i.get("type") for i in api_response.get("output", [])],
+                                     api_response.get("status"))
+                    except ValueError as e:
+                        logger.error("SSE parsing failed: %s (Content-Type: %s, body[:200]: %s)", e, content_type, raw_body[:200])
+                        return None, web.json_response(
+                            {"error": {"message": f"SSE parsing error: {e}", "type": "server_error"}},
+                            status=502,
+                        )
+                else:
+                    try:
+                        api_response = json.loads(raw_body)
+                    except json.JSONDecodeError:
+                        logger.error("Invalid JSON response from ChatGPT (Content-Type: %s, body[:200]: %s)", content_type, raw_body[:200])
+                        return None, web.json_response(
+                            {"error": {"message": "Invalid response from upstream", "type": "server_error"}},
+                            status=502,
+                        )
+
+    except aiohttp.ClientError as e:
+        logger.error("Connection to ChatGPT failed: %s", e)
+        return None, web.json_response(
+            {"error": {"message": f"Upstream connection error: {e}", "type": "server_error"}},
+            status=502,
+        )
+
+    return api_response, None
 
 
 async def handle_chat_completions(request: web.Request) -> web.Response:
@@ -72,84 +166,13 @@ async def handle_chat_completions(request: web.Request) -> web.Response:
             status=500,
         )
 
-    # Get OAuth token
-    try:
-        token = await _token_manager.get_token()
-        account_id = await _token_manager.get_account_id()
-    except Exception as e:
-        logger.error("Token retrieval failed: %s", e)
-        return web.json_response(
-            {"error": {"message": str(e), "type": "authentication_error"}},
-            status=401,
-        )
-
-    # Forward to ChatGPT
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json",
-        "OpenAI-Beta": "responses=experimental",
-        "accept": "text/event-stream",
-    }
-    if account_id:
-        headers["chatgpt-account-id"] = account_id
-
     logger.debug("Proxy request: model=%s -> %s, tools=%d, messages=%d",
                  original_model, translated_request.get("model"),
                  len(body.get("tools") or []), len(body.get("messages") or []))
 
-    try:
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                CHATGPT_RESPONSES_URL,
-                json=translated_request,
-                headers=headers,
-                timeout=aiohttp.ClientTimeout(total=300),
-            ) as resp:
-                raw_body = await resp.text()
-
-                if resp.status != 200:
-                    # Try to parse error
-                    try:
-                        error_body = json.loads(raw_body)
-                    except json.JSONDecodeError:
-                        error_body = {"error": {"message": raw_body}}
-
-                    translated_error, status = api_translator.translate_error(error_body, resp.status)
-                    logger.warning("ChatGPT API error (%d): %s", resp.status, raw_body[:200])
-                    return web.json_response(translated_error, status=status)
-
-                # Parse response (may be SSE or JSON)
-                # Always request stream=true, so check both Content-Type and body format
-                content_type = resp.headers.get("Content-Type", "")
-                is_sse = "text/event-stream" in content_type or raw_body.lstrip().startswith("event:")
-                if is_sse:
-                    try:
-                        api_response = api_translator.collect_sse_to_response(raw_body)
-                        logger.debug("SSE parsed: output_items=%s status=%s",
-                                     [i.get("type") for i in api_response.get("output", [])],
-                                     api_response.get("status"))
-                    except ValueError as e:
-                        logger.error("SSE parsing failed: %s (Content-Type: %s, body[:200]: %s)", e, content_type, raw_body[:200])
-                        return web.json_response(
-                            {"error": {"message": f"SSE parsing error: {e}", "type": "server_error"}},
-                            status=502,
-                        )
-                else:
-                    try:
-                        api_response = json.loads(raw_body)
-                    except json.JSONDecodeError:
-                        logger.error("Invalid JSON response from ChatGPT (Content-Type: %s, body[:200]: %s)", content_type, raw_body[:200])
-                        return web.json_response(
-                            {"error": {"message": "Invalid response from upstream", "type": "server_error"}},
-                            status=502,
-                        )
-
-    except aiohttp.ClientError as e:
-        logger.error("Connection to ChatGPT failed: %s", e)
-        return web.json_response(
-            {"error": {"message": f"Upstream connection error: {e}", "type": "server_error"}},
-            status=502,
-        )
+    api_response, err = await _forward_to_codex(translated_request)
+    if err is not None:
+        return err
 
     # Translate response back to Chat Completions format
     try:
@@ -162,3 +185,31 @@ async def handle_chat_completions(request: web.Request) -> web.Response:
         )
 
     return web.json_response(result)
+
+
+async def handle_responses(request: web.Request) -> web.Response:
+    """Proxy a Responses API request directly to the ChatGPT Codex backend.
+
+    The openai-agents Runner already emits a Responses-shaped body, so no
+    format translation is needed.  The response is returned to the caller
+    as-is (no back-translation to Chat Completions format).
+    """
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        return web.json_response(
+            {"error": {"message": "Invalid JSON body", "type": "invalid_request_error"}},
+            status=400,
+        )
+
+    translated = api_translator.prepare_responses_passthrough(body)
+
+    logger.debug("Responses passthrough: model=%s -> %s, tools=%d",
+                 body.get("model"), translated.get("model"),
+                 len(body.get("tools") or []))
+
+    api_response, err = await _forward_to_codex(translated)
+    if err is not None:
+        return err
+
+    return web.json_response(api_response)

--- a/cores/llm/agent_bridge.py
+++ b/cores/llm/agent_bridge.py
@@ -1,0 +1,136 @@
+"""
+agent_bridge.py — lightweight helpers for wiring mcp_agent Agent objects into
+the cores/llm port layer.
+
+Design constraints:
+- No mcp_agent or openai imports at module top-level (keeps import safe even
+  when those SDKs are absent; used in tests and non-journal code paths).
+- Only stdlib + cores.llm imports at module level.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+from cores.llm.ports import AgentSpec, LLMBackend, LLMParams
+
+if TYPE_CHECKING:
+    from cores.llm.mcp_registry import McpServerRegistry
+
+# ---------------------------------------------------------------------------
+# Idempotency flag for ensure_openai_agents_configured()
+# ---------------------------------------------------------------------------
+_configured: bool = False
+
+
+def spec_from_mcp_agent(agent: Any, *, model: str, params: LLMParams) -> AgentSpec:
+    """Build an AgentSpec from any object that duck-types an mcp_agent Agent.
+
+    Reads:
+    - ``agent.name``        → AgentSpec.name
+    - ``agent.instruction`` → AgentSpec.instructions  (mcp_agent uses singular)
+    - ``getattr(agent, "server_names", []) or []`` → AgentSpec.mcp_servers
+
+    Works on real mcp_agent Agents and on plain test fakes — no SDK import needed.
+
+    Args:
+        agent:  Any object exposing .name, .instruction, and optionally .server_names.
+        model:  Model identifier string (e.g. "gpt-5.4-mini").
+        params: LLMParams instance with max_tokens / reasoning_effort / etc.
+
+    Returns:
+        A frozen AgentSpec ready to pass to any LLMBackend.run().
+    """
+    server_names = getattr(agent, "server_names", []) or []
+    return AgentSpec(
+        name=agent.name,
+        instructions=agent.instruction,
+        model=model,
+        mcp_servers=tuple(server_names),
+        params=params,
+    )
+
+
+def ensure_openai_agents_configured() -> None:
+    """Idempotently configure the openai-agents SDK for the current environment.
+
+    Call order priority:
+    1. If OPENAI_BASE_URL is set → proxy mode (configure_openai_agents_for_proxy).
+    2. Elif OPENAI_API_KEY is set → real OpenAI API (set_default_openai_* helpers).
+    3. Else → RuntimeError with a clear message.
+
+    All SDK imports are guarded inside this function so the module can be
+    imported even when openai-agents / openai are not installed.
+
+    Raises:
+        RuntimeError: if neither OPENAI_BASE_URL nor OPENAI_API_KEY is set,
+                      or if the openai-agents SDK is not installed.
+    """
+    global _configured
+    if _configured:
+        return
+
+    base_url = os.environ.get("OPENAI_BASE_URL")
+    api_key = os.environ.get("OPENAI_API_KEY")
+
+    if base_url:
+        # Proxy branch — delegate entirely to the existing helper which already
+        # imports and configures the SDK.
+        from cores.llm.backends.openai_agents_backend import (
+            configure_openai_agents_for_proxy,
+        )
+
+        proxy_key = api_key or "chatgpt-oauth-placeholder"
+        configure_openai_agents_for_proxy(base_url, proxy_key)
+    elif api_key:
+        # Direct OpenAI API branch — bind a default client explicitly so that
+        # the Responses API is used (required by openai-agents 0.7.x).
+        try:
+            from agents import set_default_openai_api, set_default_openai_client, set_default_openai_key
+            from openai import AsyncOpenAI
+        except ImportError as exc:
+            raise RuntimeError(
+                "ensure_openai_agents_configured: openai-agents SDK is not installed. "
+                "Install it with: pip install openai-agents"
+            ) from exc
+
+        client = AsyncOpenAI(api_key=api_key)
+        set_default_openai_client(client)
+        set_default_openai_api("responses")
+        set_default_openai_key(api_key)
+    else:
+        raise RuntimeError(
+            "ensure_openai_agents_configured: neither OPENAI_BASE_URL nor "
+            "OPENAI_API_KEY is set. Set one of these environment variables before "
+            "using the openai_agents LLM backend."
+        )
+
+    _configured = True
+
+
+def get_llm_backend(registry: "McpServerRegistry") -> LLMBackend:
+    """Return the active LLMBackend based on the LLM_BACKEND environment variable.
+
+    Supported values:
+    - ``"openai_agents"`` → OpenAIAgentsBackend(registry)
+    - anything else       → NotImplementedError (mcp_agent stays inline in callers)
+
+    Args:
+        registry: McpServerRegistry built by load_mcp_registry().
+
+    Returns:
+        A configured LLMBackend instance.
+
+    Raises:
+        NotImplementedError: if LLM_BACKEND is not "openai_agents".
+    """
+    backend_name = os.environ.get("LLM_BACKEND", "mcp_agent")
+    if backend_name == "openai_agents":
+        from cores.llm.backends.openai_agents_backend import OpenAIAgentsBackend
+
+        return OpenAIAgentsBackend(registry)
+    raise NotImplementedError(
+        f"get_llm_backend: LLM_BACKEND={backend_name!r} is not handled here. "
+        "The mcp_agent default path remains inline in the calling module."
+    )

--- a/cores/llm/backends/__init__.py
+++ b/cores/llm/backends/__init__.py
@@ -1,0 +1,9 @@
+"""
+LLM backend adapters — concrete implementations of cores.llm.ports.LLMBackend.
+
+Each submodule guards its SDK import so collection never fails when the SDK
+is absent (e.g. in the lightweight test environment).
+
+Available adapters:
+  - mcp_agent_backend.McpAgentBackend  (strangler shim, Phase 1–4)
+"""

--- a/cores/llm/backends/mcp_agent_backend.py
+++ b/cores/llm/backends/mcp_agent_backend.py
@@ -1,0 +1,74 @@
+"""
+Strangler shim: wraps mcp_agent so domain code can call LLMBackend.run().
+
+This adapter is the ONLY place in the codebase that imports mcp_agent.
+It will be removed in Phase 5 once all call sites have migrated to the
+openai-agents SDK backend.
+
+Import guard: the module-level try/except means this file can be imported
+(and tests collected) even when mcp_agent is not installed.  A clear
+RuntimeError is raised at call time instead.
+"""
+
+from typing import Any
+
+# --- SDK import guard ---------------------------------------------------
+try:
+    from mcp_agent.agents.agent import Agent
+    from mcp_agent.workflows.llm.augmented_llm import RequestParams
+
+    _mcp_agent_available = True
+except ImportError:
+    Agent = None  # type: ignore[assignment,misc]
+    RequestParams = None  # type: ignore[assignment]
+    _mcp_agent_available = False
+# ------------------------------------------------------------------------
+
+from cores.llm.ports import AgentSpec, LLMBackend, LLMResult
+
+
+class McpAgentBackend(LLMBackend):
+    """LLMBackend adapter that delegates to the mcp-agent framework.
+
+    Must be run in the environment where mcp-agent is installed (db-server).
+    Calling ``run()`` when mcp-agent is absent raises a clear RuntimeError;
+    the constructor itself never fails.
+    """
+
+    name = "mcp_agent"
+
+    async def run(self, spec: AgentSpec, user_input: Any) -> LLMResult:
+        """Build an mcp_agent Agent, attach OpenAIResponsesLLM, run, return result.
+
+        Raises:
+            RuntimeError: if mcp-agent is not installed in the current environment.
+        """
+        if not _mcp_agent_available:
+            raise RuntimeError(
+                "McpAgentBackend requires the 'mcp-agent' package, which is not "
+                "installed in this environment.  Run this workload on the db-server "
+                "where mcp-agent is available, or switch to a different LLMBackend."
+            )
+
+        # Local import so it only resolves when mcp_agent is present.
+        from cores.llm.openai_responses_llm import OpenAIResponsesLLM  # noqa: PLC0415
+
+        agent = Agent(
+            name=spec.name,
+            instruction=spec.instructions,
+            server_names=list(spec.mcp_servers),
+        )
+
+        async with agent:
+            agent.attach_llm(OpenAIResponsesLLM)
+            result_text: str = await agent.generate_str(
+                message=user_input,
+                request_params=RequestParams(
+                    model=spec.model,
+                    maxTokens=spec.params.max_tokens,
+                    reasoning_effort=spec.params.reasoning_effort or "none",
+                    max_iterations=spec.params.max_iterations,
+                ),
+            )
+
+        return LLMResult(text=result_text)

--- a/cores/llm/backends/openai_agents_backend.py
+++ b/cores/llm/backends/openai_agents_backend.py
@@ -1,0 +1,215 @@
+# openai_agents_backend.py
+
+"""
+openai-agents SDK backend: implements LLMBackend using the openai-agents 0.7.x SDK.
+
+This is the Phase 2 LLM port adapter.  All openai-agents imports are guarded so
+this module can be imported (and tests collected) even if the SDK is not installed.
+A clear RuntimeError is raised at *call time* rather than at import time.
+"""
+
+import contextlib
+from typing import Any, Optional
+
+from cores.llm.mcp_registry import McpServerRegistry
+from cores.llm.ports import AgentSpec, LLMBackend, LLMParams, LLMResult
+
+# --- SDK import guard ---------------------------------------------------
+try:
+    from agents import Agent, ModelSettings, Runner
+    from agents import set_default_openai_api, set_default_openai_client, set_default_openai_key
+    from agents.mcp import MCPServerStdio, MCPServerStdioParams
+    from openai import AsyncOpenAI
+    from openai.types.shared import Reasoning
+
+    _sdk_available = True
+except ImportError:
+    Agent = None  # type: ignore[assignment,misc]
+    ModelSettings = None  # type: ignore[assignment]
+    Runner = None  # type: ignore[assignment]
+    MCPServerStdio = None  # type: ignore[assignment]
+    MCPServerStdioParams = None  # type: ignore[assignment]
+    Reasoning = None  # type: ignore[assignment]
+    set_default_openai_api = None  # type: ignore[assignment]
+    set_default_openai_client = None  # type: ignore[assignment]
+    set_default_openai_key = None  # type: ignore[assignment]
+    AsyncOpenAI = None  # type: ignore[assignment]
+    _sdk_available = False
+# ------------------------------------------------------------------------
+
+
+def configure_openai_agents_for_proxy(
+    base_url: str,
+    api_key: str = "chatgpt-oauth-placeholder",
+) -> None:
+    """Point the openai-agents SDK at the ChatGPT OAuth proxy's Responses endpoint.
+
+    After calling this, Runner will send Responses API requests to
+    ``{base_url}/responses`` (i.e. the proxy's /v1/responses route) instead
+    of the real OpenAI API.  The proxy translates the OAuth token, forces
+    ``store=False`` and ``stream=True``, and forwards the request to the
+    Codex backend.
+
+    Must be called before the first Runner.run() call.  Do NOT call at
+    module import time — only call explicitly from application startup code.
+
+    Args:
+        base_url: Base URL of the proxy, e.g. ``http://localhost:18741/v1``.
+        api_key:  Placeholder key accepted by the proxy (no real auth needed).
+
+    Raises:
+        RuntimeError: if the openai-agents SDK is not installed.
+    """
+    if not _sdk_available:
+        raise RuntimeError(
+            "configure_openai_agents_for_proxy requires the 'openai-agents' package, "
+            "which is not installed in this environment."
+        )
+
+    client = AsyncOpenAI(base_url=base_url, api_key=api_key)
+    set_default_openai_client(client)
+    set_default_openai_api("responses")
+    set_default_openai_key(api_key)
+
+
+def build_model_settings(params: LLMParams) -> "ModelSettings":
+    """Map LLMParams to an openai-agents ModelSettings instance.
+
+    - max_tokens is always forwarded.
+    - temperature is only set when not None.
+    - reasoning is only set when reasoning_effort is truthy and != "none".
+
+    Raises:
+        RuntimeError: if the openai-agents SDK is not installed.
+    """
+    if not _sdk_available:
+        raise RuntimeError(
+            "OpenAIAgentsBackend requires the 'openai-agents' package, which is not "
+            "installed in this environment."
+        )
+
+    kwargs: dict[str, Any] = {"max_tokens": params.max_tokens}
+
+    if params.temperature is not None:
+        kwargs["temperature"] = params.temperature
+
+    if params.reasoning_effort and params.reasoning_effort != "none":
+        kwargs["reasoning"] = Reasoning(effort=params.reasoning_effort)
+
+    return ModelSettings(**kwargs)
+
+
+def build_mcp_server(name: str, registry: McpServerRegistry) -> "MCPServerStdio":
+    """Build an MCPServerStdio for *name* using spec from *registry*.
+
+    Raises:
+        RuntimeError: if the openai-agents SDK is not installed.
+        KeyError: if *name* is not in the registry.
+    """
+    if not _sdk_available:
+        raise RuntimeError(
+            "OpenAIAgentsBackend requires the 'openai-agents' package, which is not "
+            "installed in this environment."
+        )
+
+    spec = registry.get(name)
+
+    params = MCPServerStdioParams(
+        command=spec.command,
+        args=list(spec.args),
+        env=dict(spec.env) if spec.env else None,
+        cwd=None,
+    )
+
+    return MCPServerStdio(
+        params=params,
+        client_session_timeout_seconds=spec.read_timeout_seconds,
+        cache_tools_list=True,
+        name=name,
+    )
+
+
+def build_agent(spec: AgentSpec, mcp_servers: list) -> "Agent":
+    """Construct an openai-agents Agent from an AgentSpec.
+
+    Raises:
+        RuntimeError: if the openai-agents SDK is not installed.
+    """
+    if not _sdk_available:
+        raise RuntimeError(
+            "OpenAIAgentsBackend requires the 'openai-agents' package, which is not "
+            "installed in this environment."
+        )
+
+    return Agent(
+        name=spec.name,
+        instructions=spec.instructions,
+        model=spec.model,
+        model_settings=build_model_settings(spec.params),
+        mcp_servers=mcp_servers,
+        output_type=spec.output_schema,
+    )
+
+
+class OpenAIAgentsBackend(LLMBackend):
+    """LLMBackend adapter that delegates to the openai-agents 0.7.x SDK.
+
+    Must be run in an environment where openai-agents is installed.
+    Calling ``run()`` when the SDK is absent raises a clear RuntimeError;
+    the constructor itself never fails.
+
+    Import guard: the module-level try/except means this file can be imported
+    (and tests collected) even when openai-agents is not installed.  A clear
+    RuntimeError is raised at call time instead.
+    """
+
+    name = "openai_agents"
+
+    def __init__(
+        self,
+        registry: McpServerRegistry,
+        runner: Optional[Any] = None,
+    ) -> None:
+        self._registry = registry
+        # Injectable for testing; defaults to the real SDK Runner class.
+        self._runner = runner if runner is not None else Runner
+
+    async def run(self, spec: AgentSpec, user_input: Any) -> LLMResult:
+        """Build an openai-agents Agent, attach MCP servers, run, return result.
+
+        Uses AsyncExitStack to guarantee each MCPServerStdio is connected on
+        entry and cleaned up on exit — even if runner.run() raises.
+
+        Raises:
+            RuntimeError: if openai-agents is not installed in the current environment.
+        """
+        if not _sdk_available:
+            raise RuntimeError(
+                "OpenAIAgentsBackend requires the 'openai-agents' package, which is not "
+                "installed in this environment.  Install it or switch to a different "
+                "LLMBackend."
+            )
+
+        async with contextlib.AsyncExitStack() as stack:
+            servers = [
+                await stack.enter_async_context(build_mcp_server(srv_name, self._registry))
+                for srv_name in spec.mcp_servers
+            ]
+
+            agent = build_agent(spec, servers)
+
+            result = await self._runner.run(
+                agent,
+                user_input,
+                max_turns=spec.params.max_iterations,
+            )
+
+        text = result.final_output if isinstance(result.final_output, str) else ""
+        structured = result.final_output if spec.output_schema is not None else None
+
+        return LLMResult(
+            text=text,
+            structured=structured,
+            response_id=getattr(result, "last_response_id", None),
+            raw=result,
+        )

--- a/cores/llm/config_loader.py
+++ b/cores/llm/config_loader.py
@@ -1,0 +1,173 @@
+"""
+Config loader for the LLM stack.
+
+Provides env-interpolation, secret resolution, and MCP server registry loading
+without depending on the mcp_agent framework's config files.
+
+Search order for load_mcp_registry:
+  (a) explicit config_path argument
+  (b) PRISM_MCP_CONFIG environment variable
+  (c) native cores/llm/mcp_servers.yaml
+  (d) legacy mcp_agent.config.yaml (DEPRECATION warning — removed in Phase 5)
+
+Secrets come from environment variables (.env); use resolve_secret() for
+required credentials. YAML env values support ${VAR} / ${VAR:-default}
+interpolation so no secrets are stored in config files.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+# Path of this file: cores/llm/config.py → parent.parent == project root
+_HERE = Path(__file__).resolve().parent
+_PROJECT_ROOT = _HERE.parent.parent
+
+_NATIVE_CONFIG = _HERE / "mcp_servers.yaml"
+_LEGACY_CONFIG = _PROJECT_ROOT / "mcp_agent.config.yaml"
+
+_ENV_VAR_RE = re.compile(r"\$\{([^}:]+)(?::-([^}]*))?\}")
+
+
+def interpolate_env(value: str) -> str:
+    """Expand ``${VAR}`` and ``${VAR:-default}`` placeholders using ``os.environ``.
+
+    - ``${VAR}`` → value of VAR; empty string if VAR is unset.
+    - ``${VAR:-default}`` → value of VAR if set and non-empty, else ``default``.
+    - Non-string input is returned unchanged.
+    """
+    if not isinstance(value, str):
+        return value  # type: ignore[return-value]
+
+    def _replace(m: re.Match) -> str:
+        var_name = m.group(1)
+        default = m.group(2)  # None if no ":-" clause
+        env_val = os.environ.get(var_name, "")
+        if env_val:
+            return env_val
+        return default if default is not None else ""
+
+    return _ENV_VAR_RE.sub(_replace, value)
+
+
+def _interpolate_obj(obj):
+    """Recursively apply ``interpolate_env`` to every string in *obj*.
+
+    Traverses dicts and lists in-place (returns a new structure for immutable
+    input types). Non-container, non-string values are returned as-is.
+    """
+    if isinstance(obj, str):
+        return interpolate_env(obj)
+    if isinstance(obj, dict):
+        return {k: _interpolate_obj(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_interpolate_obj(item) for item in obj]
+    return obj
+
+
+def resolve_secret(
+    name: str,
+    default: Optional[str] = None,
+    *,
+    required: bool = False,
+) -> Optional[str]:
+    """Read a secret from the environment.
+
+    Args:
+        name:     Environment variable name (e.g. ``"OPENAI_API_KEY"``).
+        default:  Value to return when the variable is absent or empty.
+        required: If ``True`` and the variable is absent/empty (after applying
+                  *default*), raise ``RuntimeError`` naming the variable.
+
+    Returns:
+        The variable's value, *default*, or ``None``.
+
+    Raises:
+        RuntimeError: when ``required=True`` and no non-empty value is found.
+    """
+    value = os.environ.get(name) or default
+    if required and not value:
+        raise RuntimeError(
+            f"Required secret '{name}' is not set. "
+            f"Add {name}=<value> to your .env file or environment."
+        )
+    return value or None
+
+
+def load_mcp_registry(config_path: "str | Path | None" = None):
+    """Load and return a :class:`McpServerRegistry` from YAML config.
+
+    Search order:
+      (a) *config_path* argument (if provided)
+      (b) ``PRISM_MCP_CONFIG`` environment variable
+      (c) ``cores/llm/mcp_servers.yaml`` (native, no-secret config)
+      (d) ``mcp_agent.config.yaml`` at project root — **LEGACY FALLBACK**
+          (emits a DEPRECATION warning; will be removed in Phase 5)
+
+    The loaded YAML is processed with :func:`_interpolate_obj` so that
+    ``${ENV_VAR}`` references in env blocks are resolved from the process
+    environment before building the registry.
+
+    Auto-detects YAML shape:
+      - Native: top-level ``servers:`` key
+      - Legacy:  top-level ``mcp.servers:`` path (normalised before parsing)
+
+    Raises:
+        FileNotFoundError: if no config file is found via any search path.
+    """
+    # Import here to avoid circular imports; config.py must stay SDK-free.
+    from cores.llm.mcp_registry import McpServerRegistry  # noqa: PLC0415
+
+    resolved: Optional[Path] = None
+
+    if config_path is not None:
+        resolved = Path(config_path)
+        if not resolved.exists():
+            raise FileNotFoundError(
+                f"MCP config not found at explicit path: {resolved}"
+            )
+    else:
+        env_override = os.environ.get("PRISM_MCP_CONFIG")
+        if env_override:
+            resolved = Path(env_override)
+            if not resolved.exists():
+                raise FileNotFoundError(
+                    f"MCP config from PRISM_MCP_CONFIG not found: {resolved}"
+                )
+        elif _NATIVE_CONFIG.exists():
+            resolved = _NATIVE_CONFIG
+        elif _LEGACY_CONFIG.exists():
+            logger.warning(
+                "DEPRECATION: loading MCP config from legacy mcp_agent.config.yaml. "
+                "Migrate to cores/llm/mcp_servers.yaml or set PRISM_MCP_CONFIG. "
+                "This fallback will be removed in Phase 5."
+            )
+            resolved = _LEGACY_CONFIG
+        else:
+            raise FileNotFoundError(
+                "No MCP config found. Expected one of:\n"
+                f"  - PRISM_MCP_CONFIG env var\n"
+                f"  - {_NATIVE_CONFIG}\n"
+                f"  - {_LEGACY_CONFIG}"
+            )
+
+    raw = yaml.safe_load(resolved.read_text())
+    raw = _interpolate_obj(raw)
+
+    # Auto-detect shape and normalise to {"mcp": {"servers": {...}}}
+    if "servers" in raw and "mcp" not in raw:
+        # Native shape: top-level `servers:` key
+        normalised = {"mcp": {"servers": raw["servers"]}}
+    else:
+        # Legacy shape already has `mcp.servers`
+        normalised = raw
+
+    return McpServerRegistry.from_yaml_dict(normalised)

--- a/cores/llm/fakes.py
+++ b/cores/llm/fakes.py
@@ -1,0 +1,56 @@
+"""
+In-process fake backend for domain unit tests — zero network, zero SDK deps.
+
+Usage::
+
+    from cores.llm.fakes import FakeLLMBackend
+    from cores.llm.ports import LLMResult
+
+    backend = FakeLLMBackend([LLMResult(text="buy"), LLMResult(text="hold")])
+    result = await backend.run(spec, "analyse AAPL")
+    assert result.text == "buy"
+    assert backend.calls[0] == (spec, "analyse AAPL")
+"""
+
+from collections import deque
+from typing import Any, Callable, List, Union
+
+from cores.llm.ports import AgentSpec, LLMBackend, LLMResult
+
+
+class FakeLLMBackend(LLMBackend):
+    """Scripted LLM backend for deterministic unit tests.
+
+    Pass either:
+    - a list of ``LLMResult`` objects that are returned in order, or
+    - a callable ``(spec, user_input) -> LLMResult`` for dynamic responses.
+
+    Each call is recorded in ``.calls`` as a ``(AgentSpec, user_input)`` tuple.
+    Raises ``IndexError`` if the scripted queue is exhausted (list mode).
+    """
+
+    name = "fake"
+
+    def __init__(
+        self,
+        responses: Union[List[LLMResult], Callable[[AgentSpec, Any], LLMResult]],
+    ) -> None:
+        if callable(responses):
+            self._callable: Callable[[AgentSpec, Any], LLMResult] = responses
+            self._queue: deque[LLMResult] = deque()
+        else:
+            self._callable = None  # type: ignore[assignment]
+            self._queue = deque(responses)
+        self.calls: list[tuple[AgentSpec, Any]] = []
+
+    async def run(self, spec: AgentSpec, user_input: Any) -> LLMResult:
+        """Return the next scripted result and record the call."""
+        self.calls.append((spec, user_input))
+        if self._callable is not None:
+            return self._callable(spec, user_input)
+        if not self._queue:
+            raise IndexError(
+                "FakeLLMBackend: scripted response queue is empty. "
+                "Add more LLMResult entries to the responses list."
+            )
+        return self._queue.popleft()

--- a/cores/llm/mcp_registry.py
+++ b/cores/llm/mcp_registry.py
@@ -1,0 +1,98 @@
+"""
+MCP server registry: adapter-agnostic catalogue of MCP server definitions.
+
+Reads the ``mcp.servers`` section of mcp_agent.config.yaml (or any equivalent
+dict) and exposes server specs as plain dataclasses with no SDK coupling.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class McpServerSpec:
+    """Immutable description of a single MCP server entry.
+
+    Mirrors the mcp_agent.config.yaml ``mcp.servers.<name>`` shape::
+
+        perplexity:
+          command: uvx
+          args: [mcp-server-perplexity-ask]
+          env: {PERPLEXITY_API_KEY: "..."}
+          read_timeout_seconds: 120
+    """
+
+    name: str
+    command: str
+    args: tuple = ()
+    env: dict = field(default_factory=dict, compare=False, hash=False)
+    read_timeout_seconds: Optional[int] = None
+
+
+class McpServerRegistry:
+    """Catalogue of MCP server specs, keyed by logical name.
+
+    Build from the raw ``mcp.servers`` dict parsed from YAML::
+
+        import yaml
+        with open("mcp_agent.config.yaml") as f:
+            cfg = yaml.safe_load(f)
+        registry = McpServerRegistry.from_yaml_dict(cfg)
+        spec = registry.get("perplexity")
+    """
+
+    def __init__(self, specs: dict[str, McpServerSpec]) -> None:
+        self._specs: dict[str, McpServerSpec] = dict(specs)
+
+    @classmethod
+    def from_yaml_dict(cls, yaml_dict: dict) -> "McpServerRegistry":
+        """Parse the top-level config dict (i.e. the full YAML document).
+
+        Expects the shape ``{"mcp": {"servers": {<name>: {command, args?, env?, ...}}}}``.
+        Both ``args`` and ``env`` are optional; missing fields default to empty.
+
+        Raises:
+            KeyError: if the ``mcp.servers`` path is absent from *yaml_dict*.
+            ValueError: if a server entry is missing the required ``command`` field.
+        """
+        try:
+            servers_dict: dict = yaml_dict["mcp"]["servers"]
+        except KeyError as exc:
+            raise KeyError(
+                f"Expected 'mcp.servers' in config dict; missing key: {exc}"
+            ) from exc
+
+        specs: dict[str, McpServerSpec] = {}
+        for name, entry in servers_dict.items():
+            if "command" not in entry:
+                raise ValueError(
+                    f"MCP server {name!r} is missing required field 'command'."
+                )
+            raw_args = entry.get("args", [])
+            specs[name] = McpServerSpec(
+                name=name,
+                command=entry["command"],
+                args=tuple(raw_args),
+                env=dict(entry.get("env", {})),
+                read_timeout_seconds=entry.get("read_timeout_seconds"),
+            )
+
+        return cls(specs)
+
+    def get(self, name: str) -> McpServerSpec:
+        """Return the spec for *name*.
+
+        Raises:
+            KeyError: with a clear message if *name* is not registered.
+        """
+        try:
+            return self._specs[name]
+        except KeyError:
+            available = ", ".join(sorted(self._specs))
+            raise KeyError(
+                f"MCP server {name!r} not found. Registered servers: {available}"
+            ) from None
+
+    def names(self) -> list[str]:
+        """Return all registered server names."""
+        return list(self._specs)

--- a/cores/llm/mcp_servers.yaml
+++ b/cores/llm/mcp_servers.yaml
@@ -1,0 +1,56 @@
+servers:
+  webresearch:
+    command: npx
+    args:
+    - -y
+    - '@mzxrai/mcp-webresearch@latest'
+    read_timeout_seconds: 120
+  firecrawl:
+    command: npx
+    args:
+    - -y
+    - firecrawl-mcp
+    env:
+      FIRECRAWL_API_KEY: ${FIRECRAWL_API_KEY}
+  kospi_kosdaq:
+    command: python3
+    args:
+    - -m
+    - kospi_kosdaq_stock_server
+    env:
+      KAKAO_ID: ${KAKAO_ID}
+      KAKAO_PW: ${KAKAO_PW}
+      KRX_LOGIN_METHOD: ${KRX_LOGIN_METHOD}
+  perplexity:
+    command: node
+    args:
+    - perplexity-ask/dist/index.js
+    env:
+      PERPLEXITY_API_KEY: ${PERPLEXITY_API_KEY}
+  sqlite:
+    command: uv
+    args:
+    - --directory
+    - sqlite
+    - run
+    - mcp-server-sqlite
+    - --db-path
+    - ../stock_tracking_db.sqlite
+  time:
+    command: uvx
+    args:
+    - mcp-server-time
+  deepsearch:
+    command: npx
+    args:
+    - -y
+    - mcp-remote
+    - http://localhost:8000/sse
+    read_timeout_seconds: 120
+  yahoo_finance:
+    command: uvx
+    args:
+    - --from
+    - yahoo-finance-mcp
+    - yahoo-finance-mcp
+    read_timeout_seconds: 120

--- a/cores/llm/models.py
+++ b/cores/llm/models.py
@@ -1,0 +1,77 @@
+"""
+Model registry: maps logical role names to (model_id, LLMParams).
+
+Keeps model selection out of domain code so swapping models is config-only.
+Default roles reflect real production usage (KR side).
+"""
+
+from typing import Optional
+from cores.llm.ports import LLMParams
+
+# Production-derived defaults.  model_id strings are plain — no SDK coupling.
+_DEFAULT_MAPPING: dict[str, tuple[str, LLMParams]] = {
+    "sell_decision": (
+        "gpt-5.5",
+        LLMParams(max_tokens=30000),
+    ),
+    "trading": (
+        "gpt-5.5",
+        LLMParams(max_tokens=30000),
+    ),
+    "journal": (
+        "gpt-5.4-mini",
+        LLMParams(reasoning_effort="none", max_tokens=16000),
+    ),
+    "summary": (
+        "gpt-5.4-mini",
+        LLMParams(reasoning_effort="none", max_tokens=16000),
+    ),
+}
+
+
+class ModelRegistry:
+    """Maps logical role strings to ``(model_id, LLMParams)`` pairs.
+
+    Construct via ``from_mapping()`` with a plain dict, or use the
+    class-level defaults that mirror real production usage.
+
+    Example::
+
+        reg = ModelRegistry.from_mapping({
+            "sell_decision": ("gpt-5.5", LLMParams(max_tokens=30000)),
+        })
+        model_id, params = reg.resolve("sell_decision")
+    """
+
+    def __init__(self, mapping: dict[str, tuple[str, LLMParams]]) -> None:
+        self._mapping: dict[str, tuple[str, LLMParams]] = dict(mapping)
+
+    @classmethod
+    def from_mapping(cls, mapping: dict[str, tuple[str, LLMParams]]) -> "ModelRegistry":
+        """Construct from a caller-supplied dict (merged over defaults)."""
+        merged = dict(_DEFAULT_MAPPING)
+        merged.update(mapping)
+        return cls(merged)
+
+    @classmethod
+    def defaults(cls) -> "ModelRegistry":
+        """Return a registry pre-loaded with the production defaults."""
+        return cls(dict(_DEFAULT_MAPPING))
+
+    def resolve(self, role: str) -> tuple[str, LLMParams]:
+        """Return ``(model_id, LLMParams)`` for *role*.
+
+        Raises:
+            KeyError: with a clear message listing available roles.
+        """
+        try:
+            return self._mapping[role]
+        except KeyError:
+            available = ", ".join(sorted(self._mapping))
+            raise KeyError(
+                f"Unknown model role {role!r}. Available roles: {available}"
+            ) from None
+
+    def roles(self) -> list[str]:
+        """Return all registered role names."""
+        return list(self._mapping)

--- a/cores/llm/ports.py
+++ b/cores/llm/ports.py
@@ -1,0 +1,80 @@
+"""
+Provider-agnostic port layer for LLM access (Phase 1 — anti-corruption layer).
+
+Domain code depends ONLY on these types; no mcp_agent or openai SDK imports here.
+All concrete SDK adapters live in cores/llm/backends/ and are never imported by
+domain modules directly.
+"""
+
+import abc
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class LLMParams:
+    """Immutable LLM tuning parameters, SDK-independent.
+
+    reasoning_effort: one of None, "none", "low", "medium", "high".
+      None means "use the model default / omit the parameter".
+    stop_sequences: tuple so the dataclass stays hashable/frozen.
+    """
+
+    max_tokens: int = 8000
+    reasoning_effort: Optional[str] = None
+    temperature: Optional[float] = None
+    max_iterations: int = 10
+    stop_sequences: tuple = ()
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    """Everything needed to describe a single agent invocation.
+
+    mcp_servers: logical server names that map to McpServerRegistry entries.
+    output_schema: optional type hint for structured JSON output (used by
+      backends that support it; ignored otherwise).
+    """
+
+    name: str
+    instructions: str
+    model: str
+    mcp_servers: tuple = ()
+    output_schema: Optional[type] = None
+    params: LLMParams = field(default_factory=LLMParams)
+
+
+@dataclass
+class LLMResult:
+    """Normalised output from any LLM backend.
+
+    text: the primary string output.
+    structured: parsed structured object when output_schema was given.
+    response_id: opaque backend ID (e.g. Responses API previous_response_id).
+    usage: token-count dict if the backend surfaces it, else None.
+    raw: the unmodified backend response object for debugging / migration.
+    """
+
+    text: str = ""
+    structured: Any = None
+    response_id: Optional[str] = None
+    usage: Optional[dict] = None
+    raw: Any = None
+
+
+class LLMBackend(abc.ABC):
+    """Single seam that domain code calls.
+
+    Subclass in cores/llm/backends/ for each concrete SDK.
+    The ``name`` class attribute identifies the backend in logs/config.
+    """
+
+    name: str = "base"
+
+    @abc.abstractmethod
+    async def run(self, spec: AgentSpec, user_input: Any) -> LLMResult:
+        """Execute the agent described by *spec* against *user_input*.
+
+        Returns a normalised LLMResult regardless of the underlying SDK.
+        Raises RuntimeError if the backend SDK is not installed.
+        """

--- a/cores/llm/tests/test_agent_bridge.py
+++ b/cores/llm/tests/test_agent_bridge.py
@@ -1,0 +1,201 @@
+"""
+Unit tests for cores/llm/agent_bridge.py.
+
+Network-free, no mcp_agent import, no openai-agents import at module level.
+"""
+
+import pytest
+import sys
+import types
+
+import cores.llm.agent_bridge as bridge_mod
+from cores.llm.ports import AgentSpec, LLMParams
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fakes
+# ---------------------------------------------------------------------------
+
+class _FakeAgent:
+    """Minimal duck-type of an mcp_agent Agent for spec_from_mcp_agent tests."""
+
+    def __init__(self, name, instruction, server_names=None):
+        self.name = name
+        self.instruction = instruction
+        self.server_names = server_names
+
+
+# ---------------------------------------------------------------------------
+# spec_from_mcp_agent
+# ---------------------------------------------------------------------------
+
+class TestSpecFromMcpAgent:
+    def _params(self):
+        return LLMParams(max_tokens=16000, reasoning_effort="none")
+
+    def test_basic_fields(self):
+        agent = _FakeAgent(
+            name="trading_journal_agent",
+            instruction="You are a journal writer.",
+            server_names=["kospi_kosdaq", "sqlite", "time"],
+        )
+        params = self._params()
+        spec = bridge_mod.spec_from_mcp_agent(agent, model="gpt-5.4-mini", params=params)
+
+        assert isinstance(spec, AgentSpec)
+        assert spec.name == "trading_journal_agent"
+        assert spec.instructions == "You are a journal writer."
+        assert spec.model == "gpt-5.4-mini"
+        assert spec.mcp_servers == ("kospi_kosdaq", "sqlite", "time")
+        assert spec.params is params
+
+    def test_missing_server_names_gives_empty_tuple(self):
+        """Agent without server_names attribute should yield empty mcp_servers."""
+        agent = _FakeAgent(
+            name="no_servers_agent",
+            instruction="Instruction.",
+        )
+        # Remove attribute entirely to test getattr fallback
+        del agent.server_names
+        params = self._params()
+        spec = bridge_mod.spec_from_mcp_agent(agent, model="gpt-5.4-mini", params=params)
+        assert spec.mcp_servers == ()
+
+    def test_none_server_names_gives_empty_tuple(self):
+        """server_names=None should also yield empty mcp_servers."""
+        agent = _FakeAgent(
+            name="none_servers_agent",
+            instruction="Instruction.",
+            server_names=None,
+        )
+        spec = bridge_mod.spec_from_mcp_agent(
+            agent, model="gpt-5.4-mini", params=self._params()
+        )
+        assert spec.mcp_servers == ()
+
+    def test_mcp_servers_is_tuple(self):
+        """mcp_servers must be a tuple (AgentSpec is frozen)."""
+        agent = _FakeAgent("a", "b", ["x", "y"])
+        spec = bridge_mod.spec_from_mcp_agent(
+            agent, model="gpt-5.4-mini", params=self._params()
+        )
+        assert isinstance(spec.mcp_servers, tuple)
+
+
+# ---------------------------------------------------------------------------
+# get_llm_backend
+# ---------------------------------------------------------------------------
+
+class _FakeRegistry:
+    """Minimal stand-in for McpServerRegistry."""
+
+
+class TestGetLlmBackend:
+    def test_openai_agents_returns_backend(self, monkeypatch):
+        monkeypatch.setenv("LLM_BACKEND", "openai_agents")
+        registry = _FakeRegistry()
+        backend = bridge_mod.get_llm_backend(registry)
+        # Check by name attribute — avoids importing OpenAIAgentsBackend
+        assert backend.name == "openai_agents"
+
+    def test_default_mcp_agent_raises_not_implemented(self, monkeypatch):
+        monkeypatch.delenv("LLM_BACKEND", raising=False)
+        with pytest.raises(NotImplementedError):
+            bridge_mod.get_llm_backend(_FakeRegistry())
+
+    def test_unknown_value_raises_not_implemented(self, monkeypatch):
+        monkeypatch.setenv("LLM_BACKEND", "some_future_backend")
+        with pytest.raises(NotImplementedError):
+            bridge_mod.get_llm_backend(_FakeRegistry())
+
+
+# ---------------------------------------------------------------------------
+# ensure_openai_agents_configured
+# ---------------------------------------------------------------------------
+
+def _reset_configured():
+    """Reset the module-level _configured flag between tests."""
+    bridge_mod._configured = False
+
+
+class TestEnsureOpenaiAgentsConfigured:
+    def setup_method(self):
+        _reset_configured()
+
+    def teardown_method(self):
+        _reset_configured()
+
+    def test_proxy_branch_called_when_base_url_set(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:18741/v1")
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+        calls = []
+
+        # Monkeypatch configure_openai_agents_for_proxy inside the backend module
+        import cores.llm.backends.openai_agents_backend as backend_mod
+        monkeypatch.setattr(
+            backend_mod,
+            "configure_openai_agents_for_proxy",
+            lambda url, key: calls.append((url, key)),
+        )
+
+        bridge_mod.ensure_openai_agents_configured()
+
+        assert len(calls) == 1
+        assert calls[0] == ("http://localhost:18741/v1", "test-key")
+        assert bridge_mod._configured is True
+
+    def test_proxy_branch_idempotent(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:18741/v1")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        calls = []
+        import cores.llm.backends.openai_agents_backend as backend_mod
+        monkeypatch.setattr(
+            backend_mod,
+            "configure_openai_agents_for_proxy",
+            lambda url, key: calls.append((url, key)),
+        )
+
+        bridge_mod.ensure_openai_agents_configured()
+        bridge_mod.ensure_openai_agents_configured()  # second call — must be no-op
+
+        assert len(calls) == 1  # recorded exactly once
+
+    def test_no_env_raises_runtime_error(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        with pytest.raises(RuntimeError, match="OPENAI_BASE_URL"):
+            bridge_mod.ensure_openai_agents_configured()
+
+    def test_api_key_branch_taken_when_no_base_url(self, monkeypatch):
+        """When only OPENAI_API_KEY is set, the direct-API branch runs."""
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-real")
+
+        set_calls = []
+
+        # Inject fake agents SDK into sys.modules so the lazy import inside
+        # ensure_openai_agents_configured succeeds without the real SDK.
+        fake_agents = types.ModuleType("agents")
+        fake_agents.set_default_openai_client = lambda c: set_calls.append(("client", c))
+        fake_agents.set_default_openai_api = lambda v: set_calls.append(("api", v))
+        fake_agents.set_default_openai_key = lambda k: set_calls.append(("key", k))
+
+        fake_openai = types.ModuleType("openai")
+
+        class _FakeAsyncOpenAI:
+            def __init__(self, **kw):
+                self.kw = kw
+
+        fake_openai.AsyncOpenAI = _FakeAsyncOpenAI
+
+        monkeypatch.setitem(sys.modules, "agents", fake_agents)
+        monkeypatch.setitem(sys.modules, "openai", fake_openai)
+
+        bridge_mod.ensure_openai_agents_configured()
+
+        assert ("api", "responses") in set_calls
+        assert ("key", "sk-test-real") in set_calls
+        assert bridge_mod._configured is True

--- a/cores/llm/tests/test_config.py
+++ b/cores/llm/tests/test_config.py
@@ -1,0 +1,209 @@
+"""Tests for cores.llm.config_loader — interpolation, secret resolution, registry loading.
+
+All tests are network-free and filesystem-contained (tmp_path fixtures).
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from cores.llm.config_loader import (
+    _interpolate_obj,
+    interpolate_env,
+    load_mcp_registry,
+    resolve_secret,
+)
+
+
+# ---------------------------------------------------------------------------
+# interpolate_env
+# ---------------------------------------------------------------------------
+
+class TestInterpolateEnv:
+    def test_set_var(self, monkeypatch):
+        monkeypatch.setenv("MY_KEY", "hello")
+        assert interpolate_env("${MY_KEY}") == "hello"
+
+    def test_unset_var_no_default(self, monkeypatch):
+        monkeypatch.delenv("UNSET_VAR_XYZ", raising=False)
+        assert interpolate_env("${UNSET_VAR_XYZ}") == ""
+
+    def test_var_with_default_set(self, monkeypatch):
+        monkeypatch.setenv("MY_KEY", "real")
+        assert interpolate_env("${MY_KEY:-fallback}") == "real"
+
+    def test_var_with_default_unset(self, monkeypatch):
+        monkeypatch.delenv("UNSET_VAR_XYZ", raising=False)
+        assert interpolate_env("${UNSET_VAR_XYZ:-mydefault}") == "mydefault"
+
+    def test_literal_passthrough(self):
+        assert interpolate_env("no-placeholders") == "no-placeholders"
+
+    def test_non_string_passthrough(self):
+        assert interpolate_env(42) == 42  # type: ignore[arg-type]
+        assert interpolate_env(None) is None  # type: ignore[arg-type]
+
+    def test_mixed_string(self, monkeypatch):
+        monkeypatch.setenv("HOST", "localhost")
+        assert interpolate_env("http://${HOST}:8080") == "http://localhost:8080"
+
+
+class TestInterpolateObj:
+    def test_dict_values_interpolated(self, monkeypatch):
+        monkeypatch.setenv("FOO", "bar")
+        result = _interpolate_obj({"key": "${FOO}"})
+        assert result == {"key": "bar"}
+
+    def test_nested_dict(self, monkeypatch):
+        monkeypatch.setenv("A", "1")
+        result = _interpolate_obj({"outer": {"inner": "${A}"}})
+        assert result["outer"]["inner"] == "1"
+
+    def test_list_items(self, monkeypatch):
+        monkeypatch.setenv("X", "val")
+        result = _interpolate_obj(["${X}", "plain"])
+        assert result == ["val", "plain"]
+
+    def test_non_string_values_unchanged(self):
+        result = _interpolate_obj({"num": 42, "flag": True})
+        assert result == {"num": 42, "flag": True}
+
+
+# ---------------------------------------------------------------------------
+# resolve_secret
+# ---------------------------------------------------------------------------
+
+class TestResolveSecret:
+    def test_present(self, monkeypatch):
+        monkeypatch.setenv("MY_SECRET", "s3cr3t")
+        assert resolve_secret("MY_SECRET") == "s3cr3t"
+
+    def test_missing_with_default(self, monkeypatch):
+        monkeypatch.delenv("NO_SUCH_VAR", raising=False)
+        assert resolve_secret("NO_SUCH_VAR", "fallback") == "fallback"
+
+    def test_missing_no_default(self, monkeypatch):
+        monkeypatch.delenv("NO_SUCH_VAR", raising=False)
+        assert resolve_secret("NO_SUCH_VAR") is None
+
+    def test_required_missing_raises(self, monkeypatch):
+        monkeypatch.delenv("REQUIRED_KEY", raising=False)
+        with pytest.raises(RuntimeError, match="REQUIRED_KEY"):
+            resolve_secret("REQUIRED_KEY", required=True)
+
+    def test_required_present_ok(self, monkeypatch):
+        monkeypatch.setenv("REQUIRED_KEY", "present")
+        assert resolve_secret("REQUIRED_KEY", required=True) == "present"
+
+
+# ---------------------------------------------------------------------------
+# load_mcp_registry
+# ---------------------------------------------------------------------------
+
+_NATIVE_YAML = """\
+servers:
+  myserver:
+    command: uvx
+    args:
+      - mcp-server-time
+    env:
+      TESTKEY: ${TESTKEY}
+"""
+
+_LEGACY_YAML = """\
+mcp:
+  servers:
+    legacyserver:
+      command: uvx
+      args:
+        - mcp-server-time
+"""
+
+
+class TestLoadMcpRegistry:
+    def test_native_yaml_with_env_interpolation(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "mcp_servers.yaml"
+        cfg.write_text(_NATIVE_YAML)
+        monkeypatch.setenv("TESTKEY", "resolved_value")
+
+        registry = load_mcp_registry(cfg)
+        spec = registry.get("myserver")
+        assert spec.env["TESTKEY"] == "resolved_value"
+
+    def test_legacy_yaml_mcp_servers_shape(self, tmp_path):
+        cfg = tmp_path / "mcp_agent.config.yaml"
+        cfg.write_text(_LEGACY_YAML)
+
+        registry = load_mcp_registry(cfg)
+        assert "legacyserver" in registry.names()
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_mcp_registry(tmp_path / "nonexistent.yaml")
+
+    def test_prism_mcp_config_env_override(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "override.yaml"
+        cfg.write_text(_NATIVE_YAML)
+        monkeypatch.setenv("PRISM_MCP_CONFIG", str(cfg))
+        monkeypatch.setenv("TESTKEY", "from_env_override")
+        # Pass no config_path — should pick up PRISM_MCP_CONFIG
+        # Temporarily patch _NATIVE_CONFIG so it doesn't exist
+        import cores.llm.config_loader as config_mod
+        orig_native = config_mod._NATIVE_CONFIG
+        orig_legacy = config_mod._LEGACY_CONFIG
+        config_mod._NATIVE_CONFIG = tmp_path / "does_not_exist.yaml"
+        config_mod._LEGACY_CONFIG = tmp_path / "also_not_there.yaml"
+        try:
+            registry = load_mcp_registry(None)
+        finally:
+            config_mod._NATIVE_CONFIG = orig_native
+            config_mod._LEGACY_CONFIG = orig_legacy
+        assert "myserver" in registry.names()
+
+    def test_none_path_loads_native_config(self, tmp_path, monkeypatch):
+        """When config_path=None and no PRISM_MCP_CONFIG, native yaml is used."""
+        import cores.llm.config_loader as config_mod
+        cfg = tmp_path / "mcp_servers.yaml"
+        cfg.write_text(_NATIVE_YAML)
+        monkeypatch.delenv("PRISM_MCP_CONFIG", raising=False)
+        monkeypatch.setenv("TESTKEY", "nativeload")
+        orig_native = config_mod._NATIVE_CONFIG
+        config_mod._NATIVE_CONFIG = cfg
+        try:
+            registry = load_mcp_registry(None)
+        finally:
+            config_mod._NATIVE_CONFIG = orig_native
+        assert "myserver" in registry.names()
+
+
+# ---------------------------------------------------------------------------
+# Real mcp_servers.yaml: exists and contains no inline secrets
+# ---------------------------------------------------------------------------
+
+class TestRealMcpServersYaml:
+    def test_file_exists(self):
+        from cores.llm.config_loader import _NATIVE_CONFIG
+        assert _NATIVE_CONFIG.exists(), f"Native config not found: {_NATIVE_CONFIG}"
+
+    def test_parses_cleanly(self):
+        from cores.llm.config_loader import _NATIVE_CONFIG
+        data = yaml.safe_load(_NATIVE_CONFIG.read_text())
+        assert "servers" in data
+        assert len(data["servers"]) > 0
+
+    def test_no_inline_secrets_in_env_values(self):
+        """Every env value must be ${VAR} — never a raw secret string."""
+        from cores.llm.config_loader import _NATIVE_CONFIG
+        data = yaml.safe_load(_NATIVE_CONFIG.read_text())
+        inline = [
+            (server_name, key, val)
+            for server_name, spec in data["servers"].items()
+            for key, val in (spec.get("env") or {}).items()
+            if not re.match(r"^\$\{.*\}$", str(val))
+        ]
+        assert inline == [], (
+            f"Found inline secret values (should be ${{VAR}}): {inline}"
+        )

--- a/cores/llm/tests/test_fakes.py
+++ b/cores/llm/tests/test_fakes.py
@@ -1,0 +1,116 @@
+"""Tests for cores.llm.fakes — FakeLLMBackend."""
+
+import pytest
+from cores.llm.fakes import FakeLLMBackend
+from cores.llm.ports import AgentSpec, LLMParams, LLMResult
+
+
+def _make_spec(name="test_agent"):
+    return AgentSpec(
+        name=name,
+        instructions="do something",
+        model="gpt-5.5",
+        mcp_servers=("sqlite",),
+        params=LLMParams(max_tokens=1000),
+    )
+
+
+class TestFakeLLMBackendScripted:
+    @pytest.mark.asyncio
+    async def test_returns_scripted_results_in_order(self):
+        backend = FakeLLMBackend([
+            LLMResult(text="first"),
+            LLMResult(text="second"),
+        ])
+        spec = _make_spec()
+        r1 = await backend.run(spec, "input A")
+        r2 = await backend.run(spec, "input B")
+        assert r1.text == "first"
+        assert r2.text == "second"
+
+    @pytest.mark.asyncio
+    async def test_records_calls(self):
+        backend = FakeLLMBackend([LLMResult(text="ok"), LLMResult(text="ok2")])
+        spec = _make_spec()
+        await backend.run(spec, "query 1")
+        await backend.run(spec, "query 2")
+        assert len(backend.calls) == 2
+        assert backend.calls[0] == (spec, "query 1")
+        assert backend.calls[1] == (spec, "query 2")
+
+    @pytest.mark.asyncio
+    async def test_empty_queue_raises_index_error(self):
+        backend = FakeLLMBackend([LLMResult(text="only")])
+        spec = _make_spec()
+        await backend.run(spec, "first")
+        with pytest.raises(IndexError, match="empty"):
+            await backend.run(spec, "second")
+
+    @pytest.mark.asyncio
+    async def test_structured_result(self):
+        payload = {"decision": "buy", "confidence": 0.9}
+        backend = FakeLLMBackend([LLMResult(text="buy", structured=payload)])
+        result = await backend.run(_make_spec(), "analyse")
+        assert result.structured == payload
+
+    @pytest.mark.asyncio
+    async def test_calls_empty_before_run(self):
+        backend = FakeLLMBackend([LLMResult(text="x")])
+        assert backend.calls == []
+
+
+class TestFakeLLMBackendCallable:
+    @pytest.mark.asyncio
+    async def test_callable_receives_spec_and_input(self):
+        received = []
+
+        def handler(spec, user_input):
+            received.append((spec, user_input))
+            return LLMResult(text=f"echo:{user_input}")
+
+        backend = FakeLLMBackend(handler)
+        spec = _make_spec()
+        result = await backend.run(spec, "hello")
+        assert result.text == "echo:hello"
+        assert received[0] == (spec, "hello")
+
+    @pytest.mark.asyncio
+    async def test_callable_records_calls(self):
+        backend = FakeLLMBackend(lambda s, i: LLMResult(text="ok"))
+        spec = _make_spec()
+        await backend.run(spec, "a")
+        await backend.run(spec, "b")
+        assert len(backend.calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_callable_dynamic_response(self):
+        def handler(spec, user_input):
+            return LLMResult(text=f"model={spec.model}")
+
+        backend = FakeLLMBackend(handler)
+        result = await backend.run(_make_spec("x"), "q")
+        assert result.text == "model=gpt-5.5"
+
+
+class TestMcpAgentBackendImportAndRuntime:
+    """Verify the backend imports cleanly and raises the right error when SDK absent."""
+
+    def test_module_imports_without_error(self):
+        # Must not raise even though mcp_agent is not installed.
+        import cores.llm.backends.mcp_agent_backend as mod
+        assert hasattr(mod, "McpAgentBackend")
+
+    def test_constructor_does_not_raise(self):
+        from cores.llm.backends.mcp_agent_backend import McpAgentBackend
+        backend = McpAgentBackend()
+        assert backend.name == "mcp_agent"
+
+    @pytest.mark.asyncio
+    async def test_run_raises_runtime_error_when_sdk_absent(self):
+        from cores.llm.backends.mcp_agent_backend import McpAgentBackend, _mcp_agent_available
+        if _mcp_agent_available:
+            pytest.skip("mcp_agent IS installed; skipping absent-SDK test")
+        backend = McpAgentBackend()
+        spec = _make_spec()
+        with pytest.raises(RuntimeError, match="mcp-agent"):
+            await backend.run(spec, "test")

--- a/cores/llm/tests/test_mcp_registry.py
+++ b/cores/llm/tests/test_mcp_registry.py
@@ -1,0 +1,95 @@
+"""Tests for cores.llm.mcp_registry — McpServerRegistry and McpServerSpec."""
+
+import pytest
+from cores.llm.mcp_registry import McpServerRegistry, McpServerSpec
+
+# Sample dict mirroring the real mcp_agent.config.yaml mcp.servers shape,
+# with representative servers from the production YAML (perplexity, sqlite, time).
+SAMPLE_YAML_DICT = {
+    "mcp": {
+        "servers": {
+            "perplexity": {
+                "command": "uvx",
+                "args": ["mcp-server-perplexity-ask"],
+                "env": {"PERPLEXITY_API_KEY": "pk-test"},
+                "read_timeout_seconds": 120,
+            },
+            "sqlite": {
+                "command": "uvx",
+                "args": ["mcp-server-sqlite", "--db-path", "/data/trading.db"],
+            },
+            "time": {
+                "command": "uvx",
+                "args": ["mcp-server-time", "--local-timezone", "Asia/Seoul"],
+            },
+        }
+    }
+}
+
+
+class TestMcpServerRegistryParsing:
+    def setup_method(self):
+        self.registry = McpServerRegistry.from_yaml_dict(SAMPLE_YAML_DICT)
+
+    def test_names_returns_all_servers(self):
+        assert set(self.registry.names()) == {"perplexity", "sqlite", "time"}
+
+    def test_perplexity_command(self):
+        spec = self.registry.get("perplexity")
+        assert spec.command == "uvx"
+
+    def test_perplexity_args(self):
+        spec = self.registry.get("perplexity")
+        assert spec.args == ("mcp-server-perplexity-ask",)
+
+    def test_perplexity_env(self):
+        spec = self.registry.get("perplexity")
+        assert spec.env == {"PERPLEXITY_API_KEY": "pk-test"}
+
+    def test_perplexity_read_timeout(self):
+        spec = self.registry.get("perplexity")
+        assert spec.read_timeout_seconds == 120
+
+    def test_sqlite_args_tuple(self):
+        spec = self.registry.get("sqlite")
+        assert isinstance(spec.args, tuple)
+        assert "mcp-server-sqlite" in spec.args
+
+    def test_time_no_env(self):
+        spec = self.registry.get("time")
+        assert spec.env == {}
+
+    def test_time_no_read_timeout(self):
+        spec = self.registry.get("time")
+        assert spec.read_timeout_seconds is None
+
+    def test_spec_is_frozen(self):
+        spec = self.registry.get("time")
+        with pytest.raises((AttributeError, TypeError)):
+            spec.command = "other"  # type: ignore[misc]
+
+    def test_spec_name_matches_key(self):
+        spec = self.registry.get("perplexity")
+        assert spec.name == "perplexity"
+
+
+class TestMcpServerRegistryErrors:
+    def test_missing_server_raises_key_error(self):
+        registry = McpServerRegistry.from_yaml_dict(SAMPLE_YAML_DICT)
+        with pytest.raises(KeyError, match="yahoo_finance"):
+            registry.get("yahoo_finance")
+
+    def test_missing_server_error_lists_available(self):
+        registry = McpServerRegistry.from_yaml_dict(SAMPLE_YAML_DICT)
+        with pytest.raises(KeyError) as exc_info:
+            registry.get("ghost")
+        assert "Registered servers" in str(exc_info.value)
+
+    def test_missing_mcp_key_raises(self):
+        with pytest.raises(KeyError):
+            McpServerRegistry.from_yaml_dict({"other": {}})
+
+    def test_missing_command_raises_value_error(self):
+        bad = {"mcp": {"servers": {"broken": {"args": []}}}}
+        with pytest.raises(ValueError, match="command"):
+            McpServerRegistry.from_yaml_dict(bad)

--- a/cores/llm/tests/test_models.py
+++ b/cores/llm/tests/test_models.py
@@ -1,0 +1,73 @@
+"""Tests for cores.llm.models — ModelRegistry."""
+
+import pytest
+from cores.llm.models import ModelRegistry
+from cores.llm.ports import LLMParams
+
+
+class TestModelRegistryDefaults:
+    def test_resolve_sell_decision(self):
+        reg = ModelRegistry.defaults()
+        model_id, params = reg.resolve("sell_decision")
+        assert model_id == "gpt-5.5"
+        assert params.max_tokens == 30000
+
+    def test_resolve_journal(self):
+        reg = ModelRegistry.defaults()
+        model_id, params = reg.resolve("journal")
+        assert model_id == "gpt-5.4-mini"
+        assert params.reasoning_effort == "none"
+        assert params.max_tokens == 16000
+
+    def test_resolve_summary(self):
+        reg = ModelRegistry.defaults()
+        model_id, params = reg.resolve("summary")
+        assert model_id == "gpt-5.4-mini"
+
+    def test_resolve_trading(self):
+        reg = ModelRegistry.defaults()
+        model_id, _ = reg.resolve("trading")
+        assert model_id == "gpt-5.5"
+
+    def test_missing_role_raises_key_error(self):
+        reg = ModelRegistry.defaults()
+        with pytest.raises(KeyError, match="nonexistent_role"):
+            reg.resolve("nonexistent_role")
+
+    def test_missing_role_error_lists_available(self):
+        reg = ModelRegistry.defaults()
+        with pytest.raises(KeyError) as exc_info:
+            reg.resolve("ghost")
+        assert "Available roles" in str(exc_info.value)
+
+    def test_roles_returns_list(self):
+        reg = ModelRegistry.defaults()
+        roles = reg.roles()
+        assert isinstance(roles, list)
+        assert "sell_decision" in roles
+
+
+class TestModelRegistryFromMapping:
+    def test_custom_mapping_overrides_default(self):
+        reg = ModelRegistry.from_mapping(
+            {"sell_decision": ("gpt-custom", LLMParams(max_tokens=5000))}
+        )
+        model_id, params = reg.resolve("sell_decision")
+        assert model_id == "gpt-custom"
+        assert params.max_tokens == 5000
+
+    def test_custom_mapping_preserves_other_defaults(self):
+        reg = ModelRegistry.from_mapping(
+            {"custom_role": ("gpt-x", LLMParams())}
+        )
+        # original defaults still present
+        model_id, _ = reg.resolve("journal")
+        assert model_id == "gpt-5.4-mini"
+        # new role also present
+        model_id2, _ = reg.resolve("custom_role")
+        assert model_id2 == "gpt-x"
+
+    def test_empty_mapping_uses_defaults(self):
+        reg = ModelRegistry.from_mapping({})
+        model_id, _ = reg.resolve("trading")
+        assert model_id == "gpt-5.5"

--- a/cores/llm/tests/test_openai_agents_backend.py
+++ b/cores/llm/tests/test_openai_agents_backend.py
@@ -1,0 +1,415 @@
+# test_openai_agents_backend.py
+
+"""
+Network-free unit tests for cores/llm/backends/openai_agents_backend.py.
+
+All SDK interactions are replaced with fakes/monkeypatches so no real API
+calls are made.  Each async test is decorated with @pytest.mark.asyncio.
+"""
+
+import contextlib
+from typing import Any
+
+import pytest
+
+from cores.llm.backends.openai_agents_backend import (
+    OpenAIAgentsBackend,
+    build_agent,
+    build_model_settings,
+    build_mcp_server,
+)
+from cores.llm.mcp_registry import McpServerRegistry
+from cores.llm.ports import AgentSpec, LLMParams
+
+
+# ---------------------------------------------------------------------------
+# Helpers / shared fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_YAML: dict = {
+    "mcp": {
+        "servers": {
+            "perplexity": {
+                "command": "uvx",
+                "args": ["mcp-server-perplexity-ask"],
+                "env": {"PERPLEXITY_API_KEY": "test-key"},
+                "read_timeout_seconds": 120,
+            },
+            "sqlite": {
+                "command": "uvx",
+                "args": ["mcp-server-sqlite", "--db", "/tmp/test.db"],
+                "read_timeout_seconds": None,
+            },
+        }
+    }
+}
+
+
+def make_registry() -> McpServerRegistry:
+    return McpServerRegistry.from_yaml_dict(SAMPLE_YAML)
+
+
+def make_spec(
+    *,
+    mcp_servers: tuple = (),
+    output_schema: Any = None,
+    params: LLMParams = LLMParams(),
+) -> AgentSpec:
+    return AgentSpec(
+        name="test-agent",
+        instructions="You are a test agent.",
+        model="gpt-4o",
+        mcp_servers=mcp_servers,
+        output_schema=output_schema,
+        params=params,
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_model_settings tests
+# ---------------------------------------------------------------------------
+
+
+def test_build_model_settings_no_reasoning_effort_none():
+    """reasoning_effort=None → ModelSettings.reasoning must be None."""
+    params = LLMParams(max_tokens=1000, reasoning_effort=None)
+    ms = build_model_settings(params)
+    assert ms.reasoning is None
+
+
+def test_build_model_settings_no_reasoning_effort_string_none():
+    """reasoning_effort='none' → ModelSettings.reasoning must be None."""
+    params = LLMParams(max_tokens=1000, reasoning_effort="none")
+    ms = build_model_settings(params)
+    assert ms.reasoning is None
+
+
+def test_build_model_settings_reasoning_high():
+    """reasoning_effort='high' → ModelSettings.reasoning.effort == 'high'."""
+    params = LLMParams(max_tokens=500, reasoning_effort="high")
+    ms = build_model_settings(params)
+    assert ms.reasoning is not None
+    assert ms.reasoning.effort == "high"
+
+
+def test_build_model_settings_reasoning_medium():
+    """reasoning_effort='medium' → ModelSettings.reasoning.effort == 'medium'."""
+    params = LLMParams(reasoning_effort="medium")
+    ms = build_model_settings(params)
+    assert ms.reasoning is not None
+    assert ms.reasoning.effort == "medium"
+
+
+def test_build_model_settings_reasoning_low():
+    """reasoning_effort='low' → ModelSettings.reasoning.effort == 'low'."""
+    params = LLMParams(reasoning_effort="low")
+    ms = build_model_settings(params)
+    assert ms.reasoning is not None
+    assert ms.reasoning.effort == "low"
+
+
+def test_build_model_settings_max_tokens_propagated():
+    """max_tokens is forwarded to ModelSettings."""
+    params = LLMParams(max_tokens=4096)
+    ms = build_model_settings(params)
+    assert ms.max_tokens == 4096
+
+
+def test_build_model_settings_temperature_none_not_forced():
+    """temperature=None → ModelSettings.temperature is None (not forced to 0)."""
+    params = LLMParams(temperature=None)
+    ms = build_model_settings(params)
+    # The field should remain None, not coerced to 0 or any other default
+    assert ms.temperature is None
+
+
+def test_build_model_settings_temperature_set():
+    """temperature value is forwarded to ModelSettings."""
+    params = LLMParams(temperature=0.7)
+    ms = build_model_settings(params)
+    assert ms.temperature == 0.7
+
+
+# ---------------------------------------------------------------------------
+# build_mcp_server tests
+# ---------------------------------------------------------------------------
+
+
+def test_build_mcp_server_perplexity_command_and_args():
+    """build_mcp_server for 'perplexity' produces correct command/args."""
+    registry = make_registry()
+    server = build_mcp_server("perplexity", registry)
+    # params is a Pydantic StdioServerParameters — use attribute access
+    assert server.params.command == "uvx"
+    assert server.params.args == ["mcp-server-perplexity-ask"]
+
+
+def test_build_mcp_server_perplexity_env():
+    """build_mcp_server for 'perplexity' passes env dict."""
+    registry = make_registry()
+    server = build_mcp_server("perplexity", registry)
+    assert server.params.env == {"PERPLEXITY_API_KEY": "test-key"}
+
+
+def test_build_mcp_server_perplexity_name():
+    """build_mcp_server sets the server name correctly."""
+    registry = make_registry()
+    server = build_mcp_server("perplexity", registry)
+    assert server.name == "perplexity"
+
+
+def test_build_mcp_server_sqlite_no_env():
+    """build_mcp_server for 'sqlite' (no env) passes env=None."""
+    registry = make_registry()
+    server = build_mcp_server("sqlite", registry)
+    assert server.params.env is None
+
+
+def test_build_mcp_server_sqlite_args():
+    """build_mcp_server for 'sqlite' passes multi-element args list."""
+    registry = make_registry()
+    server = build_mcp_server("sqlite", registry)
+    assert server.params.args == ["mcp-server-sqlite", "--db", "/tmp/test.db"]
+
+
+def test_build_mcp_server_timeout_passed():
+    """read_timeout_seconds is forwarded as client_session_timeout_seconds."""
+    registry = make_registry()
+    server = build_mcp_server("perplexity", registry)
+    assert server.client_session_timeout_seconds == 120
+
+
+# ---------------------------------------------------------------------------
+# build_agent tests
+# ---------------------------------------------------------------------------
+
+
+def test_build_agent_model():
+    """build_agent sets the model from AgentSpec."""
+    spec = make_spec()
+    agent = build_agent(spec, [])
+    assert agent.model == "gpt-4o"
+
+
+def test_build_agent_output_type_none():
+    """build_agent with output_schema=None sets output_type=None."""
+    spec = make_spec(output_schema=None)
+    agent = build_agent(spec, [])
+    assert agent.output_type is None
+
+
+def test_build_agent_output_type_set():
+    """build_agent with output_schema propagates it as output_type."""
+    class MySchema:
+        pass
+
+    spec = make_spec(output_schema=MySchema)
+    agent = build_agent(spec, [])
+    assert agent.output_type is MySchema
+
+
+def test_build_agent_mcp_servers_count():
+    """build_agent stores the passed mcp_servers list."""
+
+    class DummyServer:
+        pass
+
+    dummy_servers = [DummyServer(), DummyServer()]
+    spec = make_spec()
+    agent = build_agent(spec, dummy_servers)
+    assert len(agent.mcp_servers) == 2
+
+
+def test_build_agent_no_mcp_servers():
+    """build_agent with empty servers list results in len 0."""
+    spec = make_spec()
+    agent = build_agent(spec, [])
+    assert len(agent.mcp_servers) == 0
+
+
+# ---------------------------------------------------------------------------
+# FakeServer / FakeRunner for run() orchestration tests
+# ---------------------------------------------------------------------------
+
+
+class FakeRunResult:
+    """Minimal stub matching the RunResult interface used by the backend."""
+
+    def __init__(self, final_output: Any, last_response_id: str = "resp-123"):
+        self.final_output = final_output
+        self.last_response_id = last_response_id
+
+
+class FakeRunner:
+    """Injectable Runner replacement — async classmethod run()."""
+
+    def __init__(self, result: FakeRunResult):
+        self._result = result
+
+    async def run(self, agent: Any, user_input: Any, **kwargs: Any) -> FakeRunResult:
+        return self._result
+
+
+class FakeRunnerRaises:
+    """Injectable Runner that raises on run()."""
+
+    async def run(self, agent: Any, user_input: Any, **kwargs: Any) -> None:
+        raise RuntimeError("runner exploded")
+
+
+class FakeServer:
+    """Async context manager that records connect/cleanup lifecycle calls."""
+
+    def __init__(self, name: str = "fake"):
+        self.name = name
+        self.connected = False
+        self.cleaned_up = False
+
+    async def __aenter__(self) -> "FakeServer":
+        self.connected = True
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        self.cleaned_up = True
+
+
+# ---------------------------------------------------------------------------
+# run() orchestration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_text_output_mapped(monkeypatch):
+    """run() maps string final_output to LLMResult.text."""
+    fake_result = FakeRunResult(final_output="hello world", last_response_id="r-1")
+    fake_runner = FakeRunner(fake_result)
+
+    registry = make_registry()
+    backend = OpenAIAgentsBackend(registry, runner=fake_runner)
+
+    spec = make_spec()
+    result = await backend.run(spec, "test input")
+
+    assert result.text == "hello world"
+    assert result.response_id == "r-1"
+    assert result.raw is fake_result
+
+
+@pytest.mark.asyncio
+async def test_run_output_schema_none_structured_is_none(monkeypatch):
+    """When output_schema=None, structured must be None regardless of final_output."""
+    fake_result = FakeRunResult(final_output="some text")
+    fake_runner = FakeRunner(fake_result)
+
+    registry = make_registry()
+    backend = OpenAIAgentsBackend(registry, runner=fake_runner)
+
+    spec = make_spec(output_schema=None)
+    result = await backend.run(spec, "q")
+
+    assert result.structured is None
+
+
+@pytest.mark.asyncio
+async def test_run_output_schema_set_structured_populated(monkeypatch):
+    """When output_schema is set, structured = final_output."""
+
+    class MySchema:
+        pass
+
+    obj = MySchema()
+    fake_result = FakeRunResult(final_output=obj)
+    fake_runner = FakeRunner(fake_result)
+
+    registry = make_registry()
+    backend = OpenAIAgentsBackend(registry, runner=fake_runner)
+
+    spec = make_spec(output_schema=MySchema)
+    result = await backend.run(spec, "q")
+
+    assert result.structured is obj
+    # text should be empty string (final_output is not a str)
+    assert result.text == ""
+
+
+@pytest.mark.asyncio
+async def test_run_server_connected_and_cleaned_up(monkeypatch):
+    """MCP server is connected and cleaned up during a successful run."""
+    fake_server = FakeServer("perplexity")
+    fake_result = FakeRunResult(final_output="ok")
+    fake_runner = FakeRunner(fake_result)
+
+    import cores.llm.backends.openai_agents_backend as mod
+
+    monkeypatch.setattr(mod, "build_mcp_server", lambda name, registry: fake_server)
+
+    registry = make_registry()
+    backend = OpenAIAgentsBackend(registry, runner=fake_runner)
+
+    spec = make_spec(mcp_servers=("perplexity",))
+    await backend.run(spec, "input")
+
+    assert fake_server.connected, "server.connect() was not called"
+    assert fake_server.cleaned_up, "server.cleanup() was not called"
+
+
+@pytest.mark.asyncio
+async def test_run_cleanup_called_even_on_runner_failure(monkeypatch):
+    """MCP server cleanup is guaranteed even when runner.run() raises."""
+    fake_server = FakeServer("perplexity")
+    fake_runner = FakeRunnerRaises()
+
+    import cores.llm.backends.openai_agents_backend as mod
+
+    monkeypatch.setattr(mod, "build_mcp_server", lambda name, registry: fake_server)
+
+    registry = make_registry()
+    backend = OpenAIAgentsBackend(registry, runner=fake_runner)
+
+    spec = make_spec(mcp_servers=("perplexity",))
+
+    with pytest.raises(RuntimeError, match="runner exploded"):
+        await backend.run(spec, "input")
+
+    assert fake_server.connected, "server was never entered"
+    assert fake_server.cleaned_up, "server was NOT cleaned up after runner failure"
+
+
+@pytest.mark.asyncio
+async def test_run_response_id_from_last_response_id(monkeypatch):
+    """response_id in LLMResult comes from result.last_response_id."""
+    fake_result = FakeRunResult(final_output="text", last_response_id="unique-id-xyz")
+    fake_runner = FakeRunner(fake_result)
+
+    registry = make_registry()
+    backend = OpenAIAgentsBackend(registry, runner=fake_runner)
+
+    spec = make_spec()
+    result = await backend.run(spec, "q")
+
+    assert result.response_id == "unique-id-xyz"
+
+
+@pytest.mark.asyncio
+async def test_run_no_mcp_servers_no_build_mcp_server_called(monkeypatch):
+    """When spec.mcp_servers is empty, build_mcp_server is never called."""
+    called = []
+
+    import cores.llm.backends.openai_agents_backend as mod
+
+    def record_call(name, registry):
+        called.append(name)
+        return FakeServer(name)
+
+    monkeypatch.setattr(mod, "build_mcp_server", record_call)
+
+    fake_result = FakeRunResult(final_output="ok")
+    fake_runner = FakeRunner(fake_result)
+
+    registry = make_registry()
+    backend = OpenAIAgentsBackend(registry, runner=fake_runner)
+
+    spec = make_spec(mcp_servers=())
+    await backend.run(spec, "q")
+
+    assert called == []

--- a/cores/llm/tests/test_ports.py
+++ b/cores/llm/tests/test_ports.py
@@ -1,0 +1,81 @@
+"""Tests for cores.llm.ports — dataclass defaults and immutability."""
+
+import pytest
+from cores.llm.ports import AgentSpec, LLMParams, LLMResult
+
+
+class TestLLMParams:
+    def test_defaults(self):
+        p = LLMParams()
+        assert p.max_tokens == 8000
+        assert p.reasoning_effort is None
+        assert p.temperature is None
+        assert p.max_iterations == 10
+        assert p.stop_sequences == ()
+
+    def test_custom_values(self):
+        p = LLMParams(
+            max_tokens=30000,
+            reasoning_effort="none",
+            temperature=0.0,
+            max_iterations=5,
+            stop_sequences=("DONE",),
+        )
+        assert p.max_tokens == 30000
+        assert p.reasoning_effort == "none"
+        assert p.temperature == 0.0
+        assert p.max_iterations == 5
+        assert p.stop_sequences == ("DONE",)
+
+    def test_frozen(self):
+        p = LLMParams()
+        with pytest.raises((AttributeError, TypeError)):
+            p.max_tokens = 999  # type: ignore[misc]
+
+    def test_hashable(self):
+        p = LLMParams(max_tokens=100)
+        assert hash(p) is not None
+        d = {p: "ok"}
+        assert d[p] == "ok"
+
+
+class TestAgentSpec:
+    def test_defaults(self):
+        spec = AgentSpec(name="test", instructions="do stuff", model="gpt-5.5")
+        assert spec.mcp_servers == ()
+        assert spec.output_schema is None
+        assert isinstance(spec.params, LLMParams)
+
+    def test_with_mcp_servers(self):
+        spec = AgentSpec(
+            name="trader",
+            instructions="trade",
+            model="gpt-5.5",
+            mcp_servers=("sqlite", "yahoo_finance"),
+        )
+        assert "sqlite" in spec.mcp_servers
+        assert len(spec.mcp_servers) == 2
+
+    def test_frozen(self):
+        spec = AgentSpec(name="a", instructions="b", model="c")
+        with pytest.raises((AttributeError, TypeError)):
+            spec.name = "other"  # type: ignore[misc]
+
+
+class TestLLMResult:
+    def test_defaults(self):
+        r = LLMResult()
+        assert r.text == ""
+        assert r.structured is None
+        assert r.response_id is None
+        assert r.usage is None
+        assert r.raw is None
+
+    def test_mutable(self):
+        r = LLMResult(text="hello")
+        r.text = "world"
+        assert r.text == "world"
+
+    def test_with_usage(self):
+        r = LLMResult(text="ok", usage={"input": 10, "output": 20})
+        assert r.usage["input"] == 10

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,10 @@ requests~=2.32.3
 aiohttp~=3.11.13
 python-dateutil~=2.9.0.post0
 email-validator
-openai>=1.66.0,<2.0.0
+# openai bumped from <2.0.0: openai-agents requires >=2.9; verified mcp-agent 0.2.6
+# runs on openai 2.x (2026-06-19 coexistence test). See tasks/mcp_agent_removal_prd.md.
+openai>=2.9,<3
+openai-agents==0.7.0
 anthropic~=0.64.0
 markdown>=3.3.0
 python-telegram-bot>=20.0

--- a/tests/test_chatgpt_oauth/test_responses_passthrough.py
+++ b/tests/test_chatgpt_oauth/test_responses_passthrough.py
@@ -1,0 +1,128 @@
+"""Unit tests for prepare_responses_passthrough in api_translator."""
+
+import pytest
+from cores.chatgpt_proxy.api_translator import prepare_responses_passthrough
+
+
+class TestPrepareResponsesPassthrough:
+    """Test that prepare_responses_passthrough prepares a Responses API body correctly."""
+
+    def test_forces_store_false(self):
+        body = {"model": "gpt-5.4-mini", "input": [{"role": "user", "content": "hi"}]}
+        result = prepare_responses_passthrough(body)
+        assert result["store"] is False
+
+    def test_forces_stream_true(self):
+        body = {"model": "gpt-5.4-mini", "input": [{"role": "user", "content": "hi"}]}
+        result = prepare_responses_passthrough(body)
+        assert result["stream"] is True
+
+    def test_maps_gpt4o_to_gpt54mini(self):
+        body = {"model": "gpt-4o", "input": []}
+        result = prepare_responses_passthrough(body)
+        assert result["model"] == "gpt-5.4-mini"
+
+    def test_maps_gpt4o_mini_to_gpt54mini(self):
+        body = {"model": "gpt-4o-mini", "input": []}
+        result = prepare_responses_passthrough(body)
+        assert result["model"] == "gpt-5.4-mini"
+
+    def test_unknown_model_passes_through_unchanged(self):
+        body = {"model": "gpt-5.4-mini", "input": []}
+        result = prepare_responses_passthrough(body)
+        assert result["model"] == "gpt-5.4-mini"
+
+    def test_unknown_custom_model_passes_through(self):
+        body = {"model": "my-custom-model-v2", "input": []}
+        result = prepare_responses_passthrough(body)
+        assert result["model"] == "my-custom-model-v2"
+
+    def test_injects_default_instructions_when_missing(self):
+        body = {"model": "gpt-5.4-mini", "input": []}
+        result = prepare_responses_passthrough(body)
+        assert result["instructions"] == "You are a helpful assistant."
+
+    def test_injects_default_instructions_when_empty_string(self):
+        body = {"model": "gpt-5.4-mini", "input": [], "instructions": ""}
+        result = prepare_responses_passthrough(body)
+        assert result["instructions"] == "You are a helpful assistant."
+
+    def test_preserves_existing_instructions(self):
+        body = {"model": "gpt-5.4-mini", "input": [], "instructions": "You are a stock analyst."}
+        result = prepare_responses_passthrough(body)
+        assert result["instructions"] == "You are a stock analyst."
+
+    def test_preserves_input_unchanged(self):
+        input_val = [{"role": "user", "content": "analyze AAPL"}]
+        body = {"model": "gpt-5.4-mini", "input": input_val}
+        result = prepare_responses_passthrough(body)
+        assert result["input"] == input_val
+
+    def test_preserves_tools_unchanged(self):
+        tools = [{"type": "function", "name": "get_price", "parameters": {}}]
+        body = {"model": "gpt-5.4-mini", "input": [], "tools": tools}
+        result = prepare_responses_passthrough(body)
+        assert result["tools"] == tools
+
+    def test_preserves_text_format(self):
+        text = {"format": {"type": "json_schema", "name": "Output", "schema": {}}}
+        body = {"model": "gpt-5.4-mini", "input": [], "text": text}
+        result = prepare_responses_passthrough(body)
+        assert result["text"] == text
+
+    def test_preserves_reasoning(self):
+        reasoning = {"effort": "high"}
+        body = {"model": "gpt-5.4-mini", "input": [], "reasoning": reasoning}
+        result = prepare_responses_passthrough(body)
+        assert result["reasoning"] == reasoning
+
+    def test_strips_max_output_tokens(self):
+        # Codex backend rejects max_output_tokens (live-verified 400). It must be stripped.
+        body = {"model": "gpt-5.4-mini", "input": [], "max_output_tokens": 4096}
+        result = prepare_responses_passthrough(body)
+        assert "max_output_tokens" not in result
+
+    def test_preserves_temperature(self):
+        body = {"model": "gpt-5.4-mini", "input": [], "temperature": 0.7}
+        result = prepare_responses_passthrough(body)
+        assert result["temperature"] == 0.7
+
+    def test_preserves_top_p(self):
+        body = {"model": "gpt-5.4-mini", "input": [], "top_p": 0.9}
+        result = prepare_responses_passthrough(body)
+        assert result["top_p"] == 0.9
+
+    def test_preserves_tool_choice(self):
+        body = {"model": "gpt-5.4-mini", "input": [], "tool_choice": "auto"}
+        result = prepare_responses_passthrough(body)
+        assert result["tool_choice"] == "auto"
+
+    def test_does_not_mutate_input_dict(self):
+        body = {"model": "gpt-4o", "input": [], "store": True, "stream": False}
+        original_model = body["model"]
+        original_store = body["store"]
+        original_stream = body["stream"]
+
+        prepare_responses_passthrough(body)
+
+        # Input dict must be unchanged
+        assert body["model"] == original_model
+        assert body["store"] == original_store
+        assert body["stream"] == original_stream
+
+    def test_missing_model_defaults_to_gpt54mini(self):
+        body = {"input": []}
+        result = prepare_responses_passthrough(body)
+        assert result["model"] == "gpt-5.4-mini"
+
+    def test_overrides_caller_store_true(self):
+        """Caller passing store=True must be overridden — Codex requires store=False."""
+        body = {"model": "gpt-5.4-mini", "input": [], "store": True}
+        result = prepare_responses_passthrough(body)
+        assert result["store"] is False
+
+    def test_overrides_caller_stream_false(self):
+        """Caller passing stream=False must be overridden — Codex requires stream=True."""
+        body = {"model": "gpt-5.4-mini", "input": [], "stream": False}
+        result = prepare_responses_passthrough(body)
+        assert result["stream"] is True

--- a/tests/test_chatgpt_oauth/test_responses_passthrough_codex.py
+++ b/tests/test_chatgpt_oauth/test_responses_passthrough_codex.py
@@ -1,0 +1,61 @@
+"""Regression tests for Codex-backend constraints discovered during LIVE verification
+of the openai-agents -> /v1/responses path (2026-06-18).
+
+Each constraint below was observed as a real 400 from chatgpt.com/backend-api/codex:
+  - {"detail":"Input must be a list"}            -> input string must be wrapped
+  - {"detail":"Unsupported parameter: max_output_tokens"} -> strip max_output_tokens
+  - empty `tools: []` rejected                   -> drop empty tools
+These tests lock in `prepare_responses_passthrough` so the fixes never regress.
+"""
+from cores.chatgpt_proxy.api_translator import prepare_responses_passthrough
+
+
+def test_string_input_wrapped_into_list():
+    out = prepare_responses_passthrough({"model": "gpt-5.4-mini", "input": "say hi"})
+    assert out["input"] == [{"role": "user", "content": "say hi"}]
+
+
+def test_list_input_preserved():
+    items = [{"role": "user", "content": "x"}, {"type": "function_call_output", "call_id": "c", "output": "y"}]
+    out = prepare_responses_passthrough({"model": "m", "input": items})
+    assert out["input"] == items
+
+
+def test_max_output_tokens_stripped():
+    out = prepare_responses_passthrough({"model": "m", "input": [], "max_output_tokens": 500})
+    assert "max_output_tokens" not in out
+
+
+def test_include_stripped():
+    out = prepare_responses_passthrough({"model": "m", "input": [], "include": []})
+    assert "include" not in out
+
+
+def test_empty_tools_dropped():
+    out = prepare_responses_passthrough({"model": "m", "input": [], "tools": []})
+    assert "tools" not in out
+
+
+def test_nonempty_tools_kept():
+    tools = [{"type": "function", "name": "t", "parameters": {}}]
+    out = prepare_responses_passthrough({"model": "m", "input": [], "tools": tools})
+    assert out["tools"] == tools
+
+
+def test_store_stream_forced_and_model_mapped():
+    out = prepare_responses_passthrough({"model": "gpt-4o", "input": [], "store": True, "stream": False})
+    assert out["store"] is False
+    assert out["stream"] is True
+    assert out["model"] == "gpt-5.4-mini"
+
+
+def test_default_instructions_only_when_missing():
+    assert prepare_responses_passthrough({"model": "m", "input": []})["instructions"] == "You are a helpful assistant."
+    assert prepare_responses_passthrough({"model": "m", "input": [], "instructions": "custom"})["instructions"] == "custom"
+
+
+def test_does_not_mutate_caller():
+    body = {"model": "m", "input": "hi", "max_output_tokens": 10}
+    prepare_responses_passthrough(body)
+    assert body["input"] == "hi"
+    assert body["max_output_tokens"] == 10

--- a/tools/oauth_healthcheck.py
+++ b/tools/oauth_healthcheck.py
@@ -1,0 +1,201 @@
+"""ChatGPT OAuth health & usage watchdog.
+
+Runs on the db-server via cron (e.g. every 30 min) to catch the two failure
+modes introduced by running on the ChatGPT subscription (OAuth) instead of an
+API key:
+
+  1. LOGIN EXPIRY  — the OAuth refresh_token was revoked/expired, so every LLM
+     call starts failing with ChatGPTAuthExpiredError. Detected by attempting a
+     real token refresh via TokenManager.
+  2. COST / RATE LIMIT — subscription usage caps hit, surfacing as 429 /
+     rate-limit / insufficient_quota / authentication errors in the orchestrator
+     logs. Detected by scanning recent log files.
+
+On a problem it sends a Telegram alert (to OAUTH_ALERT_CHAT_ID, falling back to
+TELEGRAM_CHANNEL_ID) using TELEGRAM_BOT_TOKEN. A small state file suppresses
+duplicate alerts within a cooldown window so cron does not spam.
+
+This script is READ-ONLY w.r.t. trading/DB. It only reads the token + logs and
+sends a Telegram message. Intended cron line (db-server):
+
+    */30 * * * * cd /root/prism-insight && /root/.pyenv/shims/python tools/oauth_healthcheck.py >> logs/oauth_health.log 2>&1
+
+Exit code: 0 = healthy, 1 = problem detected (alert attempted).
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv(ROOT / ".env")
+except Exception:
+    pass
+
+# --- Config (env-driven) ---------------------------------------------------
+LOG_DIR = Path(os.getenv("OAUTH_HEALTH_LOG_DIR", str(ROOT / "logs")))
+LOG_SCAN_MINUTES = int(os.getenv("OAUTH_HEALTH_LOG_WINDOW_MIN", "90"))
+ERROR_THRESHOLD = int(os.getenv("OAUTH_HEALTH_ERROR_THRESHOLD", "3"))
+EXPIRY_WARN_HOURS = int(os.getenv("OAUTH_HEALTH_EXPIRY_WARN_HOURS", "24"))
+ALERT_COOLDOWN_MIN = int(os.getenv("OAUTH_HEALTH_ALERT_COOLDOWN_MIN", "180"))
+STATE_FILE = Path(os.getenv("OAUTH_HEALTH_STATE_FILE", "/tmp/oauth_health_state"))
+ALERT_CHAT_ID = os.getenv("OAUTH_ALERT_CHAT_ID") or os.getenv("TELEGRAM_CHANNEL_ID")
+BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+
+# Patterns that indicate auth/usage problems in orchestrator logs.
+# Deliberately SPECIFIC: must match real OpenAI/proxy error strings and NOT
+# benign trading-log text (e.g. "1,291,429 KRW" or "(limit)"). So we anchor on
+# SDK error formatting ("Error code: 429"), exception class names, and exact
+# OpenAI error codes — never a bare number or the word "limit"/"quota".
+ERROR_PATTERNS = re.compile(
+    r"ChatGPTAuthExpiredError"
+    r"|insufficient_quota|quota[ _]?exceeded"
+    r"|RateLimitError|rate_limit_exceeded|Too Many Requests"
+    r"|Error code:\s*(?:429|401|403)"
+    r"|authentication_error|AuthenticationError|PermissionDeniedError"
+    r"|invalid_api_key|Incorrect API key"
+    r"|Token refresh failed|Token retrieval failed|OAuth proxy.*fail",
+    re.IGNORECASE,
+)
+
+
+def _send_telegram(text: str) -> bool:
+    """Send a Telegram alert. Returns True on success. Uses the Bot HTTP API."""
+    if not BOT_TOKEN or not ALERT_CHAT_ID:
+        print(f"[oauth-health] cannot alert: BOT_TOKEN or chat id missing. msg={text}")
+        return False
+    try:
+        import requests
+
+        resp = requests.post(
+            f"https://api.telegram.org/bot{BOT_TOKEN}/sendMessage",
+            json={"chat_id": ALERT_CHAT_ID, "text": text, "disable_web_page_preview": True},
+            timeout=15,
+        )
+        return resp.status_code == 200
+    except Exception as e:  # noqa: BLE001
+        print(f"[oauth-health] telegram send error: {e}")
+        return False
+
+
+def _already_alerted(signature: str) -> bool:
+    """Cooldown: skip if the same alert signature fired within the window."""
+    try:
+        if STATE_FILE.exists():
+            last_sig, last_ts = STATE_FILE.read_text().strip().split("|", 1)
+            if last_sig == signature and (time.time() - float(last_ts)) < ALERT_COOLDOWN_MIN * 60:
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def _record_alert(signature: str) -> None:
+    try:
+        STATE_FILE.write_text(f"{signature}|{time.time()}")
+    except Exception:
+        pass
+
+
+def _alert(title: str, body: str) -> None:
+    sig = hashlib.sha1(f"{title}".encode()).hexdigest()[:12]
+    if _already_alerted(sig):
+        print(f"[oauth-health] suppressed (cooldown): {title}")
+        return
+    msg = f"🚨 PRISM OAuth 경보\n{title}\n\n{body}"
+    ok = _send_telegram(msg)
+    _record_alert(sig)
+    print(f"[oauth-health] ALERT sent={ok}: {title}")
+
+
+async def _check_token() -> tuple[bool, str]:
+    """Return (healthy, detail). Attempts a real refresh via TokenManager."""
+    from cores.chatgpt_proxy.constants import AUTH_FILE
+    from cores.chatgpt_proxy.token_manager import ChatGPTAuthExpiredError, TokenManager
+
+    if not Path(AUTH_FILE).exists():
+        return False, f"OAuth 토큰 파일 없음: {AUTH_FILE} (재로그인 필요)"
+
+    tm = TokenManager()
+    try:
+        await tm.get_token()  # refreshes if expired; raises if refresh_token dead
+        data = tm._auth_data or {}
+        expires_at = data.get("expires_at", 0)
+        hours_left = (expires_at - time.time()) / 3600.0
+        detail = f"access_token expires in {hours_left:.1f}h"
+        # Access tokens auto-refresh; only warn if a refresh somehow left it short.
+        if hours_left < 0:
+            return True, detail + " (방금 갱신됨)"
+        return True, detail
+    except ChatGPTAuthExpiredError as e:
+        return False, f"refresh_token 만료/철회 — 재로그인 필요: {e}"
+    except Exception as e:  # noqa: BLE001
+        return False, f"토큰 점검 중 예외: {e!r}"
+
+
+def _scan_logs() -> tuple[int, list[str]]:
+    """Count error-pattern hits in log files modified within the scan window."""
+    if not LOG_DIR.is_dir():
+        return 0, []
+    cutoff = time.time() - LOG_SCAN_MINUTES * 60
+    hits = 0
+    samples: list[str] = []
+    for log_file in LOG_DIR.glob("*.log"):
+        try:
+            if log_file.stat().st_mtime < cutoff:
+                continue
+            # Read only the tail to stay cheap.
+            with log_file.open("rb") as f:
+                f.seek(0, 2)
+                size = f.tell()
+                f.seek(max(0, size - 200_000))
+                tail = f.read().decode("utf-8", errors="ignore")
+            for line in tail.splitlines():
+                if ERROR_PATTERNS.search(line):
+                    hits += 1
+                    if len(samples) < 5:
+                        samples.append(f"{log_file.name}: {line.strip()[:160]}")
+        except Exception:
+            continue
+    return hits, samples
+
+
+async def main() -> int:
+    oauth_mode = os.getenv("PRISM_OPENAI_AUTH_MODE") == "chatgpt_oauth"
+    problems = 0
+
+    # 1) Token / login health (only meaningful when OAuth mode is active OR a token exists)
+    token_healthy, token_detail = await _check_token()
+    if oauth_mode and not token_healthy:
+        problems += 1
+        _alert("OAuth 로그인 풀림", token_detail + "\n→ `python -m cores.chatgpt_proxy.oauth_login` 후 토큰 재배치 필요")
+    print(f"[oauth-health] oauth_mode={oauth_mode} token_healthy={token_healthy} ({token_detail})")
+
+    # 2) Cost / rate-limit error scan
+    hits, samples = _scan_logs()
+    print(f"[oauth-health] log error hits (last {LOG_SCAN_MINUTES}m) = {hits} (threshold {ERROR_THRESHOLD})")
+    if hits >= ERROR_THRESHOLD:
+        problems += 1
+        _alert(
+            f"LLM 인증/리밋 에러 급증 ({hits}건/{LOG_SCAN_MINUTES}분)",
+            "최근 로그 샘플:\n" + "\n".join(samples),
+        )
+
+    if problems == 0:
+        print("[oauth-health] OK")
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tools/verify_openai_agents_live.py
+++ b/tools/verify_openai_agents_live.py
@@ -1,0 +1,198 @@
+"""Manual LIVE verification of the openai-agents backend.
+
+Proves the Phase 2 migration target end-to-end against BOTH auth paths:
+  --auth api    : openai-agents Runner (Responses) -> real OpenAI API (uses OPENAI_API_KEY env or secrets.yaml)
+  --auth proxy  : openai-agents Runner (Responses) -> ChatGPT OAuth proxy /v1/responses -> Codex backend
+
+NO trading, NO telegram, NO DB writes. Safe to run. Only effect: one (or a few)
+LLM calls + optional read-only MCP tool calls.
+
+PREREQUISITES:
+  api mode   : OPENAI_API_KEY in .env / environment, or openai.api_key in mcp_agent.secrets.yaml.
+  proxy mode : a valid ChatGPT OAuth token at ~/.config/prism-insight/chatgpt_auth.json
+               (create via `python -m cores.chatgpt_proxy.oauth_login`).
+  MCP        : the chosen server's command on PATH (uvx/npx/node/uv) + its key set in environment.
+               MCP config loaded from cores/llm/mcp_servers.yaml (override with --config).
+  Deps in .venv: openai>=2.9, openai-agents==0.7.0, aiohttp, pyyaml, python-dotenv.
+
+USAGE (graduated):
+  # API key path
+  .venv/bin/python tools/verify_openai_agents_live.py --auth api
+  .venv/bin/python tools/verify_openai_agents_live.py --auth api --mcp time
+  .venv/bin/python tools/verify_openai_agents_live.py --auth api --mcp yahoo_finance \
+      --prompt "What is the latest closing price of AAPL?"
+  # OAuth proxy path
+  .venv/bin/python tools/verify_openai_agents_live.py --auth proxy --mcp time
+  # Override MCP config
+  .venv/bin/python tools/verify_openai_agents_live.py --auth api --mcp time --config /path/to/config.yaml
+
+Exit code 0 = PASS, non-zero = FAIL.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+# Load .env early so env-based secrets and ${VAR} interpolation work.
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+TOKEN_PATH = Path.home() / ".config" / "prism-insight" / "chatgpt_auth.json"
+SECRETS_PATH = ROOT / "mcp_agent.secrets.yaml"
+
+
+def _load_openai_key_from_secrets() -> str | None:
+    if os.environ.get("OPENAI_API_KEY"):
+        return os.environ["OPENAI_API_KEY"]
+    if SECRETS_PATH.exists():
+        data = yaml.safe_load(SECRETS_PATH.read_text()) or {}
+        key = (data.get("openai") or {}).get("api_key")
+        if key and "example" not in key.lower():
+            return key
+    return None
+
+
+def _disable_tracing() -> None:
+    try:
+        from agents import set_tracing_disabled
+
+        set_tracing_disabled(True)
+    except Exception:
+        pass
+
+
+async def _setup_api() -> bool:
+    """Configure SDK to hit the real OpenAI API. Returns True on success."""
+    key = _load_openai_key_from_secrets()
+    if not key:
+        print("[FAIL] No OpenAI API key in OPENAI_API_KEY env or mcp_agent.secrets.yaml (openai.api_key).")
+        return False
+    os.environ["OPENAI_API_KEY"] = key
+    os.environ.pop("OPENAI_BASE_URL", None)  # ensure we hit real api.openai.com
+    _disable_tracing()
+    # Responses is the agents-SDK default; be explicit + bind a clean client.
+    from agents import set_default_openai_api, set_default_openai_client, set_default_openai_key
+    from openai import AsyncOpenAI
+
+    set_default_openai_client(AsyncOpenAI(api_key=key))
+    set_default_openai_api("responses")
+    set_default_openai_key(key)
+    print(f"[info] auth=api  endpoint=api.openai.com  key=set({len(key)} chars)")
+    return True
+
+
+async def _setup_proxy() -> bool:
+    """Start the OAuth proxy and point the SDK at it. Returns True on success."""
+    if not TOKEN_PATH.exists():
+        print(f"[FAIL] ChatGPT OAuth token not found at {TOKEN_PATH}.")
+        print("       Run: python -m cores.chatgpt_proxy.oauth_login")
+        return False
+    from cores.chatgpt_proxy import inject_env, start_proxy
+    from cores.llm.backends.openai_agents_backend import configure_openai_agents_for_proxy
+
+    _disable_tracing()
+    inject_env()
+    started = await start_proxy()
+    base_url = os.environ.get("OPENAI_BASE_URL", "")
+    print(f"[info] auth=proxy  started={started}  base_url={base_url}")
+    configure_openai_agents_for_proxy(
+        base_url, os.environ.get("OPENAI_API_KEY", "chatgpt-oauth-placeholder")
+    )
+    return True
+
+
+async def _teardown_proxy() -> None:
+    try:
+        from cores.chatgpt_proxy import stop_proxy
+
+        await stop_proxy()
+    except Exception:
+        pass
+
+
+async def _run(args: argparse.Namespace) -> int:
+    from cores.llm.backends.openai_agents_backend import OpenAIAgentsBackend
+    from cores.llm.ports import AgentSpec, LLMParams
+
+    if args.auth == "api":
+        if not await _setup_api():
+            return 2
+    else:
+        if not await _setup_proxy():
+            return 2
+
+    try:
+        registry = None
+        if args.mcp:
+            from cores.llm.config_loader import load_mcp_registry
+            try:
+                registry = load_mcp_registry(args.config)
+            except FileNotFoundError as exc:
+                print(f"[FAIL] MCP requested but config not found: {exc}")
+                return 3
+            missing = [n for n in args.mcp if n not in registry.names()]
+            if missing:
+                print(f"[FAIL] MCP server(s) not in config: {missing}")
+                print(f"       Registered: {registry.names()}")
+                return 4
+
+        spec = AgentSpec(
+            name="live-verify",
+            instructions="You are a verification assistant. Answer briefly and factually.",
+            model=args.model,
+            mcp_servers=tuple(args.mcp),
+            params=LLMParams(
+                max_tokens=args.max_tokens,
+                reasoning_effort=args.reasoning,
+                max_iterations=args.max_iters,
+            ),
+        )
+
+        backend = OpenAIAgentsBackend(registry)
+        print(f"[info] running: model={args.model} mcp={list(args.mcp)} reasoning={args.reasoning}")
+        result = await backend.run(spec, args.prompt)
+
+        print("\n===== RESULT =====")
+        print("text        :", (result.text or "").strip()[:1500])
+        print("response_id :", result.response_id)
+        print("usage       :", result.usage)
+        print("==================")
+        if not (result.text or "").strip():
+            print("[WARN] empty text — check proxy logs / Codex field rejections.")
+            return 5
+        print(f"[PASS] openai-agents ({args.auth}) -> Responses roundtrip OK"
+              + (f" + MCP {list(args.mcp)}" if args.mcp else ""))
+        return 0
+    finally:
+        if args.auth == "proxy":
+            await _teardown_proxy()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--auth", choices=["api", "proxy"], default="proxy", help="auth path to verify")
+    ap.add_argument("--mcp", nargs="*", default=[], help="MCP server names from mcp_agent.config.yaml")
+    ap.add_argument("--model", default="gpt-5.4-mini")
+    ap.add_argument("--prompt", default="In one sentence, confirm you can respond.")
+    ap.add_argument("--reasoning", default="none", help="none|low|medium|high")
+    ap.add_argument("--max-tokens", type=int, default=2000, dest="max_tokens")
+    ap.add_argument("--max-iters", type=int, default=5, dest="max_iters")
+    ap.add_argument("--config", default=None, help="MCP config YAML path (default: auto-detect via load_mcp_registry search order)")
+    args = ap.parse_args()
+    return asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tracking/journal.py
+++ b/tracking/journal.py
@@ -85,19 +85,39 @@ class JournalManager:
             # Create journal agent
             journal_agent = create_trading_journal_agent(self.language)
 
-            async with journal_agent:
-                llm = await journal_agent.attach_llm(OpenAIAugmentedLLM)
+            # Build prompt once — shared by both execution paths
+            prompt = self._build_analysis_prompt(
+                company_name, ticker, buy_price, buy_date,
+                scenario_data, sell_price, profit_rate, holding_days, sell_reason
+            )
 
-                prompt = self._build_analysis_prompt(
-                    company_name, ticker, buy_price, buy_date,
-                    scenario_data, sell_price, profit_rate, holding_days, sell_reason
+            import os as _os
+            if _os.getenv("LLM_BACKEND", "mcp_agent") == "openai_agents":
+                from cores.llm.agent_bridge import (
+                    ensure_openai_agents_configured,
+                    get_llm_backend,
+                    spec_from_mcp_agent,
                 )
+                from cores.llm.config_loader import load_mcp_registry
+                from cores.llm.ports import LLMParams
 
-                response = await llm.generate_str(
-                    message=prompt,
-                    request_params=RequestParams(model="gpt-5.4-mini", reasoning_effort="none", maxTokens=16000)
+                ensure_openai_agents_configured()
+                registry = load_mcp_registry()
+                spec = spec_from_mcp_agent(
+                    journal_agent,
+                    model="gpt-5.4-mini",
+                    params=LLMParams(max_tokens=16000, reasoning_effort="none"),
                 )
-                logger.info(f"Journal agent response received: {len(response)} chars")
+                result = await get_llm_backend(registry).run(spec, prompt)
+                response = result.text
+            else:
+                async with journal_agent:
+                    llm = await journal_agent.attach_llm(OpenAIAugmentedLLM)
+                    response = await llm.generate_str(
+                        message=prompt,
+                        request_params=RequestParams(model="gpt-5.4-mini", reasoning_effort="none", maxTokens=16000)
+                    )
+            logger.info(f"Journal agent response received: {len(response)} chars")
 
             # Parse and save
             journal_data = self._parse_response(response)


### PR DESCRIPTION
## 목적
`mcp-agent` 프레임워크(미운영 포크) 의존을 제거하고 최신 OpenAI SDK(`openai-agents`/Responses)를 자유롭게 추종하기 위한 **토대 + 첫 호출부 전환**. 전부 **additive·플래그 기본 OFF**라 프로덕션 동작 불변.

## 변경 요약
- **cores/llm 포트 레이어**: `LLMBackend`/`AgentSpec`/`LLMParams`/`LLMResult`, `ModelRegistry`, `McpServerRegistry`, `FakeLLMBackend`, `config_loader`(env 시크릿 + `${VAR}` 보간 + 네이티브 `mcp_servers.yaml`, 레거시 `mcp_agent.config.yaml` 폴백).
- **백엔드 2종(동일 포트)**: `McpAgentBackend`(strangler shim), `OpenAIAgentsBackend`(openai-agents 0.7 + `MCPServerStdio` + `AsyncExitStack` 생명주기).
- **ChatGPT OAuth 프록시에 `/v1/responses` 추가**: 구독(OAuth) 유지하며 Responses API 사용. Codex 제약 처리(input→list, `max_output_tokens`/`include` strip, 빈 tools 제거).
- **Phase 3**: `tracking/journal.py`를 포트 경유로 배선. `LLM_BACKEND` env 기본 `mcp_agent`(기존 경로 바이트 동일), `openai_agents`만 새 경로.
- **deps**: `openai>=2.9,<3` + `openai-agents==0.7.0` (아래 공존 검증).

## 검증
- 단위테스트 cores/llm **106 passed**, chatgpt_oauth responses passthrough green.
- **라이브 PASS(양쪽 인증)**: API 키 + ChatGPT OAuth, 둘 다 LLM 왕복 + MCP stdio 툴 루프(`time`/`yahoo_finance`).
- **공존 검증**: mcp-agent 0.2.6(포크)이 **openai 2.43에서 정상 동작**(openai-agents와 동일 venv). prod 모듈 import-smoke + 프롬프트룰 46 passed.

## 배포 안전성
- `LLM_BACKEND` 미설정 시 기존 mcp_agent 경로 → **동작 불변**.
- db-server는 `git pull`만 하므로 머지로 자동 업그레이드 안 됨. `pip install -r requirements.txt` 실행 시에만 openai 2.x 반영.
- 실매매 호출부는 **SHADOW→백테스트→사용자확인** 후에만 전환 예정(이 PR엔 없음).

## 남은 작업
- db-server에서 `LLM_BACKEND=openai_agents`로 journal 라이브 비교 → 점진 확대 → Phase 4(EvaluatorOptimizer) → Phase 5(mcp-agent+yaml 삭제).

🤖 Generated with [Claude Code](https://claude.com/claude-code)