### PR TITLE
Phase 6 S3: O'Neil buy-quality vision gate (SHADOW, log-only)

### DIFF
--- a/cores/analysis.py
+++ b/cores/analysis.py
@@ -250,6 +250,43 @@ async def analyze_stock(company_code: str = "000660", company_name: str = "SK하
             except Exception:
                 pass  # render QA must never affect the pipeline
 
+        # 10c. Buy-quality vision gate (Phase 6 S3) — SHADOW by default, log-only.
+        # Computes a CAN SLIM base analysis + per-regime verdict and LOGS it.
+        # In shadow mode it has ZERO effect on the report or any buy decision.
+        if vision_available():
+            try:
+                import base64 as _bq_base64
+                import re as _bq_re
+                from cores.llm.capabilities import vision_shadow
+                from cores.llm.features.buy_quality import analyze_base, gate_verdict
+                _bq_html = price_chart_html
+                _bq_regime = (macro_context or {}).get("market_regime", "sideways")
+                if _bq_html:
+                    _bq_m = _bq_re.search(r'base64,([^"]+)"', _bq_html)
+                    if _bq_m:
+                        _bq_img = _bq_base64.b64decode(_bq_m.group(1))
+                        _bq_analysis = await analyze_base(_bq_img)
+                        if _bq_analysis is not None:
+                            _bq_verdict = gate_verdict(_bq_analysis, _bq_regime)
+                            logger.info(
+                                "[BUY_QUALITY][SHADOW] code=%s regime=%s would_buy=%s "
+                                "qscore=%s thr=%s base=%s",
+                                company_code,
+                                _bq_regime,
+                                _bq_verdict["would_buy"],
+                                _bq_verdict["quality_score"],
+                                _bq_verdict["threshold"],
+                                _bq_analysis.base_type,
+                            )
+                            # TODO(S5/LIVE): when not vision_shadow(), inject
+                            # _bq_verdict into the entry matrix (Step 2 of the
+                            # trading_scenario_agent prompt) so it gates real
+                            # buys. Do NOT implement live injection until S4
+                            # backtest passes and the user confirms (S5).
+                            _ = vision_shadow  # referenced to mark the LIVE seam
+            except Exception:
+                pass  # buy-quality gate must never affect the pipeline
+
         # 11. Build macro section (before final report composition)
         macro_section = ""
         if macro_context:

--- a/cores/llm/features/buy_quality.py
+++ b/cores/llm/features/buy_quality.py
@@ -1,0 +1,274 @@
+# buy_quality.py
+
+"""
+O'Neil buy-quality vision gate — Phase 6 S3 (SHADOW by default, log-only).
+
+Produces a CAN SLIM "base" analysis from a chart image and computes a
+per-regime pass/fail verdict. In SHADOW mode (PRISM_VISION_SHADOW=true, the
+default) the verdict is logged but NEVER fed into trading decisions.
+
+Public API::
+
+    analysis = await analyze_base(chart_image, numeric_pivot=..., current_price=...)
+    # Returns None when vision is unavailable (off / no key) or on error.
+
+    verdict = gate_verdict(analysis, regime)   # pure function, no side effects
+    # {would_buy, regime, threshold, quality_score, reason}
+
+Design constraints (mirror S1/S2):
+- analyze_image is imported at module level but is itself cheap to import
+  (its heavy deps are lazy-loaded only when vision_available() is True).
+- vision_available() is checked first; if False, returns None immediately.
+- Never raises to caller. All errors return None silently.
+- BaseAnalysis is strict-JSON-schema compatible (extra="forbid", every field
+  required) for OpenAI json_schema strict mode.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from cores.llm.capabilities import vision_available
+from cores.llm.features.vision import ImageInput, analyze_image
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# Structured vision output schema (§2 of tasks/phase6_vision_oneil.md)         #
+# --------------------------------------------------------------------------- #
+class BaseAnalysis(BaseModel):
+    """CAN SLIM base-structure analysis of a stock chart.
+
+    Strict-JSON-schema compatible (OpenAI json_schema strict mode): every field
+    is required and no extra properties are allowed.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    base_type: Literal[
+        "cup-handle",
+        "flat",
+        "double-bottom",
+        "high-tight-flag",
+        "ascending",
+        "saucer",
+        "none",
+        "faulty",
+    ]
+    base_length_weeks: int
+    depth_pct: float            # correction depth of the base
+    handle_present: bool
+    handle_in_upper_half: bool  # handle sits in the upper half of the base (proper)
+    tightness: Literal["tight", "normal", "loose"]
+    volume_dryup_in_handle: bool
+    pivot_price: float
+    dist_to_pivot_pct: float    # current price distance to pivot/buy point
+    rs_line_new_high: bool      # RS line at a new high BEFORE price (O'Neil's strongest tell)
+    proper_or_faulty: Literal["proper", "faulty"]
+    quality_score: int          # 0-100
+    confidence: int             # 0-100
+    rationale: str
+
+
+# --------------------------------------------------------------------------- #
+# Per-regime quality_score pass floors (§1 of the plan).                       #
+#                                                                              #
+# TUNABLE PLACEHOLDERS — these are S3 starting values only. S4 backtest will   #
+# tune them and they will move to features.yaml (vision.regime_thresholds).    #
+# Behaviour encoded: lenient in bull regimes, strict in sideways, very strict  #
+# in bear regimes, block-ish in parabolic (overheated chase defence).          #
+#                                                                              #
+# Keys cover the 6 regimes referenced by the buy matrix. The 5 deterministic   #
+# strings emitted by _compute_kr_regime are strong_bull / moderate_bull /      #
+# sideways / moderate_bear / strong_bear; "parabolic" is a derived activation  #
+# regime in the buy prompt. "bull" is accepted as an alias for moderate_bull.  #
+# --------------------------------------------------------------------------- #
+REGIME_THRESHOLDS: dict[str, int] = {
+    "strong_bull": 55,      # lenient — early/incomplete bases tolerated
+    "moderate_bull": 60,    # lenient
+    "bull": 60,             # alias for moderate_bull (plan §1 wording)
+    "sideways": 75,         # strict — only tight proper bases
+    "moderate_bear": 85,    # very strict — top-grade bases only
+    "strong_bear": 90,      # very strict — almost no new buys
+    "parabolic": 90,        # block-ish — suppress overheated chasing
+}
+
+# Default floor for any unrecognised regime: treat conservatively (strict).
+_DEFAULT_THRESHOLD = 75
+
+# Numeric cross-check tolerance: if the model's pivot deviates from the
+# externally computed pivot by more than this fraction, penalise quality.
+_PIVOT_TOLERANCE_PCT = 3.0
+# Deterministic penalty applied to quality_score on a pivot mismatch.
+_PIVOT_MISMATCH_PENALTY = 25
+
+
+_BASE_PROMPT = """\
+You are a CAN SLIM chart analyst trained in William O'Neil's methodology. Your \
+ONLY job is to assess the BASE structure of the price chart for a potential \
+buy point. Do NOT give buy/sell advice — only describe the base objectively.
+
+Identify the base type. Proper O'Neil bases include:
+- cup-with-handle, flat base, double-bottom, high-tight-flag, ascending base, saucer.
+Mark base_type "none" if there is no constructive base, and "faulty" if the base \
+is defective.
+
+Apply these O'Neil rules to judge proper vs faulty:
+- A PROPER base is reasonably tight, has constructive (declining/drying) volume, \
+and (for cup-with-handle) a handle that drifts in the UPPER HALF of the base with \
+volume dry-up.
+- A FAULTY base is wide-and-loose, V-shaped (no real consolidation), has a handle \
+in the lower half, or shows wedging/heavy volume in the handle.
+- volume_dryup_in_handle: true only if volume visibly contracts through the handle.
+- rs_line_new_high: true only if the Relative Strength line is making a NEW HIGH \
+ahead of price (O'Neil's strongest confirmation).
+- pivot_price: the buy point (top of the handle / breakout level).
+- dist_to_pivot_pct: percent distance from the current price to the pivot \
+(negative if price is already above the pivot).
+
+Score the base:
+- quality_score (0-100): overall O'Neil base quality. Tight proper cup-with-handle \
+with RS new high and volume dry-up scores high; wide/loose/faulty/no-base scores low.
+- confidence (0-100): your confidence in this assessment.
+- rationale: one or two sentences justifying the scores.
+
+Return a strict JSON object with exactly these fields: base_type, \
+base_length_weeks, depth_pct, handle_present, handle_in_upper_half, tightness, \
+volume_dryup_in_handle, pivot_price, dist_to_pivot_pct, rs_line_new_high, \
+proper_or_faulty, quality_score, confidence, rationale.
+"""
+
+
+def _apply_pivot_cross_check(
+    analysis: BaseAnalysis,
+    numeric_pivot: float | None,
+) -> BaseAnalysis:
+    """Penalise quality_score when the model's pivot deviates from a numeric one.
+
+    Deterministic hallucination guard. Mutates and returns *analysis*. When
+    numeric_pivot is None or non-positive, or the model pivot is non-positive,
+    this is a no-op (we cannot compute a meaningful deviation).
+    """
+    if numeric_pivot is None or numeric_pivot <= 0:
+        return analysis
+    if analysis.pivot_price <= 0:
+        return analysis
+
+    deviation_pct = abs(analysis.pivot_price - numeric_pivot) / numeric_pivot * 100.0
+    if deviation_pct > _PIVOT_TOLERANCE_PCT:
+        original = analysis.quality_score
+        analysis.quality_score = max(0, original - _PIVOT_MISMATCH_PENALTY)
+        analysis.rationale = (
+            f"{analysis.rationale} "
+            f"[pivot cross-check: model pivot {analysis.pivot_price:g} deviates "
+            f"{deviation_pct:.1f}% from numeric pivot {numeric_pivot:g} "
+            f"(> {_PIVOT_TOLERANCE_PCT:g}% tol); quality penalised "
+            f"{original}->{analysis.quality_score}]"
+        ).strip()
+    return analysis
+
+
+async def analyze_base(
+    chart_image: ImageInput,
+    *,
+    numeric_pivot: float | None = None,
+    current_price: float | None = None,
+) -> BaseAnalysis | None:
+    """Analyse the base structure of *chart_image* via vision (CAN SLIM).
+
+    Args:
+        chart_image:   Path/bytes of the chart image (same as analyze_image input).
+        numeric_pivot: Optional externally-computed pivot for cross-check. When
+                       the model's pivot deviates beyond tolerance, quality_score
+                       is penalised deterministically.
+        current_price: Optional current price (reserved for future numeric checks;
+                       currently informational only).
+
+    Returns:
+        - ``None`` when vision is unavailable (off / no key) or on error.
+        - :class:`BaseAnalysis` instance on success.
+
+    Never raises.
+    """
+    if not vision_available():
+        return None
+
+    prompt = _BASE_PROMPT
+    if numeric_pivot is not None or current_price is not None:
+        hints = []
+        if numeric_pivot is not None:
+            hints.append(f"numeric pivot estimate = {numeric_pivot:g}")
+        if current_price is not None:
+            hints.append(f"current price = {current_price:g}")
+        prompt = (
+            f"{_BASE_PROMPT}\n"
+            f"Reference values (for sanity-checking your pivot, not to copy "
+            f"blindly): {', '.join(hints)}.\n"
+        )
+
+    try:
+        result = await analyze_image(chart_image, prompt, schema=BaseAnalysis)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[BUY_QUALITY] error during analyze_image: %s", exc)
+        return None
+
+    if result is None:
+        return None
+
+    if not isinstance(result, BaseAnalysis):
+        logger.warning(
+            "[BUY_QUALITY] unexpected result type=%s", type(result).__name__
+        )
+        return None
+
+    return _apply_pivot_cross_check(result, numeric_pivot)
+
+
+def gate_verdict(analysis: BaseAnalysis, regime: str) -> dict:
+    """Compute a per-regime buy-quality verdict. Pure function, no side effects.
+
+    A faulty base is an automatic No-Entry regardless of score. Otherwise the
+    base's quality_score is compared against the regime's pass floor.
+
+    Returns a dict with keys:
+        would_buy (bool), regime (str), threshold (int), quality_score (int),
+        reason (str).
+    """
+    threshold = REGIME_THRESHOLDS.get(regime, _DEFAULT_THRESHOLD)
+    quality_score = analysis.quality_score
+
+    if analysis.proper_or_faulty == "faulty" or analysis.base_type == "faulty":
+        return {
+            "would_buy": False,
+            "regime": regime,
+            "threshold": threshold,
+            "quality_score": quality_score,
+            "reason": "faulty base — automatic No-Entry",
+        }
+
+    if analysis.base_type == "none":
+        return {
+            "would_buy": False,
+            "regime": regime,
+            "threshold": threshold,
+            "quality_score": quality_score,
+            "reason": "no constructive base detected",
+        }
+
+    would_buy = quality_score >= threshold
+    if would_buy:
+        reason = f"quality_score {quality_score} >= {regime} floor {threshold}"
+    else:
+        reason = f"quality_score {quality_score} < {regime} floor {threshold}"
+
+    return {
+        "would_buy": would_buy,
+        "regime": regime,
+        "threshold": threshold,
+        "quality_score": quality_score,
+        "reason": reason,
+    }

--- a/tests/test_buy_quality.py
+++ b/tests/test_buy_quality.py
@@ -1,0 +1,273 @@
+# test_buy_quality.py
+
+"""
+Phase 6 S3 — Buy-quality vision gate unit tests.
+
+All tests are fully mocked: zero network, zero real OpenAI client.
+Run with:  .venv/bin/python -m pytest tests/test_buy_quality.py -q
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from cores.llm.features.buy_quality import (
+    REGIME_THRESHOLDS,
+    BaseAnalysis,
+    analyze_base,
+    gate_verdict,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                     #
+# --------------------------------------------------------------------------- #
+def _make_analysis(**overrides) -> BaseAnalysis:
+    base = dict(
+        base_type="cup-handle",
+        base_length_weeks=8,
+        depth_pct=22.0,
+        handle_present=True,
+        handle_in_upper_half=True,
+        tightness="tight",
+        volume_dryup_in_handle=True,
+        pivot_price=100.0,
+        dist_to_pivot_pct=1.5,
+        rs_line_new_high=True,
+        proper_or_faulty="proper",
+        quality_score=80,
+        confidence=75,
+        rationale="tight cup-with-handle, RS new high",
+    )
+    base.update(overrides)
+    return BaseAnalysis(**base)
+
+
+# --------------------------------------------------------------------------- #
+# Schema strictness                                                           #
+# --------------------------------------------------------------------------- #
+class TestSchemaStrict:
+    def test_schema_is_strict_safe(self):
+        schema = BaseAnalysis.model_json_schema()
+        assert schema.get("additionalProperties") is False
+        required = set(schema.get("required", []))
+        props = set(schema.get("properties", {}).keys())
+        # strict mode requires EVERY property to be in `required`
+        assert required == props
+        # spot-check the key fields exist
+        for field in (
+            "base_type",
+            "quality_score",
+            "confidence",
+            "pivot_price",
+            "rs_line_new_high",
+            "rationale",
+        ):
+            assert field in props
+
+
+# --------------------------------------------------------------------------- #
+# analyze_base — vision OFF                                                    #
+# --------------------------------------------------------------------------- #
+class TestAnalyzeBaseVisionOff:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_vision_off(self, monkeypatch):
+        monkeypatch.delenv("PRISM_FEATURE_VISION", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-realkey")
+
+        called = {"n": 0}
+
+        async def _fake_analyze_image(*args, **kwargs):  # pragma: no cover
+            called["n"] += 1
+            return _make_analysis()
+
+        monkeypatch.setattr(
+            "cores.llm.features.buy_quality.analyze_image", _fake_analyze_image
+        )
+
+        result = await analyze_base(b"\x89PNG\r\n\x1a\n")
+        assert result is None
+        assert called["n"] == 0  # zero vision calls when off
+
+
+# --------------------------------------------------------------------------- #
+# analyze_base — vision ON                                                     #
+# --------------------------------------------------------------------------- #
+class TestAnalyzeBaseVisionOn:
+    @pytest.mark.asyncio
+    async def test_returns_analysis_when_on(self, monkeypatch):
+        monkeypatch.setenv("PRISM_FEATURE_VISION", "on")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-realkey")
+
+        expected = _make_analysis(quality_score=82)
+
+        async def _fake_analyze_image(image, prompt, *, schema=None, model=None):
+            assert schema is BaseAnalysis
+            return expected
+
+        monkeypatch.setattr(
+            "cores.llm.features.buy_quality.analyze_image", _fake_analyze_image
+        )
+
+        result = await analyze_base(b"\x89PNG\r\n\x1a\n")
+        assert isinstance(result, BaseAnalysis)
+        assert result.quality_score == 82
+
+    @pytest.mark.asyncio
+    async def test_pivot_cross_check_penalises_on_deviation(self, monkeypatch):
+        monkeypatch.setenv("PRISM_FEATURE_VISION", "on")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-realkey")
+
+        # model says pivot 100; numeric pivot 130 => 30% deviation > 3% tol
+        returned = _make_analysis(pivot_price=100.0, quality_score=80)
+
+        async def _fake_analyze_image(image, prompt, *, schema=None, model=None):
+            return returned
+
+        monkeypatch.setattr(
+            "cores.llm.features.buy_quality.analyze_image", _fake_analyze_image
+        )
+
+        result = await analyze_base(b"img", numeric_pivot=130.0)
+        assert result is not None
+        assert result.quality_score == 55  # 80 - 25 penalty
+        assert "pivot cross-check" in result.rationale
+
+    @pytest.mark.asyncio
+    async def test_pivot_cross_check_no_penalty_within_tolerance(self, monkeypatch):
+        monkeypatch.setenv("PRISM_FEATURE_VISION", "on")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-realkey")
+
+        returned = _make_analysis(pivot_price=100.0, quality_score=80)
+
+        async def _fake_analyze_image(image, prompt, *, schema=None, model=None):
+            return returned
+
+        monkeypatch.setattr(
+            "cores.llm.features.buy_quality.analyze_image", _fake_analyze_image
+        )
+
+        # 101 vs 100 = 1% deviation, within 3% tol => unchanged
+        result = await analyze_base(b"img", numeric_pivot=101.0)
+        assert result is not None
+        assert result.quality_score == 80
+        assert "pivot cross-check" not in result.rationale
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_analyze_image_returns_none(self, monkeypatch):
+        monkeypatch.setenv("PRISM_FEATURE_VISION", "on")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-realkey")
+
+        async def _fake_analyze_image(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(
+            "cores.llm.features.buy_quality.analyze_image", _fake_analyze_image
+        )
+
+        result = await analyze_base(b"img")
+        assert result is None
+
+
+# --------------------------------------------------------------------------- #
+# gate_verdict — per-regime thresholds (§1)                                    #
+# --------------------------------------------------------------------------- #
+class TestGateVerdict:
+    def test_thresholds_ordering(self):
+        # §1 behaviour: lenient bull, strict sideways, very strict bear, block parabolic
+        assert REGIME_THRESHOLDS["strong_bull"] < REGIME_THRESHOLDS["sideways"]
+        assert REGIME_THRESHOLDS["moderate_bull"] < REGIME_THRESHOLDS["sideways"]
+        assert REGIME_THRESHOLDS["sideways"] < REGIME_THRESHOLDS["strong_bear"]
+        assert REGIME_THRESHOLDS["moderate_bear"] <= REGIME_THRESHOLDS["strong_bear"]
+        assert REGIME_THRESHOLDS["parabolic"] >= REGIME_THRESHOLDS["strong_bear"]
+
+    def test_fixed_score_flips_across_regimes(self):
+        # A mid-quality base (score 65): passes lenient bull, fails strict bear/sideways
+        analysis = _make_analysis(quality_score=65)
+
+        bull = gate_verdict(analysis, "strong_bull")
+        assert bull["would_buy"] is True
+        assert bull["threshold"] == 55
+
+        side = gate_verdict(analysis, "sideways")
+        assert side["would_buy"] is False
+        assert side["threshold"] == 75
+
+        bear = gate_verdict(analysis, "strong_bear")
+        assert bear["would_buy"] is False
+        assert bear["threshold"] == 90
+
+    def test_high_score_passes_everywhere_except_when_faulty(self):
+        analysis = _make_analysis(quality_score=95)
+        for regime in REGIME_THRESHOLDS:
+            v = gate_verdict(analysis, regime)
+            assert v["would_buy"] is True, regime
+
+    def test_faulty_base_is_auto_no_entry(self):
+        analysis = _make_analysis(quality_score=99, proper_or_faulty="faulty")
+        v = gate_verdict(analysis, "strong_bull")
+        assert v["would_buy"] is False
+        assert "faulty" in v["reason"]
+
+    def test_none_base_is_no_entry(self):
+        analysis = _make_analysis(quality_score=99, base_type="none")
+        v = gate_verdict(analysis, "strong_bull")
+        assert v["would_buy"] is False
+        assert "no constructive base" in v["reason"]
+
+    def test_unknown_regime_uses_default_threshold(self):
+        analysis = _make_analysis(quality_score=74)
+        v = gate_verdict(analysis, "totally_unknown_regime")
+        assert v["threshold"] == 75
+        assert v["would_buy"] is False
+
+    def test_verdict_shape(self):
+        v = gate_verdict(_make_analysis(), "sideways")
+        assert set(v.keys()) == {
+            "would_buy",
+            "regime",
+            "threshold",
+            "quality_score",
+            "reason",
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Shadow logging path (integration of analyze_base + gate_verdict + logging)    #
+# --------------------------------------------------------------------------- #
+class TestShadowLoggingPath:
+    @pytest.mark.asyncio
+    async def test_shadow_path_logs_and_does_not_raise(self, monkeypatch, caplog):
+        monkeypatch.setenv("PRISM_FEATURE_VISION", "on")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-realkey")
+
+        expected = _make_analysis(quality_score=82, base_type="cup-handle")
+
+        async def _fake_analyze_image(image, prompt, *, schema=None, model=None):
+            return expected
+
+        monkeypatch.setattr(
+            "cores.llm.features.buy_quality.analyze_image", _fake_analyze_image
+        )
+
+        logger = logging.getLogger("cores.llm.features.buy_quality")
+
+        # Simulate the shadow hook from cores/analysis.py
+        with caplog.at_level(logging.INFO, logger="cores.llm.features.buy_quality"):
+            analysis = await analyze_base(b"img")
+            assert analysis is not None
+            verdict = gate_verdict(analysis, "strong_bull")
+            logger.info(
+                "[BUY_QUALITY][SHADOW] code=%s regime=%s would_buy=%s "
+                "qscore=%s thr=%s base=%s",
+                "005930",
+                "strong_bull",
+                verdict["would_buy"],
+                verdict["quality_score"],
+                verdict["threshold"],
+                analysis.base_type,
+            )
+
+        assert any("[BUY_QUALITY][SHADOW]" in r.message for r in caplog.records)


### PR DESCRIPTION
## What
오닐 CAN SLIM **매수 자리 품질검사**(비전). **기본 SHADOW(로그만)·OFF — 실제 매수결정 영향 0.** LIVE는 S4 백테스트 + S5 사용자확인 후.

- `cores/llm/features/buy_quality.py`:
  - `BaseAnalysis`(Pydantic, strict-json-schema safe): base_type/length/depth/handle/tightness/volume_dryup/pivot/dist_to_pivot/**rs_line_new_high**/proper_or_faulty/quality_score/confidence.
  - `analyze_base()`: 차트이미지→오닐 프롬프트(컵손잡이·flat·이중바닥·high-tight-flag·RS선 선행돌파)→`analyze_image(schema=BaseAnalysis)`. OFF시 None.
  - **숫자 피벗 교차검증**: 모델 pivot이 numeric pivot과 >3% 이탈 시 quality_score 결정론적 페널티(환각 방어).
  - `REGIME_THRESHOLDS`(§1 레짐별 합격선, **S4 튜닝용 placeholder**): strong_bull 55 / moderate_bull 60 / sideways 75 / moderate_bear 85 / strong_bear 90 / parabolic 90.
  - `gate_verdict(analysis, regime)`: 순수함수, would_buy 판정. faulty 베이스 즉시 차단.
- `cores/analysis.py` SHADOW 훅: `vision_available()` 가드 + `try/except pass`, `macro_context.market_regime`로 레짐 획득, `[BUY_QUALITY][SHADOW]` 로그. **vision_shadow()=True(기본)면 결정 미변경.** `# TODO(S5/LIVE)` seam 표시.

## Safety
- 기본 OFF + SHADOW → would_buy는 **로그만**, 매수결정 코드 경로 불변.
- 매트릭스 임계는 placeholder → **S4 cadence-aware 백테스트로 확정 전 LIVE 금지.**

## Tests
- `tests/test_buy_quality.py` 14건 + 회귀(plumbing/render_qa) = **51 passed**, mock-only.
- `cores/analysis.py` py_compile OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)