### PR TITLE
fix(security): parameterize SQL values to prevent injection (batch 5)

### DIFF
--- a/prism-btc/analysis/intraday_proto.py
+++ b/prism-btc/analysis/intraday_proto.py
@@ -38,8 +38,9 @@ RISK = 0.01              # 1% per trade (복리 평가용)
 
 def load_tf(conn, tf: str) -> pd.DataFrame:
     df = pd.read_sql(
-        f"SELECT open_time, open, high, low, close FROM klines "
-        f"WHERE timeframe='{tf}' AND confirmed=1 ORDER BY open_time", conn)
+        "SELECT open_time, open, high, low, close FROM klines "
+        "WHERE timeframe=? AND confirmed=1 ORDER BY open_time",
+        conn, params=(tf,))
     df["t"] = pd.to_datetime(df.open_time, unit="ms", utc=True)
     return df.reset_index(drop=True)
 


### PR DESCRIPTION
## Summary

- `prism-btc/analysis/intraday_proto.py`: `load_tf()` 함수에서 `WHERE timeframe='{tf}'` f-string 직접 보간 → `?` placeholder + `params=(tf,)` 파라미터 바인딩으로 수정 (B608 진짜 위험 1건 제거)

## 분석 결과

bandit B608 13건 중 실제 값 직접 보간 케이스는 1건:
- `intraday_proto.py:41` — `tf` 문자열을 SQL WHERE 절에 직접 보간 → **수정 완료**

나머지 12건은 모두 false positive:
- `archive_db.py` 3건: 컬럼명/절(`{col_name}`, `{set_clause}`, `{where}`) 보간 — 식별자, 값 바인딩 불가
- `persistent_insights.py` 6건: `{placeholders}` (`?,?,?` join 패턴) + tuple 바인딩 이미 안전, `{supersede_clause}` 절 보간
- `query_engine.py` 3건: `{placeholders}` + list 바인딩 이미 안전, `{where}` 절 보간

## 검증

- `python -m compileall -q cores/archive prism-btc/analysis`: 에러 0
- import smoke test: OK
- bandit B608: 13건 → 12건 (`intraday_proto.py` 항목 제거 확인)
- `ruff check prism-btc/analysis/intraday_proto.py`: All checks passed (신규 위반 0)

## git diff --stat

```
prism-btc/analysis/intraday_proto.py | 5 +++--
1 file changed, 3 insertions(+), 2 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)