### PR TITLE
feat(report): optional vision chart-pattern analysis in technical section

### DIFF
--- a/cores/analysis.py
+++ b/cores/analysis.py
@@ -261,14 +261,19 @@ async def analyze_stock(company_code: str = "000660", company_name: str = "SK하
         # 10c. Buy-quality vision gate (Phase 6 S3) — SHADOW by default, log-only.
         # Computes a CAN SLIM base analysis + per-regime verdict and LOGS it.
         # In shadow mode it has ZERO effect on the report or any buy decision.
+        # When PRISM_FEATURE_VISION_IN_REPORT=on, the descriptive base analysis is
+        # ALSO surfaced as a markdown subsection in the technical section below —
+        # a SOFT input the buy agent reads, never a buy gate (that stays S5/TODO).
+        vision_pattern_md = ""
         if vision_available():
             try:
                 import base64 as _bq_base64
                 import re as _bq_re
-                from cores.llm.capabilities import vision_shadow
+                from cores.llm.capabilities import vision_shadow, vision_in_report
                 from cores.llm.features.buy_quality import (
                     analyze_base,
                     analyze_base_oneil,
+                    format_vision_pattern_md,
                     gate_verdict,
                 )
                 _bq_html = price_chart_html
@@ -300,6 +305,14 @@ async def analyze_stock(company_code: str = "000660", company_name: str = "SK하
                         _bq_verdict["threshold"],
                         _bq_analysis.base_type,
                     )
+                    # Opt-in (PRISM_FEATURE_VISION_IN_REPORT=on): surface the
+                    # descriptive base analysis into the report's technical
+                    # section. SOFT report content the buy agent reads — this is
+                    # NOT the buy gate (that remains the S5/TODO below).
+                    if vision_in_report():
+                        vision_pattern_md = format_vision_pattern_md(
+                            _bq_analysis, language
+                        )
                     # TODO(S5/LIVE): when not vision_shadow(), inject
                     # _bq_verdict into the entry matrix (Step 2 of the
                     # trading_scenario_agent prompt) so it gates real
@@ -412,6 +425,11 @@ async def analyze_stock(company_code: str = "000660", company_name: str = "SK하
             final_report += main_headers["tech_analysis"]
             if "price_volume_analysis" in section_reports:
                 final_report += section_reports["price_volume_analysis"] + "\n\n"
+                # Vision chart-pattern analysis (opt-in; empty unless
+                # PRISM_FEATURE_VISION_IN_REPORT=on). Placed right after the
+                # price/volume prose and before the chart images.
+                if vision_pattern_md:
+                    final_report += vision_pattern_md
                 # Add price and volume charts
                 if price_chart_html or volume_chart_html:
                     chart_title = "### 가격 및 거래량 차트\n\n" if language == "ko" else "### Price and Volume Charts\n\n"

--- a/cores/llm/capabilities.py
+++ b/cores/llm/capabilities.py
@@ -93,6 +93,19 @@ def vision_shadow() -> bool:
     return os.environ.get("PRISM_VISION_SHADOW", "true").strip().lower() != "false"
 
 
+def vision_in_report() -> bool:
+    """Return True when the vision base analysis should be rendered into the
+    analysis report's technical section (default: off).
+
+    Independent, opt-in sub-flag of the vision pipeline. When on (and vision is
+    available), the CAN SLIM base analysis already computed in the S3 hook is
+    surfaced as a descriptive markdown subsection that the buy agent reads —
+    a SOFT input, never a gate. Default off keeps the report byte-identical and
+    adds no work. Requires PRISM_FEATURE_VISION=on (vision must already run).
+    """
+    return os.environ.get("PRISM_FEATURE_VISION_IN_REPORT", "off").strip().lower() == "on"
+
+
 def vision_model() -> str:
     """Return the vision model id (default: gpt-4o)."""
     return os.environ.get("PRISM_VISION_MODEL", _DEFAULT_VISION_MODEL).strip() or _DEFAULT_VISION_MODEL

--- a/cores/llm/features/buy_quality.py
+++ b/cores/llm/features/buy_quality.py
@@ -299,6 +299,75 @@ def validate_levels(
         return []
 
 
+def format_vision_pattern_md(
+    analysis: BaseAnalysis,
+    language: str = "ko",
+) -> str:
+    """Render a :class:`BaseAnalysis` as a descriptive markdown subsection.
+
+    SOFT, descriptive chart-pattern content that the buy agent reads as one more
+    input in the report's technical section — it is NOT a buy/sell gate and does
+    not inject a would_buy verdict. Never raises; returns "" on any error so the
+    report pipeline is never broken.
+    """
+    try:
+        def _levels(xs: list[float]) -> str:
+            vals = [x for x in (xs or []) if x and x > 0]
+            if not vals:
+                return "없음" if language == "ko" else "none"
+            return ", ".join(f"{x:,.0f}" for x in vals)
+
+        a = analysis
+        if language == "ko":
+            out = ["### 차트 패턴 분석 (AI 비전·참고용)\n"]
+            out.append(f"- **베이스 유형**: {a.base_type} ({a.proper_or_faulty})")
+            out.append(f"- **베이스 품질**: {a.quality_score}/100 (신뢰도 {a.confidence})")
+            if a.pivot_price and a.pivot_price > 0:
+                out.append(
+                    f"- **피벗(매수 기준선)**: {a.pivot_price:,.0f}원 "
+                    f"(현재가 대비 {a.dist_to_pivot_pct:+.1f}%)"
+                )
+            out.append(
+                f"- **지지선**: {_levels(a.support_levels)}  ·  "
+                f"**저항선**: {_levels(a.resistance_levels)}"
+            )
+            if a.stop_loss and a.stop_loss > 0:
+                out.append(f"- **참고 손절선**: {a.stop_loss:,.0f}원")
+            out.append(
+                f"- **RS선 신고가**: {'예' if a.rs_line_new_high else '아니오'}  ·  "
+                f"**핸들 거래량 위축**: {'예' if a.volume_dryup_in_handle else '아니오'}"
+            )
+            if a.rationale:
+                out.append(f"\n{a.rationale}")
+            out.append("\n> ⓘ AI 차트 비전의 보조 분석입니다(참고용). 최종 판단은 종합 분석을 따릅니다.")
+        else:
+            out = ["### Chart Pattern Analysis (AI vision — informational)\n"]
+            out.append(f"- **Base type**: {a.base_type} ({a.proper_or_faulty})")
+            out.append(f"- **Base quality**: {a.quality_score}/100 (confidence {a.confidence})")
+            if a.pivot_price and a.pivot_price > 0:
+                out.append(
+                    f"- **Pivot (buy point)**: {a.pivot_price:,.0f} "
+                    f"({a.dist_to_pivot_pct:+.1f}% vs current)"
+                )
+            out.append(
+                f"- **Support**: {_levels(a.support_levels)}  ·  "
+                f"**Resistance**: {_levels(a.resistance_levels)}"
+            )
+            if a.stop_loss and a.stop_loss > 0:
+                out.append(f"- **Stop reference**: {a.stop_loss:,.0f}")
+            out.append(
+                f"- **RS line new high**: {a.rs_line_new_high}  ·  "
+                f"**Handle volume dry-up**: {a.volume_dryup_in_handle}"
+            )
+            if a.rationale:
+                out.append(f"\n{a.rationale}")
+            out.append("\n> ⓘ Supplementary AI chart-vision read (informational).")
+        return "\n".join(out) + "\n\n"
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[VISION_REPORT] format_vision_pattern_md failed: %s", exc)
+        return ""
+
+
 async def analyze_base(
     chart_image: ImageInput,
     *,

--- a/tests/test_buy_quality.py
+++ b/tests/test_buy_quality.py
@@ -17,6 +17,7 @@ from cores.llm.features.buy_quality import (
     REGIME_THRESHOLDS,
     BaseAnalysis,
     analyze_base,
+    format_vision_pattern_md,
     gate_verdict,
 )
 
@@ -366,3 +367,55 @@ class TestAnalyzeBaseOneil:
 
         result = await bq.analyze_base_oneil("005930", "삼성전자")
         assert result is None
+
+
+# --------------------------------------------------------------------------- #
+# format_vision_pattern_md — report subsection rendering (soft, not a gate)     #
+# --------------------------------------------------------------------------- #
+class TestFormatVisionPatternMd:
+    def test_ko_renders_descriptive_subsection(self):
+        a = _make_analysis(
+            base_type="cup-handle",
+            quality_score=80,
+            confidence=75,
+            pivot_price=23250.0,
+            dist_to_pivot_pct=-1.2,
+            support_levels=[22000.0, 21500.0],
+            resistance_levels=[24000.0],
+            stop_loss=21000.0,
+            rationale="타이트한 손잡이컵, RS 신고가.",
+        )
+        md = format_vision_pattern_md(a, "ko")
+        assert md  # non-empty
+        assert "### 차트 패턴 분석" in md
+        assert "참고용" in md            # framed as informational, not a directive
+        assert "cup-handle" in md
+        assert "80/100" in md
+        assert "23,250" in md            # pivot rendered with thousands separator
+        assert "22,000" in md and "24,000" in md  # support & resistance
+        assert "타이트한 손잡이컵" in md  # rationale surfaced
+        # Contract: this is SOFT report content, never a buy gate.
+        assert "would_buy" not in md
+        assert md.endswith("\n\n")
+
+    def test_en_renders_english_header(self):
+        a = _make_analysis(rationale="tight cup, RS new high")
+        md = format_vision_pattern_md(a, "en")
+        assert "### Chart Pattern Analysis" in md
+        assert "would_buy" not in md
+
+    def test_empty_levels_and_no_pivot_do_not_break(self):
+        a = _make_analysis(
+            pivot_price=0.0,
+            stop_loss=0.0,
+            support_levels=[],
+            resistance_levels=[],
+        )
+        md = format_vision_pattern_md(a, "ko")
+        assert md
+        assert "없음" in md              # empty level lists render as 없음
+        assert "피벗" not in md          # no pivot line when pivot_price <= 0
+
+    def test_never_raises_on_bad_input(self):
+        # A malformed object must not blow up the report pipeline -> returns "".
+        assert format_vision_pattern_md(object(), "ko") == ""  # type: ignore[arg-type]

--- a/tests/test_vision_plumbing.py
+++ b/tests/test_vision_plumbing.py
@@ -94,6 +94,17 @@ class TestCapabilities:
         from cores.llm import capabilities
         assert capabilities.vision_shadow() is False
 
+    def test_vision_in_report_default_off(self, monkeypatch):
+        # Safety contract: report is byte-identical unless explicitly enabled.
+        monkeypatch.delenv("PRISM_FEATURE_VISION_IN_REPORT", raising=False)
+        from cores.llm import capabilities
+        assert capabilities.vision_in_report() is False
+
+    def test_vision_in_report_on(self, monkeypatch):
+        monkeypatch.setenv("PRISM_FEATURE_VISION_IN_REPORT", "on")
+        from cores.llm import capabilities
+        assert capabilities.vision_in_report() is True
+
     def test_vision_model_default(self, monkeypatch):
         monkeypatch.delenv("PRISM_VISION_MODEL", raising=False)
         from cores.llm import capabilities


### PR DESCRIPTION
## What
Rocky's original idea, done simply: surface the **CAN SLIM chart-pattern analysis** (already computed in the S3 vision hook) as a **descriptive markdown subsection** in the report's **technical-analysis section**, so the **buy agent reads it** as one more input.

## Why this design (not the Phase 6 self-improvement machine)
A prior plan over-engineered this into a self-calibrating quantitative **gate** (snapshot spine → 60-cell calibration → S5 hard gate), which failed review on 4 criteria (no profit-mgmt scope, won't converge on data, journal seam conflict). This PR is the **soft, natural** version:
- **Soft input, NOT a gate** — the buy agent weighs it like any other report content. The S5/LIVE verdict-injection TODO is left untouched.
- **No journal conflict** — journal and this are both soft inputs to the same LLM (already how the system works). No competing seam.
- **No buy-starvation risk** — it's text, not a `would_buy=False` block.

## Behavior / safety
- New flag **`PRISM_FEATURE_VISION_IN_REPORT` (default off)** → report is **byte-identical** when off.
- **Zero extra API call** — reuses the already-computed `_bq_analysis` from the existing S3 hook.
- Requires `PRISM_FEATURE_VISION=on` (vision already runs, **API-keyed and isolated from the default OAuth policy** — no policy conflict).
- Complements (does not duplicate) the Python-rendered chart: text reading placed right above the chart image.

## Changes
- `capabilities.vision_in_report()` — default off
- `buy_quality.format_vision_pattern_md()` — pure renderer (ko/en, never raises, no `would_buy` directive)
- `analysis.py` — render under flag, inject after price/volume prose & before chart
- tests: formatter (4) + flag default-off safety contract (2)

## Tests
`pytest tests/test_buy_quality.py tests/test_vision_plumbing.py` → **47 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)