### PR TITLE
Phase 6 S3.5: O'Neil daily+weekly charts (RS line) + multi-image vision

### DIFF
--- a/cores/analysis.py
+++ b/cores/analysis.py
@@ -258,32 +258,44 @@ async def analyze_stock(company_code: str = "000660", company_name: str = "SK하
                 import base64 as _bq_base64
                 import re as _bq_re
                 from cores.llm.capabilities import vision_shadow
-                from cores.llm.features.buy_quality import analyze_base, gate_verdict
+                from cores.llm.features.buy_quality import (
+                    analyze_base,
+                    analyze_base_oneil,
+                    gate_verdict,
+                )
                 _bq_html = price_chart_html
                 _bq_regime = (macro_context or {}).get("market_regime", "sideways")
-                if _bq_html:
+                # Phase 6 S3.5: prefer the two-timeframe O'Neil path (daily +
+                # weekly with RS line), which grounds rs_line_new_high and the
+                # weekly base reading. Falls back to the single daily report
+                # image when the two-timeframe generation returns None (e.g.
+                # pykrx/index data unavailable). Still SHADOW/log-only.
+                _bq_analysis = await analyze_base_oneil(
+                    company_code, company_name, regime=_bq_regime
+                )
+                if _bq_analysis is None and _bq_html:
                     _bq_m = _bq_re.search(r'base64,([^"]+)"', _bq_html)
                     if _bq_m:
                         _bq_img = _bq_base64.b64decode(_bq_m.group(1))
                         _bq_analysis = await analyze_base(_bq_img)
-                        if _bq_analysis is not None:
-                            _bq_verdict = gate_verdict(_bq_analysis, _bq_regime)
-                            logger.info(
-                                "[BUY_QUALITY][SHADOW] code=%s regime=%s would_buy=%s "
-                                "qscore=%s thr=%s base=%s",
-                                company_code,
-                                _bq_regime,
-                                _bq_verdict["would_buy"],
-                                _bq_verdict["quality_score"],
-                                _bq_verdict["threshold"],
-                                _bq_analysis.base_type,
-                            )
-                            # TODO(S5/LIVE): when not vision_shadow(), inject
-                            # _bq_verdict into the entry matrix (Step 2 of the
-                            # trading_scenario_agent prompt) so it gates real
-                            # buys. Do NOT implement live injection until S4
-                            # backtest passes and the user confirms (S5).
-                            _ = vision_shadow  # referenced to mark the LIVE seam
+                if _bq_analysis is not None:
+                    _bq_verdict = gate_verdict(_bq_analysis, _bq_regime)
+                    logger.info(
+                        "[BUY_QUALITY][SHADOW] code=%s regime=%s would_buy=%s "
+                        "qscore=%s thr=%s base=%s",
+                        company_code,
+                        _bq_regime,
+                        _bq_verdict["would_buy"],
+                        _bq_verdict["quality_score"],
+                        _bq_verdict["threshold"],
+                        _bq_analysis.base_type,
+                    )
+                    # TODO(S5/LIVE): when not vision_shadow(), inject
+                    # _bq_verdict into the entry matrix (Step 2 of the
+                    # trading_scenario_agent prompt) so it gates real
+                    # buys. Do NOT implement live injection until S4
+                    # backtest passes and the user confirms (S5).
+                    _ = vision_shadow  # referenced to mark the LIVE seam
             except Exception:
                 pass  # buy-quality gate must never affect the pipeline
 

--- a/cores/llm/features/buy_quality.py
+++ b/cores/llm/features/buy_quality.py
@@ -143,6 +143,32 @@ proper_or_faulty, quality_score, confidence, rationale.
 """
 
 
+# Two-timeframe (daily + weekly) variant of the prompt. Used by
+# analyze_base_oneil, which sends two labeled images in one message.
+_BASE_PROMPT_TWO_TF = (
+    _BASE_PROMPT
+    + """
+
+IMPORTANT — you are given TWO images of the SAME stock, in this order:
+- IMAGE 1 = DAILY chart (candles + MA5/20/60/120 + volume + an RS line panel \
+labeled "RS vs <index>").
+- IMAGE 2 = WEEKLY chart (weekly candles + 10-week and 40-week MAs + weekly \
+volume + the same RS line, weekly).
+
+How to read them:
+- Read the BASE and HANDLE structure PRIMARILY on the WEEKLY chart (image 2): \
+base_type, base_length_weeks, depth_pct, handle position, tightness, and \
+weekly volume behavior are best judged there.
+- Read the PIVOT / breakout level and the ENTRY TIMING (dist_to_pivot_pct) \
+PRIMARILY on the DAILY chart (image 1).
+- Judge rs_line_new_high from the LABELED RS line panel: it is true only if \
+the RS line is making a NEW HIGH (a green ^ marker / RS at its running max), \
+ideally BEFORE price confirms (O'Neil's strongest tell). Do NOT infer RS from \
+price alone — use the dedicated RS panel.
+"""
+)
+
+
 def _apply_pivot_cross_check(
     analysis: BaseAnalysis,
     numeric_pivot: float | None,
@@ -222,6 +248,139 @@ async def analyze_base(
     if not isinstance(result, BaseAnalysis):
         logger.warning(
             "[BUY_QUALITY] unexpected result type=%s", type(result).__name__
+        )
+        return None
+
+    return _apply_pivot_cross_check(result, numeric_pivot)
+
+
+def _fig_to_bytes(fig, *, image_format: str = "jpg", dpi: int = 80) -> bytes | None:
+    """Render a matplotlib figure to raw image bytes (JPEG/PNG).
+
+    Mirrors the buffer/compression approach in
+    stock_chart.get_chart_as_base64_html, but returns raw bytes (not HTML).
+    Closes the figure to avoid leaks. Returns None on error.
+    """
+    try:
+        from io import BytesIO
+
+        import matplotlib.pyplot as plt
+
+        buffer = BytesIO()
+        fig.savefig(buffer, format=image_format, bbox_inches="tight", dpi=dpi)
+        plt.close(fig)
+        buffer.seek(0)
+
+        if image_format.lower() in ("jpg", "jpeg"):
+            try:
+                from PIL import Image
+
+                img = Image.open(buffer)
+                if img.mode != "RGB":
+                    img = img.convert("RGB")
+                new_buffer = BytesIO()
+                img.save(new_buffer, format="JPEG", quality=85, optimize=True)
+                return new_buffer.getvalue()
+            except ImportError:
+                return buffer.getvalue()
+        return buffer.getvalue()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[BUY_QUALITY] fig->bytes failed: %s", exc)
+        return None
+
+
+async def analyze_base_oneil(
+    ticker: str,
+    company_name: str | None = None,
+    *,
+    regime: str | None = None,
+    numeric_pivot: float | None = None,
+    current_price: float | None = None,
+    market: str | None = None,
+) -> BaseAnalysis | None:
+    """Two-timeframe O'Neil base analysis: generate DAILY + WEEKLY charts (with
+    RS line) for *ticker* and analyse both in a single multi-image vision call.
+
+    Grounds BaseAnalysis.rs_line_new_high (RS line panel) and the weekly base
+    reading instead of relying on a single daily image.
+
+    Args:
+        ticker:        Stock ticker symbol.
+        company_name:  Company name for chart titles (auto-fetched if None).
+        regime:        Optional market regime (informational; not used here —
+                        gate_verdict applies the regime threshold downstream).
+        numeric_pivot: Optional externally-computed pivot for cross-check.
+        current_price: Optional current price (informational).
+        market:        Optional 'KOSPI'/'KOSDAQ' hint for index selection.
+
+    Returns:
+        - ``None`` when vision is unavailable, chart generation fails, or on
+          any error.
+        - :class:`BaseAnalysis` instance on success.
+
+    Never raises.
+    """
+    if not vision_available():
+        return None
+
+    # Lazy import — chart generation pulls in matplotlib/pykrx; only do it when
+    # vision is actually on.
+    try:
+        from cores.stock_chart import (
+            create_oneil_daily_chart,
+            create_oneil_weekly_chart,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[BUY_QUALITY] oneil chart import failed: %s", exc)
+        return None
+
+    try:
+        daily_fig = create_oneil_daily_chart(
+            ticker, company_name=company_name, market=market
+        )
+        weekly_fig = create_oneil_weekly_chart(
+            ticker, company_name=company_name, market=market
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[BUY_QUALITY] oneil chart generation failed: %s", exc)
+        return None
+
+    if daily_fig is None or weekly_fig is None:
+        logger.warning("[BUY_QUALITY] oneil chart(s) unavailable for %s", ticker)
+        return None
+
+    daily_bytes = _fig_to_bytes(daily_fig)
+    weekly_bytes = _fig_to_bytes(weekly_fig)
+    if daily_bytes is None or weekly_bytes is None:
+        return None
+
+    prompt = _BASE_PROMPT_TWO_TF
+    if numeric_pivot is not None or current_price is not None:
+        hints = []
+        if numeric_pivot is not None:
+            hints.append(f"numeric pivot estimate = {numeric_pivot:g}")
+        if current_price is not None:
+            hints.append(f"current price = {current_price:g}")
+        prompt = (
+            f"{_BASE_PROMPT_TWO_TF}\n"
+            f"Reference values (for sanity-checking your pivot, not to copy "
+            f"blindly): {', '.join(hints)}.\n"
+        )
+
+    try:
+        result = await analyze_image(
+            [daily_bytes, weekly_bytes], prompt, schema=BaseAnalysis
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[BUY_QUALITY] error during oneil analyze_image: %s", exc)
+        return None
+
+    if result is None:
+        return None
+
+    if not isinstance(result, BaseAnalysis):
+        logger.warning(
+            "[BUY_QUALITY] unexpected oneil result type=%s", type(result).__name__
         )
         return None
 

--- a/cores/llm/features/vision.py
+++ b/cores/llm/features/vision.py
@@ -31,19 +31,25 @@ logger = logging.getLogger(__name__)
 
 # Type alias for caller convenience
 ImageInput = Union[str, bytes, "os.PathLike[str]"]
+# A single image, or an ordered list of images (multi-image vision).
+ImageInputs = Union[ImageInput, "list[ImageInput]"]
 
 
 async def analyze_image(
-    image_path_or_bytes: ImageInput,
+    image_path_or_bytes: ImageInputs,
     prompt: str,
     *,
     schema: "type[BaseModel] | None" = None,
     model: str | None = None,
 ) -> Any | None:
-    """Analyse an image with GPT-4o (or configured vision model).
+    """Analyse one OR several images with GPT-4o (or configured vision model).
 
     Args:
-        image_path_or_bytes: File path (str/Path) or raw bytes of the image.
+        image_path_or_bytes: EITHER a single image (file path str/Path or raw
+                             bytes) OR a ``list`` of images. When a list is
+                             given, every image is attached (in order) as its
+                             own ``input_image`` part, followed by the text
+                             prompt, all in ONE Responses API message.
         prompt:              Text prompt describing the analysis task.
         schema:              Optional Pydantic model for structured output.
                              When provided, the response is parsed and returned
@@ -85,32 +91,43 @@ async def analyze_image(
 
     resolved_model = model or vision_model()
 
+    def _to_data_url(image: ImageInput) -> str:
+        if isinstance(image, (str, pathlib.Path)):
+            raw = pathlib.Path(image).read_bytes()
+        else:
+            raw = bytes(image)
+        b64 = base64.b64encode(raw).decode("ascii")
+        return f"data:image/png;base64,{b64}"
+
     try:
         # ------------------------------------------------------------------ #
-        # Encode image to base64 data URL                                     #
+        # Normalize to an ordered list of images (single OR multi-image).     #
+        # bytes/str/PathLike count as a SINGLE image; an actual list is the   #
+        # multi-image path. (bytes is not treated as an iterable of images.)  #
         # ------------------------------------------------------------------ #
-        if isinstance(image_path_or_bytes, (str, pathlib.Path)):
-            raw = pathlib.Path(image_path_or_bytes).read_bytes()
+        if isinstance(image_path_or_bytes, list):
+            images = list(image_path_or_bytes)
         else:
-            raw = bytes(image_path_or_bytes)
-
-        b64 = base64.b64encode(raw).decode("ascii")
-        data_url = f"data:image/png;base64,{b64}"
+            images = [image_path_or_bytes]
 
         # ------------------------------------------------------------------ #
         # Build input_items in Responses API format (mirrors                  #
-        # openai_responses_llm.py's input_items list structure)               #
+        # openai_responses_llm.py's input_items list structure). All images   #
+        # (in order) precede the single text part, in ONE message.            #
         # ------------------------------------------------------------------ #
         image_content: list[dict] = [
             {
                 "type": "input_image",
-                "image_url": data_url,
-            },
+                "image_url": _to_data_url(image),
+            }
+            for image in images
+        ]
+        image_content.append(
             {
                 "type": "input_text",
                 "text": prompt,
-            },
-        ]
+            }
+        )
         input_items: list[dict] = [
             {
                 "role": "user",

--- a/cores/stock_chart.py
+++ b/cores/stock_chart.py
@@ -1668,7 +1668,7 @@ def create_oneil_daily_chart(
 def create_oneil_weekly_chart(
     ticker,
     company_name=None,
-    weeks=156,
+    weeks=104,
     adjusted=True,
     save_path=None,
     market=None,
@@ -1684,7 +1684,7 @@ def create_oneil_weekly_chart(
     Args:
         ticker:       Stock ticker symbol.
         company_name: Company name for the title (auto-fetched if None).
-        weeks:        Number of weeks to display (default 156 ~= 3 years).
+        weeks:        Number of weeks to display (default 104 ~= 2 years).
         adjusted:     Use adjusted prices (default True).
         save_path:    If given, save the figure there; otherwise just return it.
         market:       Optional 'KOSPI'/'KOSDAQ' hint to pick the index.
@@ -1694,7 +1694,9 @@ def create_oneil_weekly_chart(
         matplotlib figure, or None if stock data is unavailable.
     """
     # Fetch daily ONCE with a buffer, then resample to weekly.
-    days = weeks * 7 + 40
+    # KRX rejects periods longer than ~730 days (INVALIDPERIOD2), so clamp.
+    _KRX_MAX_DAYS = 730
+    days = min(weeks * 7 + 40, _KRX_MAX_DAYS)
     end_date = datetime.now().strftime('%Y%m%d')
     start_date = (datetime.now() - timedelta(days=days)).strftime('%Y%m%d')
 

--- a/cores/stock_chart.py
+++ b/cores/stock_chart.py
@@ -1404,6 +1404,412 @@ def create_comprehensive_report(ticker, company_name=None, days=730, output_dir=
 
     return report_paths
 
+
+# =========================================================================== #
+# O'Neil / CAN SLIM vision-only charts (Phase 6 S3.5).                         #
+#                                                                              #
+# These are ADDITIVE, vision-only helpers. They do NOT replace or modify the  #
+# existing human-report charts above. They add an RS (Relative Strength) line  #
+# vs the market index and a weekly timeframe so the vision buy-quality         #
+# analyzer can ground BaseAnalysis.rs_line_new_high and weekly-base reading    #
+# instead of hallucinating. Both return a matplotlib `fig` (like               #
+# create_price_chart) so get_chart_as_base64_html can render them.             #
+# =========================================================================== #
+
+# KRX index tickers (pykrx get_index_ohlcv): composite index per market.
+_KOSPI_INDEX_TICKER = "1001"
+_KOSDAQ_INDEX_TICKER = "2001"
+
+# Module-level cache of the KOSPI ticker set, used for market detection.
+# Populated lazily on first call; failures fall back to KOSPI default.
+_KOSPI_TICKERS_CACHE: set | None = None
+
+
+def _detect_index_ticker(ticker: str) -> str:
+    """Return the index ticker for *ticker*'s listing market.
+
+    KOSPI(1001) if the stock is KOSPI-listed, otherwise KOSDAQ(2001).
+    On any detection failure, defaults to KOSPI (1001). Never raises.
+    """
+    global _KOSPI_TICKERS_CACHE
+    try:
+        from pykrx import stock as _pykrx_stock
+
+        if _KOSPI_TICKERS_CACHE is None:
+            _KOSPI_TICKERS_CACHE = set(
+                _pykrx_stock.get_market_ticker_list(market="KOSPI")
+            )
+        if ticker in _KOSPI_TICKERS_CACHE:
+            return _KOSPI_INDEX_TICKER
+        return _KOSDAQ_INDEX_TICKER
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            f"[ONEIL] market detection failed for {ticker}, "
+            f"defaulting to KOSPI index: {e}"
+        )
+        return _KOSPI_INDEX_TICKER
+
+
+def _fetch_index_close(index_ticker: str, start_date: str, end_date: str):
+    """Fetch index daily close series via pykrx get_index_ohlcv.
+
+    Returns a pandas Series indexed by DatetimeIndex (close prices), or None on
+    failure. Uses the Korean '종가' (close) column. Never raises.
+    """
+    try:
+        from pykrx import stock as _pykrx_stock
+
+        idf = _pykrx_stock.get_index_ohlcv(start_date, end_date, index_ticker)
+        if idf is None or len(idf) == 0:
+            return None
+        if not isinstance(idf.index, pd.DatetimeIndex):
+            idf.index = pd.to_datetime(idf.index)
+        close_col = "종가" if "종가" in idf.columns else (
+            "Close" if "Close" in idf.columns else None
+        )
+        if close_col is None:
+            return None
+        s = idf[close_col].sort_index()
+        s = s[s > 0]
+        return s if len(s) > 0 else None
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"[ONEIL] index fetch failed for {index_ticker}: {e}")
+        return None
+
+
+def _compute_rs_line(stock_close, index_close):
+    """Compute the O'Neil RS line = (stock/index) normalized to 100 at window start.
+
+    Aligns both series on their common dates, then normalizes the ratio to 100
+    at the first common date. Returns a pandas Series aligned to the stock's
+    index (reindexed/forward-filled to the stock dates), or None if alignment
+    yields nothing usable.
+    """
+    try:
+        idx = index_close.reindex(stock_close.index).ffill().bfill()
+        ratio = stock_close / idx
+        ratio = ratio.replace([np.inf, -np.inf], np.nan).dropna()
+        if len(ratio) == 0:
+            return None
+        base = ratio.iloc[0]
+        if base == 0:
+            return None
+        rs = ratio / base * 100.0
+        return rs.reindex(stock_close.index)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"[ONEIL] RS line computation failed: {e}")
+        return None
+
+
+def _add_rs_panel(fig, rs_series, label):
+    """Draw the RS line as a thin dedicated bottom subpanel on *fig*.
+
+    Adds a small axis spanning the bottom strip of the figure (kept out of the
+    way of the mplfinance price/volume panels). Highlights the most recent RS
+    new-high point if one exists. Never raises; on error the chart is unchanged.
+    """
+    try:
+        if rs_series is None:
+            return
+        rs_clean = rs_series.dropna()
+        if len(rs_clean) == 0:
+            return
+        # Dedicated thin axis at the very bottom of the figure.
+        rs_ax = fig.add_axes([0.08, 0.02, 0.84, 0.10])
+        x = range(len(rs_clean))
+        rs_ax.plot(x, rs_clean.values, color="#8e44ad", linewidth=1.0)
+        # Mark the most recent RS new high (running-max equals current value).
+        running_max = rs_clean.cummax()
+        is_new_high = rs_clean.values >= running_max.values
+        if bool(is_new_high[-1]):
+            rs_ax.plot(
+                len(rs_clean) - 1,
+                rs_clean.values[-1],
+                marker="^",
+                color="#27ae60",
+                markersize=7,
+            )
+        rs_ax.set_xticks([])
+        rs_ax.tick_params(axis="y", labelsize=6)
+        rs_ax.margins(x=0.01)
+        rs_title = f"RS vs {label} (norm=100 at start)"
+        if KOREAN_FONT_PROP:
+            rs_ax.set_ylabel(rs_title, fontsize=7, fontproperties=KOREAN_FONT_PROP)
+        else:
+            rs_ax.set_ylabel(rs_title, fontsize=7)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"[ONEIL] RS panel draw failed: {e}")
+
+
+def create_oneil_daily_chart(
+    ticker,
+    company_name=None,
+    days=400,
+    adjusted=True,
+    save_path=None,
+    market=None,
+    index_ticker=None,
+):
+    """Generate an O'Neil DAILY chart (vision-only): candles + MA5/20/60/120 +
+    volume + an RS line vs the market index.
+
+    Reuses create_price_chart's data-fetch + styling + Korean-font setup.
+    ~400 trading days so the most recent base is not over-compressed.
+
+    Args:
+        ticker:       Stock ticker symbol.
+        company_name: Company name for the title (auto-fetched if None).
+        days:         Lookback window in calendar days (default 400).
+        adjusted:     Use adjusted prices (default True).
+        save_path:    If given, save the figure there; otherwise just return it.
+        market:       Optional 'KOSPI'/'KOSDAQ' hint to pick the index.
+        index_ticker: Optional explicit index ticker override (e.g. '1001').
+
+    Returns:
+        matplotlib figure, or None if stock data is unavailable.
+    """
+    end_date = datetime.now().strftime('%Y%m%d')
+    start_date = (datetime.now() - timedelta(days=days)).strftime('%Y%m%d')
+
+    if company_name is None:
+        try:
+            company_name = get_market_ticker_name(ticker)
+        except Exception:
+            company_name = ticker
+
+    df = get_market_ohlcv_by_date(start_date, end_date, ticker, adjusted=adjusted)
+    if df is None or len(df) == 0:
+        logger.info(f"[ONEIL] No daily data for {ticker}.")
+        return None
+
+    ohlc_cols = [c for c in ['Open', 'High', 'Low', 'Close'] if c in df.columns]
+    if ohlc_cols:
+        df = df[df[ohlc_cols].sum(axis=1) > 0]
+        if len(df) == 0:
+            logger.info(f"[ONEIL] No valid daily OHLCV for {ticker}.")
+            return None
+
+    if not isinstance(df.index, pd.DatetimeIndex):
+        df.index = pd.to_datetime(df.index)
+    df = df.sort_index()
+
+    df['MA5'] = df['Close'].rolling(window=5).mean()
+    df['MA20'] = df['Close'].rolling(window=20).mean()
+    df['MA60'] = df['Close'].rolling(window=60).mean()
+    df['MA120'] = df['Close'].rolling(window=120).mean()
+
+    ohlc_df = df[['Open', 'High', 'Low', 'Close', 'Volume']].copy()
+    s = create_mpf_style()
+
+    # Resolve index for RS line.
+    if index_ticker is None:
+        if market and market.upper() == "KOSPI":
+            index_ticker = _KOSPI_INDEX_TICKER
+        elif market and market.upper() in ("KOSDAQ", "KOSDAK"):
+            index_ticker = _KOSDAQ_INDEX_TICKER
+        else:
+            index_ticker = _detect_index_ticker(ticker)
+    index_label = "KOSPI" if index_ticker == _KOSPI_INDEX_TICKER else "KOSDAQ"
+    index_close = _fetch_index_close(index_ticker, start_date, end_date)
+    rs_series = _compute_rs_line(df['Close'], index_close) if index_close is not None else None
+    if rs_series is None:
+        logger.warning(
+            f"[ONEIL] RS line omitted for {ticker} (daily); chart still rendered."
+        )
+
+    additional_plots = [
+        mpf.make_addplot(df['MA5'], color='#00aa44', width=1),
+        mpf.make_addplot(df['MA20'], color='#ff9500', width=1),
+        mpf.make_addplot(df['MA60'], color='#0066cc', width=1.5),
+        mpf.make_addplot(df['MA120'], color='#cc3300', width=1.5, linestyle='--'),
+    ]
+
+    if KOREAN_FONT_PATH:
+        font_prop = fm.FontProperties(fname=KOREAN_FONT_PATH)
+        plt.rcParams['font.family'] = font_prop.get_name()
+        mpl.rcParams['font.family'] = font_prop.get_name()
+
+    title = f"{company_name} ({ticker}) - O'Neil Daily (RS vs {index_label})"
+    fig, axes = mpf.plot(
+        ohlc_df,
+        type='candle',
+        style=s,
+        title=title,
+        ylabel='Price',
+        volume=True,
+        figsize=(12, 9),
+        tight_layout=True,
+        addplot=additional_plots,
+        panel_ratios=(4, 1),
+        returnfig=True,
+    )
+
+    if KOREAN_FONT_PROP:
+        fig.suptitle(title, fontproperties=KOREAN_FONT_PROP, fontsize=15, fontweight='bold')
+
+    ax1 = axes[0]
+    ax1.legend(['MA5', 'MA20', 'MA60', 'MA120'], loc='upper left')
+    max_price = df['High'].max()
+    ax1.yaxis.set_major_formatter(select_number_formatter(max_price))
+
+    # RS line as a dedicated thin bottom panel (clearly labeled).
+    _add_rs_panel(fig, rs_series, index_label)
+
+    fig.text(0.99, 0.005, "AI Stock Analysis", ha='right', va='bottom',
+             color='#cccccc', fontsize=8)
+
+    if save_path:
+        fig.savefig(save_path, bbox_inches='tight', dpi=80)
+        logger.info(f"[ONEIL] daily chart saved: {save_path}")
+
+    return fig
+
+
+def create_oneil_weekly_chart(
+    ticker,
+    company_name=None,
+    weeks=156,
+    adjusted=True,
+    save_path=None,
+    market=None,
+    index_ticker=None,
+):
+    """Generate an O'Neil WEEKLY chart (vision-only): weekly candles + 10-week
+    and 40-week MAs (O'Neil standard) + weekly volume + an RS line vs the index.
+
+    Fetches ~ (weeks*7 + buffer) days of DAILY OHLCV ONCE and resamples to
+    weekly with pandas (open=first, high=max, low=min, close=last, volume=sum)
+    — no extra per-bar fetch.
+
+    Args:
+        ticker:       Stock ticker symbol.
+        company_name: Company name for the title (auto-fetched if None).
+        weeks:        Number of weeks to display (default 156 ~= 3 years).
+        adjusted:     Use adjusted prices (default True).
+        save_path:    If given, save the figure there; otherwise just return it.
+        market:       Optional 'KOSPI'/'KOSDAQ' hint to pick the index.
+        index_ticker: Optional explicit index ticker override.
+
+    Returns:
+        matplotlib figure, or None if stock data is unavailable.
+    """
+    # Fetch daily ONCE with a buffer, then resample to weekly.
+    days = weeks * 7 + 40
+    end_date = datetime.now().strftime('%Y%m%d')
+    start_date = (datetime.now() - timedelta(days=days)).strftime('%Y%m%d')
+
+    if company_name is None:
+        try:
+            company_name = get_market_ticker_name(ticker)
+        except Exception:
+            company_name = ticker
+
+    daily = get_market_ohlcv_by_date(start_date, end_date, ticker, adjusted=adjusted)
+    if daily is None or len(daily) == 0:
+        logger.info(f"[ONEIL] No daily data for {ticker} (weekly).")
+        return None
+
+    ohlc_cols = [c for c in ['Open', 'High', 'Low', 'Close'] if c in daily.columns]
+    if ohlc_cols:
+        daily = daily[daily[ohlc_cols].sum(axis=1) > 0]
+        if len(daily) == 0:
+            logger.info(f"[ONEIL] No valid daily OHLCV for {ticker} (weekly).")
+            return None
+
+    if not isinstance(daily.index, pd.DatetimeIndex):
+        daily.index = pd.to_datetime(daily.index)
+    daily = daily.sort_index()
+
+    # Resample daily -> weekly (O'Neil aggregation).
+    weekly = daily.resample('W').agg({
+        'Open': 'first',
+        'High': 'max',
+        'Low': 'min',
+        'Close': 'last',
+        'Volume': 'sum',
+    }).dropna(subset=['Open', 'High', 'Low', 'Close'])
+
+    if len(weekly) == 0:
+        logger.info(f"[ONEIL] Weekly resample empty for {ticker}.")
+        return None
+
+    # Keep only the most recent `weeks` bars.
+    weekly = weekly.tail(weeks)
+
+    # O'Neil standard weekly MAs: 10-week and 40-week.
+    weekly['MA10'] = weekly['Close'].rolling(window=10).mean()
+    weekly['MA40'] = weekly['Close'].rolling(window=40).mean()
+
+    ohlc_df = weekly[['Open', 'High', 'Low', 'Close', 'Volume']].copy()
+    s = create_mpf_style()
+
+    # Resolve index for RS line, fetch over the same window, resample to weekly.
+    if index_ticker is None:
+        if market and market.upper() == "KOSPI":
+            index_ticker = _KOSPI_INDEX_TICKER
+        elif market and market.upper() in ("KOSDAQ", "KOSDAK"):
+            index_ticker = _KOSDAQ_INDEX_TICKER
+        else:
+            index_ticker = _detect_index_ticker(ticker)
+    index_label = "KOSPI" if index_ticker == _KOSPI_INDEX_TICKER else "KOSDAQ"
+    index_daily = _fetch_index_close(index_ticker, start_date, end_date)
+    rs_series = None
+    if index_daily is not None:
+        try:
+            index_weekly = index_daily.resample('W').last()
+            rs_series = _compute_rs_line(weekly['Close'], index_weekly)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"[ONEIL] weekly RS resample failed for {ticker}: {e}")
+    if rs_series is None:
+        logger.warning(
+            f"[ONEIL] RS line omitted for {ticker} (weekly); chart still rendered."
+        )
+
+    additional_plots = [
+        mpf.make_addplot(weekly['MA10'], color='#ff9500', width=1.2),
+        mpf.make_addplot(weekly['MA40'], color='#cc3300', width=1.5, linestyle='--'),
+    ]
+
+    if KOREAN_FONT_PATH:
+        font_prop = fm.FontProperties(fname=KOREAN_FONT_PATH)
+        plt.rcParams['font.family'] = font_prop.get_name()
+        mpl.rcParams['font.family'] = font_prop.get_name()
+
+    title = f"{company_name} ({ticker}) - O'Neil Weekly (RS vs {index_label})"
+    fig, axes = mpf.plot(
+        ohlc_df,
+        type='candle',
+        style=s,
+        title=title,
+        ylabel='Price',
+        volume=True,
+        figsize=(12, 9),
+        tight_layout=True,
+        addplot=additional_plots,
+        panel_ratios=(4, 1),
+        returnfig=True,
+    )
+
+    if KOREAN_FONT_PROP:
+        fig.suptitle(title, fontproperties=KOREAN_FONT_PROP, fontsize=15, fontweight='bold')
+
+    ax1 = axes[0]
+    ax1.legend(['MA10 (10wk)', 'MA40 (40wk)'], loc='upper left')
+    max_price = weekly['High'].max()
+    ax1.yaxis.set_major_formatter(select_number_formatter(max_price))
+
+    _add_rs_panel(fig, rs_series, index_label)
+
+    fig.text(0.99, 0.005, "AI Stock Analysis", ha='right', va='bottom',
+             color='#cccccc', fontsize=8)
+
+    if save_path:
+        fig.savefig(save_path, bbox_inches='tight', dpi=80)
+        logger.info(f"[ONEIL] weekly chart saved: {save_path}")
+
+    return fig
+
+
 def check_font_available():
     """
     Check Korean font availability and provide installation guidance

--- a/cores/stock_chart.py
+++ b/cores/stock_chart.py
@@ -411,7 +411,8 @@ from krx_data_client import (
     get_market_trading_value_by_investor,
     get_market_trading_volume_by_date,
     get_market_trading_value_by_date,
-    get_market_ticker_name
+    get_market_ticker_name,
+    get_index_ohlcv_by_date,
 )
 
 # Professional chart style configuration
@@ -1451,15 +1452,15 @@ def _detect_index_ticker(ticker: str) -> str:
 
 
 def _fetch_index_close(index_ticker: str, start_date: str, end_date: str):
-    """Fetch index daily close series via pykrx get_index_ohlcv.
+    """Fetch index daily close series via the authenticated krx_data_client.
 
+    Uses get_index_ohlcv_by_date (the project-standard authenticated wrapper)
+    instead of raw pykrx, which fails under the auth layer and returns empty.
     Returns a pandas Series indexed by DatetimeIndex (close prices), or None on
-    failure. Uses the Korean '종가' (close) column. Never raises.
+    failure. Never raises.
     """
     try:
-        from pykrx import stock as _pykrx_stock
-
-        idf = _pykrx_stock.get_index_ohlcv(start_date, end_date, index_ticker)
+        idf = get_index_ohlcv_by_date(start_date, end_date, index_ticker)
         if idf is None or len(idf) == 0:
             return None
         if not isinstance(idf.index, pd.DatetimeIndex):
@@ -1629,7 +1630,10 @@ def create_oneil_daily_chart(
         plt.rcParams['font.family'] = font_prop.get_name()
         mpl.rcParams['font.family'] = font_prop.get_name()
 
-    title = f"{company_name} ({ticker}) - O'Neil Daily (RS vs {index_label})"
+    if rs_series is not None:
+        title = f"{company_name} ({ticker}) - O'Neil Daily (RS vs {index_label})"
+    else:
+        title = f"{company_name} ({ticker}) - O'Neil Daily"
     fig, axes = mpf.plot(
         ohlc_df,
         type='candle',
@@ -1777,7 +1781,10 @@ def create_oneil_weekly_chart(
         plt.rcParams['font.family'] = font_prop.get_name()
         mpl.rcParams['font.family'] = font_prop.get_name()
 
-    title = f"{company_name} ({ticker}) - O'Neil Weekly (RS vs {index_label})"
+    if rs_series is not None:
+        title = f"{company_name} ({ticker}) - O'Neil Weekly (RS vs {index_label})"
+    else:
+        title = f"{company_name} ({ticker}) - O'Neil Weekly"
     fig, axes = mpf.plot(
         ohlc_df,
         type='candle',

--- a/tests/test_buy_quality.py
+++ b/tests/test_buy_quality.py
@@ -271,3 +271,98 @@ class TestShadowLoggingPath:
             )
 
         assert any("[BUY_QUALITY][SHADOW]" in r.message for r in caplog.records)
+
+
+# --------------------------------------------------------------------------- #
+# analyze_base_oneil — two-timeframe (daily + weekly) path (Phase 6 S3.5)       #
+# All chart generation + vision are mocked: NO network / NO pykrx.             #
+# --------------------------------------------------------------------------- #
+class TestAnalyzeBaseOneil:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_vision_off(self, monkeypatch):
+        monkeypatch.delenv("PRISM_FEATURE_VISION", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-realkey")
+
+        from cores.llm.features.buy_quality import analyze_base_oneil
+
+        called = {"charts": 0}
+
+        def _fake_daily(*a, **k):  # pragma: no cover
+            called["charts"] += 1
+            return object()
+
+        monkeypatch.setattr(
+            "cores.stock_chart.create_oneil_daily_chart", _fake_daily, raising=False
+        )
+
+        result = await analyze_base_oneil("005930", "삼성전자")
+        assert result is None
+        assert called["charts"] == 0  # no chart work when vision off
+
+    @pytest.mark.asyncio
+    async def test_two_timeframe_sends_two_images(self, monkeypatch):
+        monkeypatch.setenv("PRISM_FEATURE_VISION", "on")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-realkey")
+
+        import cores.llm.features.buy_quality as bq
+
+        # Mock chart generators (avoid matplotlib/pykrx) — return sentinels.
+        monkeypatch.setattr(
+            "cores.stock_chart.create_oneil_daily_chart",
+            lambda *a, **k: "DAILY_FIG",
+        )
+        monkeypatch.setattr(
+            "cores.stock_chart.create_oneil_weekly_chart",
+            lambda *a, **k: "WEEKLY_FIG",
+        )
+        # Mock fig->bytes so no real rendering happens.
+        monkeypatch.setattr(
+            bq, "_fig_to_bytes", lambda fig, **k: f"{fig}_BYTES".encode()
+        )
+
+        captured = {}
+
+        async def _fake_analyze_image(images, prompt, *, schema=None, model=None):
+            captured["images"] = images
+            captured["prompt"] = prompt
+            captured["schema"] = schema
+            return _make_analysis(quality_score=88, rs_line_new_high=True)
+
+        monkeypatch.setattr(bq, "analyze_image", _fake_analyze_image)
+
+        result = await bq.analyze_base_oneil("005930", "삼성전자", regime="strong_bull")
+
+        assert isinstance(result, BaseAnalysis)
+        assert result.quality_score == 88
+        # A list of EXACTLY two images (daily first, weekly second).
+        assert isinstance(captured["images"], list)
+        assert len(captured["images"]) == 2
+        assert captured["images"][0] == b"DAILY_FIG_BYTES"
+        assert captured["images"][1] == b"WEEKLY_FIG_BYTES"
+        assert captured["schema"] is BaseAnalysis
+        # Prompt names the two timeframes for the model.
+        assert "DAILY" in captured["prompt"] and "WEEKLY" in captured["prompt"]
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_chart_unavailable(self, monkeypatch):
+        monkeypatch.setenv("PRISM_FEATURE_VISION", "on")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-realkey")
+
+        import cores.llm.features.buy_quality as bq
+
+        # Daily chart returns None (e.g. no data) -> whole call returns None.
+        monkeypatch.setattr(
+            "cores.stock_chart.create_oneil_daily_chart", lambda *a, **k: None
+        )
+        monkeypatch.setattr(
+            "cores.stock_chart.create_oneil_weekly_chart",
+            lambda *a, **k: "WEEKLY_FIG",
+        )
+
+        async def _fake_analyze_image(*a, **k):  # pragma: no cover
+            raise AssertionError("analyze_image must not be called")
+
+        monkeypatch.setattr(bq, "analyze_image", _fake_analyze_image)
+
+        result = await bq.analyze_base_oneil("005930", "삼성전자")
+        assert result is None

--- a/tests/test_vision_plumbing.py
+++ b/tests/test_vision_plumbing.py
@@ -327,3 +327,83 @@ class TestAnalyzeImageErrorPath:
 
         assert result is None
         assert any("[VISION_ERROR]" in record.message for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Multi-image path (Phase 6 S3.5)
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeImageMultiImage:
+    @pytest.mark.asyncio
+    async def test_list_of_two_images_makes_two_input_image_parts(
+        self, monkeypatch
+    ):
+        """A list of 2 images -> 2 input_image parts + 1 input_text in ONE call."""
+        monkeypatch.setenv("PRISM_FEATURE_VISION", "on")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-realkey")
+
+        mock_response = _make_mock_response("two-timeframe analysis")
+
+        mock_client = MagicMock()
+        mock_client.responses = MagicMock()
+        mock_client.responses.create = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        daily_bytes = b"\x89PNG\r\n\x1a\nDAILY"
+        weekly_bytes = b"\x89PNG\r\n\x1a\nWEEKLY"
+
+        with patch("openai.AsyncOpenAI", return_value=mock_client):
+            from cores.llm.features import vision as vision_module
+            result = await vision_module.analyze_image(
+                [daily_bytes, weekly_bytes],
+                "image 1 = DAILY, image 2 = WEEKLY",
+            )
+
+        assert result == "two-timeframe analysis"
+        # Exactly ONE Responses API call for the whole multi-image message.
+        mock_client.responses.create.assert_called_once()
+
+        call_args = mock_client.responses.create.call_args
+        input_items = call_args.kwargs["input"]
+        content = input_items[0]["content"]
+
+        image_parts = [p for p in content if p.get("type") == "input_image"]
+        text_parts = [p for p in content if p.get("type") == "input_text"]
+
+        assert len(image_parts) == 2  # two images, in order
+        assert len(text_parts) == 1   # single text prompt
+        # Image parts must precede the text part.
+        assert content[0]["type"] == "input_image"
+        assert content[1]["type"] == "input_image"
+        assert content[2]["type"] == "input_text"
+
+    @pytest.mark.asyncio
+    async def test_single_image_still_single_input_image(self, monkeypatch):
+        """Backward compat: a single (non-list) image -> exactly 1 input_image."""
+        monkeypatch.setenv("PRISM_FEATURE_VISION", "on")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-realkey")
+
+        mock_response = _make_mock_response("single-image analysis")
+
+        mock_client = MagicMock()
+        mock_client.responses = MagicMock()
+        mock_client.responses.create = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("openai.AsyncOpenAI", return_value=mock_client):
+            from cores.llm.features import vision as vision_module
+            result = await vision_module.analyze_image(
+                b"\x89PNG\r\n\x1a\n", "single image"
+            )
+
+        assert result == "single-image analysis"
+        mock_client.responses.create.assert_called_once()
+
+        content = mock_client.responses.create.call_args.kwargs["input"][0]["content"]
+        image_parts = [p for p in content if p.get("type") == "input_image"]
+        text_parts = [p for p in content if p.get("type") == "input_text"]
+        assert len(image_parts) == 1
+        assert len(text_parts) == 1


### PR DESCRIPTION
오닐 전용 차트 보강. 기존 리포트차트 불변, 전부 vision_available() 게이트(OFF 기본·무손상).

- cores/stock_chart.py: create_oneil_daily_chart(캔들+MA5/20/60/120+거래량+**RS선 vs KOSPI**, ~400일), create_oneil_weekly_chart(일봉 resample 주봉+10/40주MA+거래량+RS선, 104주). KRX 730일 한도 클램프. RS는 **인증된 get_index_ohlcv_by_date** 사용, 실패 시 제목에서 RS 표기 제거(환각방지).
- vision.py: 멀티이미지 입력(한 메시지에 input_image 2장).
- buy_quality.py: analyze_base_oneil(일봉+주봉 2장 투입), 프롬프트 보강.
- 라이브 검증: 차트 3단(가격+거래량+RS) 정상, e2e 비전이 SK하이닉스를 'faulty/후기연장'으로 정확 판정. 테스트 58건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)