### PR TITLE
fix(tools): feature_status vision 판정이 .env dict 사용(os.environ 아님)

### DIFF
--- a/tests/test_feature_status.py
+++ b/tests/test_feature_status.py
@@ -206,7 +206,7 @@ def test_vision_buy_qa_off_vision_unset():
 
 def test_vision_publish_off_when_insight_image_unset(monkeypatch):
     """S6 broadcast OFF when PRISM_FEATURE_INSIGHT_IMAGE is unset, even if vision available."""
-    monkeypatch.setattr(fs, "_vision_available", lambda: True)
+    monkeypatch.setattr(fs, "_vision_available", lambda env: True)
     r = _results_by_id(fs.evaluate_all(env={"PRISM_FEATURE_VISION": "on"}, crontab=CRON_EMPTY))
     assert r["vision_publish"]["state"] == "OFF"
     assert "PRISM_FEATURE_INSIGHT_IMAGE" in r["vision_publish"]["evidence"]
@@ -214,7 +214,7 @@ def test_vision_publish_off_when_insight_image_unset(monkeypatch):
 
 def test_vision_publish_off_when_vision_unavailable(monkeypatch):
     """S6 broadcast OFF when image flag is on but vision is not available (no key / vision off)."""
-    monkeypatch.setattr(fs, "_vision_available", lambda: False)
+    monkeypatch.setattr(fs, "_vision_available", lambda env: False)
     env = {"PRISM_FEATURE_INSIGHT_IMAGE": "on"}
     r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_EMPTY))
     assert r["vision_publish"]["state"] == "OFF"
@@ -223,7 +223,7 @@ def test_vision_publish_off_when_vision_unavailable(monkeypatch):
 
 def test_vision_publish_live_when_image_flag_and_vision_available(monkeypatch):
     """S6 broadcast LIVE only when PRISM_FEATURE_INSIGHT_IMAGE=on AND vision available."""
-    monkeypatch.setattr(fs, "_vision_available", lambda: True)
+    monkeypatch.setattr(fs, "_vision_available", lambda env: True)
     env = {"PRISM_FEATURE_INSIGHT_IMAGE": "on"}
     r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_EMPTY))
     assert r["vision_publish"]["state"] == "LIVE"

--- a/tools/feature_status.py
+++ b/tools/feature_status.py
@@ -178,15 +178,24 @@ def _decide_vision_buy_qa(env: dict, crontab: str):
     return "OFF", f"PRISM_FEATURE_VISION={vision or '(unset)'}"
 
 
-def _vision_available() -> bool:
-    """Seam over cores.llm.capabilities.vision_available() (vision on + real API key).
+def _vision_available(env: dict) -> bool:
+    """Mirror cores.llm.capabilities.vision_available() = vision on + real API key.
 
-    Split out so tests can monkeypatch the key-dependent gate without a real key.
+    PRISM_FEATURE_VISION is read from the parsed .env dict — this reporter does
+    NOT load .env into os.environ, so calling capabilities.vision_available()
+    directly would read an empty os.environ and wrongly report 미가용. The real
+    API key is resolved via capabilities, which falls back to
+    mcp_agent.secrets.yaml when OPENAI_API_KEY is not exported (OAuth mode).
     Returns False if capabilities can't be imported (keeps the reporter robust).
     """
+    if env.get("PRISM_FEATURE_VISION", "").lower() != "on":
+        return False
+    envkey = env.get("OPENAI_API_KEY", "").strip()
+    if envkey and envkey != "chatgpt-oauth-placeholder":
+        return True
     try:
-        from cores.llm.capabilities import vision_available
-        return vision_available()
+        from cores.llm.capabilities import _secrets_api_key
+        return bool(_secrets_api_key())
     except Exception:
         return False
 
@@ -202,7 +211,7 @@ def _decide_vision_publish(env: dict, crontab: str):
     insight = env.get("PRISM_FEATURE_INSIGHT_IMAGE", "").lower()
     if insight != "on":
         return "OFF", f"PRISM_FEATURE_INSIGHT_IMAGE={insight or '(unset)'}"
-    if not _vision_available():
+    if not _vision_available(env):
         return "OFF", "PRISM_FEATURE_INSIGHT_IMAGE=on but vision 미가용(PRISM_FEATURE_VISION=on + API 키 필요)"
     return "LIVE", "PRISM_FEATURE_INSIGHT_IMAGE=on + vision 가용"
 


### PR DESCRIPTION
feature_status가 .env를 dict로만 읽는데 _vision_available가 os.environ 읽는 capabilities.vision_available()를 호출 → 서버 수동실행 시 vision 미가용 오판 → S6를 OFF로 오표시(실제는 LIVE, [INSIGHT_IMAGE] sent 확인됨). env dict + secrets 폴백으로 수정. 테스트 31 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)