### PR TITLE
chore(codacy): exclude test/example paths from analysis

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,20 @@
+# Codacy analysis configuration
+# https://docs.codacy.com/repositories-configure/codacy-configuration-file/
+#
+# Why this file exists
+# --------------------
+# Codacy's security grade was dominated by Bandit B101 ("Use of assert detected").
+# Bandit flags every `assert` because asserts are stripped under `python -O`, but
+# in TEST code asserts are the correct idiom — not a security risk. As of 2026-06,
+# ~1,000 of the repo's ~2,300 "security" findings were B101, and 100% of them were
+# in test directories (tests/, prism-us/tests/, prism-btc/tests/, cores/llm/tests/).
+#
+# Excluding test/example paths from analysis removes those false positives so the
+# grade reflects production code. (Test code is still run by CI; it is simply not
+# graded for security/style here.)
+exclude_paths:
+  - 'tests/**'
+  - '**/tests/**'
+  - '**/test_*.py'
+  - '**/*_test.py'
+  - 'examples/**'


### PR DESCRIPTION
## Root cause of the B→C grade drop (investigated via Codacy API)
Codacy commit-statistics show the drop on **2026-06-24** was a **denominator effect**, not new issues:

| date | issues | LOC | density |
|---|---|---|---|
| 06-23 | 2546 | 99,301 | 2.56% (B) |
| 06-24 | 2571 | **27,548** | **9.33% (C)** |

~72k LOC was removed from analysis that day (issue count stayed flat) → density tripled → B→C.

## What dominates the issues
Security = 2,300 of 2,630 total. Of the security findings, **~1,038 are Bandit B101 ("Use of assert"), and 100% of B101 are in test directories** (tests/ 446, prism-us/tests 346, prism-btc/tests 288, cores/llm/tests 82…). Asserts in tests are correct, not a security risk.

## This change
Add `.codacy.yaml` excluding `**/tests/**`, `**/test_*.py`, `examples/**` so the grade reflects production code and the B101 false positives drop out.

## Caveat
Codacy counts ~30k LOC (not the full local Python), so the exact post-exclusion density can only be confirmed by **re-analysis after merge**. This is the correct best-practice cleanup regardless; the grade should be re-measured and this is trivially reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)