### PR TITLE
chore(models): migrate gpt-5-nano default -> gpt-5.4-nano

### DIFF
--- a/cores/agents/telegram_translator_agent.py
+++ b/cores/agents/telegram_translator_agent.py
@@ -104,7 +104,7 @@ Only return the translated text without any explanations or metadata.
 
 async def translate_telegram_message(
     message: str,
-    model: str = "gpt-5-nano",
+    model: str = "gpt-5.4-nano",
     from_lang: str = "ko",
     to_lang: str = "en"
 ) -> str:
@@ -113,7 +113,7 @@ async def translate_telegram_message(
 
     Args:
         message: Telegram message to translate
-        model: OpenAI model to use (default: gpt-5-nano for cost efficiency)
+        model: OpenAI model to use (default: gpt-5.4-nano for cost efficiency)
         from_lang: Source language code (default: "ko" for Korean)
         to_lang: Target language code (default: "en" for English)
 

--- a/cores/chatgpt_proxy/api_translator.py
+++ b/cores/chatgpt_proxy/api_translator.py
@@ -18,12 +18,13 @@ _MODEL_MAP: dict[str, str] = {
     "gpt-3.5-turbo": "gpt-5.4-mini",
     "o4-mini": "gpt-5.4-mini",
     "o3-mini": "gpt-5.4-mini",
-    # gpt-5-nano is rejected by the Codex/ChatGPT-account endpoint
+    # nano-tier models are rejected by the Codex/ChatGPT-account endpoint
     # ("model is not supported when using Codex with a ChatGPT account").
-    # Map to the lightest Codex-compatible model so OAuth-mode callers
+    # Map them to the lightest Codex-compatible model so OAuth-mode callers
     # (telegram_translator, dashboards, weekly intelligence) keep working.
-    # API-key mode bypasses this proxy, so it still uses real gpt-5-nano.
-    "gpt-5-nano": "gpt-5.4-mini",
+    # API-key mode bypasses this proxy, so it uses the real nano model.
+    "gpt-5.4-nano": "gpt-5.4-mini",   # current nano default (2026-03)
+    "gpt-5-nano": "gpt-5.4-mini",     # back-compat (older nano, still live)
 }
 
 

--- a/examples/generate_dashboard_json.py
+++ b/examples/generate_dashboard_json.py
@@ -96,7 +96,7 @@ class DashboardDataGenerator:
         # Initialize translator
         if self.enable_translation:
             try:
-                self.translator = DashboardTranslator(model="gpt-5-nano")
+                self.translator = DashboardTranslator(model="gpt-5.4-nano")
                 logger.info("Translation enabled.")
             except Exception as e:
                 self.enable_translation = False

--- a/examples/generate_us_dashboard_json.py
+++ b/examples/generate_us_dashboard_json.py
@@ -135,7 +135,7 @@ class USDashboardDataGenerator:
         # Initialize translator
         if self.enable_translation:
             try:
-                self.translator = DashboardTranslator(model="gpt-5-nano")
+                self.translator = DashboardTranslator(model="gpt-5.4-nano")
                 logger.info("Translation feature enabled.")
             except Exception as e:
                 self.enable_translation = False

--- a/examples/translation_utils.py
+++ b/examples/translation_utils.py
@@ -18,12 +18,12 @@ logger = logging.getLogger(__name__)
 class DashboardTranslator:
     """Dashboard data translation class"""
     
-    def __init__(self, model: str = "gpt-5-nano"):
+    def __init__(self, model: str = "gpt-5.4-nano"):
         """
         Initialize translator
 
         Args:
-            model: OpenAI model to use (default: gpt-5-nano)
+            model: OpenAI model to use (default: gpt-5.4-nano)
         """
         self.model = model
 
@@ -444,7 +444,7 @@ if __name__ == "__main__":
     import os
 
     async def test():
-        translator = DashboardTranslator(model="gpt-5-nano")
+        translator = DashboardTranslator(model="gpt-5.4-nano")
 
         # Single translation test
         result = await translator.translate_text("The automotive industry outlook is bright.")

--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -671,7 +671,7 @@ class USStockAnalysisOrchestrator:
                         logger.info(f"Translating US telegram message to {lang}")
                         translated_message = await translate_telegram_message(
                             original_message,
-                            model="gpt-5-nano",
+                            model="gpt-5.4-nano",
                             from_lang="ko",
                             to_lang=lang
                         )
@@ -728,7 +728,7 @@ class USStockAnalysisOrchestrator:
 
                         translated_report = await translate_telegram_message(
                             text_for_translation,
-                            model="gpt-5-nano",
+                            model="gpt-5.4-nano",
                             from_lang="ko",
                             to_lang=lang
                         )
@@ -874,7 +874,7 @@ class USStockAnalysisOrchestrator:
                     logger.info(f"Translating US trigger alert to {lang}")
                     translated_message = await translate_telegram_message(
                         original_message,
-                        model="gpt-5-nano",
+                        model="gpt-5.4-nano",
                         from_lang="ko",
                         to_lang=lang
                     )

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -2876,7 +2876,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     translated_queue = []
                     for idx, message in enumerate(self.message_queue, 1):
                         logger.info(f"Translating US message {idx}/{len(self.message_queue)}")
-                        translated = await translate_telegram_message(message, model="gpt-5-nano")
+                        translated = await translate_telegram_message(message, model="gpt-5.4-nano")
                         translated_queue.append(translated)
                     self.message_queue = translated_queue
                     logger.info("All US messages translated successfully")
@@ -2989,7 +2989,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                             logger.info(f"Translating US tracking message to {lang}")
                             translated_message = await translate_telegram_message(
                                 message,
-                                model="gpt-5-nano",
+                                model="gpt-5.4-nano",
                                 from_lang="ko",
                                 to_lang=lang
                             )

--- a/stock_analysis_orchestrator.py
+++ b/stock_analysis_orchestrator.py
@@ -679,7 +679,7 @@ class StockAnalysisOrchestrator:
                         logger.info(f"Translating telegram message to {lang}")
                         translated_message = await translate_telegram_message(
                             original_message,
-                            model="gpt-5-nano",
+                            model="gpt-5.4-nano",
                             from_lang="ko",
                             to_lang=lang
                         )
@@ -737,7 +737,7 @@ class StockAnalysisOrchestrator:
 
                         translated_report = await translate_telegram_message(
                             text_for_translation,
-                            model="gpt-5-nano",
+                            model="gpt-5.4-nano",
                             from_lang="ko",
                             to_lang=lang
                         )
@@ -844,7 +844,7 @@ class StockAnalysisOrchestrator:
                 try:
                     logger.info("Translating trigger alert message to English")
                     from cores.agents.telegram_translator_agent import translate_telegram_message
-                    message = await translate_telegram_message(message, model="gpt-5-nano")
+                    message = await translate_telegram_message(message, model="gpt-5.4-nano")
                     logger.info("Translation complete")
                 except Exception as e:
                     logger.error(f"Translation failed: {str(e)}. Using original Korean message.")
@@ -903,7 +903,7 @@ class StockAnalysisOrchestrator:
                     logger.info(f"Translating trigger alert to {lang}")
                     translated_message = await translate_telegram_message(
                         original_message,
-                        model="gpt-5-nano",
+                        model="gpt-5.4-nano",
                         from_lang="ko",
                         to_lang=lang
                     )

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -1926,7 +1926,7 @@ class StockTrackingAgent:
                     translated_queue = []
                     for idx, message in enumerate(self.message_queue, 1):
                         logger.info(f"Translating message {idx}/{len(self.message_queue)}")
-                        translated = await translate_telegram_message(message, model="gpt-5-nano")
+                        translated = await translate_telegram_message(message, model="gpt-5.4-nano")
                         translated_queue.append(translated)
                     self.message_queue = translated_queue
                     logger.info("All messages translated successfully")
@@ -2032,7 +2032,7 @@ class StockTrackingAgent:
                             logger.info(f"Translating tracking message to {lang}")
                             translated_message = await translate_telegram_message(
                                 message,
-                                model="gpt-5-nano",
+                                model="gpt-5.4-nano",
                                 from_lang="ko",
                                 to_lang=lang
                             )

--- a/tests/test_chatgpt_oauth/test_api_translator.py
+++ b/tests/test_chatgpt_oauth/test_api_translator.py
@@ -37,11 +37,11 @@ class TestTranslateRequest:
         assert "max_tokens" not in result
 
     def test_gpt5_nano_mapped_to_codex_compatible(self):
-        # gpt-5-nano is rejected by the Codex/ChatGPT-account endpoint;
+        # gpt-5.4-nano is rejected by the Codex/ChatGPT-account endpoint;
         # it must be mapped to the lightest Codex-compatible model so that
         # OAuth-mode callers (e.g. telegram_translator) keep working.
         body = {
-            "model": "gpt-5-nano",
+            "model": "gpt-5.4-nano",
             "messages": [{"role": "user", "content": "안녕하세요"}],
         }
         result = translate_request(body)

--- a/tests/test_chatgpt_oauth/test_responses_passthrough.py
+++ b/tests/test_chatgpt_oauth/test_responses_passthrough.py
@@ -53,7 +53,7 @@ class TestPrepareResponsesPassthrough:
         assert result["model"] == "gpt-5.5"
 
     def test_maps_gpt5_nano_to_gpt54mini(self):
-        body = {"model": "gpt-5-nano", "input": []}
+        body = {"model": "gpt-5.4-nano", "input": []}
         result = prepare_responses_passthrough(body)
         assert result["model"] == "gpt-5.4-mini"
 

--- a/tracking/telegram.py
+++ b/tracking/telegram.py
@@ -112,7 +112,7 @@ class TelegramSender:
             translated = []
             for idx, message in enumerate(messages, 1):
                 logger.info(f"Translating message {idx}/{len(messages)}")
-                result = await translate_telegram_message(message, model="gpt-5-nano")
+                result = await translate_telegram_message(message, model="gpt-5.4-nano")
                 translated.append(result)
             logger.info("All messages translated successfully")
             return translated
@@ -143,7 +143,7 @@ class TelegramSender:
                     for message in messages:
                         try:
                             translated = await translate_telegram_message(
-                                message, model="gpt-5-nano",
+                                message, model="gpt-5.4-nano",
                                 from_lang="ko", to_lang=lang
                             )
                             await self._send_single_message(channel_id, translated)

--- a/trading/portfolio_telegram_reporter.py
+++ b/trading/portfolio_telegram_reporter.py
@@ -467,7 +467,7 @@ class PortfolioTelegramReporter:
                     # Translate message
                     translated_message = await translate_telegram_message(
                         original_message,
-                        model="gpt-5-nano",
+                        model="gpt-5.4-nano",
                         from_lang="ko",
                         to_lang=lang
                     )

--- a/weekly_firecrawl_intelligence.py
+++ b/weekly_firecrawl_intelligence.py
@@ -164,7 +164,7 @@ async def _send_broadcast(message: str, broadcast_languages: list):
 
                 logger.info(f"Translating intelligence report to {lang}")
                 translated = await translate_telegram_message(
-                    message, model="gpt-5-nano", from_lang="ko", to_lang=lang
+                    message, model="gpt-5.4-nano", from_lang="ko", to_lang=lang
                 )
                 if len(translated) > 4096:
                     for i in range(0, len(translated), 4096):

--- a/weekly_insight_report.py
+++ b/weekly_insight_report.py
@@ -533,7 +533,7 @@ async def _send_broadcast(message: str, broadcast_languages: list):
 
                 logger.info(f"Translating weekly report to {lang}")
                 translated = await translate_telegram_message(
-                    message, model="gpt-5-nano", from_lang="ko", to_lang=lang
+                    message, model="gpt-5.4-nano", from_lang="ko", to_lang=lang
                 )
                 await bot.send_message(chat_id=channel_id, text=translated, parse_mode="HTML")
                 logger.info(f"Weekly report sent to {lang} channel")


### PR DESCRIPTION
## Why
`gpt-5-nano` (2025-08) is the older nano; OpenAI now ships **`gpt-5.4-nano`** (2026-03), the current cheapest tier. Both still resolve on the account today (verified via `models.list` + a real Responses call), but move all defaults to `gpt-5.4-nano` to stay current and future-proof against gpt-5-nano retirement.

## Changes
- **14 files**: `model="gpt-5-nano"` → `"gpt-5.4-nano"` (KR + US orchestrators, tracking, weekly, portfolio reporter, translator default, examples)
- **proxy `_MODEL_MAP`**: add `"gpt-5.4-nano" → "gpt-5.4-mini"` (Codex/ChatGPT-account endpoint rejects all nano tiers, so OAuth-mode callers must remap); keep `"gpt-5-nano"` for back-compat

## Production impact: none
Production runs OAuth (`PRISM_OPENAI_AUTH_MODE=chatgpt_oauth`); the Codex proxy already remaps nano → `gpt-5.4-mini`, so subscriber translations are unchanged. The nano default only affects API-key-mode paths, where `gpt-5.4-nano` is the cheap/newest tier.

## Tests
`tests/test_chatgpt_oauth` → 49 passed, 1 **pre-existing** failure (`test_basic_text_request`, system→developer role mapping — fails on main too, unrelated). Proxy map verified: `gpt-5.4-nano`/`gpt-5-nano` → `gpt-5.4-mini`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)