### PR TITLE
fix(loop-c): snap KR amend prices to KRX 호가단위 (tick size)

### DIFF
--- a/tests/test_loop_c_fill_chaser.py
+++ b/tests/test_loop_c_fill_chaser.py
@@ -394,3 +394,63 @@ def test_selftest_runs_without_api_or_orders(monkeypatch, caplog):
     assert summary["cancel"] == 1                # the BUY also exercises cancel
     assert summary["likely"] + summary["unlikely"] == 2
     assert any("[LOOP_C][SHADOW] selftest" in r.message for r in caplog.records)
+
+
+# ── KR 호가단위 (tick size) snapping ─────────────────────────────────────────────
+def test_kr_tick_size_tiers():
+    """KRX tick (호가단위) varies by price tier; verify each tier + its boundary."""
+    assert lc._kr_tick_size(1_500) == 1          # < 2,000
+    assert lc._kr_tick_size(3_000) == 5          # 2,000 ~ 5,000
+    assert lc._kr_tick_size(12_000) == 10        # 5,000 ~ 20,000
+    assert lc._kr_tick_size(23_000) == 50        # 20,000 ~ 50,000
+    assert lc._kr_tick_size(80_000) == 100       # 50,000 ~ 200,000
+    assert lc._kr_tick_size(300_000) == 500      # 200,000 ~ 500,000
+    assert lc._kr_tick_size(700_000) == 1_000    # >= 500,000
+    # Tier boundaries are exclusive on the lower side: a price exactly at the
+    # boundary belongs to the HIGHER tier (5,000 / 20,000 / 50,000 / 200,000 / 500,000).
+    assert lc._kr_tick_size(2_000) == 5
+    assert lc._kr_tick_size(5_000) == 10
+    assert lc._kr_tick_size(20_000) == 50
+    assert lc._kr_tick_size(50_000) == 100
+    assert lc._kr_tick_size(200_000) == 500
+    assert lc._kr_tick_size(500_000) == 1_000
+
+
+def test_round_price_kr_snaps_to_tick_regression_085620():
+    """Regression for APBK0506: 085620 (~23,000 KRW) off-tick amend prices.
+
+    Loop C used to integer-round only (23,205 stayed 23,205) -> KIS rejected the
+    amend with APBK0506 (주식주문호가단위). 23,000-won stocks trade on a 50-won tick,
+    so every chased limit MUST snap to a 50-won grid. We snap DOWN (conservative).
+    """
+    assert lc._round_price("KR", 23_205) == 23_200.0
+    assert lc._round_price("KR", 23_295) == 23_250.0
+    assert lc._round_price("KR", 23_370) == 23_350.0
+    # Already on-tick -> unchanged.
+    assert lc._round_price("KR", 23_250) == 23_250.0
+
+
+def test_round_price_kr_tier_boundaries_snap_down():
+    """Snap-down lands on the correct tick across every price tier boundary."""
+    assert lc._round_price("KR", 1_999) == 1_999.0       # 1-won tick (< 2,000)
+    assert lc._round_price("KR", 3_007) == 3_005.0       # 5-won tick
+    assert lc._round_price("KR", 12_344) == 12_340.0     # 10-won tick
+    assert lc._round_price("KR", 49_999) == 49_950.0     # 50-won tick (< 50,000)
+    assert lc._round_price("KR", 87_654) == 87_600.0     # 100-won tick
+    assert lc._round_price("KR", 199_999) == 199_900.0   # 100-won tick (< 200,000)
+    assert lc._round_price("KR", 333_333) == 333_000.0   # 500-won tick
+    assert lc._round_price("KR", 777_777) == 777_000.0   # 1,000-won tick (>= 500,000)
+
+
+def test_round_price_kr_round_up_snaps_up_to_tick():
+    """round_up=True (BUY cross, #378) ceilings to the tick, not below market."""
+    assert lc._round_price("KR", 23_205, round_up=True) == 23_250.0
+    assert lc._round_price("KR", 23_250, round_up=True) == 23_250.0
+    assert lc._round_price("KR", 3_001, round_up=True) == 3_005.0
+
+
+def test_round_price_kr_nonpositive_and_us_unchanged():
+    assert lc._round_price("KR", 0) == 0.0               # guard: non-positive
+    # US still allows cents (unchanged behaviour).
+    assert lc._round_price("US", 189.567) == 189.57
+    assert lc._round_price("US", 189.561, round_up=True) == 189.57

--- a/tests/test_loop_c_fill_chaser.py
+++ b/tests/test_loop_c_fill_chaser.py
@@ -449,6 +449,22 @@ def test_round_price_kr_round_up_snaps_up_to_tick():
     assert lc._round_price("KR", 3_001, round_up=True) == 3_005.0
 
 
+def test_round_price_kr_float_noise_does_not_missnap():
+    """Upstream float noise must not push the snap onto the wrong tick rung.
+
+    KRW prices are integer-valued, but prior arithmetic can yield values like
+    23199.9999996 / 23200.0000004. Without collapsing to a whole number first,
+    floor/ceil tick math would jump a full tick (e.g. 23150 / 23250) and could
+    itself re-trigger APBK0506.
+    """
+    # floor (default): noise just below/above a grid point still lands on 23,200.
+    assert lc._round_price("KR", 23_199.9999996) == 23_200.0
+    assert lc._round_price("KR", 23_200.0000004) == 23_200.0
+    # ceil (round_up): an on-grid price with noise must NOT over-ceil to 23,250.
+    assert lc._round_price("KR", 23_200.0000004, round_up=True) == 23_200.0
+    assert lc._round_price("KR", 23_199.9999996, round_up=True) == 23_200.0
+
+
 def test_round_price_kr_nonpositive_and_us_unchanged():
     assert lc._round_price("KR", 0) == 0.0               # guard: non-positive
     # US still allows cents (unchanged behaviour).

--- a/tools/loop_c_fill_chaser.py
+++ b/tools/loop_c_fill_chaser.py
@@ -376,15 +376,49 @@ def _compute_chase_price(side: str, order_price: float, market_price: float) -> 
         return min(target, market_price)
 
 
-def _round_price(market: str, price: float, round_up: bool = False) -> float:
-    """KR limit prices are integers (KRW); US allows cents.
+# KRX 호가단위 (tick size) by price tier. Each entry is (price_below, tick):
+# a price strictly LESS than ``price_below`` uses ``tick``. The final open-ended
+# tier (>= 500,000) uses 1,000 KRW. Mirrors the KRX domestic-equity tick schedule
+# (post-2023 unified table). KIS rejects off-tick limit prices with APBK0506, so
+# every KR limit price Loop C sends MUST be snapped to its tier's tick.
+_KR_TICK_TABLE = (
+    (2_000, 1),
+    (5_000, 5),
+    (20_000, 10),
+    (50_000, 50),
+    (200_000, 100),
+    (500_000, 500),
+)
+_KR_TICK_TOP = 1_000  # >= 500,000 KRW
 
-    round_up=True ceilings to the tick — used for marketable BUY limits so the
-    rounding step never drops the price back below the live market (which would
-    defeat the cross / fill-priority intent).
+
+def _kr_tick_size(price: float) -> int:
+    """Return the KRX 호가단위 (tick) for a KR price tier."""
+    for ceiling, tick in _KR_TICK_TABLE:
+        if price < ceiling:
+            return tick
+    return _KR_TICK_TOP
+
+
+def _round_price(market: str, price: float, round_up: bool = False) -> float:
+    """Snap a limit price to a tradable unit.
+
+    KR prices must align to the KRX 호가단위 (tick), which varies by price tier; an
+    off-tick limit is rejected by KIS (APBK0506). We snap DOWN to the tick grid by
+    default (a chase-preserving, conservative direction). round_up=True ceilings to
+    the tick instead — used for marketable BUY limits so the rounding step never
+    drops the price back below the live market (which would defeat the cross /
+    fill-priority intent of #378). price<=0 falls back to integer rounding.
+
+    US allows cents -> round to 2 decimals (unchanged).
     """
     if market == "KR":
-        return float(math.ceil(price)) if round_up else float(int(round(price)))
+        if price <= 0:
+            return float(math.ceil(price)) if round_up else float(int(round(price)))
+        tick = _kr_tick_size(price)
+        if round_up:
+            return float(math.ceil(price / tick) * tick)
+        return float((int(price) // tick) * tick)
     return math.ceil(price * 100.0) / 100.0 if round_up else round(price, 2)
 
 

--- a/tools/loop_c_fill_chaser.py
+++ b/tools/loop_c_fill_chaser.py
@@ -415,10 +415,16 @@ def _round_price(market: str, price: float, round_up: bool = False) -> float:
     if market == "KR":
         if price <= 0:
             return float(math.ceil(price)) if round_up else float(int(round(price)))
-        tick = _kr_tick_size(price)
+        # KRW prices are integer-valued; collapse to a whole number FIRST so float
+        # noise from upstream arithmetic (e.g. 23199.9999996) cannot push the
+        # tick-grid math onto the wrong rung (which would itself re-trigger
+        # APBK0506). Integer ceil/floor division then keeps the snap fully
+        # float-free.
+        whole = int(round(price))
+        tick = _kr_tick_size(whole)
         if round_up:
-            return float(math.ceil(price / tick) * tick)
-        return float((int(price) // tick) * tick)
+            return float(-(-whole // tick) * tick)   # ceil to tick (integer math)
+        return float((whole // tick) * tick)          # floor to tick
     return math.ceil(price * 100.0) / 100.0 if round_up else round(price, 2)
 
 


### PR DESCRIPTION
## Root cause
Loop C (`tools/loop_c_fill_chaser.py`) chases unfilled KR orders by amending the limit toward the market. The chased price was only **integer-rounded** (`int(round(price))`), so for a ~23,000 KRW stock like **085620** an amend such as `23,205` was sent verbatim. KRX equities in the 20,000~50,000 tier trade on a **50-won tick (호가단위)**, so `23,205` is off-tick and KIS rejected the amend with **APBK0506 (주식주문호가단위)** — the order never moved and never filled.

## Symptom log
KIS amend (정정주문) responses returned `rt_cd != 0` with `msg_cd=APBK0506` / `주식주문호가단위` for ~23k KRW tickers; the chase loop logged the amend but the order stayed unfilled.

## Fix
- Add `_KR_TICK_TABLE` (post-2023 unified KRX tick schedule) + `_kr_tick_size(price)`.
- `_round_price(market, price, round_up=False)` now snaps KR limits onto the tier's tick grid:
  - **DOWN** by default — conservative for both a SELL floor and a BUY ceiling (never crosses past the computed target/ceiling).
  - **UP** when `round_up=True` — preserves the #378 buy-cross / fill-priority intent (a marketable BUY must not round back below the live market).
  - `price <= 0` keeps the integer fallback.
- **US cents behaviour unchanged** (2 decimals; `round_up` still ceilings to a cent).

## KRX 호가단위 table (근거)
| price tier (KRW) | tick |
|---|---|
| < 2,000 | 1 |
| 2,000 ~ 4,999 | 5 |
| 5,000 ~ 19,999 | 10 |
| 20,000 ~ 49,999 | 50 |
| 50,000 ~ 199,999 | 100 |
| 200,000 ~ 499,999 | 500 |
| >= 500,000 | 1,000 |

## Tests
Added to `tests/test_loop_c_fill_chaser.py`: tier-size + boundary checks, the 085620 regression (23,205→23,200, 23,295→23,250, 23,370→23,350), all-tier snap-down, `round_up` snap-up, non-positive guard, US unchanged.

`pytest tests/test_loop_c_fill_chaser.py -q` → **21 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)