### PR TITLE
Insight forecast fan + Prism track-record probability, and revive buy-quality SHADOW

### DIFF
--- a/cores/analysis.py
+++ b/cores/analysis.py
@@ -5,6 +5,14 @@ from dotenv import load_dotenv
 
 from mcp_agent.app import MCPApp
 
+# Standard logger for the buy-quality SHADOW hook. The function-local `logger`
+# (parallel_app.logger) is an mcp_agent context-bound logger that RAISES when
+# called outside an active logging context — which silently killed the
+# [BUY_QUALITY][SHADOW] verdict logs (swallowed by the hook's except). This
+# plain logger writes to stdout (captured by the cron logs) and never raises.
+import logging as _logging
+_BQ_LOG = _logging.getLogger("prism.buy_quality")
+
 from cores.agents import get_agent_directory
 from cores.report_generation import generate_report, generate_summary, generate_investment_strategy, get_disclaimer, generate_market_report
 
@@ -265,8 +273,8 @@ async def analyze_stock(company_code: str = "000660", company_name: str = "SK하
                 )
                 _bq_html = price_chart_html
                 _bq_regime = (macro_context or {}).get("market_regime", "sideways")
-                logger.info("[BUY_QUALITY][SHADOW] hook reached: code=%s regime=%s",
-                            company_code, _bq_regime)
+                _BQ_LOG.info("[BUY_QUALITY][SHADOW] hook reached: code=%s regime=%s",
+                             company_code, _bq_regime)
                 # Phase 6 S3.5: prefer the two-timeframe O'Neil path (daily +
                 # weekly with RS line), which grounds rs_line_new_high and the
                 # weekly base reading. Falls back to the single daily report
@@ -282,7 +290,7 @@ async def analyze_stock(company_code: str = "000660", company_name: str = "SK하
                         _bq_analysis = await analyze_base(_bq_img)
                 if _bq_analysis is not None:
                     _bq_verdict = gate_verdict(_bq_analysis, _bq_regime)
-                    logger.info(
+                    _BQ_LOG.info(
                         "[BUY_QUALITY][SHADOW] code=%s regime=%s would_buy=%s "
                         "qscore=%s thr=%s base=%s",
                         company_code,
@@ -299,15 +307,15 @@ async def analyze_stock(company_code: str = "000660", company_name: str = "SK하
                     # backtest passes and the user confirms (S5).
                     _ = vision_shadow  # referenced to mark the LIVE seam
                 else:
-                    logger.warning(
+                    _BQ_LOG.warning(
                         "[BUY_QUALITY][SHADOW] no analysis for %s "
                         "(analyze_base_oneil + fallback both None)",
                         company_code,
                     )
             except Exception as _bqe:
                 # Log (do NOT silently swallow) — still never affects pipeline.
-                logger.warning("[BUY_QUALITY][SHADOW] hook failed for %s: %s",
-                               company_code, _bqe, exc_info=True)
+                _BQ_LOG.warning("[BUY_QUALITY][SHADOW] hook failed for %s: %s",
+                                company_code, _bqe, exc_info=True)
 
         # 11. Build macro section (before final report composition)
         macro_section = ""

--- a/cores/analysis.py
+++ b/cores/analysis.py
@@ -265,6 +265,8 @@ async def analyze_stock(company_code: str = "000660", company_name: str = "SK하
                 )
                 _bq_html = price_chart_html
                 _bq_regime = (macro_context or {}).get("market_regime", "sideways")
+                logger.info("[BUY_QUALITY][SHADOW] hook reached: code=%s regime=%s",
+                            company_code, _bq_regime)
                 # Phase 6 S3.5: prefer the two-timeframe O'Neil path (daily +
                 # weekly with RS line), which grounds rs_line_new_high and the
                 # weekly base reading. Falls back to the single daily report
@@ -296,8 +298,16 @@ async def analyze_stock(company_code: str = "000660", company_name: str = "SK하
                     # buys. Do NOT implement live injection until S4
                     # backtest passes and the user confirms (S5).
                     _ = vision_shadow  # referenced to mark the LIVE seam
-            except Exception:
-                pass  # buy-quality gate must never affect the pipeline
+                else:
+                    logger.warning(
+                        "[BUY_QUALITY][SHADOW] no analysis for %s "
+                        "(analyze_base_oneil + fallback both None)",
+                        company_code,
+                    )
+            except Exception as _bqe:
+                # Log (do NOT silently swallow) — still never affects pipeline.
+                logger.warning("[BUY_QUALITY][SHADOW] hook failed for %s: %s",
+                               company_code, _bqe, exc_info=True)
 
         # 11. Build macro section (before final report composition)
         macro_section = ""

--- a/cores/llm/features/forecast_stats.py
+++ b/cores/llm/features/forecast_stats.py
@@ -160,8 +160,21 @@ def get_stock_scenario(ticker: str, market: Optional[str] = None) -> Optional[di
         conn.close()
 
 
+def _pctile(sorted_vals, q):
+    """Linear-interpolated percentile (q in 0..1) of an ascending list."""
+    if not sorted_vals:
+        return None
+    if len(sorted_vals) == 1:
+        return sorted_vals[0]
+    idx = q * (len(sorted_vals) - 1)
+    lo = int(idx)
+    hi = min(lo + 1, len(sorted_vals) - 1)
+    frac = idx - lo
+    return sorted_vals[lo] * (1.0 - frac) + sorted_vals[hi] * frac
+
+
 def _distribution_for(conn, sc, where_sql, params, threshold):
-    """Compute (n, up%, side%, down%, avg) for completed rows matching where_sql."""
+    """Compute (n, up%, side%, down%, avg, pcts) for completed matching rows."""
     rows = conn.execute(
         f"SELECT {sc['ret30']} AS r FROM {sc['table']} "
         f"WHERE tracking_status = 'completed' AND {sc['ret30']} IS NOT NULL {where_sql}",
@@ -175,12 +188,16 @@ def _distribution_for(conn, sc, where_sql, params, threshold):
     dn = sum(1 for v in vals if v < -threshold)
     sd = n - up - dn
     avg = sum(vals) / n
+    sv = sorted(vals)
+    pcts = {f"p{int(q*100)}": _pctile(sv, q)
+            for q in (0.10, 0.25, 0.50, 0.75, 0.90)}
     return {
         "n": n,
         "up": round(100.0 * up / n),
         "side": round(100.0 * sd / n),
         "down": round(100.0 * dn / n),
         "avg": avg,
+        "pcts": pcts,
     }
 
 

--- a/cores/llm/features/forecast_stats.py
+++ b/cores/llm/features/forecast_stats.py
@@ -1,0 +1,307 @@
+# forecast_stats.py
+"""Empirical, point-in-time forecast statistics from Prism's own track record.
+
+This module turns the realized outcomes that Prism has accumulated in
+``stock_tracking_db.sqlite`` into **honest base rates** for the subscriber-facing
+insight image:
+
+  - :func:`get_stock_scenario` — the most recent analysis row for a ticker
+    (its own ``target_price`` / ``stop_loss`` / ``buy_score`` / ``trigger_type``).
+  - :func:`get_forecast_distribution` — among PAST analyses with a *completed*
+    30-day outcome that share this stock's profile (buy-score band, optionally
+    the same trigger), what fraction rose / went sideways / fell. Returned with
+    the sample size ``n`` and which conditioning *tier* produced it.
+
+Design rules (so the numbers stay defensible):
+  - **Point-in-time**: only rows with ``tracking_status='completed'`` (their
+    forward window has already elapsed) feed the distribution — never the row
+    being rendered. No look-ahead.
+  - **Cohort frequency, not a per-stock prophecy.** The caller must label it as
+    "stocks Prism picked under these conditions historically resolved like X".
+  - **ratio units**: the stored returns are ratios (``-0.42`` == -42%), so the
+    ±move threshold is a ratio too (``0.10`` == ±10%).
+  - Tiered fallback with a minimum sample floor; the tier is reported so the
+    caption can be honest about how specific the cohort is.
+
+Everything is best-effort: any failure returns ``None`` / empty so the image
+still renders without the forecast overlay.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Repo root holds the single shared tracking DB (KR + US tables both live here).
+# This file is cores/llm/features/forecast_stats.py -> parents[3] == repo root.
+_DB_NAME = "stock_tracking_db.sqlite"
+
+# ±move threshold (ratio) and horizon that define 상승 / 횡보 / 하락.
+DEFAULT_THRESHOLD = 0.10
+DEFAULT_HORIZON = 30
+# Minimum cohort size before a tier is trusted; otherwise fall back broader.
+MIN_SAMPLE = 30
+
+# Per-market column mapping for the two tracker tables.
+_SCHEMA = {
+    "kr": {
+        "table": "analysis_performance_tracker",
+        "price": "analyzed_price",
+        "ret30": "tracked_30d_return",
+        "date": "analyzed_date",
+        "hit_target": None,   # KR has no explicit hit flag; proxy via close.
+    },
+    "us": {
+        "table": "us_analysis_performance_tracker",
+        "price": "analysis_price",
+        "ret30": "return_30d",
+        "date": "analysis_date",
+        "hit_target": "hit_target",
+    },
+}
+
+
+def _market_key(market: Optional[str]) -> str:
+    """Normalise a market hint to 'kr' or 'us' (default 'kr')."""
+    if isinstance(market, str) and market.strip().lower() in (
+        "us", "usa", "united states"
+    ):
+        return "us"
+    return "kr"
+
+
+def _db_path() -> Optional[Path]:
+    """Locate ``stock_tracking_db.sqlite``: repo root first, then a few parents."""
+    here = Path(__file__).resolve()
+    candidates = [here.parents[3] / _DB_NAME]  # repo root
+    # Defensive: also probe the immediate ancestors in case of an unusual layout.
+    candidates += [p / _DB_NAME for p in here.parents[1:5]]
+    for c in candidates:
+        try:
+            if c.is_file() and c.stat().st_size > 0:
+                return c
+        except Exception:  # noqa: BLE001
+            continue
+    return None
+
+
+def _connect() -> Optional[sqlite3.Connection]:
+    p = _db_path()
+    if p is None:
+        return None
+    try:
+        conn = sqlite3.connect(f"file:{p}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        return conn
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[FORECAST] DB open failed: %s", exc)
+        return None
+
+
+def score_band(score: Optional[float]) -> Optional[str]:
+    """Bucket a buy_score (0..~9 scale) into a quality band.
+
+    Bands are chosen from the observed monotonic break in realized outcomes:
+    low (<5) historically averages negative, mid [5,6) is the inflection, and
+    high (>=6) is where the strong positive skew lives. Returns None if no score.
+    """
+    if score is None:
+        return None
+    try:
+        s = float(score)
+    except (TypeError, ValueError):
+        return None
+    if s < 5:
+        return "low"
+    if s < 6:
+        return "mid"
+    return "high"
+
+
+_BAND_RANGE = {"low": (-1e9, 5.0), "mid": (5.0, 6.0), "high": (6.0, 1e9)}
+_BAND_KO = {"low": "신중", "mid": "보통", "high": "우수"}
+
+
+def get_stock_scenario(ticker: str, market: Optional[str] = None) -> Optional[dict]:
+    """Return the most recent tracker row's scenario fields for *ticker*.
+
+    Keys: analyzed_price, target_price, stop_loss, buy_score, trigger_type.
+    Returns None if the ticker has no row (or on any error).
+    """
+    sc = _SCHEMA[_market_key(market)]
+    conn = _connect()
+    if conn is None:
+        return None
+    try:
+        row = conn.execute(
+            f"SELECT {sc['price']} AS analyzed_price, target_price, stop_loss, "
+            f"buy_score, trigger_type "
+            f"FROM {sc['table']} WHERE ticker = ? "
+            f"ORDER BY {sc['date']} DESC, id DESC LIMIT 1",
+            (str(ticker),),
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "analyzed_price": row["analyzed_price"],
+            "target_price": row["target_price"],
+            "stop_loss": row["stop_loss"],
+            "buy_score": row["buy_score"],
+            "trigger_type": row["trigger_type"],
+        }
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[FORECAST] scenario lookup failed for %s: %s", ticker, exc)
+        return None
+    finally:
+        conn.close()
+
+
+def _distribution_for(conn, sc, where_sql, params, threshold):
+    """Compute (n, up%, side%, down%, avg) for completed rows matching where_sql."""
+    rows = conn.execute(
+        f"SELECT {sc['ret30']} AS r FROM {sc['table']} "
+        f"WHERE tracking_status = 'completed' AND {sc['ret30']} IS NOT NULL {where_sql}",
+        params,
+    ).fetchall()
+    vals = [r["r"] for r in rows if r["r"] is not None]
+    n = len(vals)
+    if n == 0:
+        return None
+    up = sum(1 for v in vals if v > threshold)
+    dn = sum(1 for v in vals if v < -threshold)
+    sd = n - up - dn
+    avg = sum(vals) / n
+    return {
+        "n": n,
+        "up": round(100.0 * up / n),
+        "side": round(100.0 * sd / n),
+        "down": round(100.0 * dn / n),
+        "avg": avg,
+    }
+
+
+def get_forecast_distribution(
+    market: Optional[str],
+    buy_score: Optional[float],
+    trigger_type: Optional[str] = None,
+    *,
+    threshold: float = DEFAULT_THRESHOLD,
+    min_sample: int = MIN_SAMPLE,
+) -> Optional[dict]:
+    """Tiered empirical up/sideways/down distribution for this stock's profile.
+
+    Tier order (first with n >= ``min_sample`` wins):
+      1. same score band AND same trigger_type
+      2. same score band
+      3. all completed rows (global base rate)
+
+    Returns a dict {up, side, down, n, avg, tier, band, threshold} (percentages
+    are ints summing to ~100), or None when even the global cohort is empty.
+    """
+    sc = _SCHEMA[_market_key(market)]
+    band = score_band(buy_score)
+    conn = _connect()
+    if conn is None:
+        return None
+    try:
+        tiers = []
+        if band is not None:
+            lo, hi = _BAND_RANGE[band]
+            if trigger_type:
+                tiers.append((
+                    "band+trigger",
+                    f"AND buy_score >= ? AND buy_score < ? AND trigger_type = ?",
+                    (lo, hi, str(trigger_type)),
+                ))
+            tiers.append((
+                "band",
+                f"AND buy_score >= ? AND buy_score < ?",
+                (lo, hi),
+            ))
+        tiers.append(("global", "", ()))
+
+        last = None
+        for tier, where_sql, params in tiers:
+            d = _distribution_for(conn, sc, where_sql, params, threshold)
+            if d is None:
+                continue
+            last = {**d, "tier": tier, "band": band, "threshold": threshold}
+            if d["n"] >= min_sample:
+                return last
+        return last  # best available even if below the floor (caller shows n)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[FORECAST] distribution failed: %s", exc)
+        return None
+    finally:
+        conn.close()
+
+
+def get_target_reach_rate(
+    market: Optional[str],
+    buy_score: Optional[float] = None,
+    *,
+    min_sample: int = MIN_SAMPLE,
+) -> Optional[dict]:
+    """Historical rate at which the analysis target was reached (30d window).
+
+    US uses the explicit ``hit_target`` flag (intraday-aware). KR has no flag, so
+    we approximate with a *close-based* proxy: the 30d close return reached the
+    target's implied gain (``target/price - 1``). Conditioned on the score band
+    when ``buy_score`` is given, with a global fallback. Returns {rate, n, proxy}
+    or None.
+    """
+    key = _market_key(market)
+    sc = _SCHEMA[key]
+    band = score_band(buy_score)
+    conn = _connect()
+    if conn is None:
+        return None
+    try:
+        band_clause, band_params = "", []
+        if band is not None:
+            lo, hi = _BAND_RANGE[band]
+            band_clause = "AND buy_score >= ? AND buy_score < ?"
+            band_params = [lo, hi]
+
+        def _rate(clause, params):
+            if sc["hit_target"]:
+                rows = conn.execute(
+                    f"SELECT {sc['hit_target']} AS h FROM {sc['table']} "
+                    f"WHERE tracking_status='completed' AND {sc['hit_target']} IS NOT NULL {clause}",
+                    params,
+                ).fetchall()
+                vals = [r["h"] for r in rows if r["h"] is not None]
+                if not vals:
+                    return None
+                return {"rate": round(100.0 * sum(1 for v in vals if v) / len(vals)),
+                        "n": len(vals), "proxy": False}
+            # KR close-based proxy
+            rows = conn.execute(
+                f"SELECT {sc['ret30']} AS r, target_price AS t, {sc['price']} AS p "
+                f"FROM {sc['table']} WHERE tracking_status='completed' "
+                f"AND {sc['ret30']} IS NOT NULL AND target_price > 0 AND {sc['price']} > 0 {clause}",
+                params,
+            ).fetchall()
+            hit = tot = 0
+            for r in rows:
+                tot += 1
+                if r["r"] >= (r["t"] / r["p"] - 1.0):
+                    hit += 1
+            if tot == 0:
+                return None
+            return {"rate": round(100.0 * hit / tot), "n": tot, "proxy": True}
+
+        d = _rate(band_clause, band_params)
+        if d and d["n"] >= min_sample:
+            return d
+        g = _rate("", [])
+        return g or d
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[FORECAST] target-reach failed: %s", exc)
+        return None
+    finally:
+        conn.close()

--- a/cores/llm/features/insight_image.py
+++ b/cores/llm/features/insight_image.py
@@ -229,22 +229,24 @@ def _draw_forecast_band(price_ax, *, ohlc_len, current_price, target, stop,
                 price_ax.plot(xs, [current_price, stop], color=_COLOR_RESISTANCE,
                               linewidth=1.7, linestyle="--", alpha=0.9, zorder=4)
 
-        # Plan levels (target/stop) in a compact top-right box — OFF the fan.
+        # Plan levels (target/stop) in a compact LEFT-CENTRE box — sits in the
+        # empty sky above the early (low-price) candles, OFF the fan, and large
+        # enough to read (the top-right corner was too cramped/high).
         def _plan(yfrac, color, text):
-            kw = dict(transform=price_ax.transAxes, color=color, fontsize=9,
-                      fontweight="bold", va="top", ha="right", zorder=8,
-                      bbox=dict(boxstyle="round,pad=0.3", facecolor=_PANEL,
-                                edgecolor=color, linewidth=0.8, alpha=0.92))
+            kw = dict(transform=price_ax.transAxes, color=color, fontsize=10,
+                      fontweight="bold", va="center", ha="left", zorder=8,
+                      bbox=dict(boxstyle="round,pad=0.35", facecolor=_PANEL,
+                                edgecolor=color, linewidth=1.0, alpha=0.93))
             if font_prop is not None:
                 kw["fontproperties"] = font_prop
-            price_ax.text(0.985, yfrac, text, **kw)
+            price_ax.text(0.02, yfrac, text, **kw)
 
         if has_t:
-            _plan(0.975, _COLOR_SUPPORT,
+            _plan(0.56, _COLOR_SUPPORT,
                   f"목표 {_format_price(target, symbol=currency_symbol, decimals=price_decimals)}"
                   f" ({_pct_str(target / current_price - 1)})")
         if has_s:
-            _plan(0.905 if has_t else 0.975, _COLOR_RESISTANCE,
+            _plan(0.47 if has_t else 0.56, _COLOR_RESISTANCE,
                   f"손절 {_format_price(stop, symbol=currency_symbol, decimals=price_decimals)}"
                   f" ({_pct_str(stop / current_price - 1)})")
 

--- a/cores/llm/features/insight_image.py
+++ b/cores/llm/features/insight_image.py
@@ -476,21 +476,22 @@ def _draw_base_box(price_ax, analysis, *, price_min, price_max,
         bottom -= pad
         top += pad
 
-        # Soft fill + crisp gold border = the "hero" pattern highlight.
+        # Subtle fill + soft dashed gold border = a light pattern highlight
+        # (kept de-emphasised so it never dominates the candles or the fan).
         price_ax.add_patch(Rectangle(
             (x_start, bottom), x_end - x_start, top - bottom,
-            linewidth=0, facecolor=_COLOR_BASEBOX, alpha=0.12, zorder=2.4))
+            linewidth=0, facecolor=_COLOR_BASEBOX, alpha=0.05, zorder=2.4))
         price_ax.add_patch(Rectangle(
             (x_start, bottom), x_end - x_start, top - bottom,
-            linewidth=2.0, edgecolor=_COLOR_BASEBOX, facecolor="none",
-            alpha=0.95, zorder=3.0))
+            linewidth=1.1, edgecolor=_COLOR_BASEBOX, facecolor="none",
+            linestyle=(0, (5, 3)), alpha=0.55, zorder=3.0))
 
         tag = (f"{_ko_base_type(analysis.base_type)} · {weeks}주"
                if weeks else _ko_base_type(analysis.base_type))
-        txt_kw = dict(color="#0b0e14", fontsize=10, fontweight="bold",
+        txt_kw = dict(color=_GOLD, fontsize=9, fontweight="bold",
                       va="center", ha="left", zorder=7,
-                      bbox=dict(boxstyle="round,pad=0.35", facecolor=_COLOR_BASEBOX,
-                                edgecolor="none", alpha=0.97))
+                      bbox=dict(boxstyle="round,pad=0.3", facecolor=_PANEL,
+                                edgecolor=_COLOR_BASEBOX, linewidth=0.8, alpha=0.9))
         if font_prop is not None:
             txt_kw["fontproperties"] = font_prop
         price_ax.text(x_start + 0.6, top, tag, **txt_kw)

--- a/cores/llm/features/insight_image.py
+++ b/cores/llm/features/insight_image.py
@@ -138,16 +138,21 @@ def _pct_str(ratio: float) -> str:
 
 
 def _draw_forecast_band(price_ax, *, ohlc_len, current_price, target, stop,
-                        font_prop, currency_symbol="₩", price_decimals=0) -> None:
-    """Draw a forward "forecast band" (cone) to the RIGHT of the last candle.
+                        pcts=None, font_prop, currency_symbol="₩",
+                        price_decimals=0) -> None:
+    """Draw a forward UNCERTAINTY FAN of where similar past picks actually ended.
 
-    Webull-style projection from today's price: an upper guide to the analysis
-    TARGET (green) and a lower guide to the STOP (red), with each half lightly
-    shaded. These are the analysis's OWN scenario levels projected forward — a
-    visual of the trade plan, NOT a price prediction. Extends the x-range into
-    empty forward space and pads y so the levels stay visible. Never raises.
+    Rather than a straight target/stop wedge, this projects the cohort's REALIZED
+    30-day return distribution (``pcts`` = p10..p90, ratios) forward from today's
+    price, widening with sqrt(time) so the cone edges CURVE naturally (honest:
+    it's the historical outcome spread, not a predicted squiggle). The analysis's
+    own target/stop live in a compact top-right plan box, kept OFF the fan so
+    nothing is occluded. Falls back to a simple target/stop wedge when no
+    distribution is available. Never raises.
     """
     try:
+        import math
+
         if not current_price or current_price <= 0 or not ohlc_len or ohlc_len < 2:
             return
         last_x = ohlc_len - 1
@@ -158,64 +163,98 @@ def _draw_forecast_band(price_ax, *, ohlc_len, current_price, target, stop,
 
         has_t = bool(target and target > 0 and abs(target - current_price) > 1e-9)
         has_s = bool(stop and stop > 0 and abs(stop - current_price) > 1e-9)
-        if not has_t and not has_s:
+        have_fan = bool(pcts) and pcts.get("p90") is not None and pcts.get("p10") is not None
+        if not has_t and not has_s and not have_fan:
             return
 
-        # Pad y so target/stop are inside the visible band.
+        # Pad y so the fan + target/stop all fit.
         ymin, ymax = price_ax.get_ylim()
-        pts = [current_price] + ([target] if has_t else []) + ([stop] if has_s else [])
-        new_min, new_max = min([ymin] + pts), max([ymax] + pts)
-        pad = (new_max - new_min) * 0.05 or max(new_max * 0.02, 1.0)
+        ext = [current_price]
+        if has_t:
+            ext.append(target)
+        if has_s:
+            ext.append(stop)
+        if have_fan:
+            ext.append(current_price * (1.0 + pcts["p90"]))
+            ext.append(current_price * (1.0 + pcts["p10"]))
+        new_min, new_max = min([ymin] + ext), max([ymax] + ext)
+        pad = (new_max - new_min) * 0.06 or max(new_max * 0.02, 1.0)
         price_ax.set_ylim(new_min - pad, new_max + pad)
 
-        # "Today" divider between history and the projected band.
+        # "Today" divider between history and the projection.
         price_ax.axvline(last_x, color=_TXT_DIM, linestyle=":", linewidth=1.0,
                          alpha=0.55, zorder=3)
-        xs = [last_x, proj_x]
-        flat = [current_price, current_price]
-        if has_t:
-            price_ax.fill_between(xs, flat, [current_price, target],
-                                  color=_COLOR_SUPPORT, alpha=0.11, zorder=2)
-            price_ax.plot(xs, [current_price, target], color=_COLOR_SUPPORT,
-                          linewidth=1.7, linestyle="--", alpha=0.92, zorder=4)
-        if has_s:
-            price_ax.fill_between(xs, [current_price, stop], flat,
-                                  color=_COLOR_RESISTANCE, alpha=0.11, zorder=2)
-            price_ax.plot(xs, [current_price, stop], color=_COLOR_RESISTANCE,
-                          linewidth=1.7, linestyle="--", alpha=0.92, zorder=4)
-        # Flat "today's price" guide across the forward region.
-        price_ax.plot(xs, flat, color=_TXT_DIM, linewidth=1.0,
-                      linestyle=(0, (2, 3)), alpha=0.6, zorder=3)
 
-        # Callouts sit INSIDE the forward whitespace (right-aligned at the band
-        # tip) so they never clip at the figure's right edge.
-        def _tag(y, color, text):
-            kw = dict(color="#0b0e14", fontsize=9, fontweight="bold",
+        if have_fan:
+            M = 24
+            tfs = [i / (M - 1) for i in range(M)]
+            xs = [last_x + tf * fwd for tf in tfs]
+
+            def _curve(p):
+                # sqrt(time) widening from today's price -> curved cone edge.
+                return [current_price * (1.0 + p * math.sqrt(tf)) for tf in tfs]
+
+            y10 = _curve(pcts["p10"])
+            y25 = _curve(pcts.get("p25") if pcts.get("p25") is not None else pcts["p10"])
+            y50 = _curve(pcts["p50"] if pcts.get("p50") is not None else 0.0)
+            y75 = _curve(pcts.get("p75") if pcts.get("p75") is not None else pcts["p90"])
+            y90 = _curve(pcts["p90"])
+            _FAN = "#5aa9e6"
+            price_ax.fill_between(xs, y10, y90, color=_FAN, alpha=0.10,
+                                  zorder=2, linewidth=0)
+            price_ax.fill_between(xs, y25, y75, color=_FAN, alpha=0.20,
+                                  zorder=2, linewidth=0)
+            price_ax.plot(xs, y50, color=_GOLD, linewidth=1.6, linestyle="--",
+                          alpha=0.95, zorder=4)
+            mk = dict(color="#0b0e14", fontsize=8.5, fontweight="bold",
                       va="center", ha="right", zorder=7,
-                      bbox=dict(boxstyle="round,pad=0.3", facecolor=color,
+                      bbox=dict(boxstyle="round,pad=0.25", facecolor=_GOLD,
                                 edgecolor="none", alpha=0.95))
             if font_prop is not None:
+                mk["fontproperties"] = font_prop
+            price_ax.annotate(f"중앙값 {_pct_str(pcts['p50'])}",
+                              xy=(proj_x, y50[-1]), xytext=(-3, 0),
+                              textcoords="offset points", **mk)
+        else:
+            xs = [last_x, proj_x]
+            flat = [current_price, current_price]
+            if has_t:
+                price_ax.fill_between(xs, flat, [current_price, target],
+                                      color=_COLOR_SUPPORT, alpha=0.11, zorder=2)
+                price_ax.plot(xs, [current_price, target], color=_COLOR_SUPPORT,
+                              linewidth=1.7, linestyle="--", alpha=0.9, zorder=4)
+            if has_s:
+                price_ax.fill_between(xs, [current_price, stop], flat,
+                                      color=_COLOR_RESISTANCE, alpha=0.11, zorder=2)
+                price_ax.plot(xs, [current_price, stop], color=_COLOR_RESISTANCE,
+                              linewidth=1.7, linestyle="--", alpha=0.9, zorder=4)
+
+        # Plan levels (target/stop) in a compact top-right box — OFF the fan.
+        def _plan(yfrac, color, text):
+            kw = dict(transform=price_ax.transAxes, color=color, fontsize=9,
+                      fontweight="bold", va="top", ha="right", zorder=8,
+                      bbox=dict(boxstyle="round,pad=0.3", facecolor=_PANEL,
+                                edgecolor=color, linewidth=0.8, alpha=0.92))
+            if font_prop is not None:
                 kw["fontproperties"] = font_prop
-            price_ax.annotate(text, xy=(proj_x, y), xytext=(-3, 0),
-                              textcoords="offset points", **kw)
+            price_ax.text(0.985, yfrac, text, **kw)
 
         if has_t:
-            _tag(target, _COLOR_SUPPORT,
-                 f"목표 {_format_price(target, symbol=currency_symbol, decimals=price_decimals)}"
-                 f" ({_pct_str(target / current_price - 1)})")
+            _plan(0.975, _COLOR_SUPPORT,
+                  f"목표 {_format_price(target, symbol=currency_symbol, decimals=price_decimals)}"
+                  f" ({_pct_str(target / current_price - 1)})")
         if has_s:
-            _tag(stop, _COLOR_RESISTANCE,
-                 f"손절 {_format_price(stop, symbol=currency_symbol, decimals=price_decimals)}"
-                 f" ({_pct_str(stop / current_price - 1)})")
+            _plan(0.905 if has_t else 0.975, _COLOR_RESISTANCE,
+                  f"손절 {_format_price(stop, symbol=currency_symbol, decimals=price_decimals)}"
+                  f" ({_pct_str(stop / current_price - 1)})")
 
-        # Title floats centered above the forward band, clear of the base box.
         title_kw = dict(color=_TXT_DIM, fontsize=8.5, va="bottom", ha="center",
                         zorder=6)
         if font_prop is not None:
             title_kw["fontproperties"] = font_prop
         y_lo, y_hi = price_ax.get_ylim()
         price_ax.text((last_x + proj_x) / 2.0, y_lo + (y_hi - y_lo) * 0.985,
-                      "← 예측 밴드(시나리오) →", **title_kw)
+                      "비슷한 종목들의 30일 결과 분포 →", **title_kw)
     except Exception as exc:  # noqa: BLE001
         logger.warning("[INSIGHT_IMAGE] forecast band failed: %s", exc)
 
@@ -655,17 +694,18 @@ def render_insight_image(
         target_reach = None
         forecast_line = None
         if forecast:
+            prob = forecast.get("dist")
             _draw_forecast_band(
                 price_ax,
                 ohlc_len=ohlc_len,
                 current_price=forecast.get("current_price"),
                 target=forecast.get("target"),
                 stop=forecast.get("stop"),
+                pcts=(prob or {}).get("pcts"),
                 font_prop=font_prop,
                 currency_symbol=currency_symbol,
                 price_decimals=price_decimals,
             )
-            prob = forecast.get("dist")
             target_reach = forecast.get("target_reach")
             if isinstance(prob, dict) and prob.get("n"):
                 forecast_line = (

--- a/cores/llm/features/insight_image.py
+++ b/cores/llm/features/insight_image.py
@@ -240,12 +240,12 @@ def _draw_prob_bar(ax, dist, *, font_prop, target_reach=None,
         if font_prop is not None:
             title_kw["fontproperties"] = font_prop
         ax.text(0.0, y + h + 0.030,
-                f"프리즘 트랙레코드 · 30일 후 분포 (유사 {n}건)", **title_kw)
+                f"프리즘이 비슷한 종목 {n}번 분석 → 30일 뒤 실제로:", **title_kw)
 
         cur = 0.0
-        for name, val, color in (("상승", up, _COLOR_SUPPORT),
-                                 ("횡보", side, _TXT_DIM),
-                                 ("하락", down, _COLOR_RESISTANCE)):
+        for name, val, color in (("올랐다", up, _COLOR_SUPPORT),
+                                 ("제자리", side, _TXT_DIM),
+                                 ("빠졌다", down, _COLOR_RESISTANCE)):
             w = val / total
             if w <= 0:
                 continue
@@ -264,10 +264,10 @@ def _draw_prob_bar(ax, dist, *, font_prop, target_reach=None,
                       color=_TXT_DIM, fontsize=9)
         if font_prop is not None:
             sub_kw["fontproperties"] = font_prop
-        sub = "※ 프리즘이 고른 종목들의 과거 실제 분포 (개별 예측·미래 보장 아님)"
+        sub = "※ 이 종목의 예측이 아니라, 과거 비슷한 종목들의 실제 결과 (올랐다=+10%↑·빠졌다=−10%↓)"
         if target_reach and target_reach.get("rate") is not None:
             approx = "≈" if target_reach.get("proxy") else ""
-            sub = f"목표가 도달 {approx}{target_reach['rate']}%   ·   " + sub
+            sub = f"이 중 목표가까지 도달 {approx}{target_reach['rate']}%   ·   " + sub
         ax.text(0.0, y - 0.045, sub, **sub_kw)
     except Exception as exc:  # noqa: BLE001
         logger.warning("[INSIGHT_IMAGE] prob bar failed: %s", exc)
@@ -627,16 +627,22 @@ def render_insight_image(
                            currency_symbol=currency_symbol, price_decimals=price_decimals)
 
         # --- Supporting levels (de-emphasised dashed lines + labels) ---------
-        for lv in supports:
-            _draw_level(price_ax, lv, _COLOR_SUPPORT, f"지지 {_fmt(lv)}",
-                        linestyle=(0, (4, 3)), linewidth=1.1, font_prop=font_prop)
-        for lv in resistances:
-            _draw_level(price_ax, lv, _COLOR_RESISTANCE, f"저항 {_fmt(lv)}",
-                        linestyle=(0, (4, 3)), linewidth=1.1, font_prop=font_prop)
-        if stop:
-            _draw_level(price_ax, stop[0], _COLOR_STOP,
-                        f"손절 {_fmt(stop[0])}", linestyle="--",
-                        linewidth=1.2, font_prop=font_prop)
+        # Decluttered: when a forecast band is drawn (production), the price
+        # panel keeps only the HERO (base box + pivot + forward band). The
+        # support/resistance/stop numbers still live in the caption text, so we
+        # skip the busy stack of on-plot lines. Without a forecast (tests /
+        # fallback) we keep them for the standalone annotated chart.
+        if not forecast:
+            for lv in supports:
+                _draw_level(price_ax, lv, _COLOR_SUPPORT, f"지지 {_fmt(lv)}",
+                            linestyle=(0, (4, 3)), linewidth=1.1, font_prop=font_prop)
+            for lv in resistances:
+                _draw_level(price_ax, lv, _COLOR_RESISTANCE, f"저항 {_fmt(lv)}",
+                            linestyle=(0, (4, 3)), linewidth=1.1, font_prop=font_prop)
+            if stop:
+                _draw_level(price_ax, stop[0], _COLOR_STOP,
+                            f"손절 {_fmt(stop[0])}", linestyle="--",
+                            linewidth=1.2, font_prop=font_prop)
         # buy pivot is rendered by _draw_pivot_marker (circle + callout) above
 
         # --- Past-trade markers (subscriber-facing; from the tracking DB) -----
@@ -663,9 +669,9 @@ def render_insight_image(
             target_reach = forecast.get("target_reach")
             if isinstance(prob, dict) and prob.get("n"):
                 forecast_line = (
-                    f"프리즘 30일 분포(유사 {prob['n']}건): "
-                    f"상승 {prob.get('up', 0)}% · 횡보 {prob.get('side', 0)}% · "
-                    f"하락 {prob.get('down', 0)}%"
+                    f"비슷한 종목 {prob['n']}번 중 30일 뒤 → "
+                    f"올랐다 {prob.get('up', 0)}% · 제자리 {prob.get('side', 0)}% · "
+                    f"빠졌다 {prob.get('down', 0)}%  (이 종목 보장 아님)"
                 )
 
         # --- Re-stack the panels into clean bands + add a caption band ---

--- a/cores/llm/features/insight_image.py
+++ b/cores/llm/features/insight_image.py
@@ -187,14 +187,16 @@ def _draw_forecast_band(price_ax, *, ohlc_len, current_price, target, stop,
         price_ax.plot(xs, flat, color=_TXT_DIM, linewidth=1.0,
                       linestyle=(0, (2, 3)), alpha=0.6, zorder=3)
 
+        # Callouts sit INSIDE the forward whitespace (right-aligned at the band
+        # tip) so they never clip at the figure's right edge.
         def _tag(y, color, text):
             kw = dict(color="#0b0e14", fontsize=9, fontweight="bold",
-                      va="center", ha="left", zorder=7,
+                      va="center", ha="right", zorder=7,
                       bbox=dict(boxstyle="round,pad=0.3", facecolor=color,
                                 edgecolor="none", alpha=0.95))
             if font_prop is not None:
                 kw["fontproperties"] = font_prop
-            price_ax.annotate(text, xy=(proj_x, y), xytext=(5, 0),
+            price_ax.annotate(text, xy=(proj_x, y), xytext=(-3, 0),
                               textcoords="offset points", **kw)
 
         if has_t:
@@ -206,11 +208,14 @@ def _draw_forecast_band(price_ax, *, ohlc_len, current_price, target, stop,
                  f"손절 {_format_price(stop, symbol=currency_symbol, decimals=price_decimals)}"
                  f" ({_pct_str(stop / current_price - 1)})")
 
-        title_kw = dict(color=_TXT_DIM, fontsize=8, va="top", ha="left", zorder=6)
+        # Title floats centered above the forward band, clear of the base box.
+        title_kw = dict(color=_TXT_DIM, fontsize=8.5, va="bottom", ha="center",
+                        zorder=6)
         if font_prop is not None:
             title_kw["fontproperties"] = font_prop
-        price_ax.text(last_x, price_ax.get_ylim()[1], " 예측 밴드(시나리오) →",
-                      **title_kw)
+        y_lo, y_hi = price_ax.get_ylim()
+        price_ax.text((last_x + proj_x) / 2.0, y_lo + (y_hi - y_lo) * 0.985,
+                      "← 예측 밴드(시나리오) →", **title_kw)
     except Exception as exc:  # noqa: BLE001
         logger.warning("[INSIGHT_IMAGE] forecast band failed: %s", exc)
 

--- a/cores/llm/features/insight_image.py
+++ b/cores/llm/features/insight_image.py
@@ -305,7 +305,7 @@ def _draw_prob_bar(ax, dist, *, font_prop, target_reach=None,
                       color=_TXT_DIM, fontsize=9)
         if font_prop is not None:
             sub_kw["fontproperties"] = font_prop
-        sub = "※ 이 종목의 예측이 아니라, 과거 비슷한 종목들의 실제 결과 (올랐다=+10%↑·빠졌다=−10%↓)"
+        sub = "※ 이 종목의 예측이 아니라, 과거 비슷한 종목들의 실제 결과 (올랐다=+10%이상·빠졌다=-10%이하)"
         if target_reach and target_reach.get("rate") is not None:
             approx = "≈" if target_reach.get("proxy") else ""
             sub = f"이 중 목표가까지 도달 {approx}{target_reach['rate']}%   ·   " + sub
@@ -400,7 +400,7 @@ def _build_caption(analysis: BaseAnalysis, *, ticker: str,
     ]
     # Use a font-safe marker ("▸") instead of the ℹ️ emoji: the Korean chart
     # font (NanumGothicCoding) has no glyph for ℹ️, so it rendered as a tofu box.
-    glossary = "▸ 용어 안내 — " + " · ".join(glossary_terms)
+    glossary = "※ 용어 안내 — " + " · ".join(glossary_terms)
     lines.append("")
     lines.append(textwrap.fill(glossary, width=58))
 

--- a/cores/llm/features/insight_image.py
+++ b/cores/llm/features/insight_image.py
@@ -129,6 +129,145 @@ def _draw_level(ax, price: float, color: str, label: str, *, linestyle: str,
     ax.text(0.015, price, label, **txt_kw)
 
 
+def _pct_str(ratio: float) -> str:
+    """Format a ratio as a signed percent (``0.123`` -> ``+12%``)."""
+    try:
+        return f"{ratio * 100:+.0f}%"
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _draw_forecast_band(price_ax, *, ohlc_len, current_price, target, stop,
+                        font_prop, currency_symbol="₩", price_decimals=0) -> None:
+    """Draw a forward "forecast band" (cone) to the RIGHT of the last candle.
+
+    Webull-style projection from today's price: an upper guide to the analysis
+    TARGET (green) and a lower guide to the STOP (red), with each half lightly
+    shaded. These are the analysis's OWN scenario levels projected forward — a
+    visual of the trade plan, NOT a price prediction. Extends the x-range into
+    empty forward space and pads y so the levels stay visible. Never raises.
+    """
+    try:
+        if not current_price or current_price <= 0 or not ohlc_len or ohlc_len < 2:
+            return
+        last_x = ohlc_len - 1
+        x0, _x1 = price_ax.get_xlim()
+        fwd = max(8, min(40, int(round(ohlc_len * 0.16))))
+        proj_x = last_x + fwd
+        price_ax.set_xlim(x0, proj_x + max(1.0, fwd * 0.08))
+
+        has_t = bool(target and target > 0 and abs(target - current_price) > 1e-9)
+        has_s = bool(stop and stop > 0 and abs(stop - current_price) > 1e-9)
+        if not has_t and not has_s:
+            return
+
+        # Pad y so target/stop are inside the visible band.
+        ymin, ymax = price_ax.get_ylim()
+        pts = [current_price] + ([target] if has_t else []) + ([stop] if has_s else [])
+        new_min, new_max = min([ymin] + pts), max([ymax] + pts)
+        pad = (new_max - new_min) * 0.05 or max(new_max * 0.02, 1.0)
+        price_ax.set_ylim(new_min - pad, new_max + pad)
+
+        # "Today" divider between history and the projected band.
+        price_ax.axvline(last_x, color=_TXT_DIM, linestyle=":", linewidth=1.0,
+                         alpha=0.55, zorder=3)
+        xs = [last_x, proj_x]
+        flat = [current_price, current_price]
+        if has_t:
+            price_ax.fill_between(xs, flat, [current_price, target],
+                                  color=_COLOR_SUPPORT, alpha=0.11, zorder=2)
+            price_ax.plot(xs, [current_price, target], color=_COLOR_SUPPORT,
+                          linewidth=1.7, linestyle="--", alpha=0.92, zorder=4)
+        if has_s:
+            price_ax.fill_between(xs, [current_price, stop], flat,
+                                  color=_COLOR_RESISTANCE, alpha=0.11, zorder=2)
+            price_ax.plot(xs, [current_price, stop], color=_COLOR_RESISTANCE,
+                          linewidth=1.7, linestyle="--", alpha=0.92, zorder=4)
+        # Flat "today's price" guide across the forward region.
+        price_ax.plot(xs, flat, color=_TXT_DIM, linewidth=1.0,
+                      linestyle=(0, (2, 3)), alpha=0.6, zorder=3)
+
+        def _tag(y, color, text):
+            kw = dict(color="#0b0e14", fontsize=9, fontweight="bold",
+                      va="center", ha="left", zorder=7,
+                      bbox=dict(boxstyle="round,pad=0.3", facecolor=color,
+                                edgecolor="none", alpha=0.95))
+            if font_prop is not None:
+                kw["fontproperties"] = font_prop
+            price_ax.annotate(text, xy=(proj_x, y), xytext=(5, 0),
+                              textcoords="offset points", **kw)
+
+        if has_t:
+            _tag(target, _COLOR_SUPPORT,
+                 f"목표 {_format_price(target, symbol=currency_symbol, decimals=price_decimals)}"
+                 f" ({_pct_str(target / current_price - 1)})")
+        if has_s:
+            _tag(stop, _COLOR_RESISTANCE,
+                 f"손절 {_format_price(stop, symbol=currency_symbol, decimals=price_decimals)}"
+                 f" ({_pct_str(stop / current_price - 1)})")
+
+        title_kw = dict(color=_TXT_DIM, fontsize=8, va="top", ha="left", zorder=6)
+        if font_prop is not None:
+            title_kw["fontproperties"] = font_prop
+        price_ax.text(last_x, price_ax.get_ylim()[1], " 예측 밴드(시나리오) →",
+                      **title_kw)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[INSIGHT_IMAGE] forecast band failed: %s", exc)
+
+
+def _draw_prob_bar(ax, dist, *, font_prop, target_reach=None,
+                   y=0.945, h=0.038) -> None:
+    """Draw a stacked 상승/횡보/하락 probability bar (axes-fraction) atop *ax*.
+
+    ``dist`` is a forecast_stats distribution dict {up, side, down, n, ...}. The
+    bar width-encodes each share; segments wide enough get an inline label. A
+    line below states the historical target-reach rate + disclaimer.
+    """
+    try:
+        from matplotlib.patches import Rectangle
+
+        up, side, down = (int(dist.get("up", 0)), int(dist.get("side", 0)),
+                          int(dist.get("down", 0)))
+        n = int(dist.get("n", 0))
+        total = max(1, up + side + down)
+        title_kw = dict(transform=ax.transAxes, va="center", ha="left",
+                        color=_TXT, fontsize=10, fontweight="bold")
+        if font_prop is not None:
+            title_kw["fontproperties"] = font_prop
+        ax.text(0.0, y + h + 0.030,
+                f"프리즘 트랙레코드 · 30일 후 분포 (유사 {n}건)", **title_kw)
+
+        cur = 0.0
+        for name, val, color in (("상승", up, _COLOR_SUPPORT),
+                                 ("횡보", side, _TXT_DIM),
+                                 ("하락", down, _COLOR_RESISTANCE)):
+            w = val / total
+            if w <= 0:
+                continue
+            ax.add_patch(Rectangle((cur, y), w, h, transform=ax.transAxes,
+                                   facecolor=color, edgecolor=_BG, linewidth=1.0,
+                                   alpha=0.92, zorder=5, clip_on=False))
+            if w > 0.10:
+                lkw = dict(transform=ax.transAxes, va="center", ha="center",
+                           color="#0b0e14", fontsize=9, fontweight="bold", zorder=6)
+                if font_prop is not None:
+                    lkw["fontproperties"] = font_prop
+                ax.text(cur + w / 2, y + h / 2, f"{name} {val}%", **lkw)
+            cur += w
+
+        sub_kw = dict(transform=ax.transAxes, va="center", ha="left",
+                      color=_TXT_DIM, fontsize=9)
+        if font_prop is not None:
+            sub_kw["fontproperties"] = font_prop
+        sub = "※ 프리즘이 고른 종목들의 과거 실제 분포 (개별 예측·미래 보장 아님)"
+        if target_reach and target_reach.get("rate") is not None:
+            approx = "≈" if target_reach.get("proxy") else ""
+            sub = f"목표가 도달 {approx}{target_reach['rate']}%   ·   " + sub
+        ax.text(0.0, y - 0.045, sub, **sub_kw)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[INSIGHT_IMAGE] prob bar failed: %s", exc)
+
+
 def _classify_axes(fig):
     """Best-effort split of an mplfinance O'Neil fig into (price, volume, rs).
 
@@ -165,7 +304,8 @@ def _classify_axes(fig):
 def _build_caption(analysis: BaseAnalysis, *, ticker: str,
                    company_name: str | None,
                    supports, resistances, buy, stop,
-                   currency_symbol="₩", price_decimals=0) -> str:
+                   currency_symbol="₩", price_decimals=0,
+                   forecast_line: str | None = None) -> str:
     """Compose the KOREAN caption-band text (tidy summary + wrapped rationale).
 
     Numeric/enum fields are mapped to Korean labels; the rationale is shown as
@@ -192,6 +332,9 @@ def _build_caption(analysis: BaseAnalysis, *, ticker: str,
         f"RS 신고가: {rs_status}    매수 피벗: {buy_txt}    손절: {stop_txt}",
         f"지지: {_won_list(supports)}    저항: {_won_list(resistances)}",
     ]
+
+    if forecast_line:
+        lines.append(forecast_line)
 
     rationale = (analysis.rationale or "").strip().replace("\n", " ")
     if rationale:
@@ -406,6 +549,8 @@ def render_insight_image(
     currency_symbol: str = "₩",
     price_decimals: int = 0,
     trades=None,
+    forecast: dict | None = None,
+    ohlc_len: int | None = None,
 ) -> bytes | None:
     """Overlay deterministic O'Neil annotations on the DAILY chart and add a
     clean Korean caption band below it.
@@ -494,6 +639,30 @@ def render_insight_image(
             _draw_trade_markers(price_ax, trades, price_min=price_min,
                                 price_max=price_max, font_prop=font_prop)
 
+        # --- Forecast band (forward scenario cone) + probability panel -------
+        prob = None
+        target_reach = None
+        forecast_line = None
+        if forecast:
+            _draw_forecast_band(
+                price_ax,
+                ohlc_len=ohlc_len,
+                current_price=forecast.get("current_price"),
+                target=forecast.get("target"),
+                stop=forecast.get("stop"),
+                font_prop=font_prop,
+                currency_symbol=currency_symbol,
+                price_decimals=price_decimals,
+            )
+            prob = forecast.get("dist")
+            target_reach = forecast.get("target_reach")
+            if isinstance(prob, dict) and prob.get("n"):
+                forecast_line = (
+                    f"프리즘 30일 분포(유사 {prob['n']}건): "
+                    f"상승 {prob.get('up', 0)}% · 횡보 {prob.get('side', 0)}% · "
+                    f"하락 {prob.get('down', 0)}%"
+                )
+
         # --- Re-stack the panels into clean bands + add a caption band ---
         _relayout_with_caption(
             daily_fig, price_ax, volume_ax, rs_ax,
@@ -501,8 +670,11 @@ def render_insight_image(
                 analysis, ticker=ticker, company_name=company_name,
                 supports=supports, resistances=resistances, buy=buy, stop=stop,
                 currency_symbol=currency_symbol, price_decimals=price_decimals,
+                forecast_line=forecast_line,
             ),
             font_prop=font_prop,
+            prob=prob,
+            target_reach=target_reach,
         )
 
         return _fig_to_jpeg(daily_fig)
@@ -512,7 +684,7 @@ def render_insight_image(
 
 
 def _relayout_with_caption(fig, price_ax, volume_ax, rs_ax, *, caption,
-                           font_prop) -> None:
+                           font_prop, prob=None, target_reach=None) -> None:
     """Grow the figure taller and re-stack panels into clean, spaced bands.
 
     Band layout (figure fraction, top→bottom), x-span 0.09..0.95:
@@ -578,11 +750,20 @@ def _relayout_with_caption(fig, price_ax, volume_ax, rs_ax, *, caption,
             _sp.set_color(_GRID)
         cap_ax.set_xticks([])
         cap_ax.set_yticks([])
+
+        # Probability bar occupies the top strip of the caption band; the text
+        # then starts below it. Without a bar, the text uses the full height.
+        text_top = 1.0
+        if isinstance(prob, dict) and prob.get("n"):
+            _draw_prob_bar(cap_ax, prob, font_prop=font_prop,
+                           target_reach=target_reach)
+            text_top = 0.84
+
         txt_kw = dict(fontsize=11, va="top", ha="left", linespacing=1.5,
                       color=_TXT)
         if font_prop is not None:
             txt_kw["fontproperties"] = font_prop
-        cap_ax.text(0.0, 1.0, caption, transform=cap_ax.transAxes, **txt_kw)
+        cap_ax.text(0.0, text_top, caption, transform=cap_ax.transAxes, **txt_kw)
     except Exception as exc:  # noqa: BLE001
         logger.warning("[INSIGHT_IMAGE] relayout failed: %s", exc)
 
@@ -726,6 +907,46 @@ async def build_insight_image_for(
         # Map trade dates -> candle-index x positions (best-effort, isolated).
         trade_xy = _map_trades_to_x(trade_events, ohlc_df) if trade_events else []
 
+        # --- Forecast band + probability (best-effort; isolated) -------------
+        # Reads THIS analysis's scenario (target/stop/score/trigger) from the
+        # tracking DB and the matching historical cohort distribution. Any
+        # failure -> forecast stays None and the image renders without it.
+        forecast = None
+        ohlc_len = None
+        try:
+            ohlc_len = int(len(ohlc_df)) if ohlc_df is not None else None
+            current_price = None
+            if ohlc_df is not None and len(ohlc_df):
+                for _c in ("Close", "close", "Adj Close"):
+                    if _c in getattr(ohlc_df, "columns", []):
+                        current_price = float(ohlc_df[_c].iloc[-1])
+                        break
+            from cores.llm.features.forecast_stats import (
+                get_forecast_distribution,
+                get_stock_scenario,
+                get_target_reach_rate,
+            )
+
+            scenario = get_stock_scenario(ticker, market=market) or {}
+            if current_price is None and scenario.get("analyzed_price"):
+                current_price = float(scenario["analyzed_price"])
+            dist = get_forecast_distribution(
+                market, scenario.get("buy_score"), scenario.get("trigger_type")
+            )
+            reach = get_target_reach_rate(market, scenario.get("buy_score"))
+            if current_price and (scenario.get("target_price") or scenario.get("stop_loss") or dist):
+                forecast = {
+                    "current_price": current_price,
+                    "target": scenario.get("target_price"),
+                    "stop": scenario.get("stop_loss"),
+                    "dist": dist,
+                    "target_reach": reach,
+                }
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[INSIGHT_IMAGE] forecast lookup failed for %s: %s",
+                           ticker, exc)
+            forecast, ohlc_len = None, None
+
         # Escape "$" as "\\$": matplotlib treats a bare "$" as mathtext, which
         # corrupts adjacent Korean glyphs (renders them via the math 'rm' font).
         _currency_symbol, _price_decimals = ("\\$", 2) if _is_us else ("₩", 0)
@@ -739,6 +960,8 @@ async def build_insight_image_for(
             currency_symbol=_currency_symbol,
             price_decimals=_price_decimals,
             trades=trade_xy,
+            forecast=forecast,
+            ohlc_len=ohlc_len,
         )
     except Exception as exc:  # noqa: BLE001
         logger.warning("[INSIGHT_IMAGE] build failed for %s: %s", ticker, exc)

--- a/tests/test_forecast_stats.py
+++ b/tests/test_forecast_stats.py
@@ -1,0 +1,114 @@
+# test_forecast_stats.py
+"""Unit tests for cores.llm.features.forecast_stats (pure DB logic).
+
+Builds a tiny in-memory-style sqlite with the two tracker tables and points the
+module's DB locator at it, then checks the scenario lookup, the tiered up/side/
+down distribution (with percentiles), and the target-reach rate. No network, no
+matplotlib — just the SQL/aggregation logic.
+"""
+
+import os
+import sqlite3
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cores.llm.features import forecast_stats as fs  # noqa: E402
+
+
+def _build_db(path):
+    conn = sqlite3.connect(path)
+    c = conn.cursor()
+    c.execute(
+        """CREATE TABLE analysis_performance_tracker (
+            id INTEGER PRIMARY KEY, ticker TEXT, company_name TEXT,
+            trigger_type TEXT, analyzed_date TEXT, analyzed_price REAL,
+            buy_score REAL, target_price REAL, stop_loss REAL,
+            tracked_30d_return REAL, tracking_status TEXT)"""
+    )
+    # 60 completed high-band rows: 40 up(+20%), 10 sideways(0), 10 down(-20%)
+    rows = []
+    for i in range(60):
+        r = 0.20 if i < 40 else (0.0 if i < 50 else -0.20)
+        rows.append(("000660", "trigA", "20260101", 100000.0, 7.0,
+                     120000.0, 95000.0, r, "completed"))
+    # a recent row for scenario lookup (latest by date)
+    rows.append(("000660", "trigA", "20260601", 100000.0, 7.0,
+                 130000.0, 90000.0, None, "in_progress"))
+    c.executemany(
+        """INSERT INTO analysis_performance_tracker
+           (ticker, trigger_type, analyzed_date, analyzed_price, buy_score,
+            target_price, stop_loss, tracked_30d_return, tracking_status)
+           VALUES (?,?,?,?,?,?,?,?,?)""",
+        rows,
+    )
+    c.execute(
+        """CREATE TABLE us_analysis_performance_tracker (
+            id INTEGER PRIMARY KEY, ticker TEXT, company_name TEXT,
+            trigger_type TEXT, analysis_date TEXT, analysis_price REAL,
+            buy_score REAL, target_price REAL, stop_loss REAL,
+            return_30d REAL, hit_target INTEGER, tracking_status TEXT)"""
+    )
+    us = []
+    for i in range(40):
+        r = 0.15 if i < 20 else -0.05
+        us.append(("AMD", "trigB", "20260101", 200.0, 7.0, 230.0, 190.0,
+                   r, 1 if i < 20 else 0, "completed"))
+    c.executemany(
+        """INSERT INTO us_analysis_performance_tracker
+           (ticker, trigger_type, analysis_date, analysis_price, buy_score,
+            target_price, stop_loss, return_30d, hit_target, tracking_status)
+           VALUES (?,?,?,?,?,?,?,?,?,?)""",
+        us,
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    p = tmp_path / "stock_tracking_db.sqlite"
+    _build_db(str(p))
+    monkeypatch.setattr(fs, "_db_path", lambda: p)
+    return p
+
+
+def test_score_band():
+    assert fs.score_band(3) == "low"
+    assert fs.score_band(5) == "mid"
+    assert fs.score_band(7) == "high"
+    assert fs.score_band(None) is None
+
+
+def test_stock_scenario_latest(db):
+    sc = fs.get_stock_scenario("000660", market="kr")
+    assert sc is not None
+    # latest row (20260601) wins
+    assert sc["target_price"] == 130000.0
+    assert sc["buy_score"] == 7.0
+
+
+def test_distribution_kr(db):
+    d = fs.get_forecast_distribution("kr", 7, "trigA", threshold=0.10)
+    assert d is not None
+    assert d["n"] == 60
+    assert d["up"] == 67 and d["down"] == 17 and d["side"] == 17  # 40/10/10
+    assert d["tier"] == "band+trigger"
+    # percentiles present and ordered
+    p = d["pcts"]
+    assert p["p10"] <= p["p50"] <= p["p90"]
+
+
+def test_distribution_fallback_global(db):
+    # unknown trigger + a band with too few rows -> falls back broader
+    d = fs.get_forecast_distribution("kr", 7, "no_such_trigger")
+    assert d is not None and d["n"] == 60  # band tier still satisfies
+
+
+def test_target_reach_us_uses_hit_flag(db):
+    r = fs.get_target_reach_rate("us", 7)
+    assert r is not None
+    assert r["proxy"] is False  # US uses explicit hit_target
+    assert r["rate"] == 50  # 20/40


### PR DESCRIPTION
## What
Subscriber insight image upgrade + revival of the dormant buy-quality SHADOW gate. One shared data spine, two consumers (display + buy-decision calibration).

### Insight image (display-only)
- **forecast_stats.py** (new): point-in-time conditional base rates (up/side/down at ±10%/30d) + percentiles (p10–p90) + target-reach rate, from `stock_tracking_db.sqlite` (KR/US). Tiered fallback (score-band+trigger → band → global), `n` reported, ratio units.
- **insight_image.py**: uncertainty **fan** (sqrt-time curved cone from cohort return percentiles) + gold median line; plain-language probability bar ("프리즘이 비슷한 종목 N번 분석 → 올랐다/제자리/빠졌다 %"); target/stop moved to a left-centre plan box (no occlusion); de-emphasised base box; decluttered (on-plot support/resistance hidden when band present); font-safe glyphs (no tofu). Wired via tracker lookup in `build_insight_image_for` (best-effort, isolated).

### Buy-quality SHADOW revival (log-only, no trading impact)
- Root cause of 0 logged verdicts: the hook used `parallel_app.logger` (mcp_agent, context-bound) which **raised** outside a logging context; the hook's `except: pass` swallowed it. Verdicts were computed but never logged.
- Fix: route `[BUY_QUALITY][SHADOW]` through a plain `logging.getLogger('prism.buy_quality')`; log (not swallow) hook exceptions; add hook-reached / no-analysis diagnostics. Verified live: `would_buy=False qscore=18 thr=75` now logs.

## Tests
- `tests/test_forecast_stats.py` (new) + existing `tests/test_insight_image.py`: **23 passed**, no glyph warnings.

## Risk
Image = display-only (broadcast already LIVE via S6). Buy-quality = SHADOW/log-only. No trading-path change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)