### PR TITLE
ci: add GitHub Actions CI workflow and code-quality badges (#346)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          pip install \
+            pydantic \
+            pyyaml \
+            "openai>=2.9,<3" \
+            "openai-agents==0.7.0" \
+            mcp \
+            pytest \
+            pytest-asyncio
+
+      - name: Run tests
+        run: python -m pytest cores/llm/tests/ -q

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </div>
 
 [![CI](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml/badge.svg)](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml)
-<!-- CODACY_BADGE: pending Codacy GitHub connection — replace with [![Codacy Badge](https://app.codacy.com/project/badge/Grade/<PROJECT_ID>)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard) -->
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/2f8fd766b0634c068ff9da57ccda00c6)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 # PRISM-INSIGHT
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
   <img src="https://img.shields.io/badge/ChatGPT_Plus-Codex_OAuth-ff6b35.svg" alt="ChatGPT Plus">
 </div>
 
+[![CI](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml/badge.svg)](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml)
+<!-- CODACY_BADGE: pending Codacy GitHub connection — replace with [![Codacy Badge](https://app.codacy.com/project/badge/Grade/<PROJECT_ID>)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard) -->
+
 # PRISM-INSIGHT
 
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/dragon1086?style=for-the-badge&logo=github-sponsors&color=ff69b4&label=Sponsors)](https://github.com/sponsors/dragon1086)

--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -1,7 +1,7 @@
 # 🐳 PRISM-INSIGHT Docker Installation Guide
 
 [![CI](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml/badge.svg)](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml)
-<!-- CODACY_BADGE: pending Codacy GitHub connection — replace with [![Codacy Badge](https://app.codacy.com/project/badge/Grade/<PROJECT_ID>)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard) -->
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/2f8fd766b0634c068ff9da57ccda00c6)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 > 📖 [한국어 문서](README_DOCKER_ko.md)
 

--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -1,5 +1,8 @@
 # 🐳 PRISM-INSIGHT Docker Installation Guide
 
+[![CI](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml/badge.svg)](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml)
+<!-- CODACY_BADGE: pending Codacy GitHub connection — replace with [![Codacy Badge](https://app.codacy.com/project/badge/Grade/<PROJECT_ID>)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard) -->
+
 > 📖 [한국어 문서](README_DOCKER_ko.md)
 
 Run Ubuntu 24.04-based AI stock analysis system easily with Docker.

--- a/README_DOCKER_ko.md
+++ b/README_DOCKER_ko.md
@@ -1,7 +1,7 @@
 # 🐳 PRISM-INSIGHT Docker 설치 가이드
 
 [![CI](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml/badge.svg)](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml)
-<!-- CODACY_BADGE: pending Codacy GitHub connection — replace with [![Codacy Badge](https://app.codacy.com/project/badge/Grade/<PROJECT_ID>)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard) -->
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/2f8fd766b0634c068ff9da57ccda00c6)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 Ubuntu 24.04 기반 AI 주식 분석 시스템을 Docker로 간편하게 실행하세요.
 

--- a/README_DOCKER_ko.md
+++ b/README_DOCKER_ko.md
@@ -1,5 +1,8 @@
 # 🐳 PRISM-INSIGHT Docker 설치 가이드
 
+[![CI](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml/badge.svg)](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml)
+<!-- CODACY_BADGE: pending Codacy GitHub connection — replace with [![Codacy Badge](https://app.codacy.com/project/badge/Grade/<PROJECT_ID>)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard) -->
+
 Ubuntu 24.04 기반 AI 주식 분석 시스템을 Docker로 간편하게 실행하세요.
 
 ---

--- a/README_es.md
+++ b/README_es.md
@@ -9,7 +9,7 @@
 </div>
 
 [![CI](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml/badge.svg)](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml)
-<!-- CODACY_BADGE: pending Codacy GitHub connection — replace with [![Codacy Badge](https://app.codacy.com/project/badge/Grade/<PROJECT_ID>)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard) -->
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/2f8fd766b0634c068ff9da57ccda00c6)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 # PRISM-INSIGHT
 

--- a/README_es.md
+++ b/README_es.md
@@ -8,6 +8,9 @@
   <img src="https://img.shields.io/badge/ChatGPT_Plus-Codex_OAuth-ff6b35.svg" alt="ChatGPT Plus">
 </div>
 
+[![CI](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml/badge.svg)](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml)
+<!-- CODACY_BADGE: pending Codacy GitHub connection — replace with [![Codacy Badge](https://app.codacy.com/project/badge/Grade/<PROJECT_ID>)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard) -->
+
 # PRISM-INSIGHT
 
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/dragon1086?style=for-the-badge&logo=github-sponsors&color=ff69b4&label=Sponsors)](https://github.com/sponsors/dragon1086)

--- a/README_ja.md
+++ b/README_ja.md
@@ -9,7 +9,7 @@
 </div>
 
 [![CI](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml/badge.svg)](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml)
-<!-- CODACY_BADGE: pending Codacy GitHub connection — replace with [![Codacy Badge](https://app.codacy.com/project/badge/Grade/<PROJECT_ID>)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard) -->
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/2f8fd766b0634c068ff9da57ccda00c6)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 # PRISM-INSIGHT
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -8,6 +8,9 @@
   <img src="https://img.shields.io/badge/ChatGPT_Plus-Codex_OAuth-ff6b35.svg" alt="ChatGPT Plus">
 </div>
 
+[![CI](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml/badge.svg)](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml)
+<!-- CODACY_BADGE: pending Codacy GitHub connection — replace with [![Codacy Badge](https://app.codacy.com/project/badge/Grade/<PROJECT_ID>)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard) -->
+
 # PRISM-INSIGHT
 
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/dragon1086?style=for-the-badge&logo=github-sponsors&color=ff69b4&label=Sponsors)](https://github.com/sponsors/dragon1086)

--- a/README_ko.md
+++ b/README_ko.md
@@ -9,7 +9,7 @@
 </div>
 
 [![CI](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml/badge.svg)](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml)
-<!-- CODACY_BADGE: pending Codacy GitHub connection — replace with [![Codacy Badge](https://app.codacy.com/project/badge/Grade/<PROJECT_ID>)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard) -->
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/2f8fd766b0634c068ff9da57ccda00c6)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 # PRISM-INSIGHT
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -8,6 +8,9 @@
   <img src="https://img.shields.io/badge/ChatGPT_Plus-Codex_OAuth-ff6b35.svg" alt="ChatGPT Plus">
 </div>
 
+[![CI](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml/badge.svg)](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml)
+<!-- CODACY_BADGE: pending Codacy GitHub connection — replace with [![Codacy Badge](https://app.codacy.com/project/badge/Grade/<PROJECT_ID>)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard) -->
+
 # PRISM-INSIGHT
 
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/dragon1086?style=for-the-badge&logo=github-sponsors&color=ff69b4&label=Sponsors)](https://github.com/sponsors/dragon1086)

--- a/README_zh.md
+++ b/README_zh.md
@@ -9,7 +9,7 @@
 </div>
 
 [![CI](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml/badge.svg)](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml)
-<!-- CODACY_BADGE: pending Codacy GitHub connection — replace with [![Codacy Badge](https://app.codacy.com/project/badge/Grade/<PROJECT_ID>)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard) -->
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/2f8fd766b0634c068ff9da57ccda00c6)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 # PRISM-INSIGHT
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -8,6 +8,9 @@
   <img src="https://img.shields.io/badge/ChatGPT_Plus-Codex_OAuth-ff6b35.svg" alt="ChatGPT Plus">
 </div>
 
+[![CI](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml/badge.svg)](https://github.com/dragon1086/prism-insight/actions/workflows/ci.yml)
+<!-- CODACY_BADGE: pending Codacy GitHub connection — replace with [![Codacy Badge](https://app.codacy.com/project/badge/Grade/<PROJECT_ID>)](https://app.codacy.com/gh/dragon1086/prism-insight/dashboard) -->
+
 # PRISM-INSIGHT
 
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/dragon1086?style=for-the-badge&logo=github-sponsors&color=ff69b4&label=Sponsors)](https://github.com/sponsors/dragon1086)


### PR DESCRIPTION
## Summary

- **CI workflow** (`.github/workflows/ci.yml`): triggers on push to `main` and all PRs; matrix over Python 3.10/3.11/3.12; runs `cores/llm/tests/` which is fully network-free (no API keys needed).
- **Minimal dep set** (no heavy mcp-agent git fork): `pydantic pyyaml "openai>=2.9,<3" "openai-agents==0.7.0" mcp pytest pytest-asyncio` — validated locally: **106 passed**.
- **CI badge** added to all 7 READMEs (`README.md`, `README_ko.md`, `README_ja.md`, `README_es.md`, `README_zh.md`, `README_DOCKER.md`, `README_DOCKER_ko.md`) near the existing badge block.
- **Codacy badge placeholder** inserted as an HTML comment on the line after the CI badge in all 7 READMEs. Once you connect the repo on app.codacy.com, replace `<PROJECT_ID>` with the actual project ID and uncomment.

## Test plan

- [ ] Confirm CI runs green on this PR across all 3 Python versions
- [ ] Connect repo on [app.codacy.com](https://app.codacy.com) → replace `<PROJECT_ID>` placeholder in all 7 READMEs → badges go live

🤖 Generated with [Claude Code](https://claude.com/claude-code)