### PR TITLE
Re-entry cooldown gate to curb churn re-buys (SHADOW-first)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -151,3 +151,10 @@ TELEGRAM_CHANNEL_ID=your_channel_id
 # FILL_CHASER_BUY_MAX_PREMIUM_PCT=3.0   # slippage budget %; beyond it -> CANCEL
 # FILL_CHASER_BUY_CROSS=true            # within budget, cross the spread to fill now
 # FILL_CHASER_BUY_CROSS_PAD_PCT=0.1     # how far above market the cross limit sits
+
+# Re-entry cooldown gate — vetoes churn re-buys of a name just sold (default
+# SHADOW: logs [REENTRY_COOLDOWN][SHADOW] WOULD_BLOCK, buy still proceeds).
+# REENTRY_COOLDOWN_ENABLED=true
+# REENTRY_COOLDOWN_LIVE=false        # false => SHADOW (log only); true => skip the buy
+# REENTRY_COOLDOWN_HOURS=0           # cooldown after a WIN/normal sell (0 = off; wins can re-enter)
+# REENTRY_COOLDOWN_LOSS_HOURS=24     # longer cooldown after a LOSS (revenge-trade prevention)

--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -17,6 +17,7 @@
 | Loop A — 고빈도 하드스톱(−7%/시나리오손절) | **LIVE** | `.env HARDSTOP_LIVE=true` (구 `LOOP_A_LIVE`, alias 유효) + cron 10분 | SHADOW 관측 후 승격(06-20) | KR 9–15 / US 9–16. 킬: `HARDSTOP_ENABLED=false` |
 | Loop B — 50MA 종가확인 추세이탈 | **LIVE** | `.env TREND_EXIT_LIVE=true` (구 `LOOP_B_LIVE`) + cron(KR 9–15 / US 9–16) | 백테스트 KR/US 순효과(휩쏘0·추가DD0) + 사용자 승인(06-24) | 코드: `tools/loop_b_trend_exit.py`. 킬: `TREND_EXIT_ENABLED=false` |
 | Loop C — 미체결 추격 + KIS TR 래퍼 | **SHADOW** | cron(KR/US */2분, `FILL_CHASER_LIVE` 미설정; 구 `LOOP_C_LIVE` alias) | **신규 KIS 정정/취소 TR 실 KIS 수락 검증**(dry-run/`--selftest`로 페이로드 필드는 검증됨) | 코드: `tools/loop_c_fill_chaser.py`. 매수=체결우선 cross(예산 `FILL_CHASER_BUY_MAX_PREMIUM_PCT`=3%, `FILL_CHASER_BUY_CROSS`=on). 상세로깅 `[LOOP_C][SHADOW]` |
+| 재진입 쿨다운 게이트(매수측) | **SHADOW** | `REENTRY_COOLDOWN_LIVE` 미설정 | SHADOW 며칠 관측(`[REENTRY_COOLDOWN][SHADOW] WOULD_BLOCK` ↔ 실매수 대조) → LIVE 승격 | 코드: `reentry_cooldown.py` (KR/US 매수 caller 훅). 손실매도 후 24h 재매수 차단(승리후 0h). prod 이력검증=리벤지 3건 차단·오탐0 |
 | 비전 배관(S1) / 렌더QA(S2) | **ON(log-only)** | `PRISM_FEATURE_VISION=on` | 무손상 인프라 | 렌더QA 비차단 경고만 |
 | 비전 매수 품질검사(S3 + S3.5 오닐 일/주봉·RS) | **SHADOW** | `PRISM_FEATURE_VISION=on` + `PRISM_VISION_SHADOW=true` | **A/B 홀드아웃 측정(승률·손절률·MDD 순효과)** → 미정 | 관측 로그 `[BUY_QUALITY][SHADOW]`. 매매영향 0 |
 | 비전 인사이트 이미지 발행(S6) | **LIVE** | `.env PRISM_FEATURE_INSIGHT_IMAGE=on` **AND** `vision_available()`(`PRISM_FEATURE_VISION=on` + 실 API 키) | 샘플 사용자 승인 후 활성화(06-24) | KR(₩)/US($) 발송 중. 차트에 매수▲/매도▼ 마커·용어설명 포함. 끄기: `PRISM_FEATURE_INSIGHT_IMAGE=off` |
@@ -43,3 +44,4 @@ SHADOW→LIVE **자동 승격**은 아래를 **모두** 충족할 때만:
 - 2026-06-24: S6 발행 게이트 갱신 — 배선 구현 완료 반영. 게이트 `PRISM_FEATURE_INSIGHT_IMAGE=on` + `vision_available()`(이전 "발행 배선 미구현" 기재 정정). `feature_status.py`도 동일 로직으로 LIVE/OFF 보고.
 - 2026-06-24: **승격·활성화 반영** — Loop B → **LIVE**(`LOOP_B_LIVE=true`+cron, 백테스트 KR/US 통과+승인). Loop C → **SHADOW**(cron 설치, `LOOP_C_LIVE` 미설정; 상세로깅+selftest 추가). S6 발행 → **LIVE**(`PRISM_FEATURE_INSIGHT_IMAGE=on`, 사용자 승인; 매매마커·용어설명 포함).
 - 2026-06-25: **env 키 리네임(코드네임 누수 제거)** — `LOOP_A_*`→`HARDSTOP_*`, `LOOP_B_*`→`TREND_EXIT_*`, `LOOP_C_*`→`FILL_CHASER_*`. **구 키는 deprecated alias로 계속 유효**(코드가 신규 먼저 읽고 구 키 폴백+경고). prod `.env`/crontab 점진 교체 가능. + **Loop C 매수추격 체결우선화**: 예산 `FILL_CHASER_BUY_MAX_PREMIUM_PCT` 0.5%→3%, `FILL_CHASER_BUY_CROSS`(on)로 예산 내 마케터블 cross 즉시체결(예산 초과 시 여전히 CANCEL). SHADOW 유지.
+- 2026-06-25: **재진입 쿨다운 게이트 신설(SHADOW)** — `reentry_cooldown.py` + KR/US 매수 caller 훅. 손실매도 후 같은 종목 24h 재매수 차단(승리후 0h=정당 연속진입 허용). MU 과매매(당일왕복 −5.6% 31건·손절후 재매수) 대응. `REENTRY_COOLDOWN_LIVE` 미설정=SHADOW(로그만). prod 이력검증: 리벤지 재매수 3건 차단·오탐 0.

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -2650,7 +2650,25 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     if rationale:
                         logger.info(f"Scenario rationale ({company_name}/{ticker}): {rationale[:300]}")
 
-                    if normalized_decision == "entry" and adjusted_score >= min_score and sector_diverse:
+                    # Re-entry cooldown gate (SHADOW logs only; LIVE vetoes a churn
+                    # re-entry — longer cooldown after a loss). Fresh entries only;
+                    # pyramiding adds (is_add) are exempt.
+                    _cd_block = False
+                    if normalized_decision == "entry" and not is_add:
+                        try:
+                            from reentry_cooldown import reentry_block, COOLDOWN_LIVE
+                            _cd = reentry_block("US", ticker)
+                        except Exception:
+                            _cd, COOLDOWN_LIVE = None, False
+                        if _cd:
+                            logger.warning(
+                                "[REENTRY_COOLDOWN][%s] %s ticker=%s last_sell=%s ret=%.1f%% gap=%.1fh<%sh after_loss=%s",
+                                "LIVE" if COOLDOWN_LIVE else "SHADOW", _cd["action"], ticker,
+                                _cd["last_sell"], _cd["last_ret"], _cd["gap_hours"],
+                                _cd["window_hours"], _cd["after_loss"])
+                            _cd_block = COOLDOWN_LIVE
+
+                    if normalized_decision == "entry" and adjusted_score >= min_score and sector_diverse and not _cd_block:
                         # is_add => pyramiding additional independent row (#288)
                         buy_success = await self.buy_stock(ticker, company_name, current_price, scenario, rank_change_msg, is_add=is_add)
 

--- a/reentry_cooldown.py
+++ b/reentry_cooldown.py
@@ -1,0 +1,115 @@
+"""Re-entry cooldown gate (deterministic, SHADOW-first).
+
+Diagnosis (2026-06-25, prod trading_history): churn is systemic — 31 KR intraday
+round-trips averaging -5.6%, and same-ticker re-buys within ~1 day of a losing
+sell (e.g. 000660 sold -10% then re-bought 0.78d later). MU (US) was representative.
+
+This gate blocks re-buying a ticker too soon after selling it — longer after a
+LOSS (revenge-trade prevention) than after a normal/win sell. It is a pure veto
+on the *fresh entry* (pyramiding adds are exempt); it never changes sizing/stops.
+
+Self-contained (stdlib + sqlite only, no project imports) so it is import-safe
+under both the root and the prism-us cores-shadowed runtimes.
+
+Fail-open: any error returns None (= allow the buy). A bug here must never block a
+legitimate entry; at worst it falls back to the old (no-gate) behavior.
+
+Default is SHADOW: `reentry_block()` returns the block verdict for logging, and
+COOLDOWN_LIVE controls whether the caller actually skips the buy.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+ENABLED = str(os.getenv("REENTRY_COOLDOWN_ENABLED", "true")).strip().lower() in ("1", "true", "yes", "on")
+# Enforce (skip the buy) when LIVE; otherwise SHADOW = log only, buy proceeds.
+COOLDOWN_LIVE = str(os.getenv("REENTRY_COOLDOWN_LIVE", "false")).strip().lower() in ("1", "true", "yes", "on")
+# Cooldown after a normal/winning sell (default 0 = OFF: re-entering a name you
+# sold at a PROFIT is often legitimate momentum continuation, and prod history
+# showed those re-buys happen 0.1-0.4h after a +25%/+10% win — not churn), and
+# the (longer) cooldown after a LOSS (the revenge re-entry we actually want to
+# block: prod showed -5%/-7% sells re-bought within ~24h).
+COOLDOWN_HOURS = float(os.getenv("REENTRY_COOLDOWN_HOURS", "0"))
+COOLDOWN_LOSS_HOURS = float(os.getenv("REENTRY_COOLDOWN_LOSS_HOURS", "24"))
+
+_TABLE = {"KR": "trading_history", "US": "us_trading_history"}
+
+
+def _db_path() -> str:
+    return (
+        os.getenv("REENTRY_COOLDOWN_DB")
+        or os.getenv("STOCK_TRACKING_DB")
+        or str(Path(__file__).resolve().parent / "stock_tracking_db.sqlite")
+    )
+
+
+def _parse_dt(s: str) -> Optional[datetime]:
+    try:
+        return datetime.strptime(str(s)[:19], "%Y-%m-%d %H:%M:%S")
+    except Exception:
+        return None
+
+
+def reentry_block(market: str, ticker: str, account_key: Optional[str] = None,
+                  db_path: Optional[str] = None, now: Optional[datetime] = None) -> Optional[dict]:
+    """If `ticker` is still inside its re-entry cooldown (relative to its most
+    recent completed sell), return a verdict dict; else None.
+
+    Verdict: {action, market, ticker, last_sell, last_ret, gap_hours, window_hours,
+              after_loss}. Fail-open: returns None on any error or when disabled.
+    """
+    if not ENABLED:
+        return None
+    table = _TABLE.get((market or "").upper())
+    if not table or not ticker:
+        return None
+    now = now or datetime.now()
+    path = db_path or _db_path()
+    try:
+        conn = sqlite3.connect(path, timeout=5)
+        try:
+            sql = (
+                f"SELECT sell_date, profit_rate FROM {table} "
+                f"WHERE ticker=? AND sell_date IS NOT NULL AND sell_date<>'' "
+            )
+            params = [ticker]
+            if account_key:
+                sql += "AND account_key=? "
+                params.append(account_key)
+            sql += "ORDER BY sell_date DESC LIMIT 1"
+            row = conn.execute(sql, params).fetchone()
+        finally:
+            conn.close()
+    except Exception:
+        return None  # fail-open
+
+    if not row or not row[0]:
+        return None
+    sell_dt = _parse_dt(row[0])
+    if sell_dt is None:
+        return None
+    gap_hours = (now - sell_dt).total_seconds() / 3600.0
+    if gap_hours < 0:
+        return None  # clock skew -> don't block
+    try:
+        last_ret = float(row[1]) if row[1] is not None else 0.0
+    except (TypeError, ValueError):
+        last_ret = 0.0
+    after_loss = last_ret < 0
+    window = COOLDOWN_LOSS_HOURS if after_loss else COOLDOWN_HOURS
+    if gap_hours >= window:
+        return None
+    return {
+        "action": "WOULD_BLOCK",
+        "market": (market or "").upper(),
+        "ticker": ticker,
+        "last_sell": row[0],
+        "last_ret": last_ret,
+        "gap_hours": round(gap_hours, 2),
+        "window_hours": window,
+        "after_loss": after_loss,
+    }

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -1707,7 +1707,24 @@ class StockTrackingAgent:
                     min_score = scenario.get("min_score", 0)
                     logger.info(f"Buy score check: {company_name}({ticker}) - Score: {buy_score}")
 
+                    # Re-entry cooldown gate (SHADOW logs only; LIVE vetoes a churn
+                    # re-entry into a name just sold — longer cooldown after a loss).
+                    _cd_block = False
                     if analysis_result.get("decision") == "Enter":
+                        try:
+                            from reentry_cooldown import reentry_block, COOLDOWN_LIVE
+                            _cd = reentry_block("KR", ticker)
+                        except Exception:
+                            _cd, COOLDOWN_LIVE = None, False
+                        if _cd:
+                            logger.warning(
+                                "[REENTRY_COOLDOWN][%s] %s ticker=%s last_sell=%s ret=%.1f%% gap=%.1fh<%sh after_loss=%s",
+                                "LIVE" if COOLDOWN_LIVE else "SHADOW", _cd["action"], ticker,
+                                _cd["last_sell"], _cd["last_ret"], _cd["gap_hours"],
+                                _cd["window_hours"], _cd["after_loss"])
+                            _cd_block = COOLDOWN_LIVE
+
+                    if analysis_result.get("decision") == "Enter" and not _cd_block:
                         buy_success = await self.buy_stock(ticker, company_name, current_price, scenario, rank_change_msg)
 
                         if buy_success:

--- a/tests/test_reentry_cooldown.py
+++ b/tests/test_reentry_cooldown.py
@@ -1,0 +1,112 @@
+"""Tests for the re-entry cooldown gate."""
+import importlib
+import sqlite3
+from datetime import datetime, timedelta
+
+import pytest
+
+
+@pytest.fixture()
+def rc(tmp_path, monkeypatch):
+    db = tmp_path / "stock_tracking_db.sqlite"
+    conn = sqlite3.connect(db)
+    for t in ("trading_history", "us_trading_history"):
+        conn.execute(
+            f"CREATE TABLE {t} (ticker TEXT, account_key TEXT, sell_date TEXT, profit_rate REAL)"
+        )
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("REENTRY_COOLDOWN_DB", str(db))
+    monkeypatch.setenv("REENTRY_COOLDOWN_ENABLED", "true")
+    monkeypatch.setenv("REENTRY_COOLDOWN_HOURS", "6")
+    monkeypatch.setenv("REENTRY_COOLDOWN_LOSS_HOURS", "24")
+    import reentry_cooldown as m
+    importlib.reload(m)
+    return m, str(db)
+
+
+def _seed(db, table, ticker, sell_dt, ret, account_key="acct1"):
+    conn = sqlite3.connect(db)
+    conn.execute(
+        f"INSERT INTO {table}(ticker, account_key, sell_date, profit_rate) VALUES(?,?,?,?)",
+        (ticker, account_key, sell_dt.strftime("%Y-%m-%d %H:%M:%S"), ret),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_no_prior_sell_allows(rc):
+    m, db = rc
+    assert m.reentry_block("US", "MU") is None
+
+
+def test_recent_loss_blocks_within_24h(rc):
+    m, db = rc
+    now = datetime(2026, 6, 25, 12, 0, 0)
+    _seed(db, "us_trading_history", "MU", now - timedelta(hours=2), -4.5)
+    v = m.reentry_block("US", "MU", now=now)
+    assert v and v["action"] == "WOULD_BLOCK" and v["after_loss"] is True
+    assert v["window_hours"] == 24
+
+
+def test_loss_beyond_24h_allows(rc):
+    m, db = rc
+    now = datetime(2026, 6, 25, 12, 0, 0)
+    _seed(db, "us_trading_history", "MU", now - timedelta(hours=30), -4.5)
+    assert m.reentry_block("US", "MU", now=now) is None
+
+
+def test_win_uses_short_window(rc):
+    m, db = rc
+    now = datetime(2026, 6, 25, 12, 0, 0)
+    # winning sell 8h ago: past the 6h normal window -> allow (loss window would've blocked)
+    _seed(db, "us_trading_history", "MU", now - timedelta(hours=8), +5.0)
+    assert m.reentry_block("US", "MU", now=now) is None
+    # winning sell 3h ago: inside 6h normal window -> block
+    _seed(db, "us_trading_history", "MU", now - timedelta(hours=3), +5.0)
+    v = m.reentry_block("US", "MU", now=now)
+    assert v and v["after_loss"] is False and v["window_hours"] == 6
+
+
+def test_kr_table_and_most_recent_used(rc):
+    m, db = rc
+    now = datetime(2026, 6, 25, 12, 0, 0)
+    _seed(db, "trading_history", "005930", now - timedelta(hours=50), -6.0)  # old
+    _seed(db, "trading_history", "005930", now - timedelta(hours=1), -2.0)   # most recent
+    v = m.reentry_block("KR", "005930", now=now)
+    assert v and v["gap_hours"] < 2 and v["last_ret"] == -2.0
+
+
+def test_account_key_filter(rc):
+    m, db = rc
+    now = datetime(2026, 6, 25, 12, 0, 0)
+    _seed(db, "us_trading_history", "MU", now - timedelta(hours=1), -3.0, account_key="A")
+    assert m.reentry_block("US", "MU", account_key="B", now=now) is None  # different account
+    assert m.reentry_block("US", "MU", account_key="A", now=now) is not None
+
+
+def test_default_win_cooldown_off_loss_still_blocks(rc, monkeypatch):
+    m, db = rc
+    now = datetime(2026, 6, 25, 12, 0, 0)
+    monkeypatch.setenv("REENTRY_COOLDOWN_HOURS", "0")  # default: no cooldown after a win
+    importlib.reload(m)
+    # winning sell 0.2h ago -> NOT blocked (legit continuation)
+    _seed(db, "us_trading_history", "WIN", now - timedelta(hours=0.2), +25.0)
+    assert m.reentry_block("US", "WIN", now=now) is None
+    # losing sell 0.2h ago -> still blocked by the 24h loss window
+    _seed(db, "us_trading_history", "LOSS", now - timedelta(hours=0.2), -5.0)
+    assert m.reentry_block("US", "LOSS", now=now) is not None
+
+
+def test_disabled_returns_none(rc, monkeypatch):
+    m, db = rc
+    now = datetime(2026, 6, 25, 12, 0, 0)
+    _seed(db, "us_trading_history", "MU", now - timedelta(hours=1), -3.0)
+    monkeypatch.setenv("REENTRY_COOLDOWN_ENABLED", "false")
+    importlib.reload(m)
+    assert m.reentry_block("US", "MU", now=now) is None
+
+
+def test_fail_open_on_bad_db(rc):
+    m, _ = rc
+    assert m.reentry_block("US", "MU", db_path="/proc/nope/x.sqlite") is None


### PR DESCRIPTION
## Problem (A0-3 overtrading)
Prod `trading_history` shows **systemic churn**: 31 KR intraday round-trips averaging **−5.6%**, and same-ticker re-buys within ~1 day of a **losing** sell (000660 sold −10% → re-bought 18.6h later; MU sold −4.5% → re-entry order ~1.5h later, unfilled into a +18% gap).

## Fix
New **`reentry_cooldown.py`** (stdlib+sqlite, import-safe under root and prism-us): `reentry_block(market, ticker)` vetoes a re-buy inside a cooldown window — **longer after a loss** (`REENTRY_COOLDOWN_LOSS_HOURS`, default **24h**) than after a win/normal sell (`REENTRY_COOLDOWN_HOURS`, default **0 = off**, since re-entering a name sold at a profit is often legit momentum continuation). **Fail-open** (errors → allow buy).

Wired into the KR/US buy callers as `and not _cd_block` on the existing entry condition — fresh entries only (pyramiding adds exempt). **Default SHADOW** (`REENTRY_COOLDOWN_LIVE` unset): logs `[REENTRY_COOLDOWN][SHADOW] WOULD_BLOCK`, the buy still proceeds. No flow change until LIVE.

## Validation
Replaying the shipped defaults over prod history blocks **exactly the 3 KR revenge re-entries** (−5%/−7%/−10% re-bought within 24h) with **zero false positives** on post-win re-entries. 9 unit tests; agents `py_compile` clean (full suite on CI).

## Risk
Low — SHADOW by default (log-only), fail-open, fresh-entries-only. Observe `[REENTRY_COOLDOWN][SHADOW]` vs trading_history before any LIVE promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)