### PR TITLE
feat(oauth): ChatGPT Plus 주간 쿼터 모니터 (테스트방 보고)

### DIFF
--- a/tasks/oauth_quota_monitor.md
+++ b/tasks/oauth_quota_monitor.md
@@ -1,0 +1,87 @@
+# ChatGPT Plus (OAuth/Codex) 주간 쿼터 모니터링
+
+전 배치를 ChatGPT 구독(OAuth)으로 돌리기 시작하면서(KR 오전/오후 + US 3개),
+주간 한도 소진(429)을 **사전 감지**하기 위한 쿼터 모니터다.
+기존 워치독 `tools/oauth_healthcheck.py`에 통합했다(전송 인프라/쿨다운 재사용).
+
+## 1. 쿼터 소스 (조사 결과 — 실측)
+
+ChatGPT/Codex 백엔드(`https://chatgpt.com/backend-api/codex/responses`)는
+**성공(200) 응답 헤더**로 Codex CLI가 표시하는 "주간 한도 X% 사용" 데이터를 그대로 노출한다.
+서버에서 OAuth 호출 1회(`gpt-5.4-mini`, low effort)로 실측한 헤더:
+
+```
+x-codex-plan-type: plus                       # 플랜 (JWT claim은 free로 지연표시 — 실제는 plus)
+x-codex-active-limit: premium
+x-codex-primary-used-percent: 10              # 5시간 창 사용률
+x-codex-primary-window-minutes: 300           # = 5h
+x-codex-primary-reset-after-seconds: 10010
+x-codex-primary-reset-at: 1782113124          # unix
+x-codex-secondary-used-percent: 2             # ★ 주간 창 사용률 (목표)
+x-codex-secondary-window-minutes: 10080       # = 7일
+x-codex-secondary-reset-after-seconds: 596810
+x-codex-secondary-reset-at: 1782699924        # unix
+x-codex-credits-has-credits: False
+x-codex-credits-balance:
+x-codex-credits-unlimited: False
+```
+
+매핑:
+- **primary** = 5시간 한도(소위 "5h"), window 300분.
+- **secondary** = **주간 한도(7일)**, window 10080분 — 사용자가 보고받고 싶어한 그 수치.
+- 잔량% = `100 - used_percent`. 리셋은 `*-reset-at`(절대시각) + `*-reset-after-seconds`(상대).
+
+→ 별도 usage 엔드포인트나 429 파싱 없이도 **사전(proactive) 잔량**을 얻는다.
+   429일 때도 헤더가 따라오면 동일 파싱 + "소진·리셋시각" 보고(폴백 내장).
+
+## 2. 구현
+
+파일: `tools/oauth_healthcheck.py` (확장, 신규 파일 없음)
+
+- `_probe_quota()` — TokenManager로 토큰/account_id 획득 → Codex에 1회 경량 호출
+  → `x-codex-*` 헤더 파싱하여 dict 반환(429 포함). 헤더 없으면 실패 사유 반환.
+- `_format_quota_report()` — 한국어 요약 생성. 주간/5시간 사용·잔량·리셋(KST + 상대시간),
+  plan_type/active_limit, 크레딧. 잔량 < `OAUTH_QUOTA_WARN_REMAINING_PCT`(기본 20%) 또는 429 시 ⚠️ 강조.
+- `_run_quota(force_send)` — 프로브 후 텔레그램 전송. 위험 시 `_alert()`(쿨다운),
+  정상 시 상태 라인 전송. 전송은 기존 `_send_telegram`(OAUTH_ALERT_BOT_TOKEN/CHAT_ID) 재사용.
+- 엔트리포인트 플래그:
+  - `--quota` : 매번 현황 전송 + 위험시 경보.
+  - `--quota-dry-run` : 전송 없이 stdout에 메시지 미리보기.
+
+신규 env(선택):
+- `OAUTH_QUOTA_PROBE_MODEL` (기본 `gpt-5.4-mini` — Codex 호환 최경량, 쿼터 거의 안 씀)
+- `OAUTH_QUOTA_WARN_REMAINING_PCT` (기본 `20`)
+
+## 3. 검증 (서버 실측)
+
+dry-run (전송 없음):
+```
+📊 ChatGPT 쿼터 현황
+플랜: plus (active=premium)
+
+🗓 주간(7일): 사용 2% · 잔량 98%
+   리셋: 06/29 11:25 (6.9일 후)
+⏱ 5시간: 사용 10% · 잔량 90%
+   리셋: 06/22 16:25 (2.8시간 후)
+```
+
+실제 전송: `OAUTH_ALERT_CHAT_ID=-1002989735551 ... --quota`
+→ `status=200 plan=plus week_used=2% 5h_used=10% danger=False`, 테스트방 전송 성공.
+`.env`의 `OAUTH_ALERT_CHAT_ID`가 이미 `-1002989735551`(테스트방)이라 cron 오버라이드 불필요.
+
+## 4. 제안 cron (사용자가 직접 적용 — 본 작업에서 crontab 미변경)
+
+```
+# 쿼터 현황 (매시간; --quota는 항상 상태라인 전송, 위험시 경보)
+CRON_TZ=Asia/Seoul
+0 * * * * cd /root/prism-insight && /root/.pyenv/shims/python tools/oauth_healthcheck.py --quota >> /root/prism-insight/logs/oauth_health.log 2>&1
+```
+배치 전후 감시를 더 촘촘히 원하면 KR/US 배치 직전·직후 시각에 추가 라인을 둘 수 있다.
+
+## 5. 한계
+
+- 프로브가 호출 1회분 쿼터를 소모(극소, low effort + "ok" 입력). 매시간 ≈ 하루 24콜.
+- `x-codex-*` 헤더는 OpenAI 비공식 — 헤더명/스키마 변경 시 깨질 수 있음(헤더 없으면 실패 사유 보고).
+- 토큰 갱신 지연으로 JWT의 `chatgpt_plan_type`은 free로 보일 수 있으나, **헤더 `x-codex-plan-type`은 실제값(plus)** 이라 이를 신뢰원으로 사용.
+- 매시간 정상 현황도 전송 → 소음이면 cron 주기를 늘리거나 `_run_quota`에서 정상시 전송 생략하도록 조정 가능.
+- 프로덕션 crontab/배포는 **변경하지 않음**(PR 링크만 보고).

--- a/tools/oauth_healthcheck.py
+++ b/tools/oauth_healthcheck.py
@@ -11,14 +11,27 @@ API key:
      rate-limit / insufficient_quota / authentication errors in the orchestrator
      logs. Detected by scanning recent log files.
 
+It can ALSO report proactive subscription quota usage (--quota mode):
+
+  3. QUOTA  — the ChatGPT/Codex backend returns the same rate-limit telemetry
+     Codex CLI displays ("주간 한도 X% 사용") as `x-codex-*` response headers on
+     every successful call. We fire ONE cheap probe and read:
+       primary   window = ~300 min  (the "5h" limit)  -> x-codex-primary-*
+       secondary window = ~10080 min (the WEEKLY limit) -> x-codex-secondary-*
+     plus x-codex-plan-type / x-codex-active-limit. This lets us detect quota
+     exhaustion (429) BEFORE the batch hits it. See tasks/oauth_quota_monitor.md.
+
 On a problem it sends a Telegram alert (to OAUTH_ALERT_CHAT_ID, falling back to
 TELEGRAM_CHANNEL_ID) using TELEGRAM_BOT_TOKEN. A small state file suppresses
 duplicate alerts within a cooldown window so cron does not spam.
 
 This script is READ-ONLY w.r.t. trading/DB. It only reads the token + logs and
-sends a Telegram message. Intended cron line (db-server):
+sends a Telegram message. Intended cron lines (db-server):
 
+    # health (every 30 min)
     */30 * * * * cd /root/prism-insight && /root/.pyenv/shims/python tools/oauth_healthcheck.py >> logs/oauth_health.log 2>&1
+    # quota status report (hourly; --quota always posts a status line)
+    0 * * * * cd /root/prism-insight && /root/.pyenv/shims/python tools/oauth_healthcheck.py --quota >> logs/oauth_health.log 2>&1
 
 Exit code: 0 = healthy, 1 = problem detected (alert attempted).
 """
@@ -54,6 +67,13 @@ ALERT_CHAT_ID = os.getenv("OAUTH_ALERT_CHAT_ID") or os.getenv("TELEGRAM_CHANNEL_
 # Alerts may need a DIFFERENT bot than the public broadcast bot (the admin/personal
 # channel is often served by a separate bot). Prefer OAUTH_ALERT_BOT_TOKEN.
 BOT_TOKEN = os.getenv("OAUTH_ALERT_BOT_TOKEN") or os.getenv("TELEGRAM_BOT_TOKEN")
+
+# --- Quota config ----------------------------------------------------------
+# Probe uses the lightest Codex-compatible model (api_translator._MODEL_MAP
+# target) so it burns almost nothing of the quota it is measuring.
+QUOTA_PROBE_MODEL = os.getenv("OAUTH_QUOTA_PROBE_MODEL", "gpt-5.4-mini")
+# "Remaining < this %" on EITHER window triggers the ⚠️ warning highlight.
+QUOTA_WARN_REMAINING_PCT = int(os.getenv("OAUTH_QUOTA_WARN_REMAINING_PCT", "20"))
 
 # Patterns that indicate auth/usage problems in orchestrator logs.
 # Deliberately SPECIFIC: must match real OpenAI/proxy error strings and NOT
@@ -173,6 +193,165 @@ def _scan_logs() -> tuple[int, list[str]]:
     return hits, samples
 
 
+def _fmt_reset(reset_at: int, reset_after_s: int) -> str:
+    """Human-friendly reset time: KST clock + relative hours."""
+    if reset_at:
+        try:
+            local = time.strftime("%m/%d %H:%M", time.localtime(reset_at))
+        except Exception:
+            local = "?"
+    else:
+        local = "?"
+    if reset_after_s:
+        hrs = reset_after_s / 3600.0
+        rel = f"{hrs/24:.1f}일 후" if hrs >= 24 else f"{hrs:.1f}시간 후"
+    else:
+        rel = "?"
+    return f"{local} ({rel})"
+
+
+async def _probe_quota() -> tuple[dict | None, str]:
+    """Fire ONE cheap Codex call and read x-codex-* rate-limit headers.
+
+    Returns (quota_dict, detail). quota_dict is None on failure (detail says why).
+    On HTTP 429 we still return the parsed headers/body so the caller can report
+    "exhausted + reset time".
+    """
+    import aiohttp
+
+    from cores.chatgpt_proxy.constants import CHATGPT_RESPONSES_URL
+    from cores.chatgpt_proxy.token_manager import TokenManager
+
+    tm = TokenManager()
+    try:
+        token = await tm.get_token()
+        account_id = await tm.get_account_id()
+    except Exception as e:  # noqa: BLE001
+        return None, f"토큰 획득 실패: {e!r}"
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "OpenAI-Beta": "responses=experimental",
+        "accept": "text/event-stream",
+        "originator": "codex_cli_rs",
+    }
+    if account_id:
+        headers["chatgpt-account-id"] = account_id
+
+    body = {
+        "model": QUOTA_PROBE_MODEL,
+        "instructions": "quota probe",
+        "input": [{"type": "message", "role": "user",
+                   "content": [{"type": "input_text", "text": "ok"}]}],
+        "stream": True,
+        "store": False,
+        "reasoning": {"effort": "low"},
+    }
+
+    def _int(h: dict, key: str) -> int:
+        try:
+            return int(h.get(key, "") or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                CHATGPT_RESPONSES_URL, json=body, headers=headers,
+                timeout=aiohttp.ClientTimeout(total=120),
+            ) as resp:
+                h = resp.headers
+                status = resp.status
+                # Drain the stream so the connection closes cleanly (cheap call).
+                try:
+                    await resp.read()
+                except Exception:  # noqa: BLE001
+                    pass
+    except Exception as e:  # noqa: BLE001
+        return None, f"프록시/백엔드 호출 실패: {e!r}"
+
+    if not any(k.lower().startswith("x-codex-") for k in h):
+        return None, f"쿼터 헤더 없음 (status={status}). 백엔드 응답에 x-codex-* 미포함."
+
+    quota = {
+        "status": status,
+        "plan_type": h.get("x-codex-plan-type", "?"),
+        "active_limit": h.get("x-codex-active-limit", "?"),
+        "primary_used_pct": _int(h, "x-codex-primary-used-percent"),
+        "primary_window_min": _int(h, "x-codex-primary-window-minutes"),
+        "primary_reset_at": _int(h, "x-codex-primary-reset-at"),
+        "primary_reset_after_s": _int(h, "x-codex-primary-reset-after-seconds"),
+        "secondary_used_pct": _int(h, "x-codex-secondary-used-percent"),
+        "secondary_window_min": _int(h, "x-codex-secondary-window-minutes"),
+        "secondary_reset_at": _int(h, "x-codex-secondary-reset-at"),
+        "secondary_reset_after_s": _int(h, "x-codex-secondary-reset-after-seconds"),
+        "credits_has": h.get("x-codex-credits-has-credits", "?"),
+        "credits_balance": h.get("x-codex-credits-balance", "") or "-",
+        "credits_unlimited": h.get("x-codex-credits-unlimited", "?"),
+    }
+    return quota, f"status={status} plan={quota['plan_type']}"
+
+
+def _format_quota_report(q: dict) -> tuple[str, bool]:
+    """Build the Korean Telegram body. Returns (text, danger)."""
+    wk_used = q["secondary_used_pct"]
+    wk_left = max(0, 100 - wk_used)
+    pr_used = q["primary_used_pct"]
+    pr_left = max(0, 100 - pr_used)
+
+    is_429 = q["status"] == 429
+    low_week = wk_left < QUOTA_WARN_REMAINING_PCT
+    low_5h = pr_left < QUOTA_WARN_REMAINING_PCT
+    danger = is_429 or low_week or low_5h
+
+    head = "⚠️ ChatGPT 쿼터 경고" if danger else "📊 ChatGPT 쿼터 현황"
+    wk_mark = " ⚠️" if (is_429 or low_week) else ""
+    pr_mark = " ⚠️" if (is_429 or low_5h) else ""
+
+    lines = [
+        head,
+        f"플랜: {q['plan_type']} (active={q['active_limit']})",
+        "",
+        f"🗓 주간(7일): 사용 {wk_used}% · 잔량 {wk_left}%{wk_mark}",
+        f"   리셋: {_fmt_reset(q['secondary_reset_at'], q['secondary_reset_after_s'])}",
+        f"⏱ 5시간: 사용 {pr_used}% · 잔량 {pr_left}%{pr_mark}",
+        f"   리셋: {_fmt_reset(q['primary_reset_at'], q['primary_reset_after_s'])}",
+    ]
+    if is_429:
+        lines.insert(1, "🚨 429 — 쿼터 소진됨. 위 리셋시각까지 대기 필요.")
+    if str(q.get("credits_unlimited")).lower() == "true":
+        lines.append("크레딧: 무제한")
+    elif str(q.get("credits_has")).lower() == "true":
+        lines.append(f"크레딧 잔액: {q['credits_balance']}")
+    return "\n".join(lines), danger
+
+
+async def _run_quota(force_send: bool) -> int:
+    """Probe quota and report to Telegram. Returns 1 if danger, else 0.
+
+    force_send=True (default for --quota) posts the status line every run.
+    Danger conditions additionally route through _alert (cooldown-suppressed).
+    """
+    quota, detail = await _probe_quota()
+    if quota is None:
+        print(f"[oauth-health] quota probe failed: {detail}")
+        if force_send:
+            _send_telegram(f"📊 ChatGPT 쿼터 조회 실패\n{detail}")
+        return 0
+
+    text, danger = _format_quota_report(quota)
+    print(f"[oauth-health] quota: {detail} "
+          f"week_used={quota['secondary_used_pct']}% 5h_used={quota['primary_used_pct']}% danger={danger}")
+
+    if danger:
+        # Cooldown-suppressed critical alert (so cron does not spam on sustained low).
+        _alert("ChatGPT 쿼터 임계 도달", text)
+    if force_send and not danger:
+        _send_telegram(text)
+    return 1 if danger else 0
+
+
 async def main() -> int:
     oauth_mode = os.getenv("PRISM_OPENAI_AUTH_MODE") == "chatgpt_oauth"
     problems = 0
@@ -205,4 +384,18 @@ if __name__ == "__main__":
         _ok = _send_telegram("✅ PRISM OAuth 워치독 테스트 — 이 메시지가 보이면 알림 경로 정상입니다.")
         print(f"[oauth-health] test alert sent={_ok} chat={ALERT_CHAT_ID}")
         raise SystemExit(0 if _ok else 1)
+    if "--quota-dry-run" in sys.argv:
+        # Probe + print the report to stdout only (no Telegram send).
+        async def _dry() -> int:
+            q, det = await _probe_quota()
+            if q is None:
+                print(f"[oauth-health] quota probe failed: {det}")
+                return 1
+            txt, danger = _format_quota_report(q)
+            print(f"[oauth-health] DRY-RUN danger={danger}\n----- message -----\n{txt}\n-------------------")
+            return 0
+        raise SystemExit(asyncio.run(_dry()))
+    if "--quota" in sys.argv:
+        # Always post a quota status line; danger conditions also alert.
+        raise SystemExit(asyncio.run(_run_quota(force_send=True)))
     raise SystemExit(asyncio.run(main()))


### PR DESCRIPTION
## 목적
전 배치를 OAuth(ChatGPT 구독)로 전환(KR 오전/오후 + US 3개)함에 따라 **주간 한도 소진(429)을 사전 감지**한다. 기존 워치독 `tools/oauth_healthcheck.py`에 쿼터 섹션을 통합(전송 인프라/쿨다운 재사용).

## 쿼터 소스 (실측)
Codex 백엔드(`/backend-api/codex/responses`)의 **200 응답 헤더**가 Codex CLI의 "주간 한도 X% 사용" 데이터를 그대로 노출:
- `x-codex-secondary-*` = **주간(7일, window 10080분)** ← 목표
- `x-codex-primary-*` = 5시간(window 300분)
- `x-codex-plan-type`(=plus, JWT claim 지연과 무관한 실제값), `x-codex-active-limit`, credits

별도 엔드포인트/429 파싱 불필요. 429여도 헤더 동반 시 동일 파싱 + 리셋시각 보고(폴백 내장).

## 구현
- `_probe_quota()` 경량 1콜(`gpt-5.4-mini`, low) → `x-codex-*` 파싱
- `_format_quota_report()` 한국어 요약, 잔량<20% 또는 429 시 ⚠️
- `_run_quota()` 기존 `_send_telegram`(OAUTH_ALERT_*) 재사용
- 플래그: `--quota`(전송), `--quota-dry-run`(미리보기)
- env(선택): `OAUTH_QUOTA_PROBE_MODEL`, `OAUTH_QUOTA_WARN_REMAINING_PCT`

## 검증 (서버 실측)
dry-run/실전송 모두 성공. `status=200 plan=plus week_used=2% 5h_used=10%`, 테스트방(-1002989735551) 전송 확인.
```
🗓 주간(7일): 사용 2% · 잔량 98%  (리셋 06/29 11:25)
⏱ 5시간: 사용 10% · 잔량 90%     (리셋 06/22 16:25)
```

## 적용 cron (사용자가 직접 — 본 PR은 crontab 미변경)
```
CRON_TZ=Asia/Seoul
0 * * * * cd /root/prism-insight && /root/.pyenv/shims/python tools/oauth_healthcheck.py --quota >> /root/prism-insight/logs/oauth_health.log 2>&1
```

## 한계
프로브가 호출 1회분 소모(극소), `x-codex-*`는 비공식 헤더(변경 시 실패사유 보고). 상세: `tasks/oauth_quota_monitor.md`. **프로덕션 cron/배포 미변경.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)