### PR TITLE
Phase 6 S1+S2: vision plumbing + render QA (OFF by default)

### DIFF
--- a/cores/analysis.py
+++ b/cores/analysis.py
@@ -228,6 +228,28 @@ async def analyze_stock(company_code: str = "000660", company_name: str = "SK하
             market_cap_chart_html = None
             fundamentals_chart_html = None
 
+        # 10b. Render QA (Phase 6 S2) — OFF by default, non-blocking
+        from cores.llm.capabilities import vision_available
+        if vision_available():
+            try:
+                import base64
+                import re
+                import tempfile
+                from cores.llm.features.render_qa import qa_and_log
+                _qa_html = price_chart_html or volume_chart_html
+                if _qa_html:
+                    _m = re.search(r'base64,([^"]+)"', _qa_html)
+                    if _m:
+                        _img_bytes = base64.b64decode(_m.group(1))
+                        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as _tf:
+                            _tf.write(_img_bytes)
+                            _tf_path = _tf.name
+                        await qa_and_log(_tf_path, context_label=f"{company_code}_{company_name}")
+                        import os as _os
+                        _os.unlink(_tf_path)
+            except Exception:
+                pass  # render QA must never affect the pipeline
+
         # 11. Build macro section (before final report composition)
         macro_section = ""
         if macro_context:

--- a/cores/llm/capabilities.py
+++ b/cores/llm/capabilities.py
@@ -1,0 +1,72 @@
+"""
+Capability detection for PRISM feature flags — Phase 6 S1.
+
+All reads are lazy (first call) and cheap. Importing this module has zero
+side effects; the heavy OpenAI SDK is never imported here.
+
+Environment variables (all off/safe by default):
+    OPENAI_API_KEY          — real OpenAI API key (not a proxy placeholder)
+    PRISM_FEATURE_VISION    — "on" to enable vision pipeline (default: off)
+    PRISM_VISION_SHADOW     — "false" to disable shadow-only mode (default: true)
+    PRISM_VISION_MODEL      — override vision model id (default: gpt-4o)
+    PRISM_VISION_AUTH       — "api" or "oauth" for vision auth path (default: api)
+"""
+
+from __future__ import annotations
+
+import os
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+_DEFAULT_VISION_MODEL = "gpt-4o"
+_PLACEHOLDER_KEY = "chatgpt-oauth-placeholder"
+
+
+# ---------------------------------------------------------------------------
+# Individual capability accessors (pure env reads — no caching needed;
+# env is stable within a process and tests can monkeypatch freely)
+# ---------------------------------------------------------------------------
+
+def has_api_key() -> bool:
+    """Return True if a real OpenAI API key is present (not a proxy placeholder).
+
+    Vision requires a genuine API key because it uses base64 image inputs that
+    the ChatGPT OAuth proxy does not support.
+    """
+    key = os.environ.get("OPENAI_API_KEY", "").strip()
+    return bool(key) and key != _PLACEHOLDER_KEY
+
+
+def vision_enabled() -> bool:
+    """Return True only when PRISM_FEATURE_VISION=on (default: off)."""
+    return os.environ.get("PRISM_FEATURE_VISION", "off").strip().lower() == "on"
+
+
+def vision_shadow() -> bool:
+    """Return True when vision runs in shadow-only mode (default: True).
+
+    Shadow mode means results are logged but never fed into trading decisions.
+    Set PRISM_VISION_SHADOW=false to disable shadow mode (S3+ only).
+    """
+    return os.environ.get("PRISM_VISION_SHADOW", "true").strip().lower() != "false"
+
+
+def vision_model() -> str:
+    """Return the vision model id (default: gpt-4o)."""
+    return os.environ.get("PRISM_VISION_MODEL", _DEFAULT_VISION_MODEL).strip() or _DEFAULT_VISION_MODEL
+
+
+def vision_auth() -> str:
+    """Return the vision auth mode: 'api' (default) or 'oauth'."""
+    val = os.environ.get("PRISM_VISION_AUTH", "api").strip().lower()
+    return val if val in ("api", "oauth") else "api"
+
+
+def vision_available() -> bool:
+    """Master gate: True iff vision is enabled AND a real API key exists.
+
+    Callers MUST check this before encoding images or making vision calls.
+    When False, skip entirely — no encoding, no client, no network.
+    """
+    return vision_enabled() and has_api_key()

--- a/cores/llm/features.yaml
+++ b/cores/llm/features.yaml
@@ -1,0 +1,42 @@
+# PRISM feature toggles — Phase 6 vision plumbing (S1)
+#
+# All features are OFF by default. Set the corresponding env var to opt in.
+# This file is documentation only — capabilities.py reads env vars directly.
+# To activate features, export the env vars in your shell or .env file.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# Vision pipeline (Phase 6 S1)
+# ─────────────────────────────────────────────────────────────────────────────
+features:
+  vision:
+    # Master toggle. Must be "on" to enable any vision calls.
+    # Default: off (safe for all environments)
+    enabled_env: PRISM_FEATURE_VISION
+    enabled_default: "off"
+    valid_values: ["off", "on"]
+
+    # Shadow mode: when true, vision results are logged only (not used in decisions).
+    # Set to "false" only after S3 BaseAnalysis integration is validated.
+    shadow_env: PRISM_VISION_SHADOW
+    shadow_default: "true"
+
+    # Vision model. Must support image inputs (multimodal).
+    # Default gpt-4o is OpenAI's standard vision-capable model.
+    model_env: PRISM_VISION_MODEL
+    model_default: "gpt-4o"
+
+    # Auth path for vision calls. "api" uses OPENAI_API_KEY directly,
+    # bypassing any OAuth proxy (required for base64 image inputs).
+    auth_env: PRISM_VISION_AUTH
+    auth_default: "api"
+    valid_values: ["api", "oauth"]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Activation example (add to your .env or shell profile):
+#
+#   export OPENAI_API_KEY=sk-...          # real API key (not proxy placeholder)
+#   export PRISM_FEATURE_VISION=on        # enable vision
+#   export PRISM_VISION_SHADOW=true       # shadow-only (default; safe)
+#   export PRISM_VISION_MODEL=gpt-4o      # or gpt-4o-mini for lower cost
+#   export PRISM_VISION_AUTH=api          # force API-key path
+# ─────────────────────────────────────────────────────────────────────────────

--- a/cores/llm/features/__init__.py
+++ b/cores/llm/features/__init__.py
@@ -1,0 +1,5 @@
+"""
+cores.llm.features — optional capability modules (Phase 6).
+
+Each submodule is imported lazily to keep baseline memory footprint zero.
+"""

--- a/cores/llm/features/render_qa.py
+++ b/cores/llm/features/render_qa.py
@@ -1,0 +1,137 @@
+"""
+Render QA helper — Phase 6 S2 (OFF by default, non-blocking).
+
+Inspects a generated chart/report image for rendering defects using vision.
+When vision is OFF (default) this module is a complete no-op.
+
+Public API::
+
+    verdict = await check_render(image_path)
+    # Returns None when vision is off; RenderQAVerdict when on.
+
+    verdict = await qa_and_log(image_path, context_label="005930")
+    # Convenience wrapper: calls check_render and logs a warning on failure.
+    # Never raises. Callers may ignore the return value.
+
+Design constraints:
+- analyze_image is imported at module level but is itself cheap to import
+  (its heavy deps are lazy-loaded only when vision_available() is True).
+- vision_available() is checked first; if False, returns None immediately.
+- Never raises to caller. All errors return None silently.
+- In shadow mode results are logged but never fed into trading decisions.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from cores.llm.capabilities import vision_available
+from cores.llm.features.vision import analyze_image
+
+logger = logging.getLogger(__name__)
+
+_QA_PROMPT = """\
+You are a chart rendering quality-assurance inspector. Your ONLY job is to \
+detect visual rendering defects in the image. Do NOT analyse trading content, \
+price trends, or financial signals.
+
+Check specifically for these rendering defects:
+1. Korean (Hangul) characters rendered as empty boxes (□□□) or garbled tofu glyphs.
+2. Overlapping axis labels, tick labels, or legend entries that collide or are cut off.
+3. Missing or blank axis tick marks / labels (e.g. empty X or Y axis).
+4. Clipped or truncated text (text cut off at the chart border).
+5. Legend boxes that overlap with chart content in a way that obscures data.
+6. Blank, all-white, or corrupt image (no chart content visible at all).
+
+Return a strict JSON object with these exact fields:
+- ok (bool): true if no significant rendering defect found, false otherwise.
+- issues (array of strings): list of specific defects found; empty array if none.
+- severity (string): "none" if ok=true, "minor" for cosmetic issues, "major" for \
+serious defects (tofu text, blank image, missing axes).
+- confidence (integer 0-100): your confidence in this assessment.
+- notes (string): one-sentence summary or "" if nothing to add.
+"""
+
+
+class RenderQAVerdict(BaseModel):
+    """Structured verdict from a render QA check.
+
+    Designed to be strict-JSON-schema compatible (OpenAI json_schema strict mode):
+    all fields required, no extra properties allowed.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    ok: bool
+    issues: list[str]
+    severity: Literal["none", "minor", "major"]
+    confidence: int
+    notes: str
+
+
+async def check_render(image_path: str) -> RenderQAVerdict | None:
+    """Inspect *image_path* for rendering defects via vision.
+
+    Returns:
+        - ``None`` when vision is unavailable (off / no key) or on error.
+        - :class:`RenderQAVerdict` instance on success.
+
+    Never raises.
+    """
+    if not vision_available():
+        return None
+
+    try:
+        result = await analyze_image(image_path, _QA_PROMPT, schema=RenderQAVerdict)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[RENDER_QA] error during analyze_image: %s", exc)
+        return None
+
+    if result is None:
+        return None
+
+    if not isinstance(result, RenderQAVerdict):
+        logger.warning(
+            "[RENDER_QA] unexpected result type=%s path=%s", type(result).__name__, image_path
+        )
+        return None
+
+    return result
+
+
+async def qa_and_log(
+    image_path: str,
+    *,
+    context_label: str = "",
+) -> RenderQAVerdict | None:
+    """Run render QA and log a warning when defects are found.
+
+    This is a non-blocking convenience wrapper. Callers should fire-and-forget
+    or optionally inspect the return value, but must NEVER let this function
+    block or raise in the broadcast pipeline.
+
+    Args:
+        image_path:     Path to the PNG/JPG image to inspect.
+        context_label:  Human-readable label for log context (e.g. stock code).
+
+    Returns:
+        :class:`RenderQAVerdict` or ``None`` (same as :func:`check_render`).
+    """
+    try:
+        verdict = await check_render(image_path)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[RENDER_QA] unexpected error label=%s: %s", context_label, exc)
+        return None
+
+    if verdict is not None and not verdict.ok:
+        logger.warning(
+            "[RENDER_QA] FAIL label=%s severity=%s issues=%s",
+            context_label,
+            verdict.severity,
+            verdict.issues,
+        )
+
+    return verdict

--- a/cores/llm/features/vision.py
+++ b/cores/llm/features/vision.py
@@ -1,0 +1,183 @@
+"""
+Vision analysis helper — Phase 6 S1 (OFF by default, zero harm when off).
+
+Public API::
+
+    result = await analyze_image(path_or_bytes, "describe the chart")
+    # returns None when vision is disabled/unavailable; never raises to caller.
+
+Design constraints:
+- Heavy deps (openai, base64) are imported INSIDE the function body, only when
+  vision_available() is True. Importing this module is always cheap.
+- Uses the Responses API (client.responses.create) consistent with
+  openai_responses_llm.py.
+- Forces API-key auth even if the global env uses the OAuth proxy, by building
+  a dedicated AsyncOpenAI client from OPENAI_API_KEY directly.
+- On any error: logs one structured line [VISION_ERROR] and returns None.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, Any, Union
+
+from cores.llm.capabilities import vision_available, vision_model
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+# Type alias for caller convenience
+ImageInput = Union[str, bytes, "os.PathLike[str]"]
+
+
+async def analyze_image(
+    image_path_or_bytes: ImageInput,
+    prompt: str,
+    *,
+    schema: "type[BaseModel] | None" = None,
+    model: str | None = None,
+) -> Any | None:
+    """Analyse an image with GPT-4o (or configured vision model).
+
+    Args:
+        image_path_or_bytes: File path (str/Path) or raw bytes of the image.
+        prompt:              Text prompt describing the analysis task.
+        schema:              Optional Pydantic model for structured output.
+                             When provided, the response is parsed and returned
+                             as an instance of that model.
+        model:               Override the vision model (default: PRISM_VISION_MODEL
+                             or gpt-4o).
+
+    Returns:
+        - ``None``          when vision is unavailable (off / no key) or on error.
+        - ``str``           when schema is None and the call succeeds.
+        - Pydantic instance when schema is provided and the call succeeds.
+
+    Never raises. All errors are swallowed after a single [VISION_ERROR] log line.
+    """
+    # ------------------------------------------------------------------ #
+    # Fast exit — no encoding, no imports, no client when off             #
+    # ------------------------------------------------------------------ #
+    if not vision_available():
+        return None
+
+    # ------------------------------------------------------------------ #
+    # Lazy heavy imports (only reached when vision is on + key present)   #
+    # ------------------------------------------------------------------ #
+    try:
+        import base64
+        import pathlib
+
+        from openai import APIError, AsyncOpenAI
+    except ImportError as exc:
+        logger.error("[VISION_ERROR] type=ImportError detail=%s", exc)
+        return None
+
+    # ------------------------------------------------------------------ #
+    # Build dedicated API-key client (bypass any OAuth proxy)             #
+    # ------------------------------------------------------------------ #
+    api_key = os.environ.get("OPENAI_API_KEY", "").strip()
+    # vision_available() already guarantees key is present & non-placeholder
+
+    resolved_model = model or vision_model()
+
+    try:
+        # ------------------------------------------------------------------ #
+        # Encode image to base64 data URL                                     #
+        # ------------------------------------------------------------------ #
+        if isinstance(image_path_or_bytes, (str, pathlib.Path)):
+            raw = pathlib.Path(image_path_or_bytes).read_bytes()
+        else:
+            raw = bytes(image_path_or_bytes)
+
+        b64 = base64.b64encode(raw).decode("ascii")
+        data_url = f"data:image/png;base64,{b64}"
+
+        # ------------------------------------------------------------------ #
+        # Build input_items in Responses API format (mirrors                  #
+        # openai_responses_llm.py's input_items list structure)               #
+        # ------------------------------------------------------------------ #
+        image_content: list[dict] = [
+            {
+                "type": "input_image",
+                "image_url": data_url,
+            },
+            {
+                "type": "input_text",
+                "text": prompt,
+            },
+        ]
+        input_items: list[dict] = [
+            {
+                "role": "user",
+                "content": image_content,
+            }
+        ]
+
+        call_kwargs: dict[str, Any] = {
+            "model": resolved_model,
+            "input": input_items,
+            "store": False,
+        }
+
+        # ------------------------------------------------------------------ #
+        # Structured output via text.format json_schema (Responses API path) #
+        # ------------------------------------------------------------------ #
+        if schema is not None:
+            call_kwargs["text"] = {
+                "format": {
+                    "type": "json_schema",
+                    "name": schema.__name__,
+                    "schema": schema.model_json_schema(),
+                    "strict": True,
+                }
+            }
+
+        # ------------------------------------------------------------------ #
+        # Execute — dedicated client, no shared state                         #
+        # ------------------------------------------------------------------ #
+        async with AsyncOpenAI(api_key=api_key) as client:
+            response = await client.responses.create(**call_kwargs)  # type: ignore[attr-defined]
+
+        # ------------------------------------------------------------------ #
+        # Extract text from output items (same pattern as                     #
+        # openai_responses_llm.py)                                            #
+        # ------------------------------------------------------------------ #
+        text_parts: list[str] = []
+        for item in response.output:
+            if item.type == "message":
+                for part in item.content:
+                    if hasattr(part, "text"):
+                        text_parts.append(part.text)
+
+        raw_text = "".join(text_parts)
+
+        if schema is not None:
+            import json
+            return schema.model_validate(json.loads(raw_text))
+
+        return raw_text
+
+    except APIError as exc:
+        request_id = getattr(exc, "request_id", None)
+        status = getattr(exc, "status_code", None)
+        logger.error(
+            "[VISION_ERROR] type=%s request_id=%s status=%s model=%s detail=%s",
+            type(exc).__name__,
+            request_id,
+            status,
+            resolved_model,
+            exc,
+        )
+        return None
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "[VISION_ERROR] type=%s model=%s detail=%s",
+            type(exc).__name__,
+            resolved_model,
+            exc,
+        )
+        return None

--- a/tests/test_render_qa.py
+++ b/tests/test_render_qa.py
@@ -1,0 +1,319 @@
+"""
+Tests for cores/llm/features/render_qa.py — Phase 6 S2.
+
+All tests are mock-only (no network, no real vision calls).
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cores.llm.features.render_qa import RenderQAVerdict, check_render, qa_and_log
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_verdict(ok: bool = True, severity: str = "none") -> RenderQAVerdict:
+    return RenderQAVerdict(
+        ok=ok,
+        issues=[] if ok else ["Korean text rendered as tofu boxes"],
+        severity=severity,
+        confidence=90,
+        notes="test verdict",
+    )
+
+
+# ---------------------------------------------------------------------------
+# RenderQAVerdict schema tests
+# ---------------------------------------------------------------------------
+
+class TestRenderQAVerdictSchema:
+    def test_strict_schema_has_additional_properties_false(self):
+        """OpenAI strict json_schema requires additionalProperties: false."""
+        schema = RenderQAVerdict.model_json_schema()
+        assert schema.get("additionalProperties") is False, (
+            f"Expected additionalProperties=False in schema, got: {schema}"
+        )
+
+    def test_all_fields_required_in_schema(self):
+        schema = RenderQAVerdict.model_json_schema()
+        required = set(schema.get("required", []))
+        expected = {"ok", "issues", "severity", "confidence", "notes"}
+        assert required == expected, f"Expected all fields required, got: {required}"
+
+    def test_valid_verdict_construction(self):
+        v = _make_verdict(ok=True)
+        assert v.ok is True
+        assert v.severity == "none"
+        assert isinstance(v.issues, list)
+
+    def test_extra_fields_forbidden(self):
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError):
+            RenderQAVerdict(
+                ok=True,
+                issues=[],
+                severity="none",
+                confidence=80,
+                notes="",
+                unexpected_field="boom",
+            )
+
+
+# ---------------------------------------------------------------------------
+# check_render — vision OFF
+# ---------------------------------------------------------------------------
+
+class TestCheckRenderVisionOff:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_vision_off(self, monkeypatch, tmp_path):
+        """When vision is off, check_render must return None without any analyze_image call."""
+        monkeypatch.delenv("PRISM_FEATURE_VISION", raising=False)
+
+        img = tmp_path / "chart.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        with patch(
+            "cores.llm.features.render_qa.vision_available", return_value=False
+        ) as mock_va, patch(
+            "cores.llm.features.vision.analyze_image"
+        ) as mock_ai:
+            result = await check_render(str(img))
+
+        assert result is None
+        mock_va.assert_called_once()
+        mock_ai.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_zero_analyze_image_calls_when_vision_off(self, monkeypatch, tmp_path):
+        """Confirm analyze_image import is never reached when vision is off."""
+        monkeypatch.delenv("PRISM_FEATURE_VISION", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        with patch(
+            "cores.llm.features.render_qa.vision_available", return_value=False
+        ):
+            # Point to non-existent path — would fail if reading were attempted
+            result = await check_render("/nonexistent/path/chart.png")
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# check_render — vision ON, happy path
+# ---------------------------------------------------------------------------
+
+class TestCheckRenderVisionOn:
+    @pytest.mark.asyncio
+    async def test_returns_verdict_when_ok(self, tmp_path):
+        """When vision is on and analyze_image returns a verdict, check_render returns it."""
+        img = tmp_path / "chart.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        expected_verdict = _make_verdict(ok=True, severity="none")
+
+        with patch(
+            "cores.llm.features.render_qa.vision_available", return_value=True
+        ), patch(
+            "cores.llm.features.render_qa.analyze_image",
+            new=AsyncMock(return_value=expected_verdict),
+        ) as mock_ai:
+            result = await check_render(str(img))
+
+        assert isinstance(result, RenderQAVerdict)
+        assert result.ok is True
+        assert result.severity == "none"
+        mock_ai.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_verdict_when_fail(self, tmp_path):
+        """check_render returns a failing verdict without raising."""
+        img = tmp_path / "chart.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        fail_verdict = _make_verdict(ok=False, severity="major")
+
+        with patch(
+            "cores.llm.features.render_qa.vision_available", return_value=True
+        ), patch(
+            "cores.llm.features.render_qa.analyze_image",
+            new=AsyncMock(return_value=fail_verdict),
+        ):
+            result = await check_render(str(img))
+
+        assert result is not None
+        assert result.ok is False
+        assert result.severity == "major"
+        assert len(result.issues) > 0
+
+    @pytest.mark.asyncio
+    async def test_passes_qa_prompt_to_analyze_image(self, tmp_path):
+        """The QA prompt passed to analyze_image must mention rendering defects."""
+        img = tmp_path / "chart.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        mock_ai = AsyncMock(return_value=_make_verdict())
+
+        with patch(
+            "cores.llm.features.render_qa.vision_available", return_value=True
+        ), patch("cores.llm.features.render_qa.analyze_image", new=mock_ai):
+            await check_render(str(img))
+
+        call_args = mock_ai.call_args
+        prompt_arg = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("prompt", "")
+        assert "rendering" in prompt_arg.lower() or "render" in prompt_arg.lower()
+
+    @pytest.mark.asyncio
+    async def test_passes_schema_to_analyze_image(self, tmp_path):
+        """analyze_image must be called with schema=RenderQAVerdict."""
+        img = tmp_path / "chart.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        mock_ai = AsyncMock(return_value=_make_verdict())
+
+        with patch(
+            "cores.llm.features.render_qa.vision_available", return_value=True
+        ), patch("cores.llm.features.render_qa.analyze_image", new=mock_ai):
+            await check_render(str(img))
+
+        call_kwargs = mock_ai.call_args.kwargs
+        assert call_kwargs.get("schema") is RenderQAVerdict
+
+
+# ---------------------------------------------------------------------------
+# check_render — analyze_image returns None (error/degrade path)
+# ---------------------------------------------------------------------------
+
+class TestCheckRenderAnalyzeImageNone:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_analyze_image_returns_none(self, tmp_path):
+        """If analyze_image returns None (error/degrade), check_render returns None gracefully."""
+        img = tmp_path / "chart.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        with patch(
+            "cores.llm.features.render_qa.vision_available", return_value=True
+        ), patch(
+            "cores.llm.features.render_qa.analyze_image",
+            new=AsyncMock(return_value=None),
+        ):
+            result = await check_render(str(img))
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_analyze_image_raises(self, tmp_path):
+        """If analyze_image raises unexpectedly, check_render returns None (never re-raises)."""
+        img = tmp_path / "chart.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        with patch(
+            "cores.llm.features.render_qa.vision_available", return_value=True
+        ), patch(
+            "cores.llm.features.render_qa.analyze_image",
+            new=AsyncMock(side_effect=RuntimeError("unexpected boom")),
+        ):
+            result = await check_render(str(img))
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# qa_and_log — logging behaviour
+# ---------------------------------------------------------------------------
+
+class TestQaAndLog:
+    @pytest.mark.asyncio
+    async def test_logs_warning_when_verdict_fails(self, tmp_path, caplog):
+        """qa_and_log must emit a WARNING when verdict.ok is False."""
+        img = tmp_path / "chart.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        fail_verdict = _make_verdict(ok=False, severity="major")
+
+        with patch(
+            "cores.llm.features.render_qa.vision_available", return_value=True
+        ), patch(
+            "cores.llm.features.render_qa.analyze_image",
+            new=AsyncMock(return_value=fail_verdict),
+        ), caplog.at_level(logging.WARNING, logger="cores.llm.features.render_qa"):
+            result = await qa_and_log(str(img), context_label="005930")
+
+        assert result is not None
+        assert result.ok is False
+        assert any("[RENDER_QA] FAIL" in r.message for r in caplog.records), (
+            f"Expected [RENDER_QA] FAIL warning. Records: {[r.message for r in caplog.records]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_verdict_ok(self, tmp_path, caplog):
+        """qa_and_log must NOT emit a RENDER_QA FAIL warning when verdict.ok is True."""
+        img = tmp_path / "chart.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        ok_verdict = _make_verdict(ok=True, severity="none")
+
+        with patch(
+            "cores.llm.features.render_qa.vision_available", return_value=True
+        ), patch(
+            "cores.llm.features.render_qa.analyze_image",
+            new=AsyncMock(return_value=ok_verdict),
+        ), caplog.at_level(logging.WARNING, logger="cores.llm.features.render_qa"):
+            result = await qa_and_log(str(img), context_label="035720")
+
+        assert result is not None
+        assert result.ok is True
+        assert not any("[RENDER_QA] FAIL" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_vision_off(self, tmp_path):
+        """qa_and_log returns None when vision is off (complete no-op)."""
+        img = tmp_path / "chart.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        with patch(
+            "cores.llm.features.render_qa.vision_available", return_value=False
+        ):
+            result = await qa_and_log(str(img), context_label="000660")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_never_raises_on_internal_error(self, tmp_path):
+        """qa_and_log must swallow all errors and return None, never raise."""
+        img = tmp_path / "chart.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        with patch(
+            "cores.llm.features.render_qa.vision_available", return_value=True
+        ), patch(
+            "cores.llm.features.render_qa.analyze_image",
+            new=AsyncMock(side_effect=Exception("catastrophic failure")),
+        ):
+            # Must not raise
+            result = await qa_and_log(str(img), context_label="test")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_context_label_appears_in_warning(self, tmp_path, caplog):
+        """The context_label should appear in the FAIL warning log line."""
+        img = tmp_path / "chart.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        fail_verdict = _make_verdict(ok=False, severity="minor")
+
+        with patch(
+            "cores.llm.features.render_qa.vision_available", return_value=True
+        ), patch(
+            "cores.llm.features.render_qa.analyze_image",
+            new=AsyncMock(return_value=fail_verdict),
+        ), caplog.at_level(logging.WARNING, logger="cores.llm.features.render_qa"):
+            await qa_and_log(str(img), context_label="MY_STOCK_LABEL")
+
+        assert any("MY_STOCK_LABEL" in r.message for r in caplog.records)

--- a/tests/test_vision_plumbing.py
+++ b/tests/test_vision_plumbing.py
@@ -1,0 +1,311 @@
+"""
+Phase 6 S1 — Vision plumbing unit tests.
+
+All tests are fully mocked: zero network calls, zero real OpenAI client.
+Run with:  .venv/bin/python -m pytest tests/test_vision_plumbing.py -q
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class SimpleSchema(BaseModel):
+    label: str
+    confidence: int
+
+
+def _make_mock_response(text: str) -> MagicMock:
+    """Build a fake Responses API response with one message output item."""
+    part = MagicMock()
+    part.text = text
+
+    message_item = MagicMock()
+    message_item.type = "message"
+    message_item.content = [part]
+
+    response = MagicMock()
+    response.output = [message_item]
+    return response
+
+
+# ---------------------------------------------------------------------------
+# capabilities.py tests
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilities:
+    def test_has_api_key_false_when_missing(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        from cores.llm import capabilities
+        assert capabilities.has_api_key() is False
+
+    def test_has_api_key_false_for_placeholder(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "chatgpt-oauth-placeholder")
+        from cores.llm import capabilities
+        assert capabilities.has_api_key() is False
+
+    def test_has_api_key_true_for_real_key(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-realkey")
+        from cores.llm import capabilities
+        assert capabilities.has_api_key() is True
+
+    def test_vision_enabled_default_off(self, monkeypatch):
+        monkeypatch.delenv("PRISM_FEATURE_VISION", raising=False)
+        from cores.llm import capabilities
+        assert capabilities.vision_enabled() is False
+
+    def test_vision_enabled_on(self, monkeypatch):
+        monkeypatch.setenv("PRISM_FEATURE_VISION", "on")
+        from cores.llm import capabilities
+        assert capabilities.vision_enabled() is True
+
+    def test_vision_shadow_default_true(self, monkeypatch):
+        monkeypatch.delenv("PRISM_VISION_SHADOW", raising=False)
+        from cores.llm import capabilities
+        assert capabilities.vision_shadow() is True
+
+    def test_vision_shadow_false_when_set(self, monkeypatch):
+        monkeypatch.setenv("PRISM_VISION_SHADOW", "false")
+        from cores.llm import capabilities
+        assert capabilities.vision_shadow() is False
+
+    def test_vision_model_default(self, monkeypatch):
+        monkeypatch.delenv("PRISM_VISION_MODEL", raising=False)
+        from cores.llm import capabilities
+        assert capabilities.vision_model() == "gpt-4o"
+
+    def test_vision_model_override(self, monkeypatch):
+        monkeypatch.setenv("PRISM_VISION_MODEL", "gpt-4o-mini")
+        from cores.llm import capabilities
+        assert capabilities.vision_model() == "gpt-4o-mini"
+
+    def test_vision_auth_default_api(self, monkeypatch):
+        monkeypatch.delenv("PRISM_VISION_AUTH", raising=False)
+        from cores.llm import capabilities
+        assert capabilities.vision_auth() == "api"
+
+    def test_vision_available_false_when_off(self, monkeypatch):
+        monkeypatch.delenv("PRISM_FEATURE_VISION", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+        from cores.llm import capabilities
+        assert capabilities.vision_available() is False
+
+    def test_vision_available_false_when_no_key(self, monkeypatch):
+        monkeypatch.setenv("PRISM_FEATURE_VISION", "on")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        from cores.llm import capabilities
+        assert capabilities.vision_available() is False
+
+    def test_vision_available_true_when_on_and_key(self, monkeypatch):
+        monkeypatch.setenv("PRISM_FEATURE_VISION", "on")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+        from cores.llm import capabilities
+        assert capabilities.vision_available() is True
+
+
+# ---------------------------------------------------------------------------
+# analyze_image — OFF path (default): returns None, zero client calls
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeImageOff:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_vision_off(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("PRISM_FEATURE_VISION", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+
+        img = tmp_path / "chart.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")  # minimal PNG header bytes
+
+        with patch("openai.AsyncOpenAI") as mock_client_cls:
+            from cores.llm.features.vision import analyze_image
+            result = await analyze_image(str(img), "describe this chart")
+
+        assert result is None
+        mock_client_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_encoding_when_vision_off(self, monkeypatch, tmp_path):
+        """When vision is off, image bytes must never be read/encoded."""
+        monkeypatch.delenv("PRISM_FEATURE_VISION", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+
+        # Point to a non-existent file — would fail if read was attempted
+        with patch("openai.AsyncOpenAI") as mock_client_cls:
+            from cores.llm.features.vision import analyze_image
+            result = await analyze_image("/nonexistent/path/chart.png", "describe")
+
+        assert result is None
+        mock_client_cls.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# analyze_image — ON + no key: returns None
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeImageOnNoKey:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_api_key(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("PRISM_FEATURE_VISION", "on")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        img = tmp_path / "chart.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        with patch("openai.AsyncOpenAI") as mock_client_cls:
+            from cores.llm.features.vision import analyze_image
+            result = await analyze_image(str(img), "describe this chart")
+
+        assert result is None
+        mock_client_cls.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# analyze_image — ON + key present: happy path
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeImageHappyPath:
+    @pytest.mark.asyncio
+    async def test_calls_responses_create_once_and_returns_text(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("PRISM_FEATURE_VISION", "on")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-realkey")
+
+        img = tmp_path / "chart.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        mock_response = _make_mock_response("bullish cup-and-handle detected")
+
+        mock_client = MagicMock()
+        mock_client.responses = MagicMock()
+        mock_client.responses.create = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("openai.AsyncOpenAI", return_value=mock_client):
+            from cores.llm.features import vision as vision_module
+            # Force reimport of openai inside function via patch
+            with patch.dict("sys.modules", {}):
+                result = await vision_module.analyze_image(
+                    str(img), "describe the chart pattern"
+                )
+
+        assert result == "bullish cup-and-handle detected"
+        mock_client.responses.create.assert_called_once()
+
+        # Verify input contains image
+        call_args = mock_client.responses.create.call_args
+        input_items = call_args.kwargs.get("input") or call_args.args[0] if call_args.args else call_args.kwargs["input"]
+        assert any(
+            "input_image" in str(item) or "image_url" in str(item)
+            for item in input_items
+        )
+
+    @pytest.mark.asyncio
+    async def test_structured_output_parsed_from_json(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("PRISM_FEATURE_VISION", "on")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-realkey")
+
+        img = tmp_path / "chart.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        json_payload = json.dumps({"label": "cup-handle", "confidence": 87})
+        mock_response = _make_mock_response(json_payload)
+
+        mock_client = MagicMock()
+        mock_client.responses = MagicMock()
+        mock_client.responses.create = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("openai.AsyncOpenAI", return_value=mock_client):
+            from cores.llm.features import vision as vision_module
+            result = await vision_module.analyze_image(
+                str(img), "classify the base", schema=SimpleSchema
+            )
+
+        assert isinstance(result, SimpleSchema)
+        assert result.label == "cup-handle"
+        assert result.confidence == 87
+
+
+# ---------------------------------------------------------------------------
+# analyze_image — error path: returns None, logs [VISION_ERROR]
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeImageErrorPath:
+    @pytest.mark.asyncio
+    async def test_api_error_returns_none_and_logs(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        import logging
+
+        monkeypatch.setenv("PRISM_FEATURE_VISION", "on")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-realkey")
+
+        img = tmp_path / "chart.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        from openai import APIError
+
+        mock_exc = APIError("rate limit hit", request=MagicMock(), body=None)
+        mock_exc.request_id = "req-abc123"  # type: ignore[attr-defined]
+        mock_exc.status_code = 429  # type: ignore[attr-defined]
+
+        mock_client = MagicMock()
+        mock_client.responses = MagicMock()
+        mock_client.responses.create = AsyncMock(side_effect=mock_exc)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("openai.AsyncOpenAI", return_value=mock_client):
+            with caplog.at_level(logging.ERROR, logger="cores.llm.features.vision"):
+                from cores.llm.features import vision as vision_module
+                result = await vision_module.analyze_image(str(img), "analyse")
+
+        assert result is None
+        assert any("[VISION_ERROR]" in record.message for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_returns_none(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        import logging
+
+        monkeypatch.setenv("PRISM_FEATURE_VISION", "on")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-realkey")
+
+        img = tmp_path / "chart.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        mock_client = MagicMock()
+        mock_client.responses = MagicMock()
+        mock_client.responses.create = AsyncMock(
+            side_effect=RuntimeError("unexpected SDK crash")
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("openai.AsyncOpenAI", return_value=mock_client):
+            with caplog.at_level(logging.ERROR, logger="cores.llm.features.vision"):
+                from cores.llm.features import vision as vision_module
+                result = await vision_module.analyze_image(str(img), "analyse")
+
+        assert result is None
+        assert any("[VISION_ERROR]" in record.message for record in caplog.records)


### PR DESCRIPTION
## What
Phase 6 비전 기능의 **인프라(S1)** + **첫 실사용처 렌더QA(S2)**. 전부 **기본 OFF·무손상**.

### S1 — 비전 배관 + capability 탐지
- `cores/llm/capabilities.py`: env 게이트 (`PRISM_FEATURE_VISION`/`PRISM_VISION_SHADOW`/`MODEL`/`AUTH`), `vision_available()` 마스터 게이트. 순수 env 읽기, import 부작용 0.
- `cores/llm/features/vision.py`: `analyze_image()` — OFF 시 즉시 None(인코딩·클라이언트·네트워크 0), 지연 import, **전용 API키 클라이언트로 OAuth 프록시 우회**, Responses API 이미지 입력, 선택적 Pydantic 구조화출력, `[VISION_ERROR]` 텔레메트리로 graceful degrade. 예외 비전파.
- `cores/llm/features.yaml`: 토글 문서화(전부 안전 기본값).

### S2 — 렌더 QA (비전 첫 소비자)
- `cores/llm/features/render_qa.py`: `RenderQAVerdict`(strict-json-schema 친화) + `check_render`/`qa_and_log`. 한글폰트 깨짐·라벨겹침·축오류·빈이미지 등 **렌더 결함만** 점검. 비차단(로그 경고만).
- `cores/analysis.py` 배선: 차트 생성 후 `if vision_available():` 가드 + `try/except pass`로 호출 — **파이프라인에 절대 영향 없음**.

## Safety
- 기본 OFF → 동작·성능 변화 0 (current behavior identical).
- API 키 필수(Tier1). OAuth 단독/키 없음 → 자동 skip.
- 매매 결정 코드 **미변경**. 매수 게이트는 별도 PR(S3) + 백테스트 후 LIVE.

## Tests
- `tests/test_vision_plumbing.py` (20) + `tests/test_render_qa.py` (17) = **37 passed**, mock-only(네트워크 0).
- `cores/analysis.py` py_compile OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)