### PR TITLE
perf(broadcast): reuse one Chromium across translated-PDF renders

### DIFF
--- a/pdf_converter.py
+++ b/pdf_converter.py
@@ -981,6 +981,127 @@ async def _markdown_to_pdf_playwright_async(md_file_path, pdf_file_path, add_the
 
     logger.info(f"PDF conversion complete with Playwright: {pdf_file_path}")
 
+async def _render_markdown_page(
+    browser,
+    md_file_path,
+    pdf_file_path,
+    *,
+    add_theme=True,
+    logo_path=None,
+    enable_watermark=False,
+    watermark_opacity=0.02,
+):
+    """Render ONE markdown file to PDF using an already-launched *browser*.
+
+    Mirrors :func:`_markdown_to_pdf_playwright_async`'s page logic (file:// load,
+    A4 margins, print_background) but reuses a shared browser instead of
+    launching a new Chromium per call. A fresh page is created and closed per
+    file. Returns the pdf path string on success; raises on failure.
+    """
+    html_content = markdown_to_html(
+        md_file_path,
+        add_theme=add_theme,
+        logo_path=logo_path,
+        enable_watermark=enable_watermark,
+        watermark_opacity=watermark_opacity,
+    )
+
+    temp_html = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            suffix='.html', delete=False, mode='w', encoding='utf-8'
+        ) as f:
+            f.write(html_content)
+            temp_html = f.name
+
+        page = await browser.new_page()
+        try:
+            await page.goto(
+                f'file://{os.path.abspath(temp_html)}', wait_until='networkidle'
+            )
+            await page.pdf(
+                path=str(pdf_file_path),
+                format='A4',
+                margin={'top': '20mm', 'right': '20mm', 'bottom': '20mm', 'left': '20mm'},
+                print_background=True,
+            )
+        finally:
+            await page.close()
+        logger.info(f"PDF conversion complete (shared browser): {pdf_file_path}")
+        return str(pdf_file_path)
+    finally:
+        if temp_html and os.path.exists(temp_html):
+            try:
+                os.unlink(temp_html)
+            except OSError:
+                pass
+
+
+class PdfRenderer:
+    """Reusable single-Chromium PDF renderer for the multilingual broadcast.
+
+    Launching Chromium is slow and memory-heavy. The translated-PDF broadcast
+    used to launch a fresh browser per file (N launches for N PDFs). This keeps
+    ONE browser alive across the whole loop and renders files through it one at a
+    time, so the per-file launch overhead is paid once while the memory ceiling
+    stays at a single Chromium (safe on small hosts).
+
+    Usage::
+
+        async with PdfRenderer() as renderer:
+            for ...:
+                pdf = await renderer.render(md_path, pdf_path)  # None on failure
+    """
+
+    def __init__(self, *, add_theme=True, logo_path=None, enable_watermark=False,
+                 watermark_opacity=0.02):
+        self._opts = dict(
+            add_theme=add_theme,
+            logo_path=logo_path,
+            enable_watermark=enable_watermark,
+            watermark_opacity=watermark_opacity,
+        )
+        self._pw = None
+        self._browser = None
+
+    async def __aenter__(self):
+        from playwright.async_api import async_playwright
+
+        self._pw = await async_playwright().start()
+        self._browser = await self._pw.chromium.launch(
+            headless=True,
+            args=[
+                '--disable-dev-shm-usage',
+                '--no-sandbox',
+                '--disable-setuid-sandbox',
+                '--disable-gpu',
+            ],
+        )
+        return self
+
+    async def render(self, md_file_path, pdf_file_path):
+        """Render one file; returns the pdf path or None on failure (never raises)."""
+        if self._browser is None:
+            raise RuntimeError("PdfRenderer used outside of 'async with'")
+        try:
+            return await _render_markdown_page(
+                self._browser, md_file_path, pdf_file_path, **self._opts
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"Shared-browser PDF render failed for {md_file_path}: {e}")
+            return None
+
+    async def __aexit__(self, *exc):
+        try:
+            if self._browser is not None:
+                await self._browser.close()
+        finally:
+            self._browser = None
+            if self._pw is not None:
+                await self._pw.stop()
+                self._pw = None
+
+
 def _markdown_to_pdf_playwright_sync(md_file_path, pdf_file_path, add_theme, logo_path, enable_watermark, watermark_opacity):
     """PDF conversion using Playwright Sync API (for regular environments)"""
     from playwright.sync_api import sync_playwright

--- a/stock_analysis_orchestrator.py
+++ b/stock_analysis_orchestrator.py
@@ -722,8 +722,9 @@ class StockAnalysisOrchestrator:
         """
         try:
             from cores.agents.telegram_translator_agent import translate_telegram_message
+            from pdf_converter import PdfRenderer
 
-            async def _translate_pdfs_for_lang(lang, channel_id):
+            async def _translate_pdfs_for_lang(lang, channel_id, renderer):
                 for report_path in report_paths:
                     try:
                         logger.info(f"Translating markdown report {report_path} to {lang}")
@@ -752,10 +753,12 @@ class StockAnalysisOrchestrator:
 
                         logger.info(f"Translated report saved: {translated_report_path}")
 
-                        translated_pdf_paths = await self.convert_to_pdf([str(translated_report_path)])
+                        translated_pdf_file = PDF_REPORTS_DIR / f"{Path(translated_report_path).stem}.pdf"
+                        translated_pdf_path = await renderer.render(
+                            str(translated_report_path), str(translated_pdf_file)
+                        )
 
-                        if translated_pdf_paths and len(translated_pdf_paths) > 0:
-                            translated_pdf_path = translated_pdf_paths[0]
+                        if translated_pdf_path:
                             logger.info(f"Sending translated PDF {translated_pdf_path} to {lang} channel")
                             success = await bot_agent.send_document(channel_id, str(translated_pdf_path), msg_type="pdf")
 
@@ -775,18 +778,21 @@ class StockAnalysisOrchestrator:
                             await send_openai_quota_alert(self.telegram_config, market="KR")
                             return
 
-            # Process languages sequentially to limit memory usage
-            # (each PDF generation spawns a Playwright/Chromium instance)
-            for lang in self.telegram_config.broadcast_languages:
-                channel_id = self.telegram_config.get_broadcast_channel_id(lang)
-                if not channel_id:
-                    logger.warning(f"No channel ID configured for language: {lang}")
-                    continue
-                logger.info(f"Processing PDF translation for {lang} channel (sequential)")
-                try:
-                    await _translate_pdfs_for_lang(lang, channel_id)
-                except Exception as lang_err:
-                    logger.error(f"PDF translation failed for {lang}: {lang_err}")
+            # Languages are still processed one page at a time (memory ceiling stays
+            # at a single Chromium), but a SHARED browser is reused across all of
+            # them so the Chromium launch cost is paid ONCE instead of once per file
+            # (previously N launches for N PDFs — the batch's main slow tail).
+            async with PdfRenderer() as renderer:
+                for lang in self.telegram_config.broadcast_languages:
+                    channel_id = self.telegram_config.get_broadcast_channel_id(lang)
+                    if not channel_id:
+                        logger.warning(f"No channel ID configured for language: {lang}")
+                        continue
+                    logger.info(f"Processing PDF translation for {lang} channel (shared browser)")
+                    try:
+                        await _translate_pdfs_for_lang(lang, channel_id, renderer)
+                    except Exception as lang_err:
+                        logger.error(f"PDF translation failed for {lang}: {lang_err}")
 
         except Exception as e:
             logger.error(f"Error in _send_translated_pdfs: {str(e)}")

--- a/tests/test_pdf_renderer.py
+++ b/tests/test_pdf_renderer.py
@@ -1,0 +1,82 @@
+# test_pdf_renderer.py
+"""
+Unit tests for the shared-browser PDF renderer (pdf_converter.PdfRenderer).
+
+Fully mocked: NO real Playwright/Chromium launch. These lock the core contract —
+ONE browser is reused across many renders (the whole point of the change) and a
+fresh page is created+closed per file — without needing a browser in CI.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+import pdf_converter
+
+
+@pytest.mark.asyncio
+async def test_render_markdown_page_uses_given_browser(monkeypatch, tmp_path):
+    monkeypatch.setattr(pdf_converter, "markdown_to_html", lambda *a, **k: "<html>hi</html>")
+    page = AsyncMock()
+    browser = AsyncMock()
+    browser.new_page = AsyncMock(return_value=page)
+
+    md = tmp_path / "r.md"
+    md.write_text("x", encoding="utf-8")
+    pdf = tmp_path / "r.pdf"
+
+    out = await pdf_converter._render_markdown_page(browser, str(md), str(pdf))
+
+    assert out == str(pdf)
+    browser.new_page.assert_awaited_once()       # one page per file
+    page.goto.assert_awaited_once()
+    page.pdf.assert_awaited_once()
+    assert page.pdf.await_args.kwargs["path"] == str(pdf)
+    page.close.assert_awaited_once()             # page is closed after render
+
+
+@pytest.mark.asyncio
+async def test_pdf_renderer_reuses_one_browser(monkeypatch, tmp_path):
+    monkeypatch.setattr(pdf_converter, "markdown_to_html", lambda *a, **k: "<html>hi</html>")
+    page = AsyncMock()
+    browser = AsyncMock()
+    browser.new_page = AsyncMock(return_value=page)
+
+    r = pdf_converter.PdfRenderer()
+    r._browser = browser  # inject; skip the real Chromium launch in __aenter__
+
+    md = tmp_path / "a.md"
+    md.write_text("a", encoding="utf-8")
+    p1 = await r.render(str(md), str(tmp_path / "a.pdf"))
+    p2 = await r.render(str(md), str(tmp_path / "b.pdf"))
+
+    assert p1 == str(tmp_path / "a.pdf")
+    assert p2 == str(tmp_path / "b.pdf")
+    # The contract: TWO pages rendered through ONE shared browser.
+    assert browser.new_page.await_count == 2
+    browser.close.assert_not_awaited()  # browser stays open across renders
+
+
+@pytest.mark.asyncio
+async def test_render_returns_none_on_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(pdf_converter, "markdown_to_html", lambda *a, **k: "<html>x</html>")
+    browser = AsyncMock()
+    browser.new_page = AsyncMock(side_effect=RuntimeError("boom"))
+
+    r = pdf_converter.PdfRenderer()
+    r._browser = browser
+
+    md = tmp_path / "a.md"
+    md.write_text("a", encoding="utf-8")
+    out = await r.render(str(md), str(tmp_path / "a.pdf"))
+    assert out is None  # never raises to the caller — broadcast continues
+
+
+@pytest.mark.asyncio
+async def test_render_before_enter_raises(tmp_path):
+    r = pdf_converter.PdfRenderer()  # not entered -> no browser
+    md = tmp_path / "a.md"
+    md.write_text("a", encoding="utf-8")
+    with pytest.raises(RuntimeError):
+        await r.render(str(md), str(tmp_path / "a.pdf"))


### PR DESCRIPTION
## Problem (measured)
On the afternoon batch, analysis of 3 stocks took ~7 min, but the run kept going for ~50 min. The tail is the **multilingual PDF broadcast**: `_send_translated_pdfs` renders **4 langs × 3 stocks = 12 PDFs**, and each `convert_to_pdf` **launches a fresh Chromium** (`pdf_converter` comment: *"each PDF generation spawns a Playwright/Chromium instance"*). The loop is deliberately **sequential** to bound memory on the small host (1.7 GB RAM, already into swap), so the 12 Chromium **launches** run back-to-back — that launch overhead is the slow tail. (Not zombies, not the vision/image analysis — both verified small.)

## Fix
`pdf_converter.PdfRenderer` — an async context manager that launches **one** Chromium and renders files through it **one page at a time**. The loop stays sequential (memory ceiling = a single Chromium, unchanged), but the launch cost is paid **once** instead of **once per file** (12 → 1).

- `_render_markdown_page(browser, md, pdf)` — render one file with a given browser (mirrors the existing async render: file:// load, A4, print_background)
- `PdfRenderer` — start/stop lifecycle, `render()` never raises (returns None on failure → broadcast continues)
- `_send_translated_pdfs` — wraps the lang loop in one `PdfRenderer`; primary-report `convert_to_pdf` path is untouched

## Safety
- Memory unchanged (still one Chromium at a time; sequential preserved)
- Per-file failure isolation kept; quota-error handling unchanged
- Tests (mocked, no real Chromium): browser-reuse contract, per-page lifecycle, failure→None, use-before-enter raises → **4 passed**
- Verified with a **real Chromium** smoke render on the server (2 PDFs via one shared browser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)