### PR TITLE
fix(llm): OAuth/Codex 멀티턴 툴콜 수정 — 클라이언트측 상태 누적 (store=False)

### DIFF
--- a/cores/llm/openai_responses_llm.py
+++ b/cores/llm/openai_responses_llm.py
@@ -2,8 +2,18 @@
 OpenAI Responses API LLM for mcp-agent trading agents.
 
 Replaces Chat Completions (client.chat.completions.create) with the Responses API
-(client.responses.create), using previous_response_id so only tool results—not the
-full accumulated message history—are re-sent on each tool-call iteration.
+(client.responses.create), driving the agentic tool-call loop turn by turn.
+
+Conversation state is carried *client-side*: each turn we append the model's
+function_call items and our function_call_output items to the running ``input``
+list, and re-send the whole list. We deliberately do NOT use
+``previous_response_id`` for state, because the ChatGPT/Codex (OAuth account)
+backend forces ``store=False`` (``store=true`` returns 400) and the proxy strips
+``previous_response_id`` — there is no server-side response to reference, so a
+tool result sent alone (without its originating function_call in ``input``)
+fails with "No tool call found for function call output with call_id ...".
+Re-sending the full input is the only correct multi-turn flow under store=False,
+and remains correct under store=True (API-key mode).
 
 Drop-in replacement: swap attach_llm(OpenAIAugmentedLLM) →
                                attach_llm(OpenAIResponsesLLM)
@@ -93,7 +103,6 @@ class OpenAIResponsesLLM(OpenAIAugmentedLLM):
         if provider_config is None:
             raise RuntimeError("OpenAI provider config is missing from mcp_agent.config.yaml")
 
-        previous_response_id: Optional[str] = None
         final_text = ""
 
         async with AsyncOpenAI(
@@ -103,12 +112,13 @@ class OpenAIResponsesLLM(OpenAIAugmentedLLM):
             for i in range(params.max_iterations):
                 self._log_chat_progress(chat_turn=i, model=model)
 
+                # Always send the full accumulated conversation as `input`.
+                # State is carried client-side (no previous_response_id) so the
+                # loop works under store=False (OAuth/Codex) where the originating
+                # function_call must accompany its function_call_output.
                 call_kwargs = {**base_kwargs, "input": input_items}
-                if previous_response_id:
-                    call_kwargs["previous_response_id"] = previous_response_id
 
                 response = await client.responses.create(**call_kwargs)  # type: ignore[attr-defined]
-                previous_response_id = response.id
 
                 # Separate text content and function calls from output items
                 text_parts: List[str] = []
@@ -125,24 +135,32 @@ class OpenAIResponsesLLM(OpenAIAugmentedLLM):
                     final_text = "\n".join(text_parts)
                     break
 
-                # Execute all tool calls via MCP and collect results
-                tool_result_items = []
+                # Append the model's function_call items to the running input so
+                # the next turn pairs each output with its originating call.
+                for fc in function_calls:
+                    input_items.append(
+                        {
+                            "type": "function_call",
+                            "name": fc.name,
+                            "call_id": fc.call_id,
+                            "arguments": fc.arguments,
+                        }
+                    )
+
+                # Execute all tool calls via MCP and append their results.
                 for fc in function_calls:
                     result_str = await self._call_mcp_tool(
                         name=fc.name,
                         arguments=fc.arguments,
                         call_id=fc.call_id,
                     )
-                    tool_result_items.append(
+                    input_items.append(
                         {
                             "type": "function_call_output",
                             "call_id": fc.call_id,
                             "output": result_str,
                         }
                     )
-
-                # Next iteration only sends tool results; full context lives server-side
-                input_items = tool_result_items
 
         self._log_chat_finished(model=model)
         return final_text

--- a/tests/test_chatgpt_oauth/test_responses_llm_multiturn.py
+++ b/tests/test_chatgpt_oauth/test_responses_llm_multiturn.py
@@ -1,0 +1,142 @@
+"""Regression test for the multi-turn tool-call loop in OpenAIResponsesLLM.
+
+Locks in the fix for the OAuth/Codex (store=False) backend: because the proxy
+strips `previous_response_id` and store=False has no server-side state, every
+turn must re-send the FULL conversation in `input` — including the originating
+`function_call` paired with its `function_call_output`. Sending the tool result
+alone previously produced:
+    "No tool call found for function call output with call_id ..." (400)
+
+These tests assert that:
+  1. No `previous_response_id` is ever sent (client-side state only).
+  2. On the second turn, `input` contains the function_call AND its matching
+     function_call_output (same call_id), so the pairing the backend requires
+     is present.
+"""
+import asyncio
+import types
+
+from cores.llm.openai_responses_llm import OpenAIResponsesLLM
+
+
+class _Part:
+    def __init__(self, text):
+        self.text = text
+
+
+class _Item:
+    def __init__(self, type, content=None, name=None, call_id=None, arguments=None):
+        self.type = type
+        self.content = content
+        self.name = name
+        self.call_id = call_id
+        self.arguments = arguments
+
+
+class _Resp:
+    def __init__(self, id, output):
+        self.id = id
+        self.output = output
+
+
+class _FakeResponses:
+    """Records every responses.create() call; turn 1 asks for a tool, turn 2 ends."""
+
+    def __init__(self):
+        self.calls = []
+
+    async def create(self, **kwargs):
+        self.calls.append(kwargs)
+        if len(self.calls) == 1:
+            return _Resp(
+                "resp_1",
+                [_Item("function_call", name="get_time", call_id="call_abc", arguments="{}")],
+            )
+        return _Resp("resp_2", [_Item("message", content=[_Part("FINAL ANSWER")])])
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.responses = _FakeResponses()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+async def _run_multiturn():
+    import cores.llm.openai_responses_llm as mod
+
+    fake_client = _FakeClient()
+    orig_async_openai = mod.AsyncOpenAI
+    mod.AsyncOpenAI = lambda *a, **k: fake_client
+
+    llm = OpenAIResponsesLLM.__new__(OpenAIResponsesLLM)
+    llm.instruction = "system"
+
+    # Stub the OpenAIAugmentedLLM machinery the loop depends on.
+    params = types.SimpleNamespace(
+        max_iterations=5, maxTokens=1000, reasoning_effort=None,
+        stopSequences=None, systemPrompt=None, tool_filter=None,
+    )
+    llm.get_request_params = lambda rp: params
+    llm._reasoning = lambda model: False
+    llm._reasoning_effort = None
+
+    async def _select_model(p):
+        return "gpt-5.5"
+
+    async def _list_tools(tool_filter=None):
+        tool = types.SimpleNamespace(name="get_time", description="", inputSchema={})
+        return types.SimpleNamespace(tools=[tool])
+
+    async def _call_mcp_tool(name, arguments, call_id):
+        return "12:00"
+
+    llm.select_model = _select_model
+    llm.agent = types.SimpleNamespace(list_tools=_list_tools)
+    llm._call_mcp_tool = _call_mcp_tool
+    llm.get_provider_config = lambda ctx=None: types.SimpleNamespace(
+        api_key="k", base_url="http://x"
+    )
+    # `context` is a read-only property backed by `_context`; get_provider_config
+    # is stubbed above to ignore it, so the value itself is irrelevant.
+    llm._context = None
+    llm._log_chat_progress = lambda **k: None
+    llm._log_chat_finished = lambda **k: None
+
+    try:
+        result = await llm.generate_str("hello")
+    finally:
+        mod.AsyncOpenAI = orig_async_openai
+
+    assert result == "FINAL ANSWER"
+    calls = fake_client.responses.calls
+    assert len(calls) == 2, "expected exactly two turns"
+
+    # 1. previous_response_id must NEVER be sent (store=False has no server state).
+    for c in calls:
+        assert "previous_response_id" not in c
+
+    # 2. Turn-2 input must contain the originating function_call AND its output,
+    #    paired by call_id, so the backend can match them.
+    turn2_input = calls[1]["input"]
+    fc = [i for i in turn2_input if i.get("type") == "function_call"]
+    fco = [i for i in turn2_input if i.get("type") == "function_call_output"]
+    assert fc and fc[0]["call_id"] == "call_abc"
+    assert fco and fco[0]["call_id"] == "call_abc"
+    assert fco[0]["output"] == "12:00"
+    # The original user message is still present (full context re-sent).
+    assert any(i.get("role") == "user" for i in turn2_input)
+
+
+def test_multiturn_sends_full_input_and_no_previous_response_id():
+    """Sync wrapper so the suite runs without pytest-asyncio."""
+    asyncio.run(_run_multiturn())
+
+
+if __name__ == "__main__":
+    test_multiturn_sends_full_input_and_no_previous_response_id()
+    print("PASS: multi-turn loop re-sends full input, no previous_response_id")

--- a/tools/verify_oauth_multiturn_scenario.py
+++ b/tools/verify_oauth_multiturn_scenario.py
@@ -1,0 +1,80 @@
+"""
+Standalone multi-turn tool-call verification for the OAuth/Codex backend.
+
+Drives StockTrackingAgent._extract_trading_scenario() for ONE ticker through the
+full Responses-API tool-call loop (time -> kospi_kosdaq -> sqlite, etc.) WITHOUT
+executing any trade or writing the holdings/journal DB. Confirms we get a real
+scenario JSON (not the default_scenario fallback) and that no
+"No tool call found for function call output" / 400 occurs under store=False.
+
+Run on the server (OAuth account active):
+    /root/.pyenv/shims/python tools/verify_oauth_multiturn_scenario.py
+"""
+import asyncio
+import json
+import sys
+
+from stock_tracking_agent import StockTrackingAgent, app
+
+# Minimal but realistic KR report so the CAN SLIM agent must call market tools
+# (time-get_current_time, kospi_kosdaq-get_index_ohlcv/get_stock_ohlcv) to decide.
+REPORT = """
+# 삼성전자(005930) 분석 리포트
+
+## 종목 개요
+- 종목명: 삼성전자
+- 종목코드: 005930
+- 업종: 전기·전자
+
+## 최근 동향
+- 최근 거래대금 상위권 진입, 거래량 급증.
+- 외국인/기관 동반 순매수 전환.
+- 신고가 부근 돌파 시도 중, 모멘텀 활성.
+
+## 펀더멘털
+- 반도체 업황 회복 사이클 초입.
+- 영업이익 전년比 대폭 증가 가이던스.
+
+(이 리포트에는 KOSPI 지수 20일 데이터/분산일 정보가 없으므로 시장 레짐 판단을
+위해 kospi_kosdaq 도구로 지수 데이터를 직접 조회해야 함.)
+"""
+
+
+async def main():
+    async with app.run():
+        agent = StockTrackingAgent(db_path="stock_tracking_db.sqlite")
+        await agent.initialize(language="ko")
+        try:
+            scenario = await agent._extract_trading_scenario(
+                report_content=REPORT,
+                rank_change_msg="거래대금 순위 전일 대비 +30위 상승",
+                ticker="005930",
+                sector="전기·전자",
+                trigger_type="Volume Surge Top Stocks",
+                trigger_mode="morning",
+            )
+        finally:
+            if agent.conn:
+                agent.conn.close()
+
+    default_decision = "No entry"
+    decision = scenario.get("decision", "")
+    is_default = (
+        scenario.get("sector") in (None, "Unknown")
+        and decision == default_decision
+        and not scenario.get("scenario_summary")
+        and not scenario.get("rationale")
+    )
+
+    print("===== SCENARIO RESULT =====")
+    print(json.dumps(scenario, ensure_ascii=False, indent=2)[:1500])
+    print("===========================")
+    print(f"decision={decision!r} sector={scenario.get('sector')!r}")
+    if is_default:
+        print("RESULT: FAIL - default_scenario fallback (tool-call loop broke)")
+        sys.exit(1)
+    print("RESULT: PASS - real scenario JSON produced via multi-turn tool calls")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## 근본원인
매수결정(trading_scenario) 에이전트는 mcp_agent 기본 LLM이 아니라 커스텀 `cores/llm/openai_responses_llm.py`(`OpenAIResponsesLLM`)를 쓴다. 이 루프는 `previous_response_id`로 서버측 상태를 추적하고 **매 턴 새 tool 결과만**(`input_items = tool_result_items`) 전송했다.

OAuth/Codex 백엔드는 `store=False` 강제 → 서버측 응답 상태 없음. PR #353이 프록시에서 `previous_response_id`를 strip → 2번째 턴 요청에 `function_call_output`만 있고 원천 `function_call`이 `input`에 없음 → **"No tool call found for function call output with call_id ..." (400)** → default_scenario 폴백 → No Entry.

프록시 strip만으론 불충분(이미 #353에서 확인). 도구 제거도 불가 — 이 에이전트는 `time`/`kospi_kosdaq`(시장 레짐·분산일)/`sqlite`/`perplexity`를 실제로 호출하는 진짜 멀티턴 툴콜 에이전트다.

## 수정 (옵션 c: 클라이언트측 전체 input 누적)
루프에서 `previous_response_id` 제거. 매 턴 모델의 `function_call` 항목과 그 `function_call_output`을 누적 `input`에 append 후 전체 재전송. `store=False`(OAuth)에서 정확히 동작하고 `store=True`(API키)에서도 회귀 없음. 프록시는 변경 없음.

## 멀티턴 검증 (서버, OAuth Plus, store=False) — PASS
`tools/verify_oauth_multiturn_scenario.py`로 005930 `_extract_trading_scenario` 단독 실행(매매·DB 부작용 없음):
- `decision='진입'`, `sector='전기·전자'`, `expected_loss_pct=4.2` 등 **실제 시나리오 JSON**(default 폴백 아님)
- 순차 호출: get_current_time → get_index_ohlcv/get_stock_ohlcv → describe_table/read_query → perplexity-ask(x5)
- `No tool call found`/`Unsupported parameter`/실 400 = 0건
- 회귀테스트 standalone PASS: 2턴, previous_response_id 전무, input에 function_call+output 페어링 확인

## 변경 파일
- `cores/llm/openai_responses_llm.py` — 루프 상태누적 + docstring
- `tests/test_chatgpt_oauth/test_responses_llm_multiturn.py` — 회귀테스트(pytest-asyncio 불필요)
- `tools/verify_oauth_multiturn_scenario.py` — 실검증 하네스

## 남은 리스크
- 매 턴 전체 input 재전송으로 토큰 비용↑(store=False 불가피, 5~6턴이라 제한적)
- reasoning 항목은 재첨부 안 함(표준 stateless 패턴, 현 검증 무문제)
- 005930 1종목 1회 검증
- 서버는 검증 후 pristine(main) 복원, 미배포

🤖 Generated with [Claude Code](https://claude.com/claude-code)