### PR TITLE
fix(phase6-s6): 인사이트 캡션 용어안내 마커 ℹ️→▸ (폰트 깨짐 수정)

### DIFF
--- a/cores/llm/features/insight_image.py
+++ b/cores/llm/features/insight_image.py
@@ -209,7 +209,9 @@ def _build_caption(analysis: BaseAnalysis, *, ticker: str,
         "지지/저항=하락을 받쳐주는/상승을 막는 가격대",
         "적합·부적합=오닐 기준 매수자리로 적절/부적절한 베이스 형태",
     ]
-    glossary = "ℹ️ 용어 안내 — " + " · ".join(glossary_terms)
+    # Use a font-safe marker ("▸") instead of the ℹ️ emoji: the Korean chart
+    # font (NanumGothicCoding) has no glyph for ℹ️, so it rendered as a tofu box.
+    glossary = "▸ 용어 안내 — " + " · ".join(glossary_terms)
     lines.append("")
     lines.append(textwrap.fill(glossary, width=58))
 


### PR DESCRIPTION
NanumGothicCoding에 ℹ️ 글리프가 없어 캡션 '용어 안내' 앞 이모지가 두부글자로 깨지던 것 수정. ▲▼ 마커와 같은 계열 ▸로 교체.

🤖 Generated with [Claude Code](https://claude.com/claude-code)