### PR TITLE
feat(loops): Loop C fill chaser + KIS amend/cancel/unfilled TR wrappers (SHADOW-gated)

### DIFF
--- a/prism-us/tests/test_loop_c_fill_chaser_us.py
+++ b/prism-us/tests/test_loop_c_fill_chaser_us.py
@@ -1,0 +1,281 @@
+"""Tests for Loop C fill-chaser (tools/loop_c_fill_chaser.py) — US side.
+
+Network-free: the KIS overseas unfilled-inquiry / amend / cancel / current-price
+calls are served by a FakeTrader and the async context by a FakeCtx. No real TR
+is ever issued. Mirrors the KR test coverage with the US dict shape
+(get_unfilled_orders -> nccs_qty/ticker/ord_unpr/exchange; cent-precision prices).
+
+Covered: SHADOW default (no real call), stale/grace detection, SELL chase down,
+BUY ceiling -> cancel (never overpay), max-chases -> cancel, owner_lock
+exclusivity, partial-fill reconcile, ENABLED/LIVE gating.
+
+⚠️ cores-shadowing: run this in its OWN pytest session, never in the same process
+as the KR (root) session. We mock _open_context so no trading module is imported.
+"""
+import asyncio
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# tools/ lives under the repo root (one level above prism-us/).
+_PRISM_US = Path(__file__).resolve().parent.parent
+_ROOT = _PRISM_US.parent
+sys.path.insert(0, str(_ROOT))
+import tools.loop_c_fill_chaser as lc  # noqa: E402
+
+MARKET = "US"
+
+
+# ── Fakes ──────────────────────────────────────────────────────────────────────
+class FakeTrader:
+    def __init__(self, open_orders, prices, calls=None,
+                 amend_result=None, cancel_result=None):
+        self._open_orders = open_orders
+        self._prices = prices
+        self.calls = calls if calls is not None else []
+        self._amend_result = amend_result or {"success": True, "order_no": "NEW", "message": "ok"}
+        self._cancel_result = cancel_result or {"success": True, "order_no": "CXL", "message": "ok"}
+
+    def get_unfilled_orders(self):
+        return list(self._open_orders)
+
+    def get_current_price(self, ticker):
+        return {"current_price": self._prices.get(ticker, 0)}
+
+    def amend_order(self, ticker, orgn_odno, limit_price, quantity, exchange=None):
+        self.calls.append(f"amend:{ticker}:{orgn_odno}:{limit_price}:{quantity}:{exchange}")
+        return self._amend_result
+
+    def cancel_order(self, ticker, orgn_odno, quantity, exchange=None):
+        self.calls.append(f"cancel:{ticker}:{orgn_odno}:{quantity}:{exchange}")
+        return self._cancel_result
+
+
+class FakeCtx:
+    def __init__(self, trader):
+        self._trader = trader
+
+    async def __aenter__(self):
+        return self._trader
+
+    async def __aexit__(self, *a):
+        return False
+
+
+def _row(order_no, ticker, side_cd, nccs_qty, ord_unpr, exchange="NASD"):
+    """A raw KIS overseas unfilled row (sll_buy_dvsn_cd: 01 sell / 02 buy)."""
+    return {
+        "order_no": order_no,
+        "ticker": ticker,
+        "sll_buy_dvsn_cd": side_cd,
+        "nccs_qty": nccs_qty,
+        "ord_unpr": ord_unpr,
+        "exchange": exchange,
+    }
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    db = tmp_path / "loop_c_us.sqlite"
+    monkeypatch.setattr(lc, "DB_PATH", str(db))
+    return str(db)
+
+
+@pytest.fixture(autouse=True)
+def _fast_defaults(monkeypatch):
+    monkeypatch.setattr(lc, "LOOP_C_ENABLED", True)
+    monkeypatch.setattr(lc, "LOOP_C_LIVE", False)
+    monkeypatch.setattr(lc, "GRACE_SEC", 0)
+    monkeypatch.setattr(lc, "CHASE_AFTER_SEC", 0)
+    monkeypatch.setattr(lc, "CHASE_STEP_PCT", 1.0)
+    monkeypatch.setattr(lc, "BUY_MAX_PREMIUM_PCT", 0.02)
+    monkeypatch.setattr(lc, "MAX_CHASES", 3)
+    monkeypatch.setattr(lc, "CANCEL_ON_CEILING", True)
+    monkeypatch.setattr(lc, "LOCK_TTL_SEC", 300)
+
+
+def _patch_ctx(monkeypatch, trader):
+    monkeypatch.setattr(lc, "_open_context", lambda market, account_name=None: FakeCtx(trader))
+
+
+def _logs(db, action=None):
+    conn = sqlite3.connect(db)
+    q = "SELECT ticker, side, order_no, action, mode, old_price, new_price FROM loop_c_chase_log"
+    if action:
+        q += f" WHERE action='{action}'"
+    rows = conn.execute(q).fetchall()
+    conn.close()
+    return rows
+
+
+def _seed_seen(db, order_no, ticker="AAPL", side="SELL"):
+    conn = sqlite3.connect(db)
+    lc._ensure_schema(conn)
+    conn.execute(
+        "INSERT INTO loop_c_chase_log (ticker, market, side, order_no, action, mode, "
+        "old_price, new_price, unfilled_qty, chase_count, reason, loop_run_id, logged_ts) "
+        "VALUES (?,?,?,?,'SEEN','SHADOW',0,0,0,0,'seed','seed','2000-01-01T00:00:00+00:00')",
+        (ticker, MARKET, side, order_no),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _run():
+    return asyncio.run(lc.run_market(MARKET, "run-test-us"))
+
+
+# ── Tests ───────────────────────────────────────────────────────────────────────
+def test_disabled_kill_switch(tmp_db, monkeypatch):
+    monkeypatch.setattr(lc, "LOOP_C_ENABLED", False)
+    rc = asyncio.run(lc.main_async([MARKET]))
+    assert rc == 0
+    assert not Path(tmp_db).exists() or _logs(tmp_db) == []
+
+
+def test_grace_window_skips_first_sighting(tmp_db, monkeypatch):
+    monkeypatch.setattr(lc, "GRACE_SEC", 999)
+    trader = FakeTrader([_row("O1", "AAPL", "01", 10, 190.00)], {"AAPL": 189.00})
+    _patch_ctx(monkeypatch, trader)
+    summary = _run()
+    assert summary["grace_skipped"] == 1
+    assert trader.calls == []
+    assert [r[3] for r in _logs(tmp_db)] == ["SEEN"]
+
+
+def test_sell_chase_amends_toward_market_shadow(tmp_db, monkeypatch):
+    trader = FakeTrader([_row("O1", "AAPL", "01", 10, 190.00)], {"AAPL": 189.00})
+    _patch_ctx(monkeypatch, trader)
+    _seed_seen(tmp_db, "O1")
+    summary = _run()
+    assert summary["shadow"] == 1
+    assert trader.calls == []                 # SHADOW: no real amend
+    amend = _logs(tmp_db, "AMEND")
+    assert len(amend) == 1
+    old_price, new_price = amend[0][5], amend[0][6]
+    assert old_price == 190.00
+    assert 189.00 <= new_price < 190.00
+
+
+def test_sell_chase_amends_live(tmp_db, monkeypatch):
+    monkeypatch.setattr(lc, "LOOP_C_LIVE", True)
+    trader = FakeTrader([_row("O1", "AAPL", "01", 10, 190.00)], {"AAPL": 189.00})
+    _patch_ctx(monkeypatch, trader)
+    _seed_seen(tmp_db, "O1")
+    summary = _run()
+    assert summary["amended"] == 1
+    assert len(trader.calls) == 1 and trader.calls[0].startswith("amend:AAPL:O1:")
+    # exchange threaded through to the wrapper.
+    assert trader.calls[0].endswith(":NASD")
+
+
+def test_buy_within_ceiling_chases(tmp_db, monkeypatch):
+    monkeypatch.setattr(lc, "LOOP_C_LIVE", True)
+    # ceiling = 100 * 1.02 = 102; market 101 < ceiling => chase up.
+    trader = FakeTrader([_row("O1", "TSLA", "02", 5, 100.00)], {"TSLA": 101.00})
+    _patch_ctx(monkeypatch, trader)
+    _seed_seen(tmp_db, "O1", ticker="TSLA", side="BUY")
+    summary = _run()
+    assert summary["amended"] == 1
+    assert any(c.startswith("amend:TSLA:O1:") for c in trader.calls)
+    assert not any(c.startswith("cancel") for c in trader.calls)
+
+
+def test_buy_ceiling_hit_cancels_instead_of_overpaying(tmp_db, monkeypatch):
+    monkeypatch.setattr(lc, "LOOP_C_LIVE", True)
+    # ceiling = 100 * 1.02 = 102; market 105 > ceiling => cancel.
+    trader = FakeTrader([_row("O1", "TSLA", "02", 5, 100.00)], {"TSLA": 105.00})
+    _patch_ctx(monkeypatch, trader)
+    _seed_seen(tmp_db, "O1", ticker="TSLA", side="BUY")
+    summary = _run()
+    assert summary["cancelled"] == 1
+    assert any(c.startswith("cancel:TSLA:O1") for c in trader.calls)
+    assert not any(c.startswith("amend") for c in trader.calls)
+
+
+def test_buy_ceiling_shadow_no_real_call(tmp_db, monkeypatch):
+    trader = FakeTrader([_row("O1", "TSLA", "02", 5, 100.00)], {"TSLA": 105.00})
+    _patch_ctx(monkeypatch, trader)
+    _seed_seen(tmp_db, "O1", ticker="TSLA", side="BUY")
+    summary = _run()
+    assert summary["shadow"] == 1
+    assert trader.calls == []
+    assert _logs(tmp_db, "CANCEL")
+
+
+def test_max_chases_cancels_buy(tmp_db, monkeypatch):
+    monkeypatch.setattr(lc, "LOOP_C_LIVE", True)
+    monkeypatch.setattr(lc, "MAX_CHASES", 2)
+    trader = FakeTrader([_row("O1", "TSLA", "02", 5, 100.00)], {"TSLA": 100.50})
+    _patch_ctx(monkeypatch, trader)
+    conn = sqlite3.connect(tmp_db)
+    lc._ensure_schema(conn)
+    for _ in range(2):
+        conn.execute(
+            "INSERT INTO loop_c_chase_log (ticker, market, side, order_no, action, mode, "
+            "old_price, new_price, unfilled_qty, chase_count, reason, loop_run_id, logged_ts) "
+            "VALUES ('TSLA','US','BUY','O1','AMEND','LIVE',100,100.1,5,1,'x','seed','2000-01-01T00:00:00+00:00')"
+        )
+    conn.commit()
+    conn.close()
+    summary = _run()
+    assert summary["cancelled"] == 1
+    assert any(c.startswith("cancel:TSLA:O1") for c in trader.calls)
+
+
+def test_owner_lock_blocks_chase(tmp_db, monkeypatch):
+    monkeypatch.setattr(lc, "LOOP_C_LIVE", True)
+    trader = FakeTrader([_row("O1", "AAPL", "01", 10, 190.00)], {"AAPL": 189.00})
+    _patch_ctx(monkeypatch, trader)
+    conn = sqlite3.connect(tmp_db)
+    lc._ensure_schema(conn)
+    conn.execute(
+        "INSERT INTO loop_a_position_state (ticker, market, state, owner_lock, lock_expires_at) "
+        "VALUES ('AAPL','US','HOLDING','other-owner','2999-01-01T00:00:00+00:00')"
+    )
+    conn.commit()
+    conn.close()
+    summary = _run()
+    assert summary["skipped"] == 1
+    assert trader.calls == []
+
+
+def test_partial_fill_reconcile_uses_inquiry_remaining(tmp_db, monkeypatch):
+    monkeypatch.setattr(lc, "LOOP_C_LIVE", True)
+    trader = FakeTrader([_row("O1", "AAPL", "01", 4, 190.00)], {"AAPL": 189.00})
+    _patch_ctx(monkeypatch, trader)
+    _seed_seen(tmp_db, "O1")
+    _run()
+    conn = sqlite3.connect(tmp_db)
+    qty = conn.execute(
+        "SELECT unfilled_qty FROM loop_c_chase_log WHERE action='AMEND'"
+    ).fetchone()[0]
+    conn.close()
+    assert qty == 4
+    # qty also threaded into the live amend call.
+    assert any(":4:" in c for c in trader.calls)
+
+
+def test_fully_filled_order_is_ignored(tmp_db, monkeypatch):
+    monkeypatch.setattr(lc, "LOOP_C_LIVE", True)
+    trader = FakeTrader([_row("O1", "AAPL", "01", 0, 190.00)], {"AAPL": 189.00})
+    _patch_ctx(monkeypatch, trader)
+    summary = _run()
+    assert summary["open_orders"] == 0
+    assert trader.calls == []
+
+
+def test_inquiry_failure_degrades_to_noop(tmp_db, monkeypatch):
+    monkeypatch.setattr(lc, "LOOP_C_LIVE", True)
+
+    class Boom(FakeTrader):
+        def get_unfilled_orders(self):
+            raise RuntimeError("KIS down")
+
+    trader = Boom([], {})
+    _patch_ctx(monkeypatch, trader)
+    summary = _run()
+    assert summary["open_orders"] == 0
+    assert trader.calls == []

--- a/prism-us/trading/us_stock_trading.py
+++ b/prism-us/trading/us_stock_trading.py
@@ -1782,6 +1782,187 @@ class USStockTrading:
             logger.error(f"Error getting account summary: {str(e)}")
             return None
 
+    # ──────────────────────────────────────────────────────────────────────────
+    # Loop C prerequisites — overseas order amend/cancel + unfilled inquiry.
+    #
+    # Mirror the existing overseas order wrappers above (same _request/auth,
+    # OVRS_EXCG_CD handling, tr_id real-vs-paper switching, result-dict shape).
+    # NEW TRs — NOT exercised against live KIS at authoring time. See the
+    # TODO(live-validate) markers and tasks/loop_c_design_notes.md.
+    #
+    # TR ids confirmed against koreainvestment/open-trading-api (overseas):
+    #   - amend/cancel : real TTTT1004U / paper VTTT1004U (order-rvsecncl)
+    #   - unfilled (nccs): real TTTS3018R (paper VTTS3018R UNVERIFIED)
+    # ──────────────────────────────────────────────────────────────────────────
+    def amend_cancel_order(
+        self,
+        ticker: str,
+        orgn_odno: str,
+        rvse_cncl_dvsn_cd: str,
+        quantity: int,
+        exchange: str = None,
+        limit_price: float = 0.0,
+    ) -> Dict[str, Any]:
+        """Amend (정정) or cancel (취소) an existing overseas order.
+
+        ``rvse_cncl_dvsn_cd``: "01" = amend (new ``limit_price``), "02" = cancel.
+        For cancel, KIS expects price 0.
+
+        Returns: {success, order_no, ticker, quantity, message}.
+        """
+        if not self.auto_trading:
+            return {
+                'success': False,
+                'order_no': None,
+                'ticker': ticker,
+                'quantity': quantity,
+                'message': 'Auto trading is disabled (AUTO_TRADING=False)'
+            }
+
+        if exchange is None:
+            exchange = self._resolve_exchange(ticker)
+        else:
+            exchange = EXCHANGE_CODES.get(exchange.upper(), exchange)
+
+        api_url = "/uapi/overseas-stock/v1/trading/order-rvsecncl"
+
+        if self.mode == "real":
+            tr_id = "TTTT1004U"  # Real overseas amend/cancel
+        else:
+            tr_id = "VTTT1004U"  # Demo overseas amend/cancel
+
+        action = "Amend" if rvse_cncl_dvsn_cd == "01" else "Cancel"
+        ord_unpr = f"{limit_price:.2f}" if rvse_cncl_dvsn_cd == "01" else "0"
+
+        # TODO(live-validate): TR field layout (PDNO requirement, ORD_SVR_DVSN_CD,
+        # whether OVRS_ORD_UNPR is mandatory on cancel) unverified against live KIS.
+        params = {
+            "CANO": self.trenv.my_acct,
+            "ACNT_PRDT_CD": self.trenv.my_prod,
+            "OVRS_EXCG_CD": exchange,
+            "PDNO": ticker.upper(),
+            "ORGN_ODNO": str(orgn_odno),
+            "RVSE_CNCL_DVSN_CD": rvse_cncl_dvsn_cd,  # 01: amend, 02: cancel
+            "ORD_QTY": str(int(quantity)),
+            "OVRS_ORD_UNPR": ord_unpr,
+            "ORD_SVR_DVSN_CD": "0",
+        }
+
+        try:
+            res = self._request(api_url, tr_id, params, postFlag=True)
+
+            if res.isOK():
+                output = res.getBody().output
+                order_no = output.get('ODNO', '')
+                logger.info(
+                    f"[{ticker}] {action} order success: orgn={orgn_odno}, "
+                    f"new_no={order_no}, price={ord_unpr}"
+                )
+                return {
+                    'success': True,
+                    'order_no': order_no,
+                    'ticker': ticker,
+                    'quantity': quantity,
+                    'message': f'{action} order completed (orgn={orgn_odno})'
+                }
+            else:
+                error_msg = f"{res.getErrorCode()} - {res.getErrorMessage()}"
+                logger.error(f"[{ticker}] {action} order failed: {error_msg}")
+                return {
+                    'success': False,
+                    'order_no': None,
+                    'ticker': ticker,
+                    'quantity': quantity,
+                    'message': f'{action} order failed: {error_msg}'
+                }
+
+        except Exception as e:
+            logger.error(f"Error during {action.lower()} order: {str(e)}")
+            return {
+                'success': False,
+                'order_no': None,
+                'ticker': ticker,
+                'quantity': quantity,
+                'message': f'Error during {action.lower()} order: {str(e)}'
+            }
+
+    def amend_order(self, ticker: str, orgn_odno: str, limit_price: float,
+                    quantity: int, exchange: str = None) -> Dict[str, Any]:
+        """Convenience wrapper: amend (정정) an overseas order's limit price."""
+        return self.amend_cancel_order(
+            ticker=ticker, orgn_odno=orgn_odno, rvse_cncl_dvsn_cd="01",
+            quantity=quantity, exchange=exchange, limit_price=limit_price,
+        )
+
+    def cancel_order(self, ticker: str, orgn_odno: str, quantity: int,
+                     exchange: str = None) -> Dict[str, Any]:
+        """Convenience wrapper: cancel (취소) an overseas order."""
+        return self.amend_cancel_order(
+            ticker=ticker, orgn_odno=orgn_odno, rvse_cncl_dvsn_cd="02",
+            quantity=quantity, exchange=exchange, limit_price=0.0,
+        )
+
+    def get_unfilled_orders(self, ticker: str = None,
+                            exchange: str = "NASD") -> List[Dict[str, Any]]:
+        """Inquire overseas unfilled (미체결) orders via 미체결내역 (nccs).
+
+        TR: real TTTS3018R. ``exchange="NASD"`` queries the whole US day session.
+        Returns a normalised list, optionally filtered to ``ticker``. Returns []
+        on any failure (degrade to no-op — never treat empty as "all filled").
+
+        Each dict: {order_no, ticker, ord_qty, ccld_qty, nccs_qty, ord_unpr,
+                    sll_buy_dvsn_cd, exchange}.
+        """
+        api_url = "/uapi/overseas-stock/v1/trading/inquire-nccs"
+
+        # TODO(live-validate): paper tr_id VTTS3018R UNVERIFIED. Real TTTS3018R
+        # confirmed against the KIS overseas sample. Loop C runs SHADOW by default.
+        if self.mode == "real":
+            tr_id = "TTTS3018R"
+        else:
+            tr_id = "VTTS3018R"
+
+        params = {
+            "CANO": self.trenv.my_acct,
+            "ACNT_PRDT_CD": self.trenv.my_prod,
+            "OVRS_EXCG_CD": exchange,
+            "SORT_SQN": "DS",
+            "CTX_AREA_FK200": "",
+            "CTX_AREA_NK200": "",
+        }
+
+        out: List[Dict[str, Any]] = []
+        try:
+            res = self._request(api_url, tr_id, params)
+            if not res.isOK():
+                error_msg = f"{res.getErrorCode()} - {res.getErrorMessage()}"
+                logger.warning(f"Unfilled-order inquiry failed: {error_msg}")
+                return out
+
+            output = res.getBody().output
+            if not isinstance(output, list):
+                output = [output] if output else []
+
+            for row in output:
+                code = str(row.get('pdno', '') or '').strip().upper()
+                if ticker and code != ticker.upper():
+                    continue
+                out.append({
+                    'order_no': row.get('odno', ''),
+                    'ticker': code,
+                    'ord_qty': _safe_int(row.get('ft_ord_qty')),
+                    'ccld_qty': _safe_int(row.get('ft_ccld_qty')),
+                    'nccs_qty': _safe_int(row.get('nccs_qty')),  # unfilled remaining
+                    'ord_unpr': _safe_float(row.get('ft_ord_unpr3')),
+                    'sll_buy_dvsn_cd': row.get('sll_buy_dvsn_cd', ''),  # 01 sell / 02 buy
+                    'exchange': row.get('ovrs_excg_cd', exchange),
+                })
+            return out
+
+        except Exception as e:
+            logger.warning(f"Error during unfilled-order inquiry: {str(e)}")
+            return out
+
 
 class MultiAccountUSStockTrading:
     """Fan out trading orders to all configured US accounts for the current mode."""

--- a/tests/test_loop_c_fill_chaser.py
+++ b/tests/test_loop_c_fill_chaser.py
@@ -1,0 +1,307 @@
+"""Tests for Loop C fill-chaser (tools/loop_c_fill_chaser.py) — KR side.
+
+Network-free: the KIS unfilled-inquiry / amend / cancel / current-price calls
+are all served by a FakeTrader, and the async trading context is replaced with a
+FakeCtx. No real TR is ever issued. Safety-critical behaviour covered:
+
+  - SHADOW (default): places NO real amend/cancel — only logs + audit rows.
+  - Stale-order detection: an order is only chased after the grace window.
+  - SELL chase: amends the limit DOWN toward the market (faster fill).
+  - BUY ceiling: never chases above order_price * (1 + premium); cancels instead.
+  - max-chases -> cancel (buy) / stop (sell).
+  - owner_lock exclusivity: a held lock blocks the chase.
+  - partial-fill reconcile: unfilled_qty comes from the live inquiry, not a cache.
+  - ENABLED / LIVE gating.
+
+Run in the KR (root) pytest session (cores-shadowing: never mix with the US
+session in one process).
+"""
+import asyncio
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT))
+import tools.loop_c_fill_chaser as lc  # noqa: E402
+
+
+# ── Fakes ──────────────────────────────────────────────────────────────────────
+class FakeTrader:
+    """Serves KR open-order inquiry + price + amend/cancel from in-memory state."""
+
+    def __init__(self, open_orders, prices, calls=None,
+                 amend_result=None, cancel_result=None):
+        self._open_orders = open_orders          # raw KIS-style rows
+        self._prices = prices
+        self.calls = calls if calls is not None else []
+        self._amend_result = amend_result or {"success": True, "order_no": "NEW", "message": "ok"}
+        self._cancel_result = cancel_result or {"success": True, "order_no": "CXL", "message": "ok"}
+
+    def get_revisable_orders(self):
+        return list(self._open_orders)
+
+    def get_current_price(self, stock_code):
+        return {"current_price": self._prices.get(stock_code, 0)}
+
+    def amend_order(self, stock_code, orgn_odno, limit_price, krx_fwdg_ord_orgno=""):
+        self.calls.append(f"amend:{stock_code}:{orgn_odno}:{limit_price}")
+        return self._amend_result
+
+    def cancel_order(self, stock_code, orgn_odno, krx_fwdg_ord_orgno=""):
+        self.calls.append(f"cancel:{stock_code}:{orgn_odno}")
+        return self._cancel_result
+
+
+class FakeCtx:
+    def __init__(self, trader):
+        self._trader = trader
+
+    async def __aenter__(self):
+        return self._trader
+
+    async def __aexit__(self, *a):
+        return False
+
+
+def _row(order_no, stock_code, side_cd, psbl_qty, ord_unpr, fwdg="GNO1"):
+    """A raw KIS revisable-order row (sll_buy_dvsn_cd: 01 sell / 02 buy)."""
+    return {
+        "order_no": order_no,
+        "orgn_odno": order_no,
+        "stock_code": stock_code,
+        "sll_buy_dvsn_cd": side_cd,
+        "psbl_qty": psbl_qty,
+        "ord_unpr": ord_unpr,
+        "krx_fwdg_ord_orgno": fwdg,
+    }
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    db = tmp_path / "loop_c.sqlite"
+    monkeypatch.setattr(lc, "DB_PATH", str(db))
+    return str(db)
+
+
+@pytest.fixture(autouse=True)
+def _fast_defaults(monkeypatch):
+    """Deterministic, fast config for every test (overridable per-test)."""
+    monkeypatch.setattr(lc, "LOOP_C_ENABLED", True)
+    monkeypatch.setattr(lc, "LOOP_C_LIVE", False)        # SHADOW by default
+    monkeypatch.setattr(lc, "GRACE_SEC", 0)              # no grace unless a test wants it
+    monkeypatch.setattr(lc, "CHASE_AFTER_SEC", 0)
+    monkeypatch.setattr(lc, "CHASE_STEP_PCT", 1.0)       # chase straight to market
+    monkeypatch.setattr(lc, "BUY_MAX_PREMIUM_PCT", 0.02) # 2% ceiling
+    monkeypatch.setattr(lc, "MAX_CHASES", 3)
+    monkeypatch.setattr(lc, "CANCEL_ON_CEILING", True)
+    monkeypatch.setattr(lc, "LOCK_TTL_SEC", 300)
+
+
+def _patch_ctx(monkeypatch, trader):
+    monkeypatch.setattr(lc, "_open_context", lambda market, account_name=None: FakeCtx(trader))
+
+
+def _logs(db, action=None):
+    conn = sqlite3.connect(db)
+    q = "SELECT ticker, side, order_no, action, mode, old_price, new_price FROM loop_c_chase_log"
+    if action:
+        q += f" WHERE action='{action}'"
+    rows = conn.execute(q).fetchall()
+    conn.close()
+    return rows
+
+
+def _seed_seen(db, order_no, ticker="005930", side="SELL", market="KR"):
+    """Pre-mark an order as already SEEN with an old timestamp so the grace window
+    has elapsed — Loop C marks a fresh order SEEN on its first sighting and only
+    acts on a subsequent cycle. Tests that exercise the act path seed this row."""
+    conn = sqlite3.connect(db)
+    lc._ensure_schema(conn)
+    conn.execute(
+        "INSERT INTO loop_c_chase_log (ticker, market, side, order_no, action, mode, "
+        "old_price, new_price, unfilled_qty, chase_count, reason, loop_run_id, logged_ts) "
+        "VALUES (?,?,?,?,'SEEN','SHADOW',0,0,0,0,'seed','seed','2000-01-01T00:00:00+00:00')",
+        (ticker, market, side, order_no),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _run(market="KR"):
+    return asyncio.run(lc.run_market(market, "run-test"))
+
+
+# ── Tests ───────────────────────────────────────────────────────────────────────
+def test_disabled_kill_switch(tmp_db, monkeypatch):
+    monkeypatch.setattr(lc, "LOOP_C_ENABLED", False)
+    rc = asyncio.run(lc.main_async(["KR"]))
+    assert rc == 0
+    # Loop never opened a context / wrote a log.
+    assert not Path(tmp_db).exists() or _logs(tmp_db) == []
+
+
+def test_grace_window_skips_first_sighting(tmp_db, monkeypatch):
+    """A brand-new order is recorded as SEEN and NOT chased on first cycle."""
+    monkeypatch.setattr(lc, "GRACE_SEC", 999)
+    trader = FakeTrader([_row("O1", "005930", "01", 10, 70000)], {"005930": 69000})
+    _patch_ctx(monkeypatch, trader)
+    summary = _run()
+    assert summary["grace_skipped"] == 1
+    assert trader.calls == []                 # no amend/cancel
+    assert [r[3] for r in _logs(tmp_db)] == ["SEEN"]
+
+
+def test_sell_chase_amends_toward_market_shadow(tmp_db, monkeypatch):
+    """SELL: amend the limit DOWN toward the market; SHADOW => no real call."""
+    trader = FakeTrader([_row("O1", "005930", "01", 10, 70000)], {"005930": 69000})
+    _patch_ctx(monkeypatch, trader)
+    _seed_seen(tmp_db, "O1")
+    summary = _run()
+    assert summary["shadow"] == 1
+    assert trader.calls == []                 # SHADOW: no real amend
+    amend = _logs(tmp_db, "AMEND")
+    assert len(amend) == 1
+    # new price moved down toward market (69000), below the original 70000.
+    old_price, new_price = amend[0][5], amend[0][6]
+    assert old_price == 70000
+    assert 69000 <= new_price < 70000
+
+
+def test_sell_chase_amends_live(tmp_db, monkeypatch):
+    """LIVE SELL: a real amend_order TR is issued toward the market."""
+    monkeypatch.setattr(lc, "LOOP_C_LIVE", True)
+    trader = FakeTrader([_row("O1", "005930", "01", 10, 70000)], {"005930": 69000})
+    _patch_ctx(monkeypatch, trader)
+    _seed_seen(tmp_db, "O1")
+    summary = _run()
+    assert summary["amended"] == 1
+    assert len(trader.calls) == 1 and trader.calls[0].startswith("amend:005930:O1:")
+
+
+def test_buy_within_ceiling_chases(tmp_db, monkeypatch):
+    """BUY: market just under the 2% ceiling => chase UP (no cancel)."""
+    monkeypatch.setattr(lc, "LOOP_C_LIVE", True)
+    # ceiling = 10000 * 1.02 = 10200; market 10100 < ceiling => chase.
+    trader = FakeTrader([_row("O1", "000660", "02", 5, 10000)], {"000660": 10100})
+    _patch_ctx(monkeypatch, trader)
+    _seed_seen(tmp_db, "O1", ticker="000660", side="BUY")
+    summary = _run()
+    assert summary["amended"] == 1
+    assert any(c.startswith("amend:000660:O1:") for c in trader.calls)
+    assert not any(c.startswith("cancel") for c in trader.calls)
+
+
+def test_buy_ceiling_hit_cancels_instead_of_overpaying(tmp_db, monkeypatch):
+    """BUY: market above the 2% ceiling => CANCEL, never chase into a bad fill."""
+    monkeypatch.setattr(lc, "LOOP_C_LIVE", True)
+    # ceiling = 10000 * 1.02 = 10200; market 10500 > ceiling => cancel.
+    trader = FakeTrader([_row("O1", "000660", "02", 5, 10000)], {"000660": 10500})
+    _patch_ctx(monkeypatch, trader)
+    _seed_seen(tmp_db, "O1", ticker="000660", side="BUY")
+    summary = _run()
+    assert summary["cancelled"] == 1
+    assert any(c.startswith("cancel:000660:O1") for c in trader.calls)
+    assert not any(c.startswith("amend") for c in trader.calls)
+    reason = _logs(tmp_db, "CANCEL")[0]
+    assert reason[3] == "CANCEL"
+
+
+def test_buy_ceiling_shadow_no_real_call(tmp_db, monkeypatch):
+    """BUY ceiling hit in SHADOW: logs a WOULD-CANCEL, issues no real TR."""
+    trader = FakeTrader([_row("O1", "000660", "02", 5, 10000)], {"000660": 10500})
+    _patch_ctx(monkeypatch, trader)
+    _seed_seen(tmp_db, "O1", ticker="000660", side="BUY")
+    summary = _run()
+    assert summary["shadow"] == 1
+    assert trader.calls == []
+    assert _logs(tmp_db, "CANCEL")
+
+
+def test_max_chases_cancels_buy(tmp_db, monkeypatch):
+    """After MAX_CHASES amends already logged, a buy is cancelled."""
+    monkeypatch.setattr(lc, "LOOP_C_LIVE", True)
+    monkeypatch.setattr(lc, "MAX_CHASES", 2)
+    # market under ceiling so we don't trip the ceiling branch first.
+    trader = FakeTrader([_row("O1", "000660", "02", 5, 10000)], {"000660": 10050})
+    _patch_ctx(monkeypatch, trader)
+    # Pre-seed 2 AMEND rows so chase_count_for() == MAX_CHASES.
+    lc._ensure_schema  # noqa: B018 (ensure import resolved)
+    conn = sqlite3.connect(tmp_db)
+    lc._ensure_schema(conn)
+    for _ in range(2):
+        conn.execute(
+            "INSERT INTO loop_c_chase_log (ticker, market, side, order_no, action, mode, "
+            "old_price, new_price, unfilled_qty, chase_count, reason, loop_run_id, logged_ts) "
+            "VALUES ('000660','KR','BUY','O1','AMEND','LIVE',10000,10010,5,1,'x','seed','2000-01-01T00:00:00+00:00')"
+        )
+    conn.commit()
+    conn.close()
+    summary = _run()
+    assert summary["cancelled"] == 1
+    assert any(c.startswith("cancel:000660:O1") for c in trader.calls)
+
+
+def test_owner_lock_blocks_chase(tmp_db, monkeypatch):
+    """If another loop holds the owner_lock, Loop C defers (no amend)."""
+    monkeypatch.setattr(lc, "LOOP_C_LIVE", True)
+    trader = FakeTrader([_row("O1", "005930", "01", 10, 70000)], {"005930": 69000})
+    _patch_ctx(monkeypatch, trader)
+    conn = sqlite3.connect(tmp_db)
+    lc._ensure_schema(conn)
+    # Hold the lock for ticker under a different owner, far-future expiry.
+    conn.execute(
+        "INSERT INTO loop_a_position_state (ticker, market, state, owner_lock, lock_expires_at) "
+        "VALUES ('005930','KR','HOLDING','other-owner','2999-01-01T00:00:00+00:00')"
+    )
+    conn.commit()
+    conn.close()
+    summary = _run()
+    assert summary["skipped"] == 1
+    assert trader.calls == []
+
+
+def test_partial_fill_reconcile_uses_inquiry_remaining(tmp_db, monkeypatch):
+    """unfilled_qty comes from the live inquiry's psbl_qty, not any local cache."""
+    monkeypatch.setattr(lc, "LOOP_C_LIVE", True)
+    # psbl_qty=3 means 3 remain after a partial fill of the original order.
+    trader = FakeTrader([_row("O1", "005930", "01", 3, 70000)], {"005930": 69000})
+    _patch_ctx(monkeypatch, trader)
+    _seed_seen(tmp_db, "O1")
+    _run()
+    amend = _logs(tmp_db, "AMEND")
+    assert len(amend) == 1
+    # The qty fed to the (live) amend reflects the remaining 3.
+    conn = sqlite3.connect(tmp_db)
+    qty = conn.execute(
+        "SELECT unfilled_qty FROM loop_c_chase_log WHERE action='AMEND'"
+    ).fetchone()[0]
+    conn.close()
+    assert qty == 3
+
+
+def test_fully_filled_order_is_ignored(tmp_db, monkeypatch):
+    """psbl_qty == 0 (nothing left to amend) is filtered out by the inquiry layer."""
+    monkeypatch.setattr(lc, "LOOP_C_LIVE", True)
+    trader = FakeTrader([_row("O1", "005930", "01", 0, 70000)], {"005930": 69000})
+    _patch_ctx(monkeypatch, trader)
+    summary = _run()
+    assert summary["open_orders"] == 0
+    assert trader.calls == []
+
+
+def test_inquiry_failure_degrades_to_noop(tmp_db, monkeypatch):
+    """A throwing inquiry must NOT be treated as 'everything filled' — just no-op."""
+    monkeypatch.setattr(lc, "LOOP_C_LIVE", True)
+
+    class Boom(FakeTrader):
+        def get_revisable_orders(self):
+            raise RuntimeError("KIS down")
+
+    trader = Boom([], {})
+    _patch_ctx(monkeypatch, trader)
+    summary = _run()
+    assert summary["open_orders"] == 0
+    assert trader.calls == []

--- a/tools/loop_c_fill_chaser.py
+++ b/tools/loop_c_fill_chaser.py
@@ -1,0 +1,606 @@
+#!/usr/bin/env python3
+"""Loop C — fill chaser / 미체결 추격 (LLM-free).
+
+Runs as a standalone intraday cron, SEPARATE from the 2-3x/day batch sell cycle
+and from Loop A (hard-stop) / Loop B (trend-exit). Loops A and B only ever PLACE
+new sell orders; Loop C is the SINGLE owner of *open-order management*: it
+reconciles in-flight orders against the live KIS unfilled-order inquiry and, when
+an order has sat unfilled past a threshold, amends its limit price toward the
+market ("chases") — within a ceiling — or cancels it.
+
+WHY this loop exists (architecture §3, tasks/loop_architecture_design.md):
+  - Limit sells placed by the batch / Loop A / Loop B can sit unfilled while the
+    price walks away. A short fill-chaser materially reduces realised slippage.
+  - The single source of truth for order state MUST be the live KIS inquiry, NOT
+    an optimistic local cache — partial fills and external cancels happen.
+
+PER CYCLE, PER MARKET:
+  1. Inquire OPEN/unfilled orders from KIS (KR get_revisable_orders /
+     US get_unfilled_orders) — the single source of truth.
+  2. For each unfilled order older than LOOP_C_CHASE_AFTER_SEC:
+       - SELL orders → chase the limit DOWN toward the market (we want the fill;
+         this is a stop intent, downward chase is fine; floored at the market).
+       - BUY orders → chase the limit UP toward the market, but NEVER above
+         LOOP_C_BUY_MAX_PREMIUM_PCT over the order's original price (ceiling).
+         If the ceiling is hit → CANCEL (do not chase into a bad fill).
+  3. Reconcile partial fills off the live inquiry into loop_c_chase_log.
+
+SAFETY (read before enabling):
+  - Amend/cancel is gated behind LOOP_C_LIVE=true. Default = SHADOW: it logs
+    what it WOULD amend/cancel and places NO real TR. The trading context is only
+    opened for price/inquiry reads in SHADOW; no amend/cancel TR is ever sent.
+  - LOOP_C_ENABLED=false disables the loop entirely (kill switch).
+  - ⚠️ The KIS amend/cancel/unfilled-inquiry TR wrappers this loop depends on were
+    mirrored from existing order wrappers + the KIS sample repo but were NOT
+    validated against a live KIS account. DO NOT set LOOP_C_LIVE=true until the
+    live-validation checklist in tasks/loop_c_design_notes.md is signed off.
+  - Separate process → no in-process asyncio locks apply. Concurrency guarded by
+    a SQLite owner_lock (BEGIN IMMEDIATE) per ticker, reusing Loop A's
+    loop_a_position_state table so all loops serialise on the SAME lock.
+  - Grace window: an order placed within LOOP_C_GRACE_SEC is left alone (another
+    loop may have just placed it; let it breathe before chasing).
+  - Only Loop C amends/cancels. Loops A/B only place new sells.
+
+Usage:
+    python tools/loop_c_fill_chaser.py [--market kr|us|both] [--once]
+
+Intended cron (SHADOW until reviewed; NOT installed) — KR and US as SEPARATE
+processes (cores-shadowing isolation; --market both fans out automatically):
+    */2 9-15 * * 1-5      cd /root/prism-insight && python tools/loop_c_fill_chaser.py --market kr
+    */2 22-23,0-5 * * 1-5 cd /root/prism-insight && python tools/loop_c_fill_chaser.py --market us
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sqlite3
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+TOOLS_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = TOOLS_DIR.parent
+
+
+# ── Market-aware path bootstrap (cores-shadowing safety) ──────────────────────
+# The `cores` package is imported once per process and cached, and the US runtime
+# resolves `from cores.X` to prism-us/cores while KR resolves to the root cores.
+# A single process therefore CANNOT serve both markets without cross-wiring KR/US
+# modules. Each market runs in its own process (main(): `both` spawns two
+# subprocesses), and we set sys.path so the active market's modules win.
+def _bootstrap_path(market: str) -> None:
+    root = str(PROJECT_ROOT)
+    us = str(PROJECT_ROOT / "prism-us")
+    us_trading = str(PROJECT_ROOT / "prism-us" / "trading")
+    if market == "US":
+        for p in (root, us_trading, us):
+            sys.path.insert(0, p)
+    else:  # KR
+        for p in (us, root):
+            sys.path.insert(0, p)
+
+
+logger = logging.getLogger("loop_c")
+
+
+# ── Configuration (env-driven) ────────────────────────────────────────────────
+def _env_bool(name: str, default: bool) -> bool:
+    return str(os.getenv(name, str(default))).strip().lower() in ("1", "true", "yes", "on")
+
+
+LOOP_C_ENABLED = _env_bool("LOOP_C_ENABLED", True)        # master kill switch
+LOOP_C_LIVE = _env_bool("LOOP_C_LIVE", False)             # False => SHADOW (no real amend/cancel)
+LOCK_TTL_SEC = int(os.getenv("LOOP_C_LOCK_TTL_SEC", "300"))
+# Chase an order only after it has been unfilled this long.
+CHASE_AFTER_SEC = int(os.getenv("LOOP_C_CHASE_AFTER_SEC", "60"))
+# Leave brand-new orders alone for this long (another loop may have just placed it).
+GRACE_SEC = int(os.getenv("LOOP_C_GRACE_SEC", "20"))
+# Each chase step moves the limit this fraction toward the market.
+CHASE_STEP_PCT = float(os.getenv("LOOP_C_CHASE_STEP_PCT", "0.3"))
+# BUY ceiling: never chase a buy limit more than this PERCENT over its original
+# price. Env value is a percent (e.g. "0.5" = 0.5%); stored as a fraction.
+BUY_MAX_PREMIUM_PCT = float(os.getenv("LOOP_C_BUY_MAX_PREMIUM_PCT", "0.5")) / 100.0
+# Max number of amend steps before giving up and (optionally) cancelling.
+MAX_CHASES = int(os.getenv("LOOP_C_MAX_CHASES", "5"))
+# Whether to cancel a buy order once the ceiling is hit (else just stop chasing).
+CANCEL_ON_CEILING = _env_bool("LOOP_C_CANCEL_ON_CEILING", True)
+
+DB_PATH = os.getenv("LOOP_C_DB") or os.getenv("STOCK_TRACKING_DB") \
+    or str(PROJECT_ROOT / "stock_tracking_db.sqlite")
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+# ── SQLite state (loop_c_* table + read/lock on Loop A's shared lock) ──────────
+# Loop C creates its OWN loop_c_chase_log table and reuses Loop A's
+# loop_a_position_state owner_lock so all loops serialise on one lock per ticker.
+def _connect() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH, timeout=30)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        -- Shared owner-lock table (created by Loop A; create-if-absent here so
+        -- Loop C can run standalone). NEVER drops / alters existing rows.
+        CREATE TABLE IF NOT EXISTS loop_a_position_state (
+            ticker          TEXT NOT NULL,
+            market          TEXT NOT NULL,
+            state           TEXT NOT NULL DEFAULT 'HOLDING',
+            owner_lock      TEXT,
+            lock_expires_at TEXT,
+            last_eval_ts    TEXT,
+            PRIMARY KEY (ticker, market)
+        );
+        -- Loop C's own audit log of chase decisions (SHADOW + LIVE).
+        CREATE TABLE IF NOT EXISTS loop_c_chase_log (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            ticker        TEXT NOT NULL,
+            market        TEXT NOT NULL,
+            side          TEXT NOT NULL,           -- BUY/SELL
+            order_no      TEXT,
+            action        TEXT NOT NULL,           -- AMEND/CANCEL/SKIP
+            mode          TEXT NOT NULL,           -- SHADOW/LIVE
+            old_price     REAL,
+            new_price     REAL,
+            unfilled_qty  INTEGER,
+            chase_count   INTEGER,
+            reason        TEXT,
+            loop_run_id   TEXT NOT NULL,
+            logged_ts     TEXT NOT NULL
+        );
+        """
+    )
+    conn.commit()
+
+
+def claim_lock(conn: sqlite3.Connection, ticker: str, market: str, run_id: str) -> bool:
+    """Atomically claim the shared owner_lock (BEGIN IMMEDIATE). True if acquired."""
+    now = _now()
+    expires = _iso(now + timedelta(seconds=LOCK_TTL_SEC))
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            "INSERT OR IGNORE INTO loop_a_position_state (ticker, market, state) VALUES (?,?, 'HOLDING')",
+            (ticker, market),
+        )
+        cur = conn.execute(
+            "UPDATE loop_a_position_state SET owner_lock=?, lock_expires_at=?, last_eval_ts=? "
+            "WHERE ticker=? AND market=? "
+            "AND (owner_lock IS NULL OR lock_expires_at IS NULL OR lock_expires_at < ?)",
+            (run_id, expires, _iso(now), ticker, market, _iso(now)),
+        )
+        conn.commit()
+        return cur.rowcount == 1
+    except sqlite3.Error as e:
+        conn.rollback()
+        logger.warning("lock claim failed %s/%s: %s", ticker, market, e)
+        return False
+
+
+def release_lock(conn: sqlite3.Connection, ticker: str, market: str, run_id: str) -> None:
+    try:
+        conn.execute(
+            "UPDATE loop_a_position_state SET owner_lock=NULL, lock_expires_at=NULL "
+            "WHERE ticker=? AND market=? AND owner_lock=?",
+            (ticker, market, run_id),
+        )
+        conn.commit()
+    except sqlite3.Error as e:
+        logger.warning("lock release failed %s/%s: %s", ticker, market, e)
+
+
+def record_chase(conn: sqlite3.Connection, ticker: str, market: str, side: str,
+                 order_no: Optional[str], action: str, mode: str,
+                 old_price: float, new_price: float, unfilled_qty: int,
+                 chase_count: int, reason: str, run_id: str) -> None:
+    try:
+        conn.execute(
+            "INSERT INTO loop_c_chase_log "
+            "(ticker, market, side, order_no, action, mode, old_price, new_price, "
+            " unfilled_qty, chase_count, reason, loop_run_id, logged_ts) "
+            "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (ticker, market, side, order_no, action, mode, old_price, new_price,
+             unfilled_qty, chase_count, reason, run_id, _iso(_now())),
+        )
+        conn.commit()
+    except sqlite3.Error as e:
+        logger.warning("chase log failed %s/%s: %s", ticker, market, e)
+
+
+def chase_count_for(conn: sqlite3.Connection, order_no: str, market: str) -> int:
+    """How many AMENDs Loop C has already logged for this order_no."""
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM loop_c_chase_log "
+            "WHERE order_no=? AND market=? AND action='AMEND'",
+            (order_no, market),
+        ).fetchone()
+        return int(row[0]) if row else 0
+    except sqlite3.Error:
+        return 0
+
+
+def first_seen_ts(conn: sqlite3.Connection, order_no: str, market: str) -> Optional[datetime]:
+    """Earliest time Loop C logged anything (incl. SEEN) for this order. None if new."""
+    try:
+        row = conn.execute(
+            "SELECT MIN(logged_ts) FROM loop_c_chase_log WHERE order_no=? AND market=?",
+            (order_no, market),
+        ).fetchone()
+        if row and row[0]:
+            return datetime.fromisoformat(row[0])
+    except (sqlite3.Error, ValueError):
+        pass
+    return None
+
+
+def record_seen(conn: sqlite3.Connection, ticker: str, market: str, side: str,
+                order_no: str, price: float, unfilled_qty: int, run_id: str) -> None:
+    """First-sighting marker so the grace window has a basis (no submit ts from KIS)."""
+    record_chase(conn, ticker, market, side, order_no, "SEEN",
+                 "LIVE" if LOOP_C_LIVE else "SHADOW",
+                 price, price, unfilled_qty, 0, "first seen", run_id)
+
+
+# ── Trader context (KR / US) — read-only price + inquiry in SHADOW ─────────────
+def _open_context(market: str, account_name: Optional[str] = None):
+    if market == "KR":
+        from trading.domestic_stock_trading import AsyncTradingContext
+        return AsyncTradingContext(account_name=account_name)
+    from us_stock_trading import AsyncUSTradingContext
+    return AsyncUSTradingContext(account_name=account_name)
+
+
+# ── Order-state normalisation across KR / US inquiry wrappers ──────────────────
+def _is_sell(side_code: str) -> bool:
+    """KIS sll_buy_dvsn_cd: 01 = sell, 02 = buy (both markets)."""
+    return str(side_code).strip() == "01"
+
+
+async def _inquire_open_orders(trader, market: str) -> List[Dict[str, Any]]:
+    """Return normalised open/unfilled orders. Empty list on any failure.
+
+    Normalised dict keys (market-agnostic):
+        order_no, ticker, side ('SELL'/'BUY'), unfilled_qty, ord_unpr,
+        krx_fwdg_ord_orgno (KR only; '' for US).
+    """
+    out: List[Dict[str, Any]] = []
+    try:
+        if market == "KR":
+            rows = await asyncio.to_thread(trader.get_revisable_orders)
+            for r in rows:
+                remaining = int(r.get("psbl_qty") or 0)
+                if remaining <= 0:
+                    continue
+                out.append({
+                    "order_no": r.get("order_no", ""),
+                    "ticker": r.get("stock_code", ""),
+                    "side": "SELL" if _is_sell(r.get("sll_buy_dvsn_cd")) else "BUY",
+                    "unfilled_qty": remaining,
+                    "ord_unpr": float(r.get("ord_unpr") or 0),
+                    "krx_fwdg_ord_orgno": r.get("krx_fwdg_ord_orgno", ""),
+                })
+        else:  # US
+            rows = await asyncio.to_thread(trader.get_unfilled_orders)
+            for r in rows:
+                remaining = int(r.get("nccs_qty") or 0)
+                if remaining <= 0:
+                    continue
+                out.append({
+                    "order_no": r.get("order_no", ""),
+                    "ticker": r.get("ticker", ""),
+                    "side": "SELL" if _is_sell(r.get("sll_buy_dvsn_cd")) else "BUY",
+                    "unfilled_qty": remaining,
+                    "ord_unpr": float(r.get("ord_unpr") or 0),
+                    "exchange": r.get("exchange", "NASD"),
+                    "krx_fwdg_ord_orgno": "",
+                })
+    except Exception as e:
+        logger.warning("[%s] open-order inquiry failed: %s -> no-op", market, e)
+        return []
+    return out
+
+
+def _compute_chase_price(side: str, order_price: float, market_price: float) -> float:
+    """Move the limit a CHASE_STEP_PCT fraction toward the market price.
+
+    SELL: chase DOWN toward market (floored at market — never below).
+    BUY:  chase UP toward market (capped at market — never above).
+    """
+    if order_price <= 0 or market_price <= 0:
+        return order_price
+    if side == "SELL":
+        # want a faster fill -> lower the ask toward (or to) the market
+        target = order_price - (order_price - market_price) * CHASE_STEP_PCT
+        return max(target, market_price)
+    else:  # BUY
+        target = order_price + (market_price - order_price) * CHASE_STEP_PCT
+        return min(target, market_price)
+
+
+def _round_price(market: str, price: float) -> float:
+    """KR limit prices are integers (KRW); US allows cents."""
+    if market == "KR":
+        return float(int(round(price)))
+    return round(price, 2)
+
+
+# ── Core evaluation for one market ─────────────────────────────────────────────
+async def _act_on_order(conn, trader, market: str, order: Dict[str, Any],
+                        run_id: str, summary: Dict[str, Any]) -> None:
+    """Decide + (LIVE) execute amend/cancel for one unfilled order. Never raises."""
+    ticker = order["ticker"]
+    side = order["side"]
+    order_no = order["order_no"]
+    order_price = float(order["ord_unpr"] or 0)
+    unfilled_qty = int(order["unfilled_qty"] or 0)
+    mode = "LIVE" if LOOP_C_LIVE else "SHADOW"
+
+    if not ticker or not order_no or unfilled_qty <= 0 or order_price <= 0:
+        return
+
+    # Serialise against all other loops on the SAME owner_lock per ticker.
+    if not claim_lock(conn, ticker, market, run_id):
+        summary["skipped"] += 1
+        logger.info("[%s] %s owner_lock held -> skip chase", market, ticker)
+        return
+
+    try:
+        # Grace window: KIS unfilled inquiry gives no reliable submit timestamp,
+        # so we mark first-sighting in the log and refuse to chase an order until
+        # it has been visible to Loop C for at least GRACE_SEC. This stops Loop C
+        # from amending an order another loop placed moments ago.
+        seen = first_seen_ts(conn, order_no, market)
+        if seen is None:
+            record_seen(conn, ticker, market, side, order_no, order_price,
+                        unfilled_qty, run_id)
+            summary["grace_skipped"] += 1
+            logger.info("[%s] %s order=%s first seen -> grace skip", market, ticker, order_no)
+            return
+        if (_now() - seen).total_seconds() < GRACE_SEC:
+            summary["grace_skipped"] += 1
+            logger.info("[%s] %s order=%s within grace window -> skip", market, ticker, order_no)
+            return
+
+        # Single source of truth for the market price = live KIS read.
+        try:
+            info = await asyncio.to_thread(trader.get_current_price, ticker)
+            market_price = float((info or {}).get("current_price", 0) or 0)
+        except Exception as e:
+            logger.warning("[%s] %s price fetch failed: %s -> no-op", market, ticker, e)
+            return
+        if market_price <= 0:
+            return
+
+        already = chase_count_for(conn, order_no, market)
+        ceiling_price = order_price * (1.0 + BUY_MAX_PREMIUM_PCT)
+
+        # ── BUY ceiling enforcement ──────────────────────────────────────────
+        if side == "BUY":
+            # If the market has run above our premium ceiling, chasing would buy
+            # too expensively -> stop. Cancel (default) or leave for the batch.
+            if market_price > ceiling_price:
+                if CANCEL_ON_CEILING:
+                    await _do_cancel(conn, trader, market, order, run_id, summary,
+                                     mode, order_price,
+                                     reason=f"buy ceiling hit (mkt {market_price:.4f} > "
+                                            f"ceiling {ceiling_price:.4f})")
+                else:
+                    summary["ceiling_skipped"] += 1
+                    record_chase(conn, ticker, market, side, order_no, "SKIP", mode,
+                                 order_price, order_price, unfilled_qty, already,
+                                 "buy ceiling hit (no cancel)", run_id)
+                    logger.info("[%s] %s BUY ceiling hit -> skip (no cancel)", market, ticker)
+                return
+
+        # ── Exhausted chase budget -> stop (sell) / cancel-or-stop (buy) ──────
+        if already >= MAX_CHASES:
+            if side == "BUY" and CANCEL_ON_CEILING:
+                await _do_cancel(conn, trader, market, order, run_id, summary,
+                                 mode, order_price,
+                                 reason=f"max chases reached ({already})")
+            else:
+                summary["exhausted"] += 1
+                record_chase(conn, ticker, market, side, order_no, "SKIP", mode,
+                             order_price, order_price, unfilled_qty, already,
+                             f"max chases reached ({already})", run_id)
+                logger.info("[%s] %s max chases reached -> stop", market, ticker)
+            return
+
+        # ── Compute the chased price ────────────────────────────────────────
+        raw_new = _compute_chase_price(side, order_price, market_price)
+        new_price = _round_price(market, raw_new)
+        # Cap a buy's chased price at the ceiling too.
+        if side == "BUY":
+            new_price = min(new_price, _round_price(market, ceiling_price))
+
+        # No meaningful move -> nothing to do.
+        if abs(new_price - order_price) < (1.0 if market == "KR" else 0.01):
+            summary["no_move"] += 1
+            logger.info("[%s] %s already at market -> no amend", market, ticker)
+            return
+
+        await _do_amend(conn, trader, market, order, run_id, summary, mode,
+                        order_price, new_price, already)
+    finally:
+        release_lock(conn, ticker, market, run_id)
+
+
+async def _do_amend(conn, trader, market, order, run_id, summary, mode,
+                    old_price, new_price, already) -> None:
+    ticker, side, order_no = order["ticker"], order["side"], order["order_no"]
+    unfilled_qty = int(order["unfilled_qty"] or 0)
+
+    if not LOOP_C_LIVE:
+        summary["shadow"] += 1
+        logger.info("[SHADOW][%s] WOULD AMEND %s %s order=%s qty=%d %.4f -> %.4f (chase #%d)",
+                    market, side, ticker, order_no, unfilled_qty, old_price, new_price, already + 1)
+        record_chase(conn, ticker, market, side, order_no, "AMEND", mode,
+                     old_price, new_price, unfilled_qty, already + 1,
+                     "shadow chase", run_id)
+        return
+
+    logger.warning("[LIVE][%s] AMEND %s %s order=%s %.4f -> %.4f",
+                   market, side, ticker, order_no, old_price, new_price)
+    try:
+        if market == "KR":
+            result = await asyncio.to_thread(
+                trader.amend_order, ticker, order_no, int(new_price),
+                order.get("krx_fwdg_ord_orgno", ""),
+            )
+        else:
+            result = await asyncio.to_thread(
+                trader.amend_order, ticker, order_no, float(new_price),
+                unfilled_qty, order.get("exchange"),
+            )
+        ok = bool(result and result.get("success"))
+        summary["amended"] += 1 if ok else 0
+        record_chase(conn, ticker, market, side, order_no, "AMEND", mode,
+                     old_price, new_price, unfilled_qty, already + 1,
+                     (result or {}).get("message", ""), run_id)
+        logger.warning("[LIVE][%s] %s amend success=%s msg=%s",
+                       market, ticker, ok, (result or {}).get("message"))
+    except Exception as e:
+        logger.error("[%s] %s amend failed: %s", market, ticker, e)
+
+
+async def _do_cancel(conn, trader, market, order, run_id, summary, mode,
+                     old_price, reason) -> None:
+    ticker, side, order_no = order["ticker"], order["side"], order["order_no"]
+    unfilled_qty = int(order["unfilled_qty"] or 0)
+
+    if not LOOP_C_LIVE:
+        summary["shadow"] += 1
+        logger.info("[SHADOW][%s] WOULD CANCEL %s %s order=%s qty=%d (%s)",
+                    market, side, ticker, order_no, unfilled_qty, reason)
+        record_chase(conn, ticker, market, side, order_no, "CANCEL", mode,
+                     old_price, old_price, unfilled_qty,
+                     chase_count_for(conn, order_no, market), reason, run_id)
+        return
+
+    logger.warning("[LIVE][%s] CANCEL %s %s order=%s (%s)",
+                   market, side, ticker, order_no, reason)
+    try:
+        if market == "KR":
+            result = await asyncio.to_thread(
+                trader.cancel_order, ticker, order_no,
+                order.get("krx_fwdg_ord_orgno", ""),
+            )
+        else:
+            result = await asyncio.to_thread(
+                trader.cancel_order, ticker, order_no, unfilled_qty,
+                order.get("exchange"),
+            )
+        ok = bool(result and result.get("success"))
+        summary["cancelled"] += 1 if ok else 0
+        record_chase(conn, ticker, market, side, order_no, "CANCEL", mode,
+                     old_price, old_price, unfilled_qty,
+                     chase_count_for(conn, order_no, market), reason, run_id)
+        logger.warning("[LIVE][%s] %s cancel success=%s msg=%s",
+                       market, ticker, ok, (result or {}).get("message"))
+    except Exception as e:
+        logger.error("[%s] %s cancel failed: %s", market, ticker, e)
+
+
+async def run_market(market: str, run_id: str) -> Dict[str, Any]:
+    """Reconcile + chase every unfilled order for one market.
+
+    Never raises: any failure degrades to a no-op for that order/market. The live
+    KIS inquiry is the single source of truth — an empty/failed inquiry means
+    "nothing to chase", NEVER "everything filled".
+    """
+    summary = {"market": market, "open_orders": 0, "evaluated": 0, "shadow": 0,
+               "amended": 0, "cancelled": 0, "skipped": 0, "no_move": 0,
+               "ceiling_skipped": 0, "exhausted": 0, "grace_skipped": 0}
+    conn = _connect()
+    try:
+        _ensure_schema(conn)
+        try:
+            async with _open_context(market) as trader:
+                orders = await _inquire_open_orders(trader, market)
+                summary["open_orders"] = len(orders)
+                for order in orders:
+                    summary["evaluated"] += 1
+                    await _act_on_order(conn, trader, market, order, run_id, summary)
+        except Exception as e:  # context/credential failure -> skip whole market safely
+            logger.warning("%s trading context failed: %s", market, e)
+    finally:
+        conn.close()
+    return summary
+
+
+async def main_async(markets: List[str]) -> int:
+    if not LOOP_C_ENABLED:
+        logger.info("LOOP_C_ENABLED=false -> loop disabled, exiting.")
+        return 0
+    run_id = uuid.uuid4().hex[:12]
+    mode = "LIVE" if LOOP_C_LIVE else "SHADOW"
+    logger.info("Loop C start run_id=%s mode=%s markets=%s db=%s", run_id, mode, markets, DB_PATH)
+    totals: Dict[str, int] = {}
+    for market in markets:
+        s = await run_market(market, run_id)
+        for k, v in s.items():
+            if isinstance(v, int):
+                totals[k] = totals.get(k, 0) + v
+        logger.info("Loop C %s summary: %s", market, s)
+    logger.info("Loop C done run_id=%s mode=%s totals=%s", run_id, mode, totals)
+    return 0
+
+
+def _setup_logging() -> None:
+    log_dir = PROJECT_ROOT / "logs"
+    log_dir.mkdir(exist_ok=True)
+    handlers: List[logging.Handler] = [logging.StreamHandler(sys.stdout)]
+    try:
+        handlers.append(logging.FileHandler(log_dir / "loop_c_fill_chaser.log"))
+    except OSError:
+        pass
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=handlers,
+    )
+
+
+def _run_both_isolated() -> int:
+    """Run KR and US as SEPARATE subprocesses (cores-shadowing isolation)."""
+    import subprocess
+    rc = 0
+    for m in ("kr", "us"):
+        try:
+            proc = subprocess.run([sys.executable, str(Path(__file__).resolve()), "--market", m])
+            rc = rc or proc.returncode
+        except Exception as e:
+            logger.error("subprocess for market=%s failed: %s", m, e)
+            rc = rc or 1
+    return rc
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Loop C fill-chaser (미체결 추격)")
+    parser.add_argument("--market", choices=["kr", "us", "both"], default="both")
+    parser.add_argument("--once", action="store_true", help="(default) run a single cycle")
+    args = parser.parse_args()
+    _setup_logging()
+    if args.market == "both":
+        return _run_both_isolated()
+    market = {"kr": "KR", "us": "US"}[args.market]
+    _bootstrap_path(market)
+    return asyncio.run(main_async([market]))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/trading/domestic_stock_trading.py
+++ b/trading/domestic_stock_trading.py
@@ -89,6 +89,17 @@ def _resolve_sell_quantity(holding_quantity: int, quantity: int = None) -> int:
     return min(q, holding_quantity)
 
 
+def _safe_int(value: Any, default: int = 0) -> int:
+    """Coerce a KIS response field (often an empty string) to int. Never raises."""
+    try:
+        s = str(value).strip()
+        if not s:
+            return default
+        return int(float(s))
+    except (TypeError, ValueError):
+        return default
+
+
 class DomesticStockTrading:
     """Domestic stock trading class"""
 
@@ -1638,6 +1649,207 @@ class DomesticStockTrading:
         except Exception as e:
             logger.error(f"Error during account summary inquiry: {str(e)}")
             return {}
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Loop C prerequisites — order amend/cancel + unfilled inquiry TR wrappers.
+    #
+    # These mirror the existing order-cash wrappers above (same _request/auth/
+    # tr_id real-vs-paper switching, same result-dict shape). They are NEW TRs
+    # and were NOT exercised against live KIS at authoring time — see the
+    # TODO(live-validate) markers and tasks/loop_c_design_notes.md.
+    #
+    # TR ids confirmed against koreainvestment/open-trading-api (2025-06-01):
+    #   - amend/cancel : real TTTC0013U / paper VTTC0013U  (order-rvsecncl)
+    #     ⚠️ NOT the legacy TTTC0803U/VTTC0803U.
+    #   - revisable inquiry : real TTTC0084R (paper VTTC0084R UNVERIFIED)
+    # ──────────────────────────────────────────────────────────────────────────
+    def amend_cancel_order(
+        self,
+        stock_code: str,
+        orgn_odno: str,
+        rvse_cncl_dvsn_cd: str,
+        krx_fwdg_ord_orgno: str = "",
+        ord_dvsn: str = "00",
+        quantity: int = 0,
+        limit_price: int = 0,
+        qty_all_ord_yn: str = "Y",
+        excg_id_dvsn_cd: str = "KRX",
+    ) -> Dict[str, Any]:
+        """Amend (정정) or cancel (취소) an existing domestic order.
+
+        KIS uses ONE TR for both, distinguished by ``rvse_cncl_dvsn_cd``:
+          - "01" = 정정 (amend): supply the NEW ``limit_price`` (and ``quantity``
+            if amending a partial qty).
+          - "02" = 취소 (cancel): price is ignored by KIS; pass 0.
+
+        Args:
+            stock_code: 6-digit code (informational; KIS keys off orgn_odno).
+            orgn_odno: Original order number (ORGN_ODNO) being amended/cancelled.
+            rvse_cncl_dvsn_cd: "01" amend, "02" cancel.
+            krx_fwdg_ord_orgno: Original KRX forwarding order org no
+                (KRX_FWDG_ORD_ORGNO) returned when the original order was placed.
+            ord_dvsn: Order division of the ORIGINAL order ("00" limit, etc).
+            quantity: Quantity to amend/cancel. Ignored when qty_all_ord_yn="Y".
+            limit_price: New limit price for an amend; 0 for cancel.
+            qty_all_ord_yn: "Y" = whole remaining qty, "N" = partial (uses quantity).
+            excg_id_dvsn_cd: Exchange id division ("KRX"/"NXT"/"SOR").
+
+        Returns:
+            Result dict: {success, order_no, stock_code, message}.
+        """
+        if not self.auto_trading:
+            return {
+                'success': False,
+                'order_no': None,
+                'stock_code': stock_code,
+                'message': 'Auto trading is disabled. Cannot amend/cancel order. (AUTO_TRADING=False)'
+            }
+
+        api_url = "/uapi/domestic-stock/v1/trading/order-rvsecncl"
+
+        # Real vs paper switching, exactly like order-cash above.
+        if self.mode == "real":
+            tr_id = "TTTC0013U"  # Real amend/cancel (NOT legacy TTTC0803U)
+        else:
+            tr_id = "VTTC0013U"  # Demo amend/cancel
+
+        action = "Amend" if rvse_cncl_dvsn_cd == "01" else "Cancel"
+
+        # TODO(live-validate): TR field layout (esp. EXCG_ID_DVSN_CD requirement,
+        # ORD_UNPR semantics on cancel) unverified against live KIS. Confirmed
+        # only against the KIS GitHub sample, not a live order.
+        params = {
+            "CANO": self.trenv.my_acct,
+            "ACNT_PRDT_CD": self.trenv.my_prod,
+            "KRX_FWDG_ORD_ORGNO": krx_fwdg_ord_orgno,
+            "ORGN_ODNO": str(orgn_odno),
+            "ORD_DVSN": ord_dvsn,
+            "RVSE_CNCL_DVSN_CD": rvse_cncl_dvsn_cd,  # 01: amend, 02: cancel
+            "ORD_QTY": str(int(quantity)),
+            "ORD_UNPR": str(int(limit_price)),
+            "QTY_ALL_ORD_YN": qty_all_ord_yn,
+            "EXCG_ID_DVSN_CD": excg_id_dvsn_cd,
+            "CNDT_PRIC": "",
+        }
+
+        try:
+            res = self._request(api_url, tr_id, params, postFlag=True)
+
+            if res.isOK():
+                output = res.getBody().output
+                order_no = output.get('odno', '')
+                logger.info(
+                    f"[{stock_code}] {action} order success: orgn={orgn_odno}, "
+                    f"new_no={order_no}, price={limit_price}"
+                )
+                return {
+                    'success': True,
+                    'order_no': order_no,
+                    'stock_code': stock_code,
+                    'message': f'{action} order completed (orgn={orgn_odno})'
+                }
+            else:
+                error_msg = f"{res.getErrorCode()} - {res.getErrorMessage()}"
+                logger.error(f"[{stock_code}] {action} order failed: {error_msg}")
+                return {
+                    'success': False,
+                    'order_no': None,
+                    'stock_code': stock_code,
+                    'message': f'{action} order failed: {error_msg}'
+                }
+
+        except Exception as e:
+            logger.error(f"Error during {action.lower()} order: {str(e)}")
+            return {
+                'success': False,
+                'order_no': None,
+                'stock_code': stock_code,
+                'message': f'Error during {action.lower()} order: {str(e)}'
+            }
+
+    def amend_order(self, stock_code: str, orgn_odno: str, limit_price: int,
+                    krx_fwdg_ord_orgno: str = "", ord_dvsn: str = "00",
+                    quantity: int = 0, qty_all_ord_yn: str = "Y") -> Dict[str, Any]:
+        """Convenience wrapper: amend (정정) an order's limit price to ``limit_price``."""
+        return self.amend_cancel_order(
+            stock_code=stock_code, orgn_odno=orgn_odno, rvse_cncl_dvsn_cd="01",
+            krx_fwdg_ord_orgno=krx_fwdg_ord_orgno, ord_dvsn=ord_dvsn,
+            quantity=quantity, limit_price=limit_price, qty_all_ord_yn=qty_all_ord_yn,
+        )
+
+    def cancel_order(self, stock_code: str, orgn_odno: str,
+                     krx_fwdg_ord_orgno: str = "", ord_dvsn: str = "00",
+                     quantity: int = 0, qty_all_ord_yn: str = "Y") -> Dict[str, Any]:
+        """Convenience wrapper: cancel (취소) an existing order."""
+        return self.amend_cancel_order(
+            stock_code=stock_code, orgn_odno=orgn_odno, rvse_cncl_dvsn_cd="02",
+            krx_fwdg_ord_orgno=krx_fwdg_ord_orgno, ord_dvsn=ord_dvsn,
+            quantity=quantity, limit_price=0, qty_all_ord_yn=qty_all_ord_yn,
+        )
+
+    def get_revisable_orders(self, stock_code: str = None) -> List[Dict[str, Any]]:
+        """Inquire revisable/cancellable (= still-open / unfilled) orders.
+
+        TR: 주식정정취소가능주문조회 — real TTTC0084R. Returns a normalised list of
+        open orders, optionally filtered to ``stock_code``. Returns [] on any
+        failure (degrade to no-op — Loop C must treat empty as "nothing to chase",
+        never as "everything filled").
+
+        Each dict: {order_no, orgn_odno, stock_code, ord_qty, ord_unpr,
+                    tot_ccld_qty, psbl_qty, sll_buy_dvsn_cd, ord_dvsn,
+                    krx_fwdg_ord_orgno}.
+        """
+        api_url = "/uapi/domestic-stock/v1/trading/inquire-psbl-rvsecncl"
+
+        # TODO(live-validate): paper tr_id VTTC0084R is UNVERIFIED in the KIS
+        # sample repo. Real TTTC0084R confirmed. Loop C runs SHADOW by default.
+        if self.mode == "real":
+            tr_id = "TTTC0084R"
+        else:
+            tr_id = "VTTC0084R"
+
+        params = {
+            "CANO": self.trenv.my_acct,
+            "ACNT_PRDT_CD": self.trenv.my_prod,
+            "INQR_DVSN_1": "1",
+            "INQR_DVSN_2": "0",
+            "CTX_AREA_FK100": "",
+            "CTX_AREA_NK100": "",
+        }
+
+        out: List[Dict[str, Any]] = []
+        try:
+            res = self._request(api_url, tr_id, params)
+            if not res.isOK():
+                error_msg = f"{res.getErrorCode()} - {res.getErrorMessage()}"
+                logger.warning(f"Revisable-order inquiry failed: {error_msg}")
+                return out
+
+            output1 = res.getBody().output
+            if not isinstance(output1, list):
+                output1 = [output1] if output1 else []
+
+            for row in output1:
+                code = str(row.get('pdno', '') or '').strip()
+                if stock_code and code != stock_code:
+                    continue
+                out.append({
+                    'order_no': row.get('odno', ''),
+                    'orgn_odno': row.get('orgn_odno', ''),
+                    'stock_code': code,
+                    'ord_qty': _safe_int(row.get('ord_qty')),
+                    'ord_unpr': _safe_int(row.get('ord_unpr')),
+                    'tot_ccld_qty': _safe_int(row.get('tot_ccld_qty')),
+                    'psbl_qty': _safe_int(row.get('psbl_qty')),  # cancellable/amendable qty
+                    'sll_buy_dvsn_cd': row.get('sll_buy_dvsn_cd', ''),  # 01 sell / 02 buy
+                    'ord_dvsn': row.get('ord_dvsn_cd', ''),
+                    'krx_fwdg_ord_orgno': row.get('ord_gno_brno', ''),
+                })
+            return out
+
+        except Exception as e:
+            logger.warning(f"Error during revisable-order inquiry: {str(e)}")
+            return out
 
 
 class MultiAccountDomesticStockTrading:


### PR DESCRIPTION
## Loop C — fill chaser (미체결 추격)

Loop C is the single owner of open-order management: each cycle it inquires the
live KIS unfilled orders, and for stale orders chases the limit toward the market
(within a ceiling) or cancels. LLM-free; KR and US run as **separate processes**
(cores-shadowing isolation). Loops A/B keep only placing new sells; they defer
open-order management to Loop C.

### Prerequisite: NEW KIS TR wrappers
Added to `trading/domestic_stock_trading.py` (KR) and
`prism-us/trading/us_stock_trading.py` (US), mirroring the existing order
wrappers (same `_request`/auth/hashkey, cached `kis_auth` token, real-vs-paper
`tr_id` switching, result-dict shape):

| Wrapper | TR (real / paper) | Endpoint |
|---|---|---|
| KR amend/cancel | `TTTC0013U` / `VTTC0013U` | `domestic-stock/.../order-rvsecncl` |
| KR revisable inquiry | `TTTC0084R` / `VTTC0084R` | `.../inquire-psbl-rvsecncl` |
| US amend/cancel | `TTTT1004U` / `VTTT1004U` | `overseas-stock/.../order-rvsecncl` |
| US unfilled (nccs) | `TTTS3018R` / `VTTS3018R` | `.../inquire-nccs` |

> ⚠️ **These TRs are unit-tested but NOT live-validated.** They were mirrored from
> the existing wrappers + KIS sample and have **not** been exercised against a
> live KIS account. Uncertain field layouts (e.g. paper TR ids, cancel-side
> `ORD_UNPR`/`OVRS_ORD_UNPR`, `EXCG_ID_DVSN_CD`) carry `# TODO(live-validate)`
> markers. Do **not** trust them for real orders until the LIVE checklist is
> signed off.

### Safety
- **SHADOW is the default** (`LOOP_C_LIVE=false`): logs `WOULD AMEND/CANCEL`,
  issues **no** real TR (context opened only for price/inquiry reads).
- **LIVE is gated OFF**; `LOOP_C_ENABLED` kill switch.
- Per-ticker `owner_lock` (BEGIN IMMEDIATE) shared with Loop A so the batch and
  Loop C never amend the same order; new `loop_c_chase_log` audit table only —
  **no existing tables touched**.
- BUY chase capped at `order_price * (1 + premium)` → cancel on ceiling (never
  overpay); `MAX_CHASES` cap; never-raises degradation; empty inquiry = "nothing
  to chase", never "all filled".
- **Cron is NOT installed** (intended schedule documented in the loop docstring).

### Tests
Network-free, mocked TR/inquiry responses. KR and US run in **separate** pytest
sessions (cores-shadowing).
- `tests/test_loop_c_fill_chaser.py` — 12 passed
- `prism-us/tests/test_loop_c_fill_chaser_us.py` — 12 passed

Covers: stale/grace detection, SELL chase toward market, BUY ceiling → cancel
(not overpay), max-chases → cancel, SHADOW = no real calls, owner_lock
exclusivity, partial-fill reconcile off the inquiry, ENABLED/LIVE gating, and
inquiry-failure → no-op.

### Do NOT merge / enable
This PR ships SHADOW-only. Before `LOOP_C_LIVE=true`: place a tiny test order and
confirm the amend/cancel/inquiry round-trip per market (KR + US), and verify the
paper TR ids actually resolve in 모의.

🤖 Generated with [Claude Code](https://claude.com/claude-code)