### PR TITLE
perf(broadcast-us): reuse one Chromium across US translated-PDF renders

### DIFF
--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -713,7 +713,9 @@ class USStockAnalysisOrchestrator:
             report_paths: List of original markdown report file paths
         """
         try:
-            async def _translate_pdfs_for_lang(lang, channel_id):
+            from pdf_converter import PdfRenderer
+
+            async def _translate_pdfs_for_lang(lang, channel_id, renderer):
                 for report_path in report_paths:
                     try:
                         logger.info(f"Translating US markdown report {report_path} to {lang}")
@@ -742,10 +744,12 @@ class USStockAnalysisOrchestrator:
 
                         logger.info(f"Translated US report saved: {translated_report_path}")
 
-                        translated_pdf_paths = await self.convert_to_pdf([str(translated_report_path)])
+                        translated_pdf_file = US_PDF_REPORTS_DIR / f"{Path(translated_report_path).stem}.pdf"
+                        translated_pdf_path = await renderer.render(
+                            str(translated_report_path), str(translated_pdf_file)
+                        )
 
-                        if translated_pdf_paths and len(translated_pdf_paths) > 0:
-                            translated_pdf_path = translated_pdf_paths[0]
+                        if translated_pdf_path:
                             logger.info(f"Sending translated US PDF {translated_pdf_path} to {lang} channel")
                             success = await bot_agent.send_document(channel_id, str(translated_pdf_path), msg_type="pdf", market="us")
 
@@ -765,18 +769,21 @@ class USStockAnalysisOrchestrator:
                             await send_openai_quota_alert(self.telegram_config, market="US")
                             return
 
-            # Process languages sequentially to limit memory usage
-            # (each PDF generation spawns a Playwright/Chromium instance)
-            for lang in self.telegram_config.broadcast_languages:
-                channel_id = self.telegram_config.get_broadcast_channel_id(lang)
-                if not channel_id:
-                    logger.warning(f"No channel ID configured for language: {lang}")
-                    continue
-                logger.info(f"Processing PDF translation for US {lang} channel (sequential)")
-                try:
-                    await _translate_pdfs_for_lang(lang, channel_id)
-                except Exception as lang_err:
-                    logger.error(f"US PDF translation failed for {lang}: {lang_err}")
+            # Languages are still processed one page at a time (memory ceiling stays
+            # at a single Chromium), but a SHARED browser is reused across all of
+            # them so the Chromium launch cost is paid ONCE instead of once per file
+            # (previously N launches for N PDFs — the batch's main slow tail).
+            async with PdfRenderer() as renderer:
+                for lang in self.telegram_config.broadcast_languages:
+                    channel_id = self.telegram_config.get_broadcast_channel_id(lang)
+                    if not channel_id:
+                        logger.warning(f"No channel ID configured for language: {lang}")
+                        continue
+                    logger.info(f"Processing PDF translation for US {lang} channel (shared browser)")
+                    try:
+                        await _translate_pdfs_for_lang(lang, channel_id, renderer)
+                    except Exception as lang_err:
+                        logger.error(f"US PDF translation failed for {lang}: {lang_err}")
 
         except Exception as e:
             logger.error(f"Error in _send_translated_pdfs: {str(e)}")


### PR DESCRIPTION
## What
US counterpart of #386. `us_stock_analysis_orchestrator._send_translated_pdfs` had the **identical** pattern: a deliberately sequential per-language loop where each translated PDF called `convert_to_pdf` → **launched a fresh Chromium** (N launches for N PDFs = the slow broadcast tail).

## Fix
Reuse the shared `pdf_converter.PdfRenderer` (added in #386) — one Chromium for the whole loop, rendering into `US_PDF_REPORTS_DIR`. Loop stays sequential (single-Chromium memory ceiling unchanged); launch cost paid once.

- `_send_translated_pdfs`: wrap lang loop in `PdfRenderer`, render via shared browser
- primary US report `convert_to_pdf` path untouched

## Safety / tests
- Behavior-preserving (same PDFs, per-file failure isolation, quota handling, sleep)
- `PdfRenderer` itself verified in #386 (mocked tests + real-Chromium server smoke); this PR is identical wiring
- `tests/test_pdf_renderer.py` (shared) → 4 passed; US orchestrator `py_compile` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)