### PR TITLE
feat(loops): broadcast Loop A/B sells to Redis+GCP (subscribers were diverging)

### DIFF
--- a/loop_publish.py
+++ b/loop_publish.py
@@ -1,0 +1,58 @@
+"""Publish loop-driven (Loop A hard-stop / Loop B trend-exit) sells to the SAME
+Redis + GCP Pub/Sub signal stream the batch uses.
+
+Background: the signal publish lived only in the batch orchestration
+(`update_holdings` + the buy path), so intraday loop sells were executed but NEVER
+broadcast. With Loop A/B LIVE, subscribers (who mirror the system's portfolio on
+their own KIS keys) missed every hard-stop / trend-exit exit and their positions
+diverged — holding names the main system had already sold.
+
+The simulator close is the broadcast source of truth (Rocky's rule: sim = 방송,
+real follows), so callers publish on `sim_ok`, independent of whether our own KIS
+leg filled. Both legs are best-effort: any failure is logged and swallowed so the
+loop is never broken (mirrors the batch's non-critical publish blocks).
+
+Lives at project root (not under the messaging/ package) so importing it does not
+trigger messaging/__init__'s eager publisher imports; the actual publishers are
+imported lazily at call time and any failure (e.g. transport unconfigured) is
+caught.
+"""
+import logging
+
+logger = logging.getLogger("loop_publish")
+
+
+async def publish_loop_sell(market: str, ticker: str, company_name: str, price: float,
+                            buy_price: float, sell_reason: str, trade_result=None) -> None:
+    """Best-effort: broadcast a loop sell to Redis Streams + GCP Pub/Sub.
+
+    Auto-skips when the respective transport is unconfigured (the underlying
+    publishers no-op without UPSTASH_REDIS_* / GCP_PROJECT_ID+GCP_PUBSUB_TOPIC_ID).
+    """
+    mkt = (market or "KR").upper()
+    try:
+        profit_rate = ((price - buy_price) / buy_price * 100.0) if buy_price else 0.0
+    except Exception:
+        profit_rate = 0.0
+
+    # Redis Streams
+    try:
+        from messaging.redis_signal_publisher import publish_sell_signal
+        await publish_sell_signal(
+            ticker=ticker, company_name=company_name, price=price, buy_price=buy_price,
+            profit_rate=profit_rate, sell_reason=sell_reason, trade_result=trade_result,
+            market=mkt,
+        )
+    except Exception as e:
+        logger.warning("[loop-publish] Redis sell signal failed (non-critical): %s", e)
+
+    # GCP Pub/Sub
+    try:
+        from messaging.gcp_pubsub_signal_publisher import publish_sell_signal as gcp_publish_sell_signal
+        await gcp_publish_sell_signal(
+            ticker=ticker, company_name=company_name, price=price, buy_price=buy_price,
+            profit_rate=profit_rate, sell_reason=sell_reason, trade_result=trade_result,
+            market=mkt,
+        )
+    except Exception as e:
+        logger.warning("[loop-publish] GCP sell signal failed (non-critical): %s", e)

--- a/tests/test_loop_publish.py
+++ b/tests/test_loop_publish.py
@@ -1,0 +1,49 @@
+"""Loop sell broadcast helper must be non-fatal and pass the right args."""
+import asyncio
+import sys
+import types
+
+import loop_publish as lp
+
+
+def test_publish_loop_sell_non_fatal_when_unconfigured():
+    """With Redis/GCP transports unimportable/unconfigured, it must not raise."""
+    # messaging.* publishers require upstash/google libs not present here -> the
+    # lazy imports inside the helper raise and must be swallowed.
+    res = asyncio.run(lp.publish_loop_sell(
+        market="US", ticker="MU", company_name="Micron", price=100.0,
+        buy_price=110.0, sell_reason="TIER1:stop", trade_result={"success": True},
+    ))
+    assert res is None  # completed without raising
+
+
+def test_publish_loop_sell_forwards_args_and_profit_rate(monkeypatch):
+    """Both legs get called with normalized market + a computed profit_rate."""
+    calls = []
+
+    async def fake_pub(**kwargs):
+        calls.append(kwargs)
+        return "id"
+
+    # Inject a fake messaging package + the two publisher submodules so the helper's
+    # lazy `from messaging.X import publish_sell_signal` resolves to our fakes
+    # without running the real (dependency-heavy) messaging/__init__.
+    fake_pkg = types.ModuleType("messaging")
+    redis_mod = types.ModuleType("messaging.redis_signal_publisher")
+    redis_mod.publish_sell_signal = fake_pub
+    gcp_mod = types.ModuleType("messaging.gcp_pubsub_signal_publisher")
+    gcp_mod.publish_sell_signal = fake_pub
+    monkeypatch.setitem(sys.modules, "messaging", fake_pkg)
+    monkeypatch.setitem(sys.modules, "messaging.redis_signal_publisher", redis_mod)
+    monkeypatch.setitem(sys.modules, "messaging.gcp_pubsub_signal_publisher", gcp_mod)
+
+    asyncio.run(lp.publish_loop_sell(
+        market="kr", ticker="005930", company_name="Samsung", price=90.0,
+        buy_price=100.0, sell_reason="TIER1.5_MA50", trade_result={"success": True},
+    ))
+    assert len(calls) == 2  # redis + gcp
+    for c in calls:
+        assert c["ticker"] == "005930"
+        assert c["market"] == "KR"            # normalized upper
+        assert c["sell_reason"] == "TIER1.5_MA50"
+        assert round(c["profit_rate"], 1) == -10.0  # (90-100)/100*100

--- a/tools/loop_a_hardstop.py
+++ b/tools/loop_a_hardstop.py
@@ -406,6 +406,22 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
         except Exception as e:
             logger.warning("[%s] %s telegram flush failed: %s", market, ticker, e)
 
+        # 4) Broadcast the sell to subscribers (Redis/GCP). sim close is the source
+        # of truth so we publish on sim_ok even if our own KIS leg failed; loop sells
+        # were previously batch-only and never broadcast (subscribers diverged).
+        try:
+            from loop_publish import publish_loop_sell
+            await publish_loop_sell(
+                market=market, ticker=ticker,
+                company_name=stock_data.get("company_name", ticker),
+                price=float(stock_data.get("current_price", 0) or 0),
+                buy_price=float(stock_data.get("buy_price", 0) or 0),
+                sell_reason=reason,
+                trade_result={"success": bool(ok or sold_qty == 0), "order_no": order_no},
+            )
+        except Exception as e:
+            logger.warning("[%s] %s sell signal publish failed (non-critical): %s", market, ticker, e)
+
         record_inflight(conn, ticker, market, run_id, sold_qty,
                         "FILLED" if (ok or sold_qty == 0) else "REJECTED",
                         reason, str(order_no) if order_no else None)

--- a/tools/loop_b_trend_exit.py
+++ b/tools/loop_b_trend_exit.py
@@ -612,6 +612,22 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
         except Exception as e:
             logger.warning("[%s] %s telegram flush failed: %s", market, ticker, e)
 
+        # 4) Broadcast the sell to subscribers (Redis/GCP). sim close is the source
+        # of truth so we publish on sim_ok even if our own KIS leg failed; loop sells
+        # were previously batch-only and never broadcast (subscribers diverged).
+        try:
+            from loop_publish import publish_loop_sell
+            await publish_loop_sell(
+                market=market, ticker=ticker,
+                company_name=stock_data.get("company_name", ticker),
+                price=float(stock_data.get("current_price", 0) or 0),
+                buy_price=float(stock_data.get("buy_price", 0) or 0),
+                sell_reason=reason,
+                trade_result={"success": bool(ok or sold_qty == 0), "order_no": order_no},
+            )
+        except Exception as e:
+            logger.warning("[%s] %s sell signal publish failed (non-critical): %s", market, ticker, e)
+
         record_inflight(conn, ticker, market, run_id, sold_qty,
                         "FILLED" if (ok or sold_qty == 0) else "REJECTED",
                         reason, str(order_no) if order_no else None)


### PR DESCRIPTION
## Problem
The trade-signal publish (Redis Streams + GCP Pub/Sub) lived **only in the batch** orchestration. **Loop A (hard-stop)** and **Loop B (trend-exit)** execute real intraday sells but **never published them**. With both loops LIVE, external subscribers (mirroring the system's portfolio on their own KIS keys) missed every hard-stop / trend-exit exit → **held names the main system already sold** (position divergence — the user's "매매가 안 먹히는 느낌").

Confirmed: `grep` shows `publish_*` is called only in `update_holdings`/buy path (`stock_tracking_agent`, `us_stock_tracking_agent`); `loop_a/loop_b/loop_c` have **zero** publish references.

## Fix
- New **`loop_publish.publish_loop_sell(market, ticker, ...)`** at project root (so importing it doesn't drag in `messaging/__init__`'s eager publisher imports; publishers imported lazily, each leg best-effort/non-critical — mirrors the batch's "publish failure = non-critical" blocks).
- Wired into both loops right after the telegram flush, published on **`sim_ok`** — the simulator close is the broadcast source of truth (sim = 방송, real follows), so subscribers mirror the exit even if our own KIS leg failed.
- Loop C order-management (amend/cancel) and pyramiding adds are out of scope.

## Verification
`py_compile` clean; new helper tests (non-fatal when transports unconfigured + arg/market/profit_rate forwarding); **32 loop A/B tests still pass**.

## Risk
Low — publish is best-effort/non-critical (loop never breaks on publish failure); no change to the loops' own sell execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)