### PR TITLE
feat(phase6-s6): 인사이트 이미지에 과거 매매 마커 + LLM 컨텍스트

### DIFF
--- a/cores/llm/features/buy_quality.py
+++ b/cores/llm/features/buy_quality.py
@@ -398,9 +398,14 @@ async def analyze_base_oneil(
     numeric_pivot: float | None = None,
     current_price: float | None = None,
     market: str | None = None,
+    extra_context: str | None = None,
 ) -> BaseAnalysis | None:
     """Two-timeframe O'Neil base analysis: generate DAILY + WEEKLY charts (with
     RS line) for *ticker* and analyse both in a single multi-image vision call.
+
+    *extra_context* (optional) is appended to the prompt as additional grounding
+    text — e.g. a concise summary of the ticker's PAST trades for the insight
+    image. Purely informational; never changes the structured output schema.
 
     Grounds BaseAnalysis.rs_line_new_high (RS line panel) and the weekly base
     reading instead of relying on a single daily image.
@@ -466,6 +471,13 @@ async def analyze_base_oneil(
             f"{_BASE_PROMPT_TWO_TF}\n"
             f"Reference values (for sanity-checking your pivot, not to copy "
             f"blindly): {', '.join(hints)}.\n"
+        )
+
+    if extra_context:
+        prompt = (
+            f"{prompt}\n"
+            f"추가 참고 정보 (구조화 출력에는 영향 없음, 분석 근거로만 활용):\n"
+            f"{extra_context}\n"
         )
 
     try:

--- a/cores/llm/features/insight_image.py
+++ b/cores/llm/features/insight_image.py
@@ -61,6 +61,8 @@ _COLOR_RESISTANCE = "#f85149"   # red
 _COLOR_BUY = _GOLD              # gold pivot (hero)
 _COLOR_STOP = "#d29922"         # amber
 _COLOR_BASEBOX = _GOLD          # base highlight box
+_COLOR_TRADE_BUY = "#3fb950"    # past-trade buy marker (green ▲)
+_COLOR_TRADE_SELL = "#f85149"   # past-trade sell marker (red ▼)
 
 _DISCLAIMER = "※ 분석 의견이며 투자 조언이 아닙니다."
 
@@ -342,6 +344,55 @@ def _draw_pivot_marker(price_ax, analysis, *, price_min, price_max,
         logger.warning("[INSIGHT_IMAGE] pivot marker failed: %s", exc)
 
 
+def _draw_trade_markers(price_ax, trades, *, price_min, price_max,
+                        font_prop=None) -> None:
+    """Plot past buy/sell markers on the price axis. Best-effort, never raises.
+
+    *trades* is a list of ``(x, price, side)`` tuples where ``x`` is the
+    mplfinance candle-index position (float) and ``side`` is ``"buy"`` /
+    ``"sell"``. Buys render as a green ▲ below the trade price, sells as a red
+    ▼ above it. A tiny legend is added. Markers whose price falls outside the
+    visible band are dropped (the trade may pre-date the visible window).
+    """
+    try:
+        if not trades:
+            return
+        xmin, xmax = price_ax.get_xlim()
+        pad = (price_max - price_min) * 0.02
+        drew_buy = drew_sell = False
+        for x, price, side in trades:
+            try:
+                xf = float(x)
+                pf = float(price)
+            except (TypeError, ValueError):
+                continue
+            if not (xmin <= xf <= xmax):
+                continue
+            if not (price_min <= pf <= price_max):
+                continue
+            if side == "buy":
+                price_ax.scatter(
+                    [xf], [pf - pad], marker="^", s=130,
+                    color=_COLOR_TRADE_BUY, edgecolors="#0b0e14",
+                    linewidths=0.8, zorder=9,
+                    label=("과거 매수" if not drew_buy else None))
+                drew_buy = True
+            else:
+                price_ax.scatter(
+                    [xf], [pf + pad], marker="v", s=130,
+                    color=_COLOR_TRADE_SELL, edgecolors="#0b0e14",
+                    linewidths=0.8, zorder=9,
+                    label=("과거 매도" if not drew_sell else None))
+                drew_sell = True
+        if drew_buy or drew_sell:
+            leg = price_ax.legend(loc="lower left", fontsize=8, framealpha=0.85)
+            if leg is not None and font_prop is not None:
+                for txt in leg.get_texts():
+                    txt.set_fontproperties(font_prop)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[INSIGHT_IMAGE] trade markers failed: %s", exc)
+
+
 def render_insight_image(
     daily_fig,
     analysis: BaseAnalysis,
@@ -352,6 +403,7 @@ def render_insight_image(
     price_max: float,
     currency_symbol: str = "₩",
     price_decimals: int = 0,
+    trades=None,
 ) -> bytes | None:
     """Overlay deterministic O'Neil annotations on the DAILY chart and add a
     clean Korean caption band below it.
@@ -374,6 +426,9 @@ def render_insight_image(
         company_name: Company name (used in the caption header).
         price_min:    The chart's actual visible minimum price.
         price_max:    The chart's actual visible maximum price.
+        trades:       Optional list of ``(x, price, side)`` past-trade tuples
+                      (x = candle-index position) to overlay as buy ▲ / sell ▼
+                      markers. Empty/None -> no markers (no-op).
 
     Returns:
         JPEG bytes on success, or ``None`` on any failure. Never raises.
@@ -431,6 +486,11 @@ def render_insight_image(
                         f"손절 {_fmt(stop[0])}", linestyle="--",
                         linewidth=1.2, font_prop=font_prop)
         # buy pivot is rendered by _draw_pivot_marker (circle + callout) above
+
+        # --- Past-trade markers (subscriber-facing; from the tracking DB) -----
+        if trades:
+            _draw_trade_markers(price_ax, trades, price_min=price_min,
+                                price_max=price_max, font_prop=font_prop)
 
         # --- Re-stack the panels into clean bands + add a caption band ---
         _relayout_with_caption(
@@ -551,6 +611,38 @@ def _fig_to_jpeg(fig, *, dpi: int = 110) -> bytes | None:
         return None
 
 
+def _map_trades_to_x(events, ohlc_df):
+    """Map each TradeEvent date to its nearest mplfinance candle-index position.
+
+    mplfinance (default ``show_nontrading=False``) plots candle ``i`` at integer
+    x-position ``i`` where ``i`` indexes ``ohlc_df``. We map each trade date to
+    the position of the nearest df date. Returns a list of ``(x, price, side)``
+    tuples. Best-effort; returns ``[]`` on any error.
+    """
+    try:
+        if ohlc_df is None or len(ohlc_df) == 0 or not events:
+            return []
+        import pandas as pd
+
+        idx = ohlc_df.index
+        if not isinstance(idx, pd.DatetimeIndex):
+            idx = pd.to_datetime(idx)
+        idx_norm = idx.normalize()
+        out = []
+        for ev in events:
+            try:
+                ts = pd.Timestamp(ev.date).normalize()
+            except Exception:  # noqa: BLE001
+                continue
+            # Nearest candle position by absolute day distance.
+            pos = int((idx_norm - ts).map(lambda d: abs(d.days)).values.argmin())
+            out.append((float(pos), float(ev.price), ev.side))
+        return out
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[INSIGHT_IMAGE] trade x-mapping failed: %s", exc)
+        return []
+
+
 async def build_insight_image_for(
     ticker: str,
     company_name: str | None = None,
@@ -570,20 +662,56 @@ async def build_insight_image_for(
     if not vision_available():
         return None
 
+    _is_us = isinstance(market, str) and market.strip().lower() in (
+        "us", "usa", "united states"
+    )
+
+    # --- Past-trade lookup (NON-BLOCKING; no trades -> no markers/context) ----
+    # Fetched BEFORE the vision call so a concise text summary can be injected
+    # into analyze_base_oneil as grounding context. Any failure here must NOT
+    # break image generation, so it is fully isolated.
+    trade_events = []
+    trade_context = None
+    try:
+        from cores.llm.features.trade_history import (
+            get_trade_events,
+            summarize_trades,
+        )
+
+        trade_events = get_trade_events(ticker, market=market)
+        if trade_events:
+            # Plain text for the LLM (no matplotlib "$" escaping needed here).
+            _ctx_sym, _ctx_dec = ("$", 2) if _is_us else ("₩", 0)
+            trade_context = summarize_trades(
+                trade_events, currency_symbol=_ctx_sym, price_decimals=_ctx_dec
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[INSIGHT_IMAGE] trade-history lookup failed for %s: %s",
+                       ticker, exc)
+        trade_events, trade_context = [], None
+
     try:
         from cores.llm.features.buy_quality import analyze_base_oneil
 
         analysis = await analyze_base_oneil(
-            ticker, company_name=company_name, market=market
+            ticker, company_name=company_name, market=market,
+            extra_context=trade_context,
         )
         if analysis is None:
             return None
 
         from cores.stock_chart import create_oneil_daily_chart
 
-        daily_fig = create_oneil_daily_chart(
-            ticker, company_name=company_name, market=market
+        # Request the df so trade dates can be mapped to candle-index x-positions.
+        chart_out = create_oneil_daily_chart(
+            ticker, company_name=company_name, market=market, return_df=True
         )
+        if chart_out is None:
+            return None
+        if isinstance(chart_out, tuple):
+            daily_fig, ohlc_df = chart_out
+        else:  # defensive: older signature returned fig only
+            daily_fig, ohlc_df = chart_out, None
         if daily_fig is None:
             return None
 
@@ -593,9 +721,9 @@ async def build_insight_image_for(
             return None
         price_min, price_max = price_ax.get_ylim()
 
-        _is_us = isinstance(market, str) and market.strip().lower() in (
-            "us", "usa", "united states"
-        )
+        # Map trade dates -> candle-index x positions (best-effort, isolated).
+        trade_xy = _map_trades_to_x(trade_events, ohlc_df) if trade_events else []
+
         # Escape "$" as "\\$": matplotlib treats a bare "$" as mathtext, which
         # corrupts adjacent Korean glyphs (renders them via the math 'rm' font).
         _currency_symbol, _price_decimals = ("\\$", 2) if _is_us else ("₩", 0)
@@ -608,6 +736,7 @@ async def build_insight_image_for(
             price_max=price_max,
             currency_symbol=_currency_symbol,
             price_decimals=_price_decimals,
+            trades=trade_xy,
         )
     except Exception as exc:  # noqa: BLE001
         logger.warning("[INSIGHT_IMAGE] build failed for %s: %s", ticker, exc)

--- a/cores/llm/features/trade_history.py
+++ b/cores/llm/features/trade_history.py
@@ -1,0 +1,233 @@
+# trade_history.py
+
+"""
+Past-trade lookup for the Phase 6 S6 insight image (DISPLAY-ONLY, additive).
+
+Given a ticker + market, look up that ticker's PAST trade events from the
+tracking DB (``stock_tracking_db.sqlite``) and expose them in two shapes:
+
+1. :class:`TradeEvent` list — one event per buy and per sell, carrying a parsed
+   date (``datetime``), a price (float, native currency), and a side
+   (``"buy"`` / ``"sell"``). Used by the renderer to draw markers.
+2. A CONCISE Korean text summary (``summarize_trades``) injected into the vision
+   prompt so the analysis can reference prior trades.
+
+Tables (per market, inspected from the live schema):
+  KR  -> ``trading_history``  (closed: buy_price/buy_date/sell_price/sell_date,
+                               profit_rate) + ``stock_holdings`` (open: buy_price
+                               /buy_date).
+  US  -> ``us_trading_history`` (same columns, USD) + ``us_stock_holdings``.
+
+Design constraints (mirror the insight-image feature):
+- NON-BLOCKING: every public entry point is wrapped so any failure (missing DB,
+  missing table, bad row) returns an empty result and logs ``[INSIGHT_IMAGE]``.
+  It must NEVER raise to the caller and NEVER break image generation.
+- No trades -> empty list / ``None`` summary (caller no-ops).
+- Read-only. Does not touch trading logic.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+# Cap markers / context to the most recent N trade EVENTS (buy+sell counted
+# separately). Keeps the chart readable and the prompt short.
+MAX_EVENTS = 10
+
+
+@dataclass(frozen=True)
+class TradeEvent:
+    """One past trade leg (a buy or a sell)."""
+
+    date: datetime
+    price: float
+    side: str  # "buy" | "sell"
+    profit_rate: float | None = None  # only meaningful on the matching sell
+
+
+def _is_us(market: str | None) -> bool:
+    return isinstance(market, str) and market.strip().lower() in (
+        "us", "usa", "united states", "nasdaq", "nyse",
+    )
+
+
+def _db_path() -> str:
+    """Resolve the tracking DB path (project root / stock_tracking_db.sqlite).
+
+    This file lives at ``cores/llm/features/trade_history.py``; the project root
+    is three directories up. Falls back to the CWD-relative name (matching the
+    tracking agents' default) if that path does not exist.
+    """
+    here = os.path.dirname(os.path.abspath(__file__))
+    root = os.path.abspath(os.path.join(here, "..", "..", ".."))
+    candidate = os.path.join(root, "stock_tracking_db.sqlite")
+    if os.path.exists(candidate):
+        return candidate
+    return "stock_tracking_db.sqlite"
+
+
+def _parse_dt(value) -> datetime | None:
+    """Parse a DB date/datetime string ('YYYY-MM-DD' or 'YYYY-MM-DD HH:MM:SS')."""
+    if value is None:
+        return None
+    s = str(value).strip()
+    if not s:
+        return None
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d", "%Y/%m/%d", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            return datetime.strptime(s[: len(fmt) + 4], fmt)
+        except ValueError:
+            continue
+    # Last resort: take the leading date token.
+    try:
+        return datetime.strptime(s.split()[0], "%Y-%m-%d")
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def get_trade_events(
+    ticker: str,
+    *,
+    market: str | None = None,
+    db_path: str | None = None,
+    max_events: int = MAX_EVENTS,
+) -> list[TradeEvent]:
+    """Return past buy/sell events for *ticker*, newest-first, capped.
+
+    Pulls CLOSED round-trips from the history table (each yields a buy + a sell
+    event) and the CURRENTLY-OPEN position from the holdings table (a buy event
+    only). Returns ``[]`` on any error or when there are no trades. Never raises.
+    """
+    try:
+        hist_table = "us_trading_history" if _is_us(market) else "trading_history"
+        hold_table = "us_stock_holdings" if _is_us(market) else "stock_holdings"
+        path = db_path or _db_path()
+
+        events: list[TradeEvent] = []
+        conn = sqlite3.connect(path)
+        try:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+
+            # Closed round-trips: one buy event + one sell event each.
+            try:
+                cur.execute(
+                    f"SELECT buy_price, buy_date, sell_price, sell_date, "
+                    f"profit_rate FROM {hist_table} WHERE ticker = ? "
+                    f"ORDER BY sell_date DESC",
+                    (ticker,),
+                )
+                for row in cur.fetchall():
+                    bdt = _parse_dt(row["buy_date"])
+                    sdt = _parse_dt(row["sell_date"])
+                    pr = row["profit_rate"]
+                    if bdt is not None and row["buy_price"] is not None:
+                        events.append(
+                            TradeEvent(bdt, float(row["buy_price"]), "buy")
+                        )
+                    if sdt is not None and row["sell_price"] is not None:
+                        events.append(
+                            TradeEvent(
+                                sdt, float(row["sell_price"]), "sell",
+                                profit_rate=float(pr) if pr is not None else None,
+                            )
+                        )
+            except sqlite3.Error as exc:
+                logger.info("[INSIGHT_IMAGE] history table read skipped: %s", exc)
+
+            # Currently-open position (buy leg only, no sell yet).
+            try:
+                cur.execute(
+                    f"SELECT buy_price, buy_date FROM {hold_table} "
+                    f"WHERE ticker = ?",
+                    (ticker,),
+                )
+                for row in cur.fetchall():
+                    bdt = _parse_dt(row["buy_date"])
+                    if bdt is not None and row["buy_price"] is not None:
+                        events.append(
+                            TradeEvent(bdt, float(row["buy_price"]), "buy")
+                        )
+            except sqlite3.Error as exc:
+                logger.info("[INSIGHT_IMAGE] holdings table read skipped: %s", exc)
+        finally:
+            conn.close()
+
+        if not events:
+            return []
+
+        # Dedupe same (date-day, side, price) events; keep newest first; cap.
+        seen: set[tuple] = set()
+        deduped: list[TradeEvent] = []
+        for ev in sorted(events, key=lambda e: e.date, reverse=True):
+            key = (ev.date.date(), ev.side, round(ev.price, 4))
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(ev)
+        return deduped[: max(1, max_events)]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[INSIGHT_IMAGE] get_trade_events failed for %s: %s",
+                       ticker, exc)
+        return []
+
+
+def summarize_trades(
+    events: list[TradeEvent],
+    *,
+    currency_symbol: str = "₩",
+    price_decimals: int = 0,
+    max_lines: int = 6,
+) -> str | None:
+    """Build a CONCISE Korean text summary of past trades for the LLM prompt.
+
+    Example line: ``매수 2025-10-01 @86,000, 매도 2025-10-14 @95,300 (수익률 +10.8%)``.
+    Returns ``None`` when there are no events. Plain text only (no ``$`` escaping
+    needed — this goes into a TEXT prompt, not matplotlib). Never raises.
+    """
+    try:
+        if not events:
+            return None
+
+        def _p(value: float) -> str:
+            return f"{currency_symbol}{value:,.{price_decimals}f}"
+
+        # Pair newest-first sells with the nearest preceding buy for readable
+        # round-trip lines; surface lone buys (open position) on their own.
+        ordered = sorted(events, key=lambda e: e.date)
+        lines: list[str] = []
+        pending_buys: list[TradeEvent] = []
+        for ev in ordered:
+            if ev.side == "buy":
+                pending_buys.append(ev)
+            else:  # sell — match the earliest pending buy
+                buy = pending_buys.pop(0) if pending_buys else None
+                if buy is not None:
+                    pr = (
+                        f" (수익률 {ev.profit_rate:+.1f}%)"
+                        if ev.profit_rate is not None
+                        else ""
+                    )
+                    lines.append(
+                        f"매수 {buy.date:%Y-%m-%d} @{_p(buy.price)}, "
+                        f"매도 {ev.date:%Y-%m-%d} @{_p(ev.price)}{pr}"
+                    )
+                else:
+                    lines.append(f"매도 {ev.date:%Y-%m-%d} @{_p(ev.price)}")
+        for buy in pending_buys:  # still-open positions
+            lines.append(f"매수(보유중) {buy.date:%Y-%m-%d} @{_p(buy.price)}")
+
+        if not lines:
+            return None
+        # Most recent lines first, capped.
+        lines = lines[::-1][: max(1, max_lines)]
+        return "과거 매매 이력:\n- " + "\n- ".join(lines)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[INSIGHT_IMAGE] summarize_trades failed: %s", exc)
+        return None

--- a/cores/stock_chart.py
+++ b/cores/stock_chart.py
@@ -1581,6 +1581,7 @@ def create_oneil_daily_chart(
     save_path=None,
     market=None,
     index_ticker=None,
+    return_df=False,
 ):
     """Generate an O'Neil DAILY chart (vision-only): candles + MA5/20/60/120 +
     volume + an RS line vs the market index.
@@ -1596,9 +1597,14 @@ def create_oneil_daily_chart(
         save_path:    If given, save the figure there; otherwise just return it.
         market:       Optional 'KOSPI'/'KOSDAQ' hint to pick the index.
         index_ticker: Optional explicit index ticker override (e.g. '1001').
+        return_df:    If True, return ``(fig, ohlc_df)`` so callers can map
+                      dates to mplfinance candle index positions. The returned
+                      df has the SAME row ordering as the plotted candles
+                      (position i <-> df.index[i]).
 
     Returns:
-        matplotlib figure, or None if stock data is unavailable.
+        matplotlib figure (or ``(fig, df)`` when ``return_df=True``), or None
+        if stock data is unavailable.
     """
     end_date = datetime.now().strftime('%Y%m%d')
     start_date = (datetime.now() - timedelta(days=days)).strftime('%Y%m%d')
@@ -1697,6 +1703,8 @@ def create_oneil_daily_chart(
         fig.savefig(save_path, bbox_inches='tight', dpi=80)
         logger.info(f"[ONEIL] daily chart saved: {save_path}")
 
+    if return_df:
+        return fig, ohlc_df
     return fig
 
 

--- a/prism-us/cores/stock_chart.py
+++ b/prism-us/cores/stock_chart.py
@@ -344,6 +344,7 @@ def create_oneil_daily_chart(
     save_path=None,
     market="us",
     index_ticker=None,
+    return_df=False,
 ):
     """Generate an O'Neil DAILY chart for a US ticker (vision-only).
 
@@ -358,10 +359,14 @@ def create_oneil_daily_chart(
         save_path:    If given, save the figure there; otherwise just return it.
         market:       Market hint (default ``"us"``); informational here.
         index_ticker: Optional explicit index symbol override (e.g. ``"^IXIC"``).
+        return_df:    If True, return ``(fig, ohlc_df)`` so callers can map
+                      trade dates to mplfinance candle index positions.
 
     Returns:
         matplotlib Figure (``axes[0]`` is the price axis), or None on failure.
-        Never raises.
+        When ``return_df=True``, returns ``(fig, ohlc_df)`` so callers can map
+        trade dates to mplfinance candle index positions (position i <->
+        ohlc_df.index[i]). Never raises.
     """
     try:
         client = _get_client()
@@ -442,6 +447,8 @@ def create_oneil_daily_chart(
             fig.savefig(save_path, bbox_inches="tight", dpi=80)
             logger.info(f"[ONEIL][US] daily chart saved: {save_path}")
 
+        if return_df:
+            return fig, ohlc_df
         return fig
     except Exception as e:  # noqa: BLE001
         logger.warning(f"[ONEIL][US] daily chart build failed for {ticker}: {e}")

--- a/tests/test_trade_history.py
+++ b/tests/test_trade_history.py
@@ -1,0 +1,222 @@
+# test_trade_history.py
+
+"""
+Phase 6 S6 — past-trade lookup + insight-image marker tests (ROOT session).
+
+Mock-only: a TEMP sqlite DB is populated with the real KR/US trade-table
+schemas (``trading_history`` / ``stock_holdings`` and ``us_trading_history`` /
+``us_stock_holdings``). NO network, NO pykrx, NO vision. matplotlib runs on Agg.
+
+Covers:
+- get_trade_events for KR and US (table selection per market).
+- summarize_trades produces a concise Korean round-trip line.
+- _map_trades_to_x maps trade dates to mplfinance candle-index positions.
+- _draw_trade_markers + render_insight_image overlay markers without crashing.
+- Empty DB / missing ticker -> no-op (empty list, None summary).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless; must precede pyplot import
+import matplotlib.pyplot as plt  # noqa: E402
+import pandas as pd  # noqa: E402
+
+from cores.llm.features import trade_history as th  # noqa: E402
+from cores.llm.features.trade_history import (  # noqa: E402
+    TradeEvent,
+    get_trade_events,
+    summarize_trades,
+)
+from cores.llm.features import insight_image  # noqa: E402
+from cores.llm.features.insight_image import (  # noqa: E402
+    _draw_trade_markers,
+    _map_trades_to_x,
+    render_insight_image,
+)
+from cores.llm.features.buy_quality import BaseAnalysis  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures / helpers                                                           #
+# --------------------------------------------------------------------------- #
+def _make_db(tmp_path) -> str:
+    """Create a temp sqlite DB with the KR + US trade tables + sample rows."""
+    path = str(tmp_path / "stock_tracking_db.sqlite")
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    # KR closed round-trips.
+    cur.execute(
+        "CREATE TABLE trading_history (id INTEGER PRIMARY KEY, ticker TEXT, "
+        "company_name TEXT, buy_price REAL, buy_date TEXT, sell_price REAL, "
+        "sell_date TEXT, profit_rate REAL, holding_days INTEGER, scenario TEXT)"
+    )
+    cur.execute(
+        "CREATE TABLE stock_holdings (ticker TEXT PRIMARY KEY, company_name TEXT, "
+        "buy_price REAL, buy_date TEXT, current_price REAL)"
+    )
+    # US closed round-trips.
+    cur.execute(
+        "CREATE TABLE us_trading_history (id INTEGER PRIMARY KEY, ticker TEXT, "
+        "company_name TEXT, buy_price REAL, buy_date TEXT, sell_price REAL, "
+        "sell_date TEXT, profit_rate REAL, holding_days INTEGER, scenario TEXT)"
+    )
+    cur.execute(
+        "CREATE TABLE us_stock_holdings (ticker TEXT PRIMARY KEY, "
+        "company_name TEXT, buy_price REAL, buy_date TEXT, current_price REAL)"
+    )
+    cur.execute(
+        "INSERT INTO trading_history (ticker, company_name, buy_price, buy_date, "
+        "sell_price, sell_date, profit_rate, holding_days) VALUES "
+        "('005930','삼성전자',86000.0,'2025-10-01 16:19:21',95300.0,"
+        "'2025-10-14 10:02:15',10.81,12)"
+    )
+    cur.execute(
+        "INSERT INTO us_trading_history (ticker, company_name, buy_price, buy_date, "
+        "sell_price, sell_date, profit_rate, holding_days) VALUES "
+        "('CCL','Carnival',31.15,'2026-01-30 07:07:43',29.92,"
+        "'2026-01-31 00:51:59',-3.93,0)"
+    )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _analysis() -> BaseAnalysis:
+    return BaseAnalysis(
+        base_type="cup-handle", base_length_weeks=8, depth_pct=22.0,
+        handle_present=True, handle_in_upper_half=True, tightness="tight",
+        volume_dryup_in_handle=True, pivot_price=72000.0, dist_to_pivot_pct=1.5,
+        rs_line_new_high=True, proper_or_faulty="proper", quality_score=82,
+        confidence=75, rationale="tight cup", support_levels=[68000.0],
+        resistance_levels=[75000.0], buy_point=72000.0, stop_loss=66000.0,
+    )
+
+
+def _price_fig():
+    fig, ax = plt.subplots(figsize=(6, 4))
+    ax.plot(range(10), [70000 + i * 300 for i in range(10)])
+    ax.set_xlim(-0.5, 9.5)
+    ax.set_ylim(68000, 76000)
+    return fig
+
+
+# --------------------------------------------------------------------------- #
+# get_trade_events                                                             #
+# --------------------------------------------------------------------------- #
+class TestGetTradeEvents:
+    def test_kr_round_trip_yields_buy_and_sell(self, tmp_path):
+        events = get_trade_events("005930", market="KOSPI",
+                                  db_path=_make_db(tmp_path))
+        sides = sorted(e.side for e in events)
+        assert sides == ["buy", "sell"]
+        sell = next(e for e in events if e.side == "sell")
+        assert sell.price == 95300.0
+        assert sell.profit_rate == 10.81
+
+    def test_us_uses_us_table(self, tmp_path):
+        events = get_trade_events("CCL", market="us",
+                                  db_path=_make_db(tmp_path))
+        assert {e.side for e in events} == {"buy", "sell"}
+        buy = next(e for e in events if e.side == "buy")
+        assert buy.price == 31.15
+
+    def test_unknown_ticker_returns_empty(self, tmp_path):
+        assert get_trade_events("NOPE", market="us",
+                                db_path=_make_db(tmp_path)) == []
+
+    def test_missing_db_returns_empty_not_raises(self):
+        assert get_trade_events("005930", db_path="/no/such/db.sqlite") == []
+
+
+# --------------------------------------------------------------------------- #
+# summarize_trades                                                             #
+# --------------------------------------------------------------------------- #
+class TestSummarizeTrades:
+    def test_kr_round_trip_line(self):
+        events = [
+            TradeEvent(datetime(2025, 10, 1), 86000.0, "buy"),
+            TradeEvent(datetime(2025, 10, 14), 95300.0, "sell", profit_rate=10.8),
+        ]
+        text = summarize_trades(events, currency_symbol="₩", price_decimals=0)
+        assert text is not None
+        assert "과거 매매 이력" in text
+        assert "매수 2025-10-01 @₩86,000" in text
+        assert "매도 2025-10-14 @₩95,300" in text
+        assert "+10.8%" in text
+
+    def test_us_dollar_symbol_plain(self):
+        events = [
+            TradeEvent(datetime(2026, 1, 30), 31.15, "buy"),
+            TradeEvent(datetime(2026, 1, 31), 29.92, "sell", profit_rate=-3.93),
+        ]
+        text = summarize_trades(events, currency_symbol="$", price_decimals=2)
+        assert "$31.15" in text and "$29.92" in text
+
+    def test_empty_returns_none(self):
+        assert summarize_trades([]) is None
+
+
+# --------------------------------------------------------------------------- #
+# _map_trades_to_x                                                             #
+# --------------------------------------------------------------------------- #
+class TestMapTradesToX:
+    def test_maps_to_nearest_candle_index(self):
+        idx = pd.date_range("2025-10-01", periods=10, freq="D")
+        df = pd.DataFrame({"Close": range(10)}, index=idx)
+        events = [
+            TradeEvent(datetime(2025, 10, 1), 100.0, "buy"),   # -> pos 0
+            TradeEvent(datetime(2025, 10, 10), 110.0, "sell"),  # -> pos 9
+        ]
+        xy = _map_trades_to_x(events, df)
+        positions = sorted(x for x, _, _ in xy)
+        assert positions == [0.0, 9.0]
+
+    def test_empty_df_returns_empty(self):
+        assert _map_trades_to_x([TradeEvent(datetime(2025, 1, 1), 1.0, "buy")],
+                                None) == []
+
+
+# --------------------------------------------------------------------------- #
+# Marker rendering                                                             #
+# --------------------------------------------------------------------------- #
+class TestTradeMarkers:
+    def test_draw_markers_adds_collections_and_legend(self):
+        fig = _price_fig()
+        ax = fig.axes[0]
+        before = len(ax.collections)
+        _draw_trade_markers(
+            ax,
+            [(1.0, 70500.0, "buy"), (7.0, 74000.0, "sell")],
+            price_min=68000.0, price_max=76000.0,
+        )
+        assert len(ax.collections) > before  # scatter collections added
+        assert ax.get_legend() is not None
+        plt.close(fig)
+
+    def test_render_with_trades_returns_bytes(self):
+        out = render_insight_image(
+            _price_fig(), _analysis(), ticker="005930", company_name="삼성전자",
+            price_min=68000.0, price_max=76000.0,
+            trades=[(1.0, 70500.0, "buy"), (7.0, 74000.0, "sell")],
+        )
+        assert isinstance(out, bytes) and len(out) > 0
+
+    def test_render_with_no_trades_still_renders(self):
+        out = render_insight_image(
+            _price_fig(), _analysis(), ticker="005930", company_name="삼성전자",
+            price_min=68000.0, price_max=76000.0, trades=[],
+        )
+        assert isinstance(out, bytes) and len(out) > 0
+
+    def test_out_of_band_trade_price_dropped_no_crash(self):
+        fig = _price_fig()
+        ax = fig.axes[0]
+        # Price far outside the visible band must be silently skipped.
+        _draw_trade_markers(ax, [(2.0, 999999.0, "buy")],
+                            price_min=68000.0, price_max=76000.0)
+        plt.close(fig)


### PR DESCRIPTION
DB 매매내역 있는 종목이면 일봉차트에 매수 ▲/매도 ▼ 마커 표시(구독자) + 과거매매 요약을 비전 분석 프롬프트에 텍스트로 주입(LLM 참고). trade_history.py 신규(trading_history/us_trading_history+holdings). create_oneil_daily_chart에 return_df 옵션 추가(날짜↔캔들 매핑). vision_available 게이트+non-blocking. 매매내역 없으면 no-op. 사용자 요청.

🤖 Generated with [Claude Code](https://claude.com/claude-code)