### PR TITLE
fix(loop-c): load .env so FILL_CHASER_* config (incl. LIVE) is honored

### DIFF
--- a/tools/loop_c_fill_chaser.py
+++ b/tools/loop_c_fill_chaser.py
@@ -87,6 +87,15 @@ def _bootstrap_path(market: str) -> None:
 
 logger = logging.getLogger("loop_c")
 
+# Load .env so env-driven config below (FILL_CHASER_*, incl. FILL_CHASER_LIVE) is
+# visible — a fresh cron process does not inherit .env otherwise. loop_a/loop_b do
+# the same; without it loop_c silently used code defaults and ignored .env.
+try:
+    from dotenv import load_dotenv
+    load_dotenv(PROJECT_ROOT / ".env")
+except Exception:
+    pass
+
 
 # ── Configuration (env-driven) ────────────────────────────────────────────────
 # Canonical env prefix is FILL_CHASER_. The legacy LOOP_C_ prefix is a DEPRECATED


### PR DESCRIPTION
## Problem
`loop_c_fill_chaser.py` imported only stdlib and **never called `load_dotenv`**. A fresh cron process doesn't inherit `.env`, so every `FILL_CHASER_*` constant was evaluated from **code defaults** — `.env` was silently ignored. `loop_a`/`loop_b` already load `.env`; loop_c was the inconsistent one. Net effect: `FILL_CHASER_LIVE` (and the cross/budget tunables) set in `.env` had **no effect**.

## Fix
Add the same `load_dotenv(PROJECT_ROOT / ".env")` (after `logger`, before the config block so the constants see it). KIS creds were unaffected (trading wrappers load `.env` lazily on import), but the loop's own gates now read `.env` as intended — **required to flip `FILL_CHASER_LIVE=true`** for the SHADOW→LIVE promotion.

## Verification
`py_compile` clean; 32 loop_c tests (KR+US) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)