### PR TITLE
fix(loops): Loop A/B 매도 후 실시간 포트폴리오 메시지 발송

### DIFF
--- a/tools/loop_a_hardstop.py
+++ b/tools/loop_a_hardstop.py
@@ -365,6 +365,16 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
         except Exception as e:
             logger.error("[%s] %s KIS sell failed after sim close: %s", market, ticker, e)
 
+        # 2.5) append the realtime portfolio summary so it rides WITH the sell
+        # message — matches the batch flow (process_reports), which the loops
+        # previously skipped, so loop-driven sells now also send 실시간 포트폴리오.
+        try:
+            summary = await ag.generate_report_summary()
+            if summary:
+                ag.message_queue.append(summary)
+        except Exception as e:
+            logger.warning("[%s] %s portfolio summary append failed: %s", market, ticker, e)
+
         # 3) flush the queued telegram message (instant notification).
         try:
             await ag.send_telegram_message(CHAT_ID)

--- a/tools/loop_b_trend_exit.py
+++ b/tools/loop_b_trend_exit.py
@@ -571,6 +571,16 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
         except Exception as e:
             logger.error("[%s] %s KIS sell failed after sim close: %s", market, ticker, e)
 
+        # 2.5) append the realtime portfolio summary so it rides WITH the sell
+        # message — matches the batch flow (process_reports), which the loops
+        # previously skipped, so loop-driven sells now also send 실시간 포트폴리오.
+        try:
+            summary = await ag.generate_report_summary()
+            if summary:
+                ag.message_queue.append(summary)
+        except Exception as e:
+            logger.warning("[%s] %s portfolio summary append failed: %s", market, ticker, e)
+
         # 3) flush the queued telegram message (instant notification).
         try:
             await ag.send_telegram_message(CHAT_ID)


### PR DESCRIPTION
배치 매도는 매도 메시지 뒤에 generate_report_summary(실시간 포트폴리오)를 동봉 발송하는데, Loop A/B 매도는 매도 메시지만 보내 포트폴리오 현황이 빠졌음. flush 직전에 동일 요약을 큐에 추가. 메시지만 추가(매매로직 무변경), 실패해도 매도 안 막힘. Loop C는 매도 안 해 해당없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)