### PR TITLE
fix(chatgpt-proxy): OAuth(Codex) 호환 - nano 매핑 + previous_response_id strip

### DIFF
--- a/cores/chatgpt_proxy/api_translator.py
+++ b/cores/chatgpt_proxy/api_translator.py
@@ -64,7 +64,15 @@ def prepare_responses_passthrough(body: dict) -> dict:
     # The Codex backend rejects several Responses parameters the openai-agents
     # Runner adds by default (observed: "Unsupported parameter: max_output_tokens").
     # Strip them so subscription requests succeed.
-    for unsupported in ("max_output_tokens", "include"):
+    #
+    # previous_response_id: rejected by the Codex/ChatGPT-account endpoint
+    # ("Unsupported parameter: previous_response_id"), which broke multi-turn
+    # tool-calling agents (e.g. the gpt-5.5 trading-scenario / buy decision ->
+    # 400 -> default_scenario -> No Entry). It is also non-functional here:
+    # store=False is forced above, so there is no server-side response to
+    # reference. The full conversation is already carried in `input` (mcp_agent
+    # sends the entire message history every turn), so dropping it is lossless.
+    for unsupported in ("max_output_tokens", "include", "previous_response_id"):
         out.pop(unsupported, None)
     # Drop empty tool list (Codex dislikes an empty `tools: []`).
     if out.get("tools") == []:

--- a/cores/chatgpt_proxy/api_translator.py
+++ b/cores/chatgpt_proxy/api_translator.py
@@ -18,6 +18,12 @@ _MODEL_MAP: dict[str, str] = {
     "gpt-3.5-turbo": "gpt-5.4-mini",
     "o4-mini": "gpt-5.4-mini",
     "o3-mini": "gpt-5.4-mini",
+    # gpt-5-nano is rejected by the Codex/ChatGPT-account endpoint
+    # ("model is not supported when using Codex with a ChatGPT account").
+    # Map to the lightest Codex-compatible model so OAuth-mode callers
+    # (telegram_translator, dashboards, weekly intelligence) keep working.
+    # API-key mode bypasses this proxy, so it still uses real gpt-5-nano.
+    "gpt-5-nano": "gpt-5.4-mini",
 }
 
 

--- a/tests/test_chatgpt_oauth/test_api_translator.py
+++ b/tests/test_chatgpt_oauth/test_api_translator.py
@@ -36,6 +36,26 @@ class TestTranslateRequest:
         assert "messages" not in result
         assert "max_tokens" not in result
 
+    def test_gpt5_nano_mapped_to_codex_compatible(self):
+        # gpt-5-nano is rejected by the Codex/ChatGPT-account endpoint;
+        # it must be mapped to the lightest Codex-compatible model so that
+        # OAuth-mode callers (e.g. telegram_translator) keep working.
+        body = {
+            "model": "gpt-5-nano",
+            "messages": [{"role": "user", "content": "안녕하세요"}],
+        }
+        result = translate_request(body)
+        assert result["model"] == "gpt-5.4-mini"
+
+    def test_supported_model_not_remapped(self):
+        # A Codex-supported model passes through unchanged.
+        body = {
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        result = translate_request(body)
+        assert result["model"] == "gpt-5"
+
     def test_tool_definitions_flattened(self):
         body = {
             "model": "gpt-5",

--- a/tests/test_chatgpt_oauth/test_responses_passthrough.py
+++ b/tests/test_chatgpt_oauth/test_responses_passthrough.py
@@ -37,6 +37,26 @@ class TestPrepareResponsesPassthrough:
         result = prepare_responses_passthrough(body)
         assert result["model"] == "my-custom-model-v2"
 
+    def test_strips_previous_response_id(self):
+        # Codex/ChatGPT-account endpoint rejects previous_response_id and it is
+        # non-functional under the forced store=False. Multi-turn tool-calling
+        # agents (e.g. gpt-5.5 buy decision) carry full history in `input`, so
+        # dropping it is lossless and prevents the 400 that fell decisions back
+        # to default_scenario (No Entry).
+        body = {
+            "model": "gpt-5.5",
+            "input": [{"role": "user", "content": "hi"}],
+            "previous_response_id": "resp_abc123",
+        }
+        result = prepare_responses_passthrough(body)
+        assert "previous_response_id" not in result
+        assert result["model"] == "gpt-5.5"
+
+    def test_maps_gpt5_nano_to_gpt54mini(self):
+        body = {"model": "gpt-5-nano", "input": []}
+        result = prepare_responses_passthrough(body)
+        assert result["model"] == "gpt-5.4-mini"
+
     def test_injects_default_instructions_when_missing(self):
         body = {"model": "gpt-5.4-mini", "input": []}
         result = prepare_responses_passthrough(body)


### PR DESCRIPTION
## 배경 (06-22 LIVE OAuth 카나리에서 발견)
월요일 KR 오전배치 첫 OAuth 풀배치에서 **두 가지** Codex/ChatGPT-account 비호환이 드러남:

1. **번역(gpt-5-nano) 400**: `The 'gpt-5-nano' model is not supported when using Codex with a ChatGPT account` → en/ja/zh/es 다국어 방송 실패
2. **매수결정(gpt-5.5) 400**: `Unsupported parameter: previous_response_id` → 멀티턴 툴콜 trading_scenario_agent가 400 → default_scenario(Score 0/No Entry). **여러 종목 매수 진입이 전부 막힘** (fail-safe라 손실은 없으나 기회 상실)

한국어 본분석·Loop A 매도는 무영향.

## 수정 (cores/chatgpt_proxy/api_translator.py)
1. `_MODEL_MAP`에 `gpt-5-nano → gpt-5.4-mini` 추가 (기존 미지원모델 매핑 패턴)
2. passthrough strip 목록에 `previous_response_id` 추가 (`max_output_tokens`, `include` 옆)
   - store=False 강제 상태라 previous_response_id는 어차피 무용
   - mcp_agent는 매 턴 **전체 history를 input에 담아 전송**(augmented_llm_openai: history.get→messages) → 제거해도 **맥락 손실 없음(lossless)**

→ **OAuth로 통일해도 매수결정(gpt-5.5)·번역 모두 정상 작동.** API키 모드는 프록시 미경유라 무영향.

## 검증
- standalone: nano→gpt-5.4-mini, previous_response_id 제거, gpt-5.5/store=False 보존 확인
- 회귀 테스트 추가: test_responses_passthrough(strip/nano/gpt-5.5), test_api_translator(nano/passthrough)
- ⚠️ 머지·배포 후 **오전배치 OAuth 수동 재실행**으로 매수결정 산출물 일관성(400 부재 + 정상 시나리오) 최종 검증 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)