### PR TITLE
fix(tools): feature_status sys.path에 레포 루트 추가

### DIFF
--- a/tools/feature_status.py
+++ b/tools/feature_status.py
@@ -25,6 +25,12 @@ from pathlib import Path
 # ── Load .env from project root (best-effort) ────────────────────────────────
 _ROOT = Path(__file__).resolve().parent.parent
 
+# Make the repo root importable even when invoked as `python tools/feature_status.py`
+# (sys.path[0] would be tools/, so `from cores.llm...` in _vision_available would
+# fail and wrongly report vision 미가용). Idempotent.
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
 
 def _load_dotenv() -> None:
     """Load .env into os.environ if python-dotenv is available; silently skip."""


### PR DESCRIPTION
python tools/feature_status.py 직접 실행 시 cores import 실패로 S6 OFF 오표시되던 것 수정. _ROOT를 sys.path에 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)