### PR TITLE
fix(bot): remove daily limit on /report and /us_report (#307)

### DIFF
--- a/telegram_ai_bot.py
+++ b/telegram_ai_bot.py
@@ -636,24 +636,11 @@ class TelegramAIBot:
 
     def check_daily_limit(self, user_id: int, command: str) -> bool:
         """
-        Check daily usage limit.
+        Daily usage limit for report/us_report — removed (issue #307).
 
-        Args:
-            user_id: User ID
-            command: Command (report, us_report)
-
-        Returns:
-            bool: True if available, False if already used
+        Always returns True (unlimited). Kept as a no-op so existing call
+        sites and refund_daily_limit() stay valid without further changes.
         """
-        today = datetime.now().strftime("%Y-%m-%d")
-        key = f"{user_id}:{command}"
-
-        if self.daily_report_usage.get(key) == today:
-            logger.info(f"Daily limit exceeded: user={user_id}, command={command}")
-            return False
-
-        self.daily_report_usage[key] = today
-        logger.info(f"Daily usage recorded: user={user_id}, command={command}")
         return True
 
     def refund_daily_limit(self, user_id: int, command: str):


### PR DESCRIPTION
## 이슈
#307 — 텔레그램봇 `/report`·`/us_report`의 1일 1회 한도 제거.

## 변경
`check_daily_limit()`이 항상 `True`를 반환하도록 변경 → 두 명령 무제한.
- 호출처(report/us_report 핸들러)와 `refund_daily_limit()`은 그대로 유효한 no-op으로 보존 (회귀 위험 최소)
- dead가 된 `today`/`key` 지역변수 제거 (새 lint 이슈 0)
- +3 / −16, 단일 함수만 변경

## 검증
- compileall OK
- `check_daily_limit` 호출처 2곳(`report` L1425, `us_report` L2289) 자동 통과 확인
- `daily_report_usage`는 refund/cleanup에서 계속 쓰여 unused 아님

## 배포 메모
머지 후 **텔레그램 봇 단일 인스턴스 재기동** 필요.

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)