### PR TITLE
fix(us): 분석 실패 처리 견고화 + 날짜별 로그 압축/정리

### DIFF
--- a/prism-us/tests/test_phase6_trading.py
+++ b/prism-us/tests/test_phase6_trading.py
@@ -277,6 +277,15 @@ class TestTrackingAgentHelpers:
         for key in required_keys:
             assert key in result, f"Missing key: {key}"
 
+    def test_default_scenario_marks_analysis_failed(self):
+        """default_scenario() must flag analysis_failed so downstream code
+        skips the ticker instead of broadcasting a misleading '매수 보류'
+        message for a stock it could not actually analyze."""
+        from us_stock_tracking_agent import default_scenario
+
+        result = default_scenario()
+        assert result.get('analysis_failed') is True
+
 
 # =============================================================================
 # Test: Sector Diversity Check

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -442,7 +442,13 @@ def parse_price_value(value: Any) -> float:
 
 
 def default_scenario() -> Dict[str, Any]:
-    """Return default trading scenario for US stocks."""
+    """Return default trading scenario for US stocks.
+
+    NOTE: This is a *failure* sentinel, not a real trading decision. The
+    `analysis_failed` flag lets downstream code distinguish a genuine
+    "no_entry" judgment from an analysis/LLM failure, so we never broadcast a
+    misleading "매수 보류" message for a stock we couldn't actually analyze.
+    """
     return {
         "portfolio_analysis": "Analysis failed",
         "buy_score": 0,
@@ -452,7 +458,8 @@ def default_scenario() -> Dict[str, Any]:
         "investment_period": "short",
         "rationale": "Analysis failed",
         "sector": "Unknown",
-        "considerations": "Analysis failed"
+        "considerations": "Analysis failed",
+        "analysis_failed": True
     }
 
 
@@ -798,16 +805,40 @@ class USStockTrackingAgent:
             {report_content}
             """
 
-            response = await llm.generate_str(
-                message=prompt_message,
-                request_params=RequestParams(
-                    model="gpt-5.5",
-                    maxTokens=30000
-                )
-            )
+            # LLM scenario generation with retry+backoff. Transient API/parse
+            # failures (rate limits, truncated responses) were silently turning
+            # into default_scenario() — i.e. a misleading "Analysis failed" skip.
+            # Retry a couple of times before giving up.
+            ticker_tag = ticker or "?"
+            max_attempts = 3
+            response = None
+            scenario_json = None
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    response = await llm.generate_str(
+                        message=prompt_message,
+                        request_params=RequestParams(
+                            model="gpt-5.5",
+                            maxTokens=30000
+                        )
+                    )
+                    # JSON parsing (consolidated in cores/utils.py)
+                    scenario_json = parse_llm_json(response, context='US trading scenario')
+                    if scenario_json is not None:
+                        break
+                    logger.warning(
+                        f"[{ticker_tag}] US trading scenario parse returned None "
+                        f"(attempt {attempt}/{max_attempts})"
+                    )
+                except Exception as call_err:
+                    log_openai_error(logger, call_err, f"US trading scenario LLM call [{ticker_tag}]")
+                    logger.warning(
+                        f"[{ticker_tag}] US trading scenario LLM call failed "
+                        f"(attempt {attempt}/{max_attempts}): {call_err}"
+                    )
+                if attempt < max_attempts:
+                    await asyncio.sleep(2 * attempt)  # linear backoff: 2s, 4s
 
-            # JSON parsing (consolidated in cores/utils.py)
-            scenario_json = parse_llm_json(response, context='US trading scenario')
             if scenario_json is not None:
                 # Persist the experience-based score adjustment alongside the scenario.
                 # It rides inside the scenario JSON, stored in us_stock_holdings.scenario and
@@ -818,7 +849,10 @@ class USStockTrackingAgent:
                 logger.info(f"Scenario parsed: {json.dumps(scenario_json, ensure_ascii=False)[:200]}")
                 return scenario_json
 
-            logger.error(f"US trading scenario parse failed. Full response: {response}")
+            logger.error(
+                f"[ANALYSIS_FAILED][{ticker_tag}] US trading scenario unavailable after "
+                f"{max_attempts} attempts. Last response (truncated): {str(response)[:500]}"
+            )
             return default_scenario()
 
         except Exception as e:
@@ -868,6 +902,17 @@ class USStockTrackingAgent:
                 trigger_mode=trigger_mode
             )
 
+            # Analysis/LLM failure sentinel: do NOT emit a misleading "매수 보류"
+            # message or watchlist entry. Log clearly and skip the ticker via the
+            # same path as a hard failure (success=False), unifying both failure modes.
+            if scenario.get("analysis_failed"):
+                logger.error(
+                    f"[ANALYSIS_FAILED][{ticker}] {company_name}: trading scenario unavailable "
+                    f"after retries — skipping (no trade, no skip message, no watchlist)"
+                )
+                return {"success": False, "error": "analysis_failed",
+                        "ticker": ticker, "company_name": company_name}
+
             raw_decision = scenario.get("decision", "no_entry")
             sector = scenario.get("sector", "Unknown")
 
@@ -885,7 +930,7 @@ class USStockTrackingAgent:
             }
 
         except Exception as e:
-            logger.error(f"Error analyzing report: {str(e)}")
+            logger.error(f"[ANALYSIS_FAILED] Error analyzing report ({pdf_report_path}): {str(e)}")
             logger.error(traceback.format_exc())
             return {"success": False, "error": str(e)}
 
@@ -2501,7 +2546,11 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
             for pdf_report_path in pdf_report_paths:
                 analysis_result = await self._analyze_report_core(pdf_report_path)
                 if not analysis_result.get("success", False):
-                    logger.error(f"Report analysis failed: {pdf_report_path}")
+                    logger.error(
+                        f"[ANALYSIS_FAILED] Report analysis skipped "
+                        f"({analysis_result.get('ticker', '?')}/{analysis_result.get('company_name', '?')}): "
+                        f"{analysis_result.get('error')} — {pdf_report_path}"
+                    )
                     continue
                 analysis_states.append(
                     {

--- a/utils/cleanup_logs.sh
+++ b/utils/cleanup_logs.sh
@@ -5,14 +5,58 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"  # utils의 부모 디렉토리
 
 # 보관 기간 설정
-DAYS_TO_KEEP_LOGS=7      # 로그 파일: 7일
-DAYS_TO_KEEP_REPORTS=30  # PDF/MD 보고서: 30일
+DAYS_TO_KEEP_LOGS=7         # 비압축 로그 파일: 7일
+DAYS_TO_KEEP_REPORTS=30     # PDF/MD 보고서: 30일
+DAYS_TO_KEEP_COMPRESSED=30  # 압축(.gz) 로그: 30일 (디버깅용 히스토리 보관)
 
 # utils 디렉토리 생성 (없는 경우)
 mkdir -p "$PROJECT_ROOT/utils"
 
 # 스크립트 실행 시간 기록
 echo "$(date): 로그 정리 시작" >> "$PROJECT_ROOT/utils/log_cleanup.log"
+
+# =============================================================================
+# 0. 날짜별 로그 압축 (gzip)
+# =============================================================================
+# 날짜별로 쌓이는 *.log 파일을 gzip으로 압축한다.
+# - 오늘 작성 중인 로그(24시간 이내 수정)는 건드리지 않는다 (-mtime +0).
+# - 이미 .gz 인 파일은 건너뛴다.
+# - gzip은 원본의 수정시각을 .gz 에 보존하므로, 이후 보관기간 삭제(-mtime)가 날짜 기준으로 동작한다.
+PRISM_US_DIR="$PROJECT_ROOT/prism-us"
+LOGS_DIR="$PROJECT_ROOT/logs"
+
+# 압축 대상 날짜별 로그 패턴 (단일 누적 파일은 제외)
+COMPRESS_PATTERNS=(
+    "*stock_tracking_*.log"
+    "enhanced_stock_tracking_*.log"
+    "orchestrator_*.log"
+    "us_orchestrator_*.log"
+    "us_performance_tracker_*.log"
+    "ai_bot_*.log"
+    "compression_*.log"
+    "us_morning_*.log"
+    "us_midday_*.log"
+    "us_afternoon_*.log"
+    "us_performance_*.log"
+)
+
+compress_dated_logs() {
+    local dir="$1"
+    local maxdepth="$2"
+    [ -d "$dir" ] || return
+    local pat
+    for pat in "${COMPRESS_PATTERNS[@]}"; do
+        find "$dir" -maxdepth "$maxdepth" -name "$pat" -type f -mtime +0 ! -name "*.gz" \
+            -exec gzip -f {} \; 2>/dev/null
+    done
+}
+
+COMPRESSED_BEFORE=$(find "$PROJECT_ROOT" "$PRISM_US_DIR" "$LOGS_DIR" -name "*.log.gz" 2>/dev/null | wc -l)
+compress_dated_logs "$PROJECT_ROOT" 1
+compress_dated_logs "$PRISM_US_DIR" 1
+compress_dated_logs "$LOGS_DIR" 2
+COMPRESSED_AFTER=$(find "$PROJECT_ROOT" "$PRISM_US_DIR" "$LOGS_DIR" -name "*.log.gz" 2>/dev/null | wc -l)
+echo "$(date): 날짜별 로그 압축 완료 (.gz: ${COMPRESSED_BEFORE} -> ${COMPRESSED_AFTER})" >> "$PROJECT_ROOT/utils/log_cleanup.log"
 
 # =============================================================================
 # 1. 로그 파일 패턴 (7일 보관)
@@ -38,6 +82,14 @@ LOG_PATTERNS=(
 for PATTERN in "${LOG_PATTERNS[@]}"; do
     find "$PROJECT_ROOT" -maxdepth 1 -name "$PATTERN" -type f -mtime +$DAYS_TO_KEEP_LOGS -exec rm {} \;
 done
+
+# 압축(.gz) 로그 삭제 (DAYS_TO_KEEP_COMPRESSED 경과분) - 루트/prism-us/logs 전체
+DELETED_GZ=$(find "$PROJECT_ROOT" -maxdepth 1 -name "*.log.gz" -type f -mtime +$DAYS_TO_KEEP_COMPRESSED -exec rm {} \; -print 2>/dev/null | wc -l)
+[ -d "$PRISM_US_DIR" ] && DELETED_GZ=$((DELETED_GZ + $(find "$PRISM_US_DIR" -maxdepth 1 -name "*.log.gz" -type f -mtime +$DAYS_TO_KEEP_COMPRESSED -exec rm {} \; -print 2>/dev/null | wc -l)))
+[ -d "$LOGS_DIR" ] && DELETED_GZ=$((DELETED_GZ + $(find "$LOGS_DIR" -maxdepth 2 -name "*.log.gz" -type f -mtime +$DAYS_TO_KEEP_COMPRESSED -exec rm {} \; -print 2>/dev/null | wc -l)))
+if [ "$DELETED_GZ" -gt 0 ]; then
+    echo "$(date): 압축 로그 ${DELETED_GZ}개 삭제 (${DAYS_TO_KEEP_COMPRESSED}일 경과)" >> "$PROJECT_ROOT/utils/log_cleanup.log"
+fi
 
 # =============================================================================
 # 2. prism-us 디렉토리 내 로그 파일 (7일 보관)


### PR DESCRIPTION
## 배경
운영 db-server의 US 분석 배치(KST 새벽, America/New_York TZ)가 외부 API 불안정으로 간헐 실패하면서 **두 가지 비일관 결과**가 발생:
- 시나리오 LLM 응답 파싱 실패 → `default_scenario()`가 그대로 **오해성 "매수 보류" 메시지**(score 0 / 산업군 Unknown / 분석의견 "Analysis failed")로 전송 (예: SNDK)
- 더 상위 예외 → 종목이 **아무 메시지 없이 조용히 누락** (예: 마이크론)

## 변경
- 시나리오 LLM 호출에 **재시도+백오프(3회, 2s/4s)** 추가 → 일시적 실패 흡수
- `default_scenario()`에 `analysis_failed=True` 플래그 부착 (실패 sentinel과 실제 no_entry 판단 구분)
- 분석 실패 시 `[ANALYSIS_FAILED]` 마커로 명확히 로깅 후 **종목 스킵**(매매·워치리스트·보류메시지 모두 없음) → 두 실패 경로 통일
- `utils/cleanup_logs.sh`: 날짜별 로그 **gzip 압축** + `.gz` 30일 보관/정리 (로그 누적·비용 완화)

## 테스트
- `test_phase6_trading.py`에 `analysis_failed` 플래그 검증 테스트 추가
- 로컬 `py_compile` 통과, cleanup 셸 임시환경 기능 테스트 통과
- 런타임 검증: 배포 후 다음 US 배치 로그에서 `[ANALYSIS_FAILED]` 마커로 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)