### PR TITLE
Phase 6: vision key from mcp_agent.secrets.yaml + default model gpt-5.4-mini

### DIFF
--- a/cores/llm/capabilities.py
+++ b/cores/llm/capabilities.py
@@ -19,8 +19,48 @@ import os
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-_DEFAULT_VISION_MODEL = "gpt-4o"
+# Default to the project's standard multimodal model (registered in models.py).
+_DEFAULT_VISION_MODEL = "gpt-5.4-mini"
 _PLACEHOLDER_KEY = "chatgpt-oauth-placeholder"
+
+
+def _secrets_api_key() -> str:
+    """Read ``openai.api_key`` from mcp_agent.secrets.yaml at the project root.
+
+    Returns "" if the file/key is absent or not a real key. Never raises.
+    Split out as a seam so tests can stub the filesystem dependency.
+    """
+    try:
+        import pathlib
+
+        import yaml
+
+        # capabilities.py -> cores/llm/ -> cores/ -> <project root>
+        root = pathlib.Path(__file__).resolve().parents[2]
+        for path in (root / "mcp_agent.secrets.yaml",
+                     pathlib.Path.cwd() / "mcp_agent.secrets.yaml"):
+            if path.is_file():
+                data = yaml.safe_load(path.read_text()) or {}
+                key = str((data.get("openai") or {}).get("api_key", "")).strip()
+                if key.startswith("sk-"):
+                    return key
+    except Exception:  # noqa: BLE001 — key resolution must never crash callers
+        pass
+    return ""
+
+
+def resolve_openai_api_key() -> str:
+    """Resolve a real OpenAI API key: env first, then mcp_agent.secrets.yaml.
+
+    Under OAuth mode the key is not exported to OPENAI_API_KEY; the project's
+    long-standing real key lives in ``mcp_agent.secrets.yaml`` (``openai.api_key``).
+    Vision needs a genuine API key, so we fall back to that file. Returns "" when
+    no real key is found. Never raises.
+    """
+    env_key = os.environ.get("OPENAI_API_KEY", "").strip()
+    if env_key and env_key != _PLACEHOLDER_KEY:
+        return env_key
+    return _secrets_api_key()
 
 
 # ---------------------------------------------------------------------------
@@ -29,13 +69,12 @@ _PLACEHOLDER_KEY = "chatgpt-oauth-placeholder"
 # ---------------------------------------------------------------------------
 
 def has_api_key() -> bool:
-    """Return True if a real OpenAI API key is present (not a proxy placeholder).
+    """Return True if a real OpenAI API key is resolvable (env or secrets file).
 
     Vision requires a genuine API key because it uses base64 image inputs that
     the ChatGPT OAuth proxy does not support.
     """
-    key = os.environ.get("OPENAI_API_KEY", "").strip()
-    return bool(key) and key != _PLACEHOLDER_KEY
+    return bool(resolve_openai_api_key())
 
 
 def vision_enabled() -> bool:

--- a/cores/llm/features/vision.py
+++ b/cores/llm/features/vision.py
@@ -22,7 +22,7 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any, Union
 
-from cores.llm.capabilities import vision_available, vision_model
+from cores.llm.capabilities import resolve_openai_api_key, vision_available, vision_model
 
 if TYPE_CHECKING:
     from pydantic import BaseModel
@@ -79,8 +79,9 @@ async def analyze_image(
     # ------------------------------------------------------------------ #
     # Build dedicated API-key client (bypass any OAuth proxy)             #
     # ------------------------------------------------------------------ #
-    api_key = os.environ.get("OPENAI_API_KEY", "").strip()
-    # vision_available() already guarantees key is present & non-placeholder
+    # Resolve from env or mcp_agent.secrets.yaml; vision_available() already
+    # guarantees a real key is present (env or secrets file).
+    api_key = resolve_openai_api_key()
 
     resolved_model = model or vision_model()
 

--- a/tests/test_vision_plumbing.py
+++ b/tests/test_vision_plumbing.py
@@ -47,17 +47,32 @@ class TestCapabilities:
     def test_has_api_key_false_when_missing(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         from cores.llm import capabilities
+        monkeypatch.setattr(capabilities, "_secrets_api_key", lambda: "")
         assert capabilities.has_api_key() is False
 
     def test_has_api_key_false_for_placeholder(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "chatgpt-oauth-placeholder")
         from cores.llm import capabilities
+        monkeypatch.setattr(capabilities, "_secrets_api_key", lambda: "")
         assert capabilities.has_api_key() is False
 
     def test_has_api_key_true_for_real_key(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test-realkey")
         from cores.llm import capabilities
         assert capabilities.has_api_key() is True
+
+    def test_has_api_key_true_from_secrets_when_env_missing(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        from cores.llm import capabilities
+        monkeypatch.setattr(capabilities, "_secrets_api_key", lambda: "sk-secret")
+        assert capabilities.has_api_key() is True
+        assert capabilities.resolve_openai_api_key() == "sk-secret"
+
+    def test_resolve_env_takes_priority_over_secrets(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-env")
+        from cores.llm import capabilities
+        monkeypatch.setattr(capabilities, "_secrets_api_key", lambda: "sk-secret")
+        assert capabilities.resolve_openai_api_key() == "sk-env"
 
     def test_vision_enabled_default_off(self, monkeypatch):
         monkeypatch.delenv("PRISM_FEATURE_VISION", raising=False)
@@ -82,7 +97,7 @@ class TestCapabilities:
     def test_vision_model_default(self, monkeypatch):
         monkeypatch.delenv("PRISM_VISION_MODEL", raising=False)
         from cores.llm import capabilities
-        assert capabilities.vision_model() == "gpt-4o"
+        assert capabilities.vision_model() == "gpt-5.4-mini"
 
     def test_vision_model_override(self, monkeypatch):
         monkeypatch.setenv("PRISM_VISION_MODEL", "gpt-4o-mini")
@@ -104,6 +119,7 @@ class TestCapabilities:
         monkeypatch.setenv("PRISM_FEATURE_VISION", "on")
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         from cores.llm import capabilities
+        monkeypatch.setattr(capabilities, "_secrets_api_key", lambda: "")
         assert capabilities.vision_available() is False
 
     def test_vision_available_true_when_on_and_key(self, monkeypatch):
@@ -159,6 +175,8 @@ class TestAnalyzeImageOnNoKey:
     async def test_returns_none_when_no_api_key(self, monkeypatch, tmp_path):
         monkeypatch.setenv("PRISM_FEATURE_VISION", "on")
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        from cores.llm import capabilities
+        monkeypatch.setattr(capabilities, "_secrets_api_key", lambda: "")
 
         img = tmp_path / "chart.png"
         img.write_bytes(b"\x89PNG\r\n\x1a\n")


### PR DESCRIPTION
OAuth 모드에서 `OPENAI_API_KEY`가 env에 없지만 프로젝트 실키는 `mcp_agent.secrets.yaml`(openai.api_key)에 존재. `resolve_openai_api_key()`(env→secrets 폴백, `_secrets_api_key` seam) 추가로 .env 중복 없이 비전이 실키 사용. 기본 비전모델 gpt-4o→**gpt-5.4-mini**(프로젝트 스택 일치). 테스트 53건 통과. 여전히 기본 OFF·무손상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)