### PR TITLE
fix(loops): 실시간 포트폴리오 메시지 run-end 1회 발송 (#372 재구현)

### DIFF
--- a/tools/loop_a_hardstop.py
+++ b/tools/loop_a_hardstop.py
@@ -302,6 +302,20 @@ async def run_market(market: str, run_id: str) -> Dict[str, Any]:
         except Exception as e:  # context/credential failure -> skip whole market safely
             logger.warning("%s trading context failed: %s", market, e)
     finally:
+        # Run-end: if anything sold this run, send ONE realtime portfolio summary
+        # (matches the batch flow). Done at run-end — NOT inside the per-sell
+        # action — so generate_report_summary's DB reads never corrupt the
+        # per-sell cursor state (the bug behind the reverted #372). Sent exactly
+        # once per run. Fully wrapped; never breaks the loop.
+        if summary.get("sold", 0) > 0 and agent["ref"] is not None:
+            try:
+                _ag = agent["ref"]
+                _msg = await _ag.generate_report_summary()
+                if _msg:
+                    _ag.message_queue.append(_msg)
+                    await _ag.send_telegram_message(CHAT_ID)
+            except Exception as _e:
+                logger.warning("[%s] run-end portfolio summary failed: %s", market, _e)
         conn.close()
         if agent["ref"] is not None:
             try:

--- a/tools/loop_b_trend_exit.py
+++ b/tools/loop_b_trend_exit.py
@@ -509,6 +509,20 @@ async def run_market(market: str, run_id: str) -> Dict[str, Any]:
         except Exception as e:  # context/credential failure -> skip whole market safely
             logger.warning("%s trading context failed: %s", market, e)
     finally:
+        # Run-end: if anything sold this run, send ONE realtime portfolio summary
+        # (matches the batch flow). Done at run-end — NOT inside the per-sell
+        # action — so generate_report_summary's DB reads never corrupt the
+        # per-sell cursor state (the bug behind the reverted #372). Sent exactly
+        # once per run. Fully wrapped; never breaks the loop.
+        if summary.get("sold", 0) > 0 and agent["ref"] is not None:
+            try:
+                _ag = agent["ref"]
+                _msg = await _ag.generate_report_summary()
+                if _msg:
+                    _ag.message_queue.append(_msg)
+                    await _ag.send_telegram_message(CHAT_ID)
+            except Exception as _e:
+                logger.warning("[%s] run-end portfolio summary failed: %s", market, _e)
         conn.close()
         if agent["ref"] is not None:
             try:


### PR DESCRIPTION
#372(per-sell 발송)이 cursor 간섭으로 string indices 에러+중복 유발→#375 revert. 재구현: run_market run-end(finally 맨 위, agent conn 열린 상태)에서 summary[sold]>0일 때 1회 발송. cursor 공유 없음·중복 없음·완전 래핑. Loop A+B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)