### PR TITLE
Fix triple realtime-portfolio message on sell (de-dup broadcast)

### DIFF
--- a/portfolio_broadcast.py
+++ b/portfolio_broadcast.py
@@ -1,0 +1,80 @@
+"""Portfolio-summary broadcast de-duplication (market-keyed debounce).
+
+The realtime portfolio summary ("실시간 포트폴리오") is emitted from several
+independent run-ends — the KR/US batch agents and the intraday loops (A/B). With
+no coordination, a sell event whose window overlaps two or more of those runs
+produced 2-3 identical portfolio messages in the channel.
+
+This module provides a tiny, self-contained (stdlib-only, no project imports so it
+is import-safe under both the root and prism-us/cores-shadowed runtimes) debounce:
+`should_send_portfolio(market)` returns True at most once per debounce window per
+market, atomically recording the send time. Other queued messages (sell notices,
+etc.) are unaffected — only the portfolio-summary append is gated by this.
+
+Fail-open: any DB error returns True (send), so a hiccup never silently drops the
+user's portfolio update — at worst it falls back to the old (possibly duplicated)
+behavior.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+# Debounce window: collapse portfolio summaries emitted within this many seconds
+# of each other (per market) into one. Near-simultaneous batch/loop run-ends fall
+# inside it; genuinely separate sell events (minutes apart) do not.
+DEBOUNCE_SEC = int(os.getenv("PORTFOLIO_BROADCAST_DEBOUNCE_SEC", "120"))
+
+
+def _db_path() -> str:
+    """Same DB the batch agents and loops use (single stock_tracking_db.sqlite)."""
+    return (
+        os.getenv("PORTFOLIO_BROADCAST_DB")
+        or os.getenv("STOCK_TRACKING_DB")
+        or str(Path(__file__).resolve().parent / "stock_tracking_db.sqlite")
+    )
+
+
+def should_send_portfolio(market: str, debounce_sec: int | None = None,
+                          db_path: str | None = None) -> bool:
+    """Return True iff no portfolio summary was broadcast for `market` within the
+    debounce window, recording 'now' atomically when it returns True.
+
+    Fail-open: returns True on any error (never suppresses on a DB hiccup).
+    """
+    window = DEBOUNCE_SEC if debounce_sec is None else debounce_sec
+    path = db_path or _db_path()
+    key = (market or "DEFAULT").upper()
+    now = time.time()
+    try:
+        conn = sqlite3.connect(path, timeout=5)
+        try:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS portfolio_broadcast_log ("
+                " market TEXT PRIMARY KEY, last_sent_ts REAL NOT NULL)"
+            )
+            # Serialise concurrent run-ends: take an immediate write lock, then
+            # read-modify-write under it so two racing senders can't both pass.
+            conn.isolation_level = None
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT last_sent_ts FROM portfolio_broadcast_log WHERE market=?",
+                (key,),
+            ).fetchone()
+            if row is not None and (now - float(row[0])) < window:
+                conn.execute("ROLLBACK")
+                return False
+            conn.execute(
+                "INSERT INTO portfolio_broadcast_log(market, last_sent_ts) VALUES(?,?) "
+                "ON CONFLICT(market) DO UPDATE SET last_sent_ts=excluded.last_sent_ts",
+                (key, now),
+            )
+            conn.execute("COMMIT")
+            return True
+        finally:
+            conn.close()
+    except Exception:
+        # Fail-open: better to occasionally duplicate than to drop the update.
+        return True

--- a/prism-us/tests/test_loop_b_trend_exit_us.py
+++ b/prism-us/tests/test_loop_b_trend_exit_us.py
@@ -247,7 +247,10 @@ def test_us_live_sim_kis_telegram_order(tmp_db, monkeypatch):
 
     summary = asyncio.run(lb.run_market(MKT, "run1"))
     assert summary["sold"] == 1
-    assert calls == ["sim:AAPL", "kis:AAPL:5", "tg"]
+    # per-sell flush + run-end flush each invoke send_telegram_message; the run-end
+    # portfolio summary is de-duplicated (portfolio_broadcast) so only ONE actual
+    # portfolio message goes out in prod (see tests/test_portfolio_broadcast.py).
+    assert calls == ["sim:AAPL", "kis:AAPL:5", "tg", "tg"]
     assert _inflight(tmp_db, "FILLED") == 1
 
 

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -2834,10 +2834,20 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                 self._msg_types = []
                 return False
 
-            # Generate summary report
-            summary = await self.generate_report_summary()
-            self._msg_types.append("portfolio")
-            self.message_queue.append(summary)
+            # Generate summary report — de-duplicated so near-simultaneous run-ends
+            # (US batch + intraday loops A/B) don't emit 2-3 identical portfolio
+            # summaries. Other queued messages (sell notices) are unaffected.
+            try:
+                from portfolio_broadcast import should_send_portfolio
+                _emit_portfolio = should_send_portfolio("US")
+            except Exception:
+                _emit_portfolio = True  # fail-open
+            if _emit_portfolio:
+                summary = await self.generate_report_summary()
+                self._msg_types.append("portfolio")
+                self.message_queue.append(summary)
+            else:
+                logger.info("[portfolio-dedup] US portfolio summary skipped (sent within debounce window)")
 
             # Translate messages if English is requested
             if language == "en":

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -1886,10 +1886,20 @@ class StockTrackingAgent:
                 self._msg_types = []
                 return False
 
-            # Generate summary report
-            summary = await self.generate_report_summary()
-            self._msg_types.append("portfolio")
-            self.message_queue.append(summary)
+            # Generate summary report — de-duplicated so near-simultaneous run-ends
+            # (KR batch + intraday loops A/B) don't emit 2-3 identical portfolio
+            # summaries. Other queued messages (sell notices) are unaffected.
+            try:
+                from portfolio_broadcast import should_send_portfolio
+                _emit_portfolio = should_send_portfolio("KR")
+            except Exception:
+                _emit_portfolio = True  # fail-open
+            if _emit_portfolio:
+                summary = await self.generate_report_summary()
+                self._msg_types.append("portfolio")
+                self.message_queue.append(summary)
+            else:
+                logger.info("[portfolio-dedup] KR portfolio summary skipped (sent within debounce window)")
 
             # Translate messages if English is requested
             if language == "en":

--- a/tests/test_loop_a_hardstop.py
+++ b/tests/test_loop_a_hardstop.py
@@ -151,7 +151,10 @@ def test_live_order_is_sim_then_kis_then_telegram(tmp_db, monkeypatch):
     summary = asyncio.run(la.run_market("KR", "run1"))
 
     assert summary["sold"] == 1
-    assert calls == ["sim:005930", "kis:005930:10", "tg"]   # exact order
+    # per-sell flush + run-end flush each invoke send_telegram_message; the run-end
+    # portfolio summary is de-duplicated (portfolio_broadcast) so only ONE actual
+    # portfolio message goes out in prod (see tests/test_portfolio_broadcast.py).
+    assert calls == ["sim:005930", "kis:005930:10", "tg", "tg"]   # exact order
     assert _inflight(tmp_db, "FILLED") == 1
 
 

--- a/tests/test_loop_b_trend_exit.py
+++ b/tests/test_loop_b_trend_exit.py
@@ -318,7 +318,10 @@ def test_live_order_is_sim_then_kis_then_telegram(tmp_db, monkeypatch):
     summary = asyncio.run(lb.run_market("KR", "run1"))
 
     assert summary["sold"] == 1
-    assert calls == ["sim:005930", "kis:005930:10", "tg"]   # exact order
+    # per-sell flush + run-end flush each invoke send_telegram_message; the run-end
+    # portfolio summary is de-duplicated (portfolio_broadcast) so only ONE actual
+    # portfolio message goes out in prod (see tests/test_portfolio_broadcast.py).
+    assert calls == ["sim:005930", "kis:005930:10", "tg", "tg"]   # exact order
     assert _inflight(tmp_db, "FILLED") == 1
 
 

--- a/tests/test_portfolio_broadcast.py
+++ b/tests/test_portfolio_broadcast.py
@@ -1,0 +1,47 @@
+"""Tests for portfolio-summary broadcast de-duplication (market-keyed debounce)."""
+import importlib
+import time
+
+import pytest
+
+
+@pytest.fixture()
+def pb(tmp_path, monkeypatch):
+    db = tmp_path / "stock_tracking_db.sqlite"
+    monkeypatch.setenv("PORTFOLIO_BROADCAST_DB", str(db))
+    import portfolio_broadcast as m
+    importlib.reload(m)  # re-read env into module-level DEBOUNCE_SEC
+    return m
+
+
+def test_first_send_allowed_then_debounced(pb):
+    assert pb.should_send_portfolio("US", debounce_sec=120) is True
+    # immediate second call within the window is suppressed
+    assert pb.should_send_portfolio("US", debounce_sec=120) is False
+
+
+def test_markets_are_independent(pb):
+    assert pb.should_send_portfolio("US", debounce_sec=120) is True
+    assert pb.should_send_portfolio("KR", debounce_sec=120) is True  # different market
+    assert pb.should_send_portfolio("US", debounce_sec=120) is False
+    assert pb.should_send_portfolio("KR", debounce_sec=120) is False
+
+
+def test_window_expiry_allows_resend(pb):
+    assert pb.should_send_portfolio("US", debounce_sec=1) is True
+    assert pb.should_send_portfolio("US", debounce_sec=1) is False
+    time.sleep(1.1)
+    assert pb.should_send_portfolio("US", debounce_sec=1) is True
+
+
+def test_market_key_case_insensitive(pb):
+    assert pb.should_send_portfolio("us", debounce_sec=120) is True
+    assert pb.should_send_portfolio("US", debounce_sec=120) is False
+
+
+def test_fail_open_on_bad_db(monkeypatch):
+    import portfolio_broadcast as m
+    importlib.reload(m)
+    # point at an unwritable/invalid path -> must fail OPEN (return True), never drop
+    bad = "/proc/nonexistent_dir/cannot_create.sqlite"
+    assert m.should_send_portfolio("US", debounce_sec=120, db_path=bad) is True

--- a/tools/loop_a_hardstop.py
+++ b/tools/loop_a_hardstop.py
@@ -330,11 +330,11 @@ async def run_market(market: str, run_id: str) -> Dict[str, Any]:
         # once per run. Fully wrapped; never breaks the loop.
         if summary.get("sold", 0) > 0 and agent["ref"] is not None:
             try:
-                _ag = agent["ref"]
-                _msg = await _ag.generate_report_summary()
-                if _msg:
-                    _ag.message_queue.append(_msg)
-                    await _ag.send_telegram_message(CHAT_ID)
+                # send_telegram_message() itself appends the (de-duplicated)
+                # portfolio summary, so do NOT generate+append it here as well —
+                # doing both queued the portfolio twice (the double-send bug). Flush
+                # the queue once; cross-run de-dup lives in portfolio_broadcast.
+                await agent["ref"].send_telegram_message(CHAT_ID)
             except Exception as _e:
                 logger.warning("[%s] run-end portfolio summary failed: %s", market, _e)
         conn.close()

--- a/tools/loop_b_trend_exit.py
+++ b/tools/loop_b_trend_exit.py
@@ -537,11 +537,11 @@ async def run_market(market: str, run_id: str) -> Dict[str, Any]:
         # once per run. Fully wrapped; never breaks the loop.
         if summary.get("sold", 0) > 0 and agent["ref"] is not None:
             try:
-                _ag = agent["ref"]
-                _msg = await _ag.generate_report_summary()
-                if _msg:
-                    _ag.message_queue.append(_msg)
-                    await _ag.send_telegram_message(CHAT_ID)
+                # send_telegram_message() itself appends the (de-duplicated)
+                # portfolio summary, so do NOT generate+append it here as well —
+                # doing both queued the portfolio twice (the double-send bug). Flush
+                # the queue once; cross-run de-dup lives in portfolio_broadcast.
+                await agent["ref"].send_telegram_message(CHAT_ID)
             except Exception as _e:
                 logger.warning("[%s] run-end portfolio summary failed: %s", market, _e)
         conn.close()


### PR DESCRIPTION
## Problem
A single sell emitted the **realtime portfolio summary ("실시간 포트폴리오") 2–3 times** (user report: MU sell 2026-06-25 04:10 → 3 identical messages).

Root cause: `send_telegram_message()` **always** generates+appends a portfolio summary, and it is invoked from multiple uncoordinated run-ends (per-sell flush, loop run-end from PR #376, batch). On top of that, `loop_a`/`loop_b` **also** manually did `generate_report_summary()+append` before calling `send_telegram_message()` — queuing the portfolio a second time. One sell → up to 3 portfolio messages.

## Fix
- **New `portfolio_broadcast.py`** (stdlib-only, import-safe under both the root and the prism-us cores-shadowed runtime): `should_send_portfolio(market)` returns True at most once per debounce window (`PORTFOLIO_BROADCAST_DEBOUNCE_SEC`, default 120s) per market, recorded atomically in sqlite. **Fail-open** — a DB error never drops the update.
- **Gate the portfolio append** inside both agents' `send_telegram_message()` with it → near-simultaneous batch/loop run-ends collapse to **one** portfolio message. Other queued messages (sell notices) are unaffected.
- **Remove the redundant manual** `generate_report_summary()+append` in `loop_a`/`loop_b` run-ends.

## Verification
- New `test_portfolio_broadcast`: debounce, per-market independence, window expiry, case-insensitivity, fail-open.
- loop a/b sequence tests updated to reflect the run-end flush invocation (portfolio content deduped at the broadcast layer).
- **100 relevant tests pass** locally; full suite validated by CI (local venv lacks `mcp_agent`/`cores.openai_debug`).

## Risk
Low — change is guarded + fail-open; only the *portfolio-summary append* is gated, never the sell notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)