### PR TITLE
tools: feature_status.py — runtime LIVE/SHADOW/OFF reporter

### DIFF
--- a/tests/test_feature_status.py
+++ b/tests/test_feature_status.py
@@ -33,6 +33,19 @@ CRON_LOOP_A_ONLY = """
 # 0 18 * * * /usr/bin/python tools/loop_b_trend_exit.py   (commented out)
 """
 
+# Crontab with PRISM_OPENAI_AUTH_MODE set inline on a batch line (no .env)
+CRON_WITH_OAUTH_INLINE = """
+# system crontab
+*/10 * * * * /usr/bin/python tools/loop_a_hardstop.py
+30 09 * * 1-5 cd /Users/rocky/prism && PRISM_OPENAI_AUTH_MODE=chatgpt_oauth /usr/bin/python stock_analysis_orchestrator.py
+"""
+
+# Crontab with OAuth inline but line is commented out — must NOT count
+CRON_OAUTH_COMMENTED = """
+# 30 09 * * 1-5 PRISM_OPENAI_AUTH_MODE=chatgpt_oauth /usr/bin/python stock_analysis_orchestrator.py
+*/10 * * * * /usr/bin/python tools/loop_a_hardstop.py
+"""
+
 CRON_EMPTY = ""
 
 
@@ -53,6 +66,19 @@ def test_oauth_llm_off_api_key():
 
 def test_oauth_llm_off_unset():
     r = _results_by_id(fs.evaluate_all(env={}, crontab=CRON_EMPTY))
+    assert r["oauth_llm"]["state"] == "OFF"
+
+
+def test_oauth_llm_live_from_crontab_inline():
+    """PRISM_OPENAI_AUTH_MODE absent from env but present inline in crontab → LIVE."""
+    r = _results_by_id(fs.evaluate_all(env={}, crontab=CRON_WITH_OAUTH_INLINE))
+    assert r["oauth_llm"]["state"] == "LIVE"
+    assert "crontab inline" in r["oauth_llm"]["evidence"]
+
+
+def test_oauth_llm_not_live_when_commented_in_crontab():
+    """Commented-out crontab line must not count as OAuth evidence → OFF."""
+    r = _results_by_id(fs.evaluate_all(env={}, crontab=CRON_OAUTH_COMMENTED))
     assert r["oauth_llm"]["state"] == "OFF"
 
 

--- a/tests/test_feature_status.py
+++ b/tests/test_feature_status.py
@@ -1,0 +1,229 @@
+"""
+Tests for tools/feature_status.py — mock-only, no real crontab or .env reads.
+
+Cross-reference: docs/FEATURE_FLAGS.md (intended state registry)
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT))
+
+import tools.feature_status as fs  # noqa: E402
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _results_by_id(results):
+    return {r["id"]: r for r in results}
+
+
+CRON_WITH_ALL = """
+# system crontab
+*/10 * * * * /usr/bin/python tools/loop_a_hardstop.py
+0 18 * * * /usr/bin/python tools/loop_b_trend_exit.py
+*/5 * * * * /usr/bin/python tools/loop_c_fill_chaser.py
+"""
+
+CRON_LOOP_A_ONLY = """
+*/10 * * * * /usr/bin/python tools/loop_a_hardstop.py
+# 0 18 * * * /usr/bin/python tools/loop_b_trend_exit.py   (commented out)
+"""
+
+CRON_EMPTY = ""
+
+
+# ── OAuth LLM backend ─────────────────────────────────────────────────────────
+
+def test_oauth_llm_live():
+    env = {"PRISM_OPENAI_AUTH_MODE": "chatgpt_oauth"}
+    r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_EMPTY))
+    assert r["oauth_llm"]["state"] == "LIVE"
+    assert "chatgpt_oauth" in r["oauth_llm"]["evidence"]
+
+
+def test_oauth_llm_off_api_key():
+    env = {"PRISM_OPENAI_AUTH_MODE": "api_key"}
+    r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_EMPTY))
+    assert r["oauth_llm"]["state"] == "OFF"
+
+
+def test_oauth_llm_off_unset():
+    r = _results_by_id(fs.evaluate_all(env={}, crontab=CRON_EMPTY))
+    assert r["oauth_llm"]["state"] == "OFF"
+
+
+# ── Loop A ────────────────────────────────────────────────────────────────────
+
+def test_loop_a_live_env_and_cron():
+    env = {"LOOP_A_LIVE": "true"}
+    r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_LOOP_A_ONLY))
+    assert r["loop_a"]["state"] == "LIVE"
+    assert "cron=있음" in r["loop_a"]["evidence"]
+
+
+def test_loop_a_misscheduled_env_live_no_cron():
+    env = {"LOOP_A_LIVE": "true"}
+    r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_EMPTY))
+    assert r["loop_a"]["state"] == "미스케줄"
+
+
+def test_loop_a_shadow_cron_but_no_live_flag():
+    env = {}
+    r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_LOOP_A_ONLY))
+    assert r["loop_a"]["state"] == "SHADOW"
+
+
+def test_loop_a_off_kill_switch():
+    env = {"LOOP_A_LIVE": "true", "LOOP_A_ENABLED": "false"}
+    r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_WITH_ALL))
+    assert r["loop_a"]["state"] == "OFF"
+    assert "킬스위치" in r["loop_a"]["evidence"]
+
+
+def test_loop_a_off_no_env_no_cron():
+    r = _results_by_id(fs.evaluate_all(env={}, crontab=CRON_EMPTY))
+    assert r["loop_a"]["state"] == "OFF"
+
+
+# ── Loop B ────────────────────────────────────────────────────────────────────
+
+def test_loop_b_misscheduled_no_cron():
+    """Default registry state: cron 없음 → 미스케줄 regardless of env."""
+    r = _results_by_id(fs.evaluate_all(env={}, crontab=CRON_EMPTY))
+    assert r["loop_b"]["state"] == "미스케줄"
+
+
+def test_loop_b_live_when_env_and_cron():
+    env = {"LOOP_B_LIVE": "true"}
+    r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_WITH_ALL))
+    assert r["loop_b"]["state"] == "LIVE"
+
+
+def test_loop_b_shadow_cron_no_live_flag():
+    r = _results_by_id(fs.evaluate_all(env={}, crontab=CRON_WITH_ALL))
+    assert r["loop_b"]["state"] == "SHADOW"
+
+
+def test_loop_b_off_disabled():
+    env = {"LOOP_B_ENABLED": "false"}
+    r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_WITH_ALL))
+    assert r["loop_b"]["state"] == "OFF"
+
+
+# ── Loop C ────────────────────────────────────────────────────────────────────
+
+def test_loop_c_misscheduled_no_cron():
+    r = _results_by_id(fs.evaluate_all(env={}, crontab=CRON_EMPTY))
+    assert r["loop_c"]["state"] == "미스케줄"
+
+
+def test_loop_c_live_when_env_and_cron():
+    env = {"LOOP_C_LIVE": "true"}
+    r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_WITH_ALL))
+    assert r["loop_c"]["state"] == "LIVE"
+
+
+def test_loop_c_shadow_cron_no_live_flag():
+    r = _results_by_id(fs.evaluate_all(env={}, crontab=CRON_WITH_ALL))
+    assert r["loop_c"]["state"] == "SHADOW"
+
+
+def test_loop_c_off_disabled():
+    env = {"LOOP_C_ENABLED": "false"}
+    r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_WITH_ALL))
+    assert r["loop_c"]["state"] == "OFF"
+
+
+# ── Vision pipeline (S1/S2) ───────────────────────────────────────────────────
+
+def test_vision_pipeline_live_on_no_shadow():
+    env = {"PRISM_FEATURE_VISION": "on"}
+    r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_EMPTY))
+    assert r["vision_pipeline"]["state"] == "LIVE"
+
+
+def test_vision_pipeline_shadow_when_shadow_true():
+    env = {"PRISM_FEATURE_VISION": "on", "PRISM_VISION_SHADOW": "true"}
+    r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_EMPTY))
+    assert r["vision_pipeline"]["state"] == "SHADOW"
+
+
+def test_vision_pipeline_off_unset():
+    r = _results_by_id(fs.evaluate_all(env={}, crontab=CRON_EMPTY))
+    assert r["vision_pipeline"]["state"] == "OFF"
+
+
+# ── Vision buy QA (S3/S3.5) ───────────────────────────────────────────────────
+
+def test_vision_buy_qa_shadow_on_plus_shadow_true():
+    env = {"PRISM_FEATURE_VISION": "on", "PRISM_VISION_SHADOW": "true"}
+    r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_EMPTY))
+    assert r["vision_buy_qa"]["state"] == "SHADOW"
+
+
+def test_vision_buy_qa_live_on_no_shadow():
+    env = {"PRISM_FEATURE_VISION": "on"}
+    r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_EMPTY))
+    assert r["vision_buy_qa"]["state"] == "LIVE"
+
+
+def test_vision_buy_qa_off_vision_unset():
+    r = _results_by_id(fs.evaluate_all(env={}, crontab=CRON_EMPTY))
+    assert r["vision_buy_qa"]["state"] == "OFF"
+
+
+# ── Vision publish (S6) ───────────────────────────────────────────────────────
+
+def test_vision_publish_always_off():
+    """S6 publish wiring is not yet implemented — must always be OFF."""
+    for env in [
+        {},
+        {"PRISM_FEATURE_VISION": "on"},
+        {"PRISM_FEATURE_VISION": "on", "PRISM_VISION_SHADOW": "false"},
+    ]:
+        r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_EMPTY))
+        assert r["vision_publish"]["state"] == "OFF", f"Expected OFF for env={env}"
+
+
+# ── --json output ─────────────────────────────────────────────────────────────
+
+def test_json_output_contains_all_features(capsys):
+    env = {
+        "PRISM_OPENAI_AUTH_MODE": "chatgpt_oauth",
+        "LOOP_A_LIVE": "true",
+        "PRISM_FEATURE_VISION": "on",
+        "PRISM_VISION_SHADOW": "true",
+    }
+    results = fs.evaluate_all(env=env, crontab=CRON_LOOP_A_ONLY)
+    # Simulate --json path
+    out = {r["id"]: {"state": r["state"], "evidence": r["evidence"]} for r in results}
+    data = json.loads(json.dumps(out, ensure_ascii=False))
+
+    expected_ids = {"oauth_llm", "loop_a", "loop_b", "loop_c",
+                    "vision_pipeline", "vision_buy_qa", "vision_publish"}
+    assert expected_ids == set(data.keys())
+    assert data["oauth_llm"]["state"] == "LIVE"
+    assert data["loop_a"]["state"] == "LIVE"
+    assert data["vision_pipeline"]["state"] == "SHADOW"
+
+
+# ── Robustness: missing env / bad crontab ─────────────────────────────────────
+
+def test_empty_env_and_crontab_does_not_raise():
+    """evaluate_all must never raise even with completely empty inputs."""
+    results = fs.evaluate_all(env={}, crontab="")
+    assert len(results) == 7  # one entry per feature
+
+
+def test_cron_commented_line_not_counted():
+    cron = "# */10 * * * * /usr/bin/python tools/loop_a_hardstop.py\n"
+    assert not fs._cron_has_script(cron, "loop_a_hardstop.py")
+
+
+def test_cron_active_line_counted():
+    cron = "*/10 * * * * /usr/bin/python tools/loop_a_hardstop.py\n"
+    assert fs._cron_has_script(cron, "loop_a_hardstop.py")

--- a/tools/feature_status.py
+++ b/tools/feature_status.py
@@ -1,0 +1,248 @@
+"""
+Feature gate runtime status reporter — reads actual .env + crontab to determine
+LIVE / SHADOW / OFF state for each feature gate in prism-insight.
+
+Intended-state registry (source of truth): docs/FEATURE_FLAGS.md
+This script reports ACTUAL runtime state so it can be cross-checked against that
+document.
+
+Usage:
+    python tools/feature_status.py           # aligned text table (default)
+    python tools/feature_status.py --json    # machine-readable dict
+    python tools/feature_status.py --check   # exits non-zero if any gate is OFF
+                                             # when it should be LIVE (optional)
+
+READ-ONLY: never writes .env, never places orders, no network calls.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# ── Load .env from project root (best-effort) ────────────────────────────────
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_dotenv() -> None:
+    """Load .env into os.environ if python-dotenv is available; silently skip."""
+    env_path = _ROOT / ".env"
+    if not env_path.exists():
+        return
+    try:
+        from dotenv import load_dotenv  # type: ignore
+        load_dotenv(dotenv_path=env_path, override=False)
+    except ImportError:
+        # Fallback: manual parse (no dependencies required)
+        with open(env_path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, _, val = line.partition("=")
+                key = key.strip()
+                val = val.strip().strip('"').strip("'")
+                if key and key not in os.environ:
+                    os.environ[key] = val
+
+
+def _get_crontab() -> str:
+    """Return crontab -l output; return empty string on any failure."""
+    try:
+        result = subprocess.run(
+            ["crontab", "-l"],
+            capture_output=True, text=True, timeout=5
+        )
+        return result.stdout if result.returncode == 0 else ""
+    except Exception:
+        return ""
+
+
+def _cron_has_script(crontab_text: str, script_name: str) -> bool:
+    """Return True if script_name appears in an active (uncommented) cron line."""
+    for line in crontab_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        if script_name in stripped:
+            return True
+    return False
+
+
+# ── Feature definitions ───────────────────────────────────────────────────────
+# Each tuple: (feature_id, label_ko, decision_fn)
+# decision_fn(env, crontab) -> (state, evidence)
+# state: "LIVE" | "SHADOW" | "OFF" | "미스케줄"
+
+def _decide_oauth_llm(env: dict, crontab: str):
+    mode = env.get("PRISM_OPENAI_AUTH_MODE", "")
+    if mode == "chatgpt_oauth":
+        return "LIVE", f"PRISM_OPENAI_AUTH_MODE={mode}"
+    val = mode if mode else "(unset)"
+    return "OFF", f"PRISM_OPENAI_AUTH_MODE={val} (chatgpt_oauth 필요)"
+
+
+def _decide_loop_a(env: dict, crontab: str):
+    live = env.get("LOOP_A_LIVE", "").lower()
+    enabled = env.get("LOOP_A_ENABLED", "true").lower()
+    has_cron = _cron_has_script(crontab, "loop_a_hardstop.py")
+
+    if enabled == "false":
+        return "OFF", f"LOOP_A_ENABLED=false (킬스위치 ON)"
+    if live == "true" and has_cron:
+        return "LIVE", f"LOOP_A_LIVE=true, cron=있음"
+    if live == "true" and not has_cron:
+        return "미스케줄", f"LOOP_A_LIVE=true but cron=없음"
+    if live != "true" and has_cron:
+        return "SHADOW", f"LOOP_A_LIVE={live or '(unset)'}, cron=있음"
+    return "OFF", f"LOOP_A_LIVE={live or '(unset)'}, cron=없음"
+
+
+def _decide_loop_b(env: dict, crontab: str):
+    live = env.get("LOOP_B_LIVE", "").lower()
+    enabled = env.get("LOOP_B_ENABLED", "").lower()
+    has_cron = _cron_has_script(crontab, "loop_b_trend_exit.py")
+
+    if enabled == "false":
+        return "OFF", "LOOP_B_ENABLED=false"
+    if live == "true" and has_cron:
+        return "LIVE", "LOOP_B_LIVE=true, cron=있음"
+    if live == "true" and not has_cron:
+        return "미스케줄", "LOOP_B_LIVE=true but cron=없음"
+    if not has_cron:
+        return "미스케줄", f"cron=없음, LOOP_B_LIVE={live or '(unset)'}"
+    return "SHADOW", f"LOOP_B_LIVE={live or '(unset)'}, cron=있음"
+
+
+def _decide_loop_c(env: dict, crontab: str):
+    live = env.get("LOOP_C_LIVE", "").lower()
+    enabled = env.get("LOOP_C_ENABLED", "").lower()
+    has_cron = _cron_has_script(crontab, "loop_c_fill_chaser.py")
+
+    if enabled == "false":
+        return "OFF", "LOOP_C_ENABLED=false"
+    if live == "true" and has_cron:
+        return "LIVE", "LOOP_C_LIVE=true, cron=있음"
+    if live == "true" and not has_cron:
+        return "미스케줄", "LOOP_C_LIVE=true but cron=없음"
+    if not has_cron:
+        return "미스케줄", f"cron=없음, LOOP_C_LIVE={live or '(unset)'}"
+    return "SHADOW", f"LOOP_C_LIVE={live or '(unset)'}, cron=있음"
+
+
+def _decide_vision_pipeline(env: dict, crontab: str):
+    vision = env.get("PRISM_FEATURE_VISION", "").lower()
+    shadow = env.get("PRISM_VISION_SHADOW", "").lower()
+    if vision == "on":
+        if shadow == "true":
+            return "SHADOW", "PRISM_FEATURE_VISION=on, PRISM_VISION_SHADOW=true"
+        return "LIVE", "PRISM_FEATURE_VISION=on, PRISM_VISION_SHADOW=(unset/false)"
+    val = vision if vision else "(unset)"
+    return "OFF", f"PRISM_FEATURE_VISION={val}"
+
+
+def _decide_vision_buy_qa(env: dict, crontab: str):
+    vision = env.get("PRISM_FEATURE_VISION", "").lower()
+    shadow = env.get("PRISM_VISION_SHADOW", "").lower()
+    if vision == "on" and shadow == "true":
+        return "SHADOW", "PRISM_FEATURE_VISION=on + PRISM_VISION_SHADOW=true"
+    if vision == "on" and shadow != "true":
+        return "LIVE", "PRISM_FEATURE_VISION=on, PRISM_VISION_SHADOW!=true"
+    return "OFF", f"PRISM_FEATURE_VISION={vision or '(unset)'}"
+
+
+def _decide_vision_publish(env: dict, crontab: str):
+    vision = env.get("PRISM_FEATURE_VISION", "").lower()
+    # S6 publish wiring not yet implemented — always OFF regardless of env
+    if vision == "on":
+        return "OFF", "PRISM_FEATURE_VISION=on but 발행 배선 미구현(S6)"
+    return "OFF", f"PRISM_FEATURE_VISION={vision or '(unset)'}, 배선 미구현"
+
+
+# Registry: (id, korean label, decision function)
+FEATURES = [
+    ("oauth_llm",        "OAuth LLM 백엔드(ChatGPT 구독)",          _decide_oauth_llm),
+    ("loop_a",           "Loop A — 고빈도 하드스톱",                  _decide_loop_a),
+    ("loop_b",           "Loop B — 50MA 추세이탈",                   _decide_loop_b),
+    ("loop_c",           "Loop C — 미체결 추격",                     _decide_loop_c),
+    ("vision_pipeline",  "비전 배관·렌더QA (S1/S2)",                  _decide_vision_pipeline),
+    ("vision_buy_qa",    "비전 매수 품질검사 (S3/S3.5)",               _decide_vision_buy_qa),
+    ("vision_publish",   "비전 이미지 발행 (S6)",                     _decide_vision_publish),
+]
+
+
+def evaluate_all(env: dict | None = None, crontab: str | None = None) -> list[dict]:
+    """Return a list of dicts with keys: id, label, state, evidence."""
+    if env is None:
+        env = dict(os.environ)
+    if crontab is None:
+        crontab = _get_crontab()
+
+    results = []
+    for feat_id, label, fn in FEATURES:
+        try:
+            state, evidence = fn(env, crontab)
+        except Exception as exc:
+            state, evidence = "unknown", f"오류: {exc}"
+        results.append({"id": feat_id, "label": label, "state": state, "evidence": evidence})
+    return results
+
+
+# ── Formatters ────────────────────────────────────────────────────────────────
+
+_STATE_EMOJI = {"LIVE": "●", "SHADOW": "◐", "OFF": "○", "미스케줄": "⚠"}
+
+
+def _print_table(results: list[dict]) -> None:
+    col_label = max(len(r["label"]) for r in results) + 2
+    col_state = max(len(r["state"]) for r in results) + 2
+    header = f"{'기능':<{col_label}} {'상태':<{col_state}} 근거"
+    print(header)
+    print("─" * (col_label + col_state + 40))
+    for r in results:
+        mark = _STATE_EMOJI.get(r["state"], " ")
+        print(f"{r['label']:<{col_label}} {mark} {r['state']:<{col_state - 2}} {r['evidence']}")
+
+
+def _print_json(results: list[dict]) -> None:
+    out = {r["id"]: {"state": r["state"], "evidence": r["evidence"]} for r in results}
+    print(json.dumps(out, ensure_ascii=False, indent=2))
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="prism-insight feature gate runtime status (READ-ONLY)"
+    )
+    parser.add_argument("--json", action="store_true", help="JSON output")
+    parser.add_argument(
+        "--check", action="store_true",
+        help="Exit non-zero if any expected-LIVE gate is not LIVE"
+    )
+    args = parser.parse_args()
+
+    _load_dotenv()
+    results = evaluate_all()
+
+    if args.json:
+        _print_json(results)
+    else:
+        _print_table(results)
+
+    if args.check:
+        non_live = [r for r in results if r["state"] != "LIVE"]
+        if non_live:
+            print(
+                f"\n[CHECK] {len(non_live)}개 게이트가 LIVE 아님: "
+                + ", ".join(r["id"] for r in non_live),
+                file=sys.stderr,
+            )
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/feature_status.py
+++ b/tools/feature_status.py
@@ -71,6 +71,22 @@ def _cron_has_script(crontab_text: str, script_name: str) -> bool:
     return False
 
 
+def _cron_get_inline_env(crontab_text: str, var_name: str) -> str:
+    """Return the value of var_name if it appears as an inline env assignment
+    (e.g. ``VAR=value``) on any active (uncommented) crontab line.
+    Returns empty string if not found.
+    """
+    prefix = f"{var_name}="
+    for line in crontab_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        for token in stripped.split():
+            if token.startswith(prefix):
+                return token[len(prefix):]
+    return ""
+
+
 # ── Feature definitions ───────────────────────────────────────────────────────
 # Each tuple: (feature_id, label_ko, decision_fn)
 # decision_fn(env, crontab) -> (state, evidence)
@@ -79,9 +95,18 @@ def _cron_has_script(crontab_text: str, script_name: str) -> bool:
 def _decide_oauth_llm(env: dict, crontab: str):
     mode = env.get("PRISM_OPENAI_AUTH_MODE", "")
     if mode == "chatgpt_oauth":
-        return "LIVE", f"PRISM_OPENAI_AUTH_MODE={mode}"
-    val = mode if mode else "(unset)"
-    return "OFF", f"PRISM_OPENAI_AUTH_MODE={val} (chatgpt_oauth 필요)"
+        return "LIVE", f"PRISM_OPENAI_AUTH_MODE={mode} (env)"
+
+    # Also check for inline env assignment on active crontab lines
+    cron_mode = _cron_get_inline_env(crontab, "PRISM_OPENAI_AUTH_MODE")
+    if cron_mode == "chatgpt_oauth":
+        return "LIVE", f"PRISM_OPENAI_AUTH_MODE={cron_mode} (crontab inline)"
+
+    # Determine label: API key mode vs fully unset
+    effective_mode = mode or cron_mode
+    if effective_mode and effective_mode != "chatgpt_oauth":
+        return "OFF", f"PRISM_OPENAI_AUTH_MODE={effective_mode} (API 키 모드, chatgpt_oauth 필요)"
+    return "OFF", f"PRISM_OPENAI_AUTH_MODE=(unset) (chatgpt_oauth 필요)"
 
 
 def _decide_loop_a(env: dict, crontab: str):


### PR DESCRIPTION
기능 게이트의 **실제 런타임 상태**(LIVE/SHADOW/OFF/미스케줄)를 .env + crontab에서 읽어 출력. `docs/FEATURE_FLAGS.md`(의도 상태)와 대조용. 읽기 전용·무매매. OAuth는 crontab inline env까지 스캔. `--json` 지원. 테스트 29건. 프로덕션 검증: OAuth/Loop A=LIVE, Loop B/C=미스케줄, 비전=SHADOW 정확.

🤖 Generated with [Claude Code](https://claude.com/claude-code)