### PR TITLE
Loop C fill-priority BUY chase + rename loop env keys (LOOP_*→behavior-named)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,3 +124,30 @@ TELEGRAM_CHANNEL_ID=your_channel_id
 # BYBIT_DEMO_API_SECRET=your_bybit_demo_api_secret
 # Telegram channel for BTC ops/healthcheck alerts (prism-btc/live/healthcheck.py)
 # BTC_OPS_CHANNEL_ID=your_btc_ops_channel_id
+
+# ============================================
+# Intraday trade-management loops (all default SHADOW: log-only, no real orders)
+# ============================================
+# Canonical prefixes are behavior-named. The legacy LOOP_A_/LOOP_B_/LOOP_C_
+# prefixes still work as DEPRECATED aliases (code reads the new key first, then
+# falls back to the old one and logs a one-time deprecation warning).
+
+# Loop A — hard stop-loss (was LOOP_A_*)
+# HARDSTOP_ENABLED=true            # master kill switch (false = off)
+# HARDSTOP_LIVE=false              # false => SHADOW (no real orders)
+
+# Loop B — trend exit / 50MA close confirm (was LOOP_B_*)
+# TREND_EXIT_ENABLED=true
+# TREND_EXIT_LIVE=false
+# TREND_EXIT_CONFIRM_CHECKS=2      # consecutive day-breaches before acting
+# TREND_EXIT_CLOSE_WINDOW=false    # set true only on the close-time cron line
+
+# Loop C — fill chaser for unfilled orders (was LOOP_C_*)
+# FILL_CHASER_ENABLED=true
+# FILL_CHASER_LIVE=false           # false => SHADOW (logs WOULD_AMEND/CANCEL only)
+# FILL_CHASER_CHASE_AFTER_SEC=60   # chase an order only after unfilled this long
+# FILL_CHASER_MAX_CHASES=5
+# Fill-priority BUY chasing (slippage budget + marketable cross):
+# FILL_CHASER_BUY_MAX_PREMIUM_PCT=3.0   # slippage budget %; beyond it -> CANCEL
+# FILL_CHASER_BUY_CROSS=true            # within budget, cross the spread to fill now
+# FILL_CHASER_BUY_CROSS_PAD_PCT=0.1     # how far above market the cross limit sits

--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -3,7 +3,7 @@
 > **단일 진실원(intended state).** 릴리즈가 늘어도 "무엇이 실거래에 적용 중인지" 한눈에 보기 위한 문서.
 > 실제 런타임 상태(서버 .env·crontab 기준)는 `tools/feature_status.py`로 대조 — 이 문서와 어긋나면 그 도구가 진실.
 > 관리 주체 = 코딩 에이전트(cokac-bot). 매 릴리즈/승격 시 갱신.
-> 최종 갱신: 2026-06-24.
+> 최종 갱신: 2026-06-25.
 
 ## 상태 정의
 - **LIVE** = 실거래/실발행에 실제 영향. **SHADOW** = 코드 동작하나 로그/관측만(영향 0). **OFF** = 미실행(코드만 존재). **N/A** = 미구현.
@@ -14,9 +14,9 @@
 |---|---|---|---|---|
 | OAuth LLM 백엔드(ChatGPT 구독) | **LIVE** | crontab `PRISM_OPENAI_AUTH_MODE=chatgpt_oauth` | 카나리 검증 완료 | 전 배치 적용 |
 | TIER0 이벤트 강제청산(뉴스 자율매도 + KIS 51 관리종목) | **LIVE** | 코드 상시 | 더존 등 실증 | KR+US 매도 프롬프트 핵심-0 |
-| Loop A — 고빈도 하드스톱(−7%/시나리오손절) | **LIVE** | `.env LOOP_A_LIVE=true` + cron 10분 | SHADOW 관측 후 승격(06-20) | KR 9–15 / US 9–16. 킬: `LOOP_A_ENABLED=false` |
-| Loop B — 50MA 종가확인 추세이탈 | **LIVE** | `.env LOOP_B_LIVE=true` + cron(KR 9–15 / US 9–16) | 백테스트 KR/US 순효과(휩쏘0·추가DD0) + 사용자 승인(06-24) | 코드: `tools/loop_b_trend_exit.py`. 킬: `LOOP_B_ENABLED=false` |
-| Loop C — 미체결 추격 + KIS TR 래퍼 | **SHADOW** | cron(KR/US */2분, `LOOP_C_LIVE` 미설정) | **신규 KIS 정정/취소 TR 실 KIS 수락 검증**(dry-run/`--selftest`로 페이로드 필드는 검증됨) | 코드: `tools/loop_c_fill_chaser.py`. 상세로깅 `[LOOP_C][SHADOW]` |
+| Loop A — 고빈도 하드스톱(−7%/시나리오손절) | **LIVE** | `.env HARDSTOP_LIVE=true` (구 `LOOP_A_LIVE`, alias 유효) + cron 10분 | SHADOW 관측 후 승격(06-20) | KR 9–15 / US 9–16. 킬: `HARDSTOP_ENABLED=false` |
+| Loop B — 50MA 종가확인 추세이탈 | **LIVE** | `.env TREND_EXIT_LIVE=true` (구 `LOOP_B_LIVE`) + cron(KR 9–15 / US 9–16) | 백테스트 KR/US 순효과(휩쏘0·추가DD0) + 사용자 승인(06-24) | 코드: `tools/loop_b_trend_exit.py`. 킬: `TREND_EXIT_ENABLED=false` |
+| Loop C — 미체결 추격 + KIS TR 래퍼 | **SHADOW** | cron(KR/US */2분, `FILL_CHASER_LIVE` 미설정; 구 `LOOP_C_LIVE` alias) | **신규 KIS 정정/취소 TR 실 KIS 수락 검증**(dry-run/`--selftest`로 페이로드 필드는 검증됨) | 코드: `tools/loop_c_fill_chaser.py`. 매수=체결우선 cross(예산 `FILL_CHASER_BUY_MAX_PREMIUM_PCT`=3%, `FILL_CHASER_BUY_CROSS`=on). 상세로깅 `[LOOP_C][SHADOW]` |
 | 비전 배관(S1) / 렌더QA(S2) | **ON(log-only)** | `PRISM_FEATURE_VISION=on` | 무손상 인프라 | 렌더QA 비차단 경고만 |
 | 비전 매수 품질검사(S3 + S3.5 오닐 일/주봉·RS) | **SHADOW** | `PRISM_FEATURE_VISION=on` + `PRISM_VISION_SHADOW=true` | **A/B 홀드아웃 측정(승률·손절률·MDD 순효과)** → 미정 | 관측 로그 `[BUY_QUALITY][SHADOW]`. 매매영향 0 |
 | 비전 인사이트 이미지 발행(S6) | **LIVE** | `.env PRISM_FEATURE_INSIGHT_IMAGE=on` **AND** `vision_available()`(`PRISM_FEATURE_VISION=on` + 실 API 키) | 샘플 사용자 승인 후 활성화(06-24) | KR(₩)/US($) 발송 중. 차트에 매수▲/매도▼ 마커·용어설명 포함. 끄기: `PRISM_FEATURE_INSIGHT_IMAGE=off` |
@@ -42,3 +42,4 @@ SHADOW→LIVE **자동 승격**은 아래를 **모두** 충족할 때만:
 - 2026-06-23: 레지스트리 신설. 현황 기록(Loop A LIVE / B·C SHADOW미스케줄 / 비전 SHADOW관측).
 - 2026-06-24: S6 발행 게이트 갱신 — 배선 구현 완료 반영. 게이트 `PRISM_FEATURE_INSIGHT_IMAGE=on` + `vision_available()`(이전 "발행 배선 미구현" 기재 정정). `feature_status.py`도 동일 로직으로 LIVE/OFF 보고.
 - 2026-06-24: **승격·활성화 반영** — Loop B → **LIVE**(`LOOP_B_LIVE=true`+cron, 백테스트 KR/US 통과+승인). Loop C → **SHADOW**(cron 설치, `LOOP_C_LIVE` 미설정; 상세로깅+selftest 추가). S6 발행 → **LIVE**(`PRISM_FEATURE_INSIGHT_IMAGE=on`, 사용자 승인; 매매마커·용어설명 포함).
+- 2026-06-25: **env 키 리네임(코드네임 누수 제거)** — `LOOP_A_*`→`HARDSTOP_*`, `LOOP_B_*`→`TREND_EXIT_*`, `LOOP_C_*`→`FILL_CHASER_*`. **구 키는 deprecated alias로 계속 유효**(코드가 신규 먼저 읽고 구 키 폴백+경고). prod `.env`/crontab 점진 교체 가능. + **Loop C 매수추격 체결우선화**: 예산 `FILL_CHASER_BUY_MAX_PREMIUM_PCT` 0.5%→3%, `FILL_CHASER_BUY_CROSS`(on)로 예산 내 마케터블 cross 즉시체결(예산 초과 시 여전히 CANCEL). SHADOW 유지.

--- a/tools/feature_status.py
+++ b/tools/feature_status.py
@@ -116,51 +116,54 @@ def _decide_oauth_llm(env: dict, crontab: str):
 
 
 def _decide_loop_a(env: dict, crontab: str):
-    live = env.get("LOOP_A_LIVE", "").lower()
-    enabled = env.get("LOOP_A_ENABLED", "true").lower()
+    # Canonical HARDSTOP_* with deprecated LOOP_A_* alias fallback.
+    live = (env.get("HARDSTOP_LIVE") or env.get("LOOP_A_LIVE") or "").lower()
+    enabled = (env.get("HARDSTOP_ENABLED") or env.get("LOOP_A_ENABLED") or "true").lower()
     has_cron = _cron_has_script(crontab, "loop_a_hardstop.py")
 
     if enabled == "false":
-        return "OFF", f"LOOP_A_ENABLED=false (킬스위치 ON)"
+        return "OFF", f"HARDSTOP_ENABLED=false (킬스위치 ON)"
     if live == "true" and has_cron:
-        return "LIVE", f"LOOP_A_LIVE=true, cron=있음"
+        return "LIVE", f"HARDSTOP_LIVE=true, cron=있음"
     if live == "true" and not has_cron:
-        return "미스케줄", f"LOOP_A_LIVE=true but cron=없음"
+        return "미스케줄", f"HARDSTOP_LIVE=true but cron=없음"
     if live != "true" and has_cron:
-        return "SHADOW", f"LOOP_A_LIVE={live or '(unset)'}, cron=있음"
-    return "OFF", f"LOOP_A_LIVE={live or '(unset)'}, cron=없음"
+        return "SHADOW", f"HARDSTOP_LIVE={live or '(unset)'}, cron=있음"
+    return "OFF", f"HARDSTOP_LIVE={live or '(unset)'}, cron=없음"
 
 
 def _decide_loop_b(env: dict, crontab: str):
-    live = env.get("LOOP_B_LIVE", "").lower()
-    enabled = env.get("LOOP_B_ENABLED", "").lower()
+    # Canonical TREND_EXIT_* with deprecated LOOP_B_* alias fallback.
+    live = (env.get("TREND_EXIT_LIVE") or env.get("LOOP_B_LIVE") or "").lower()
+    enabled = (env.get("TREND_EXIT_ENABLED") or env.get("LOOP_B_ENABLED") or "").lower()
     has_cron = _cron_has_script(crontab, "loop_b_trend_exit.py")
 
     if enabled == "false":
-        return "OFF", "LOOP_B_ENABLED=false"
+        return "OFF", "TREND_EXIT_ENABLED=false"
     if live == "true" and has_cron:
-        return "LIVE", "LOOP_B_LIVE=true, cron=있음"
+        return "LIVE", "TREND_EXIT_LIVE=true, cron=있음"
     if live == "true" and not has_cron:
-        return "미스케줄", "LOOP_B_LIVE=true but cron=없음"
+        return "미스케줄", "TREND_EXIT_LIVE=true but cron=없음"
     if not has_cron:
-        return "미스케줄", f"cron=없음, LOOP_B_LIVE={live or '(unset)'}"
-    return "SHADOW", f"LOOP_B_LIVE={live or '(unset)'}, cron=있음"
+        return "미스케줄", f"cron=없음, TREND_EXIT_LIVE={live or '(unset)'}"
+    return "SHADOW", f"TREND_EXIT_LIVE={live or '(unset)'}, cron=있음"
 
 
 def _decide_loop_c(env: dict, crontab: str):
-    live = env.get("LOOP_C_LIVE", "").lower()
-    enabled = env.get("LOOP_C_ENABLED", "").lower()
+    # Canonical FILL_CHASER_* with deprecated LOOP_C_* alias fallback.
+    live = (env.get("FILL_CHASER_LIVE") or env.get("LOOP_C_LIVE") or "").lower()
+    enabled = (env.get("FILL_CHASER_ENABLED") or env.get("LOOP_C_ENABLED") or "").lower()
     has_cron = _cron_has_script(crontab, "loop_c_fill_chaser.py")
 
     if enabled == "false":
-        return "OFF", "LOOP_C_ENABLED=false"
+        return "OFF", "FILL_CHASER_ENABLED=false"
     if live == "true" and has_cron:
-        return "LIVE", "LOOP_C_LIVE=true, cron=있음"
+        return "LIVE", "FILL_CHASER_LIVE=true, cron=있음"
     if live == "true" and not has_cron:
-        return "미스케줄", "LOOP_C_LIVE=true but cron=없음"
+        return "미스케줄", "FILL_CHASER_LIVE=true but cron=없음"
     if not has_cron:
-        return "미스케줄", f"cron=없음, LOOP_C_LIVE={live or '(unset)'}"
-    return "SHADOW", f"LOOP_C_LIVE={live or '(unset)'}, cron=있음"
+        return "미스케줄", f"cron=없음, FILL_CHASER_LIVE={live or '(unset)'}"
+    return "SHADOW", f"FILL_CHASER_LIVE={live or '(unset)'}, cron=있음"
 
 
 def _decide_vision_pipeline(env: dict, crontab: str):

--- a/tools/loop_a_hardstop.py
+++ b/tools/loop_a_hardstop.py
@@ -81,18 +81,39 @@ except Exception:
 
 
 # ── Configuration (env-driven) ────────────────────────────────────────────────
-def _env_bool(name: str, default: bool) -> bool:
-    return str(os.getenv(name, str(default))).strip().lower() in ("1", "true", "yes", "on")
+# Canonical env prefix is HARDSTOP_ (this is the hard stop-loss loop). The legacy
+# LOOP_A_ prefix is a DEPRECATED alias, still honored so existing prod .env /
+# crontab survive the rename; main() warns once for any legacy key in use.
+_DEPRECATED_ENV = []
 
 
-LOOP_A_ENABLED = _env_bool("LOOP_A_ENABLED", True)     # master kill switch
-LOOP_A_LIVE = _env_bool("LOOP_A_LIVE", False)          # False => SHADOW (no real orders)
-LOCK_TTL_SEC = int(os.getenv("LOOP_A_LOCK_TTL_SEC", "300"))
-DB_PATH = os.getenv("LOOP_A_DB") or os.getenv("STOCK_TRACKING_DB") \
+def _env(suffix, default=None):
+    """Read HARDSTOP_<suffix>, falling back to the deprecated LOOP_A_<suffix>."""
+    val = os.getenv("HARDSTOP_" + suffix)
+    if val is not None:
+        return val
+    legacy = os.getenv("LOOP_A_" + suffix)
+    if legacy is not None:
+        _DEPRECATED_ENV.append("LOOP_A_" + suffix)
+        return legacy
+    return default
+
+
+def _env_flag(suffix, default):
+    raw = _env(suffix)
+    if raw is None:
+        return default
+    return str(raw).strip().lower() in ("1", "true", "yes", "on")
+
+
+LOOP_A_ENABLED = _env_flag("ENABLED", True)            # master kill switch
+LOOP_A_LIVE = _env_flag("LIVE", False)                 # False => SHADOW (no real orders)
+LOCK_TTL_SEC = int(_env("LOCK_TTL_SEC", "300"))
+DB_PATH = _env("DB") or os.getenv("STOCK_TRACKING_DB") \
     or str(PROJECT_ROOT / "stock_tracking_db.sqlite")
 # Reuse the same channel the batch/system already broadcasts to (TELEGRAM_CHANNEL_ID).
-# LOOP_A_CHAT_ID is only an optional override.
-CHAT_ID = os.getenv("LOOP_A_CHAT_ID") or os.getenv("TELEGRAM_CHANNEL_ID") or None
+# HARDSTOP_CHAT_ID is only an optional override.
+CHAT_ID = _env("CHAT_ID") or os.getenv("TELEGRAM_CHANNEL_ID") or None
 
 _HOLDINGS_TABLE = {"KR": "stock_holdings", "US": "us_stock_holdings"}
 
@@ -426,6 +447,11 @@ def _setup_logging() -> None:
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         handlers=handlers,
     )
+    if _DEPRECATED_ENV:
+        logger.warning(
+            "deprecated env keys in use (rename to HARDSTOP_*): %s",
+            ", ".join(sorted(set(_DEPRECATED_ENV))),
+        )
 
 
 def _run_both_isolated() -> int:

--- a/tools/loop_b_trend_exit.py
+++ b/tools/loop_b_trend_exit.py
@@ -113,20 +113,41 @@ except Exception:
 
 
 # ── Configuration (env-driven) ────────────────────────────────────────────────
-def _env_bool(name: str, default: bool) -> bool:
-    return str(os.getenv(name, str(default))).strip().lower() in ("1", "true", "yes", "on")
+# Canonical env prefix is TREND_EXIT_ (this is the trend-exit loop). The legacy
+# LOOP_B_ prefix is a DEPRECATED alias, still honored so existing prod .env /
+# crontab survive the rename; main() warns once for any legacy key in use.
+_DEPRECATED_ENV = []
 
 
-LOOP_B_ENABLED = _env_bool("LOOP_B_ENABLED", True)      # master kill switch
-LOOP_B_LIVE = _env_bool("LOOP_B_LIVE", False)           # False => SHADOW (no real orders)
-LOOP_B_CONFIRM_CHECKS = int(os.getenv("LOOP_B_CONFIRM_CHECKS", "2"))   # N consecutive day-breaches to act
-LOOP_B_CLOSE_WINDOW = _env_bool("LOOP_B_CLOSE_WINDOW", False)          # set true on the close-time cron line
-LOCK_TTL_SEC = int(os.getenv("LOOP_B_LOCK_TTL_SEC", "300"))
-DB_PATH = os.getenv("LOOP_B_DB") or os.getenv("STOCK_TRACKING_DB") \
+def _env(suffix, default=None):
+    """Read TREND_EXIT_<suffix>, falling back to the deprecated LOOP_B_<suffix>."""
+    val = os.getenv("TREND_EXIT_" + suffix)
+    if val is not None:
+        return val
+    legacy = os.getenv("LOOP_B_" + suffix)
+    if legacy is not None:
+        _DEPRECATED_ENV.append("LOOP_B_" + suffix)
+        return legacy
+    return default
+
+
+def _env_flag(suffix, default):
+    raw = _env(suffix)
+    if raw is None:
+        return default
+    return str(raw).strip().lower() in ("1", "true", "yes", "on")
+
+
+LOOP_B_ENABLED = _env_flag("ENABLED", True)             # master kill switch
+LOOP_B_LIVE = _env_flag("LIVE", False)                  # False => SHADOW (no real orders)
+LOOP_B_CONFIRM_CHECKS = int(_env("CONFIRM_CHECKS", "2"))   # N consecutive day-breaches to act
+LOOP_B_CLOSE_WINDOW = _env_flag("CLOSE_WINDOW", False)     # set true on the close-time cron line
+LOCK_TTL_SEC = int(_env("LOCK_TTL_SEC", "300"))
+DB_PATH = _env("DB") or os.getenv("STOCK_TRACKING_DB") \
     or str(PROJECT_ROOT / "stock_tracking_db.sqlite")
 # Reuse the same channel the batch/system already broadcasts to (TELEGRAM_CHANNEL_ID).
-# LOOP_B_CHAT_ID is only an optional override.
-CHAT_ID = os.getenv("LOOP_B_CHAT_ID") or os.getenv("TELEGRAM_CHANNEL_ID") or None
+# TREND_EXIT_CHAT_ID is only an optional override.
+CHAT_ID = _env("CHAT_ID") or os.getenv("TELEGRAM_CHANNEL_ID") or None
 
 _HOLDINGS_TABLE = {"KR": "stock_holdings", "US": "us_stock_holdings"}
 
@@ -633,6 +654,11 @@ def _setup_logging() -> None:
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         handlers=handlers,
     )
+    if _DEPRECATED_ENV:
+        logger.warning(
+            "deprecated env keys in use (rename to TREND_EXIT_*): %s",
+            ", ".join(sorted(set(_DEPRECATED_ENV))),
+        )
 
 
 def _run_both_isolated() -> int:

--- a/tools/loop_c_fill_chaser.py
+++ b/tools/loop_c_fill_chaser.py
@@ -89,36 +89,57 @@ logger = logging.getLogger("loop_c")
 
 
 # ── Configuration (env-driven) ────────────────────────────────────────────────
-def _env_bool(name: str, default: bool) -> bool:
-    return str(os.getenv(name, str(default))).strip().lower() in ("1", "true", "yes", "on")
+# Canonical env prefix is FILL_CHASER_. The legacy LOOP_C_ prefix is a DEPRECATED
+# alias, still honored so existing prod .env / crontab survive the rename; main()
+# warns once for any legacy key in use.
+_DEPRECATED_ENV: List[str] = []
 
 
-LOOP_C_ENABLED = _env_bool("LOOP_C_ENABLED", True)        # master kill switch
-LOOP_C_LIVE = _env_bool("LOOP_C_LIVE", False)             # False => SHADOW (no real amend/cancel)
-LOCK_TTL_SEC = int(os.getenv("LOOP_C_LOCK_TTL_SEC", "300"))
+def _env(suffix: str, default: Optional[str] = None) -> Optional[str]:
+    """Read FILL_CHASER_<suffix>, falling back to the deprecated LOOP_C_<suffix>."""
+    val = os.getenv("FILL_CHASER_" + suffix)
+    if val is not None:
+        return val
+    legacy = os.getenv("LOOP_C_" + suffix)
+    if legacy is not None:
+        _DEPRECATED_ENV.append("LOOP_C_" + suffix)
+        return legacy
+    return default
+
+
+def _env_flag(suffix: str, default: bool) -> bool:
+    raw = _env(suffix)
+    if raw is None:
+        return default
+    return str(raw).strip().lower() in ("1", "true", "yes", "on")
+
+
+LOOP_C_ENABLED = _env_flag("ENABLED", True)               # master kill switch
+LOOP_C_LIVE = _env_flag("LIVE", False)                    # False => SHADOW (no real amend/cancel)
+LOCK_TTL_SEC = int(_env("LOCK_TTL_SEC", "300"))
 # Chase an order only after it has been unfilled this long.
-CHASE_AFTER_SEC = int(os.getenv("LOOP_C_CHASE_AFTER_SEC", "60"))
+CHASE_AFTER_SEC = int(_env("CHASE_AFTER_SEC", "60"))
 # Leave brand-new orders alone for this long (another loop may have just placed it).
-GRACE_SEC = int(os.getenv("LOOP_C_GRACE_SEC", "20"))
+GRACE_SEC = int(_env("GRACE_SEC", "20"))
 # Each chase step moves the limit this fraction toward the market.
-CHASE_STEP_PCT = float(os.getenv("LOOP_C_CHASE_STEP_PCT", "0.3"))
+CHASE_STEP_PCT = float(_env("CHASE_STEP_PCT", "0.3"))
 # BUY ceiling = slippage budget: how far above the original limit we are willing
 # to pay to secure a fill. Env value is a percent (e.g. "3.0" = 3%); stored as a
 # fraction. Beyond it -> CANCEL (don't chase into the top of a runaway spike).
-BUY_MAX_PREMIUM_PCT = float(os.getenv("LOOP_C_BUY_MAX_PREMIUM_PCT", "3.0")) / 100.0
+BUY_MAX_PREMIUM_PCT = float(_env("BUY_MAX_PREMIUM_PCT", "3.0")) / 100.0
 # Fill-priority for BUY: when the market is within the slippage budget, place a
 # MARKETABLE limit (cross the spread) so the order fills NOW instead of trailing
 # the market CHASE_STEP_PCT-per-step and never catching a still-rising price.
 # The limit is set BUY_CROSS_PAD_PCT above the live market, then capped at the
 # budget ceiling. Disable to fall back to the legacy sub-market creep.
-BUY_CROSS = _env_bool("LOOP_C_BUY_CROSS", True)
-BUY_CROSS_PAD_PCT = float(os.getenv("LOOP_C_BUY_CROSS_PAD_PCT", "0.1")) / 100.0
+BUY_CROSS = _env_flag("BUY_CROSS", True)
+BUY_CROSS_PAD_PCT = float(_env("BUY_CROSS_PAD_PCT", "0.1")) / 100.0
 # Max number of amend steps before giving up and (optionally) cancelling.
-MAX_CHASES = int(os.getenv("LOOP_C_MAX_CHASES", "5"))
+MAX_CHASES = int(_env("MAX_CHASES", "5"))
 # Whether to cancel a buy order once the ceiling is hit (else just stop chasing).
-CANCEL_ON_CEILING = _env_bool("LOOP_C_CANCEL_ON_CEILING", True)
+CANCEL_ON_CEILING = _env_flag("CANCEL_ON_CEILING", True)
 
-DB_PATH = os.getenv("LOOP_C_DB") or os.getenv("STOCK_TRACKING_DB") \
+DB_PATH = _env("DB") or os.getenv("STOCK_TRACKING_DB") \
     or str(PROJECT_ROOT / "stock_tracking_db.sqlite")
 
 
@@ -675,6 +696,11 @@ def _setup_logging() -> None:
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         handlers=handlers,
     )
+    if _DEPRECATED_ENV:
+        logger.warning(
+            "deprecated env keys in use (rename to FILL_CHASER_*): %s",
+            ", ".join(sorted(set(_DEPRECATED_ENV))),
+        )
 
 
 # ── --selftest: exercise chase->payload->verdict->log with NO DB lock / API ────

--- a/tools/loop_c_fill_chaser.py
+++ b/tools/loop_c_fill_chaser.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import math
 import os
 import sqlite3
 import sys
@@ -101,9 +102,17 @@ CHASE_AFTER_SEC = int(os.getenv("LOOP_C_CHASE_AFTER_SEC", "60"))
 GRACE_SEC = int(os.getenv("LOOP_C_GRACE_SEC", "20"))
 # Each chase step moves the limit this fraction toward the market.
 CHASE_STEP_PCT = float(os.getenv("LOOP_C_CHASE_STEP_PCT", "0.3"))
-# BUY ceiling: never chase a buy limit more than this PERCENT over its original
-# price. Env value is a percent (e.g. "0.5" = 0.5%); stored as a fraction.
-BUY_MAX_PREMIUM_PCT = float(os.getenv("LOOP_C_BUY_MAX_PREMIUM_PCT", "0.5")) / 100.0
+# BUY ceiling = slippage budget: how far above the original limit we are willing
+# to pay to secure a fill. Env value is a percent (e.g. "3.0" = 3%); stored as a
+# fraction. Beyond it -> CANCEL (don't chase into the top of a runaway spike).
+BUY_MAX_PREMIUM_PCT = float(os.getenv("LOOP_C_BUY_MAX_PREMIUM_PCT", "3.0")) / 100.0
+# Fill-priority for BUY: when the market is within the slippage budget, place a
+# MARKETABLE limit (cross the spread) so the order fills NOW instead of trailing
+# the market CHASE_STEP_PCT-per-step and never catching a still-rising price.
+# The limit is set BUY_CROSS_PAD_PCT above the live market, then capped at the
+# budget ceiling. Disable to fall back to the legacy sub-market creep.
+BUY_CROSS = _env_bool("LOOP_C_BUY_CROSS", True)
+BUY_CROSS_PAD_PCT = float(os.getenv("LOOP_C_BUY_CROSS_PAD_PCT", "0.1")) / 100.0
 # Max number of amend steps before giving up and (optionally) cancelling.
 MAX_CHASES = int(os.getenv("LOOP_C_MAX_CHASES", "5"))
 # Whether to cancel a buy order once the ceiling is hit (else just stop chasing).
@@ -318,7 +327,9 @@ def _compute_chase_price(side: str, order_price: float, market_price: float) -> 
     """Move the limit a CHASE_STEP_PCT fraction toward the market price.
 
     SELL: chase DOWN toward market (floored at market — never below).
-    BUY:  chase UP toward market (capped at market — never above).
+    BUY:  if BUY_CROSS, jump to a MARKETABLE limit (cross the spread) for an
+          immediate fill; else legacy creep UP toward market (never crossing).
+          Either way the caller caps the result at the slippage-budget ceiling.
     """
     if order_price <= 0 or market_price <= 0:
         return order_price
@@ -327,15 +338,24 @@ def _compute_chase_price(side: str, order_price: float, market_price: float) -> 
         target = order_price - (order_price - market_price) * CHASE_STEP_PCT
         return max(target, market_price)
     else:  # BUY
+        if BUY_CROSS:
+            # Fill-priority: cross the spread now; caller caps at the ceiling.
+            return market_price * (1.0 + BUY_CROSS_PAD_PCT)
+        # Legacy creep: move only a fraction toward market, never crossing it.
         target = order_price + (market_price - order_price) * CHASE_STEP_PCT
         return min(target, market_price)
 
 
-def _round_price(market: str, price: float) -> float:
-    """KR limit prices are integers (KRW); US allows cents."""
+def _round_price(market: str, price: float, round_up: bool = False) -> float:
+    """KR limit prices are integers (KRW); US allows cents.
+
+    round_up=True ceilings to the tick — used for marketable BUY limits so the
+    rounding step never drops the price back below the live market (which would
+    defeat the cross / fill-priority intent).
+    """
     if market == "KR":
-        return float(int(round(price)))
-    return round(price, 2)
+        return float(math.ceil(price)) if round_up else float(int(round(price)))
+    return math.ceil(price * 100.0) / 100.0 if round_up else round(price, 2)
 
 
 # ── SHADOW verification helpers (dry-run payload + fill plausibility) ───────────
@@ -474,8 +494,11 @@ async def _act_on_order(conn, trader, market: str, order: Dict[str, Any],
 
         # ── Compute the chased price ────────────────────────────────────────
         raw_new = _compute_chase_price(side, order_price, market_price)
-        new_price = _round_price(market, raw_new)
-        # Cap a buy's chased price at the ceiling too.
+        # Round BUY cross prices UP to the tick so rounding never pushes the
+        # limit back below the live market (which would lose the fill).
+        new_price = _round_price(market, raw_new,
+                                 round_up=(side == "BUY" and BUY_CROSS))
+        # Cap a buy's chased price at the budget ceiling too.
         if side == "BUY":
             new_price = min(new_price, _round_price(market, ceiling_price))
 


### PR DESCRIPTION
## What
Two related changes to the intraday trade-management loops, both SHADOW-safe.

### 1. Loop C fill-priority BUY chasing (commit 1)
The fill-chaser was too conservative to ever catch a moving entry (e.g. MU 2026-06-25 gapped +18% → every chase `WOULD_CANCEL`):
- ceiling was only **+0.5%** over the original limit;
- chase crept 30%/step and was capped **at** the market, so a still-rising price was never crossed → no fill.

Now fill-first, bounded by an explicit **slippage budget**:
- `FILL_CHASER_BUY_MAX_PREMIUM_PCT` default **0.5% → 3%** (beyond it → still CANCEL, no top-chasing);
- new `FILL_CHASER_BUY_CROSS` (default on): within budget, place a **marketable** limit (`market × (1+pad)`, capped at ceiling) so the order fills now;
- BUY cross limits round **up** to the tick so rounding never drops below market.

SELL chasing unchanged. Still gated behind `FILL_CHASER_LIVE` (default SHADOW).

### 2. Rename loop env keys — drop internal codenames (commit 2)
`LOOP_A_/LOOP_B_/LOOP_C_` leaked internal codenames into the operator-facing `.env`. Renamed to behavior-named prefixes, each with a **backward-compat alias**:
- `LOOP_A_* → HARDSTOP_*`
- `LOOP_B_* → TREND_EXIT_*`
- `LOOP_C_* → FILL_CHASER_*`

Code reads the new key first, falls back to the deprecated `LOOP_X_` key, and logs a one-time deprecation warning. **Prod `.env`/crontab keep working unchanged.** Internal Python identifiers untouched.

Docs: `FEATURE_FLAGS.md` + `.env.example` updated.

## Verification
- 95 unit tests (loop A/B/C + feature_status, KR+US) pass
- `py_compile` clean; `--selftest` payloads OK + deprecation warning fires on legacy key
- numeric probe: within-budget → FILL_LIKELY cross, beyond → CANCEL; new key wins over legacy

## Risk
Low — Loop C remains SHADOW (no real orders); aliases keep Loop A/B (LIVE) prod env intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)