### PR TITLE
revert(loops): undo realtime portfolio summary after Loop A/B sells (#372)

### DIFF
--- a/tools/loop_a_hardstop.py
+++ b/tools/loop_a_hardstop.py
@@ -365,16 +365,6 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
         except Exception as e:
             logger.error("[%s] %s KIS sell failed after sim close: %s", market, ticker, e)
 
-        # 2.5) append the realtime portfolio summary so it rides WITH the sell
-        # message — matches the batch flow (process_reports), which the loops
-        # previously skipped, so loop-driven sells now also send 실시간 포트폴리오.
-        try:
-            summary = await ag.generate_report_summary()
-            if summary:
-                ag.message_queue.append(summary)
-        except Exception as e:
-            logger.warning("[%s] %s portfolio summary append failed: %s", market, ticker, e)
-
         # 3) flush the queued telegram message (instant notification).
         try:
             await ag.send_telegram_message(CHAT_ID)

--- a/tools/loop_b_trend_exit.py
+++ b/tools/loop_b_trend_exit.py
@@ -571,16 +571,6 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
         except Exception as e:
             logger.error("[%s] %s KIS sell failed after sim close: %s", market, ticker, e)
 
-        # 2.5) append the realtime portfolio summary so it rides WITH the sell
-        # message — matches the batch flow (process_reports), which the loops
-        # previously skipped, so loop-driven sells now also send 실시간 포트폴리오.
-        try:
-            summary = await ag.generate_report_summary()
-            if summary:
-                ag.message_queue.append(summary)
-        except Exception as e:
-            logger.warning("[%s] %s portfolio summary append failed: %s", market, ticker, e)
-
         # 3) flush the queued telegram message (instant notification).
         try:
             await ag.send_telegram_message(CHAT_ID)


### PR DESCRIPTION
PR #372가 LIVE 루프에서 회귀 유발: 매도 1건에 실시간 포트폴리오 메시지 2개 중복 + '[KR] sell action failed: string indices must be integers' 에러(어제까진 없던 에러). 출혈 멈추려 되돌림. 원인 파악 후 재구현 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)