### PR TITLE
feat(journal): recent stop-out churn-guard penalty in score adjustment (KR+US)

### DIFF
--- a/prism-us/tests/test_journal_recent_loss_penalty.py
+++ b/prism-us/tests/test_journal_recent_loss_penalty.py
@@ -1,0 +1,222 @@
+"""Tests for the recent stop-out churn-guard penalty in prism-us/tracking/journal.py (US).
+
+Cases:
+  (a) recent loss-sell within window + sector "+1" bonus -> net-negative + churn guard reason
+  (b) no recent loss -> adjustment unchanged from baseline
+  (c) JOURNAL_RECENT_LOSS_PENALTY=0 -> disabled, no change
+  (d) recent sell was a WIN -> no penalty
+  (e) real recent_loss() against a tiny seeded sqlite DB
+"""
+import importlib
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Repo root is parent of parent of parent (prism-us/tests -> prism-us -> prism-insight)
+REPO_ROOT = str(Path(__file__).resolve().parent.parent.parent)
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+PRISM_US_ROOT = str(Path(__file__).resolve().parent.parent)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_us_journal_manager(cursor, conn):
+    """Import USJournalManager freshly so env constants are re-evaluated."""
+    mod_key = "prism_us_tracking_journal"
+    if mod_key in sys.modules:
+        del sys.modules[mod_key]
+
+    # Stub heavy deps that prism-us/tracking/journal.py loads at module level
+    # (parse_llm_json is loaded via _import_from_main_cores at import time)
+    cores_stub = types.ModuleType("cores")
+    cores_stub.utils = types.ModuleType("cores.utils")
+    cores_stub.utils.parse_llm_json = lambda *a, **k: None
+    sys.modules.setdefault("cores", cores_stub)
+    sys.modules.setdefault("cores.utils", cores_stub.utils)
+    sys.modules.setdefault("cores_utils", cores_stub.utils)
+
+    # Patch _import_from_main_cores to return our stub (called at module level)
+    us_journal_path = Path(PRISM_US_ROOT) / "tracking" / "journal.py"
+
+    # We need to prevent the real _import_from_main_cores from running since
+    # the test environment won't have cores/utils.py accessible the same way.
+    # We patch by pre-populating the cores_utils key in sys.modules.
+    stub_utils = types.ModuleType("cores_utils")
+    stub_utils.parse_llm_json = lambda *a, **k: None
+    sys.modules["cores_utils"] = stub_utils
+
+    spec = importlib.util.spec_from_file_location(mod_key, us_journal_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.USJournalManager(cursor=cursor, conn=conn, enable_journal=True)
+
+
+def _make_db():
+    """Return (conn, cursor) for an in-memory SQLite with minimal schema."""
+    conn = sqlite3.connect(":memory:")
+    cur = conn.cursor()
+    cur.execute("""
+        CREATE TABLE trading_journal (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ticker TEXT, trade_date TEXT, profit_rate REAL,
+            buy_scenario TEXT, market TEXT
+        )
+    """)
+    cur.execute("""
+        CREATE TABLE us_analysis_performance_tracker (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            trigger_type TEXT, tracking_status TEXT,
+            return_30d REAL, was_traded INTEGER
+        )
+    """)
+    conn.commit()
+    return conn, cur
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+class TestJournalRecentLossPenaltyUS(unittest.TestCase):
+
+    def setUp(self):
+        self.conn, self.cur = _make_db()
+
+    def tearDown(self):
+        self.conn.close()
+        for k in ("JOURNAL_RECENT_LOSS_HOURS", "JOURNAL_RECENT_LOSS_PENALTY"):
+            os.environ.pop(k, None)
+
+    def _get_jm(self):
+        return _make_us_journal_manager(self.cur, self.conn)
+
+    # (a) Recent loss within window + sector "+1" bonus -> net-negative + churn guard reason
+    def test_recent_loss_cancels_positive_bonus(self):
+        os.environ["JOURNAL_RECENT_LOSS_HOURS"] = "48"
+        os.environ["JOURNAL_RECENT_LOSS_PENALTY"] = "2"
+        jm = self._get_jm()
+
+        loss_info = {"gap_hours": 1.3, "last_ret": -7.5, "last_sell": "2026-06-30 10:00:00"}
+        import reentry_cooldown
+        with patch.object(reentry_cooldown, "recent_loss", return_value=loss_info):
+            # Give sector bonus: 3 profitable US trades for sector "Technology"
+            for i in range(3):
+                self.cur.execute(
+                    "INSERT INTO trading_journal (ticker, trade_date, profit_rate, buy_scenario, market) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (f"OTHER{i}", "2026-01-01 00:00:00", 8.0, '{"sector": "Technology"}', "US"),
+                )
+            self.conn.commit()
+
+            adj, reasons = jm.get_score_adjustment("MU", sector="Technology")
+
+        self.assertLess(adj, 0, f"Expected net-negative adjustment, got {adj}")
+        self.assertTrue(
+            any("churn guard" in r for r in reasons),
+            f"Expected churn guard reason, got {reasons}",
+        )
+
+    # (b) No recent loss -> adjustment unchanged from baseline
+    def test_no_recent_loss_no_penalty(self):
+        os.environ["JOURNAL_RECENT_LOSS_HOURS"] = "48"
+        os.environ["JOURNAL_RECENT_LOSS_PENALTY"] = "2"
+        jm = self._get_jm()
+
+        import reentry_cooldown
+        with patch.object(reentry_cooldown, "recent_loss", return_value=None):
+            adj, reasons = jm.get_score_adjustment("AAPL")
+
+        self.assertEqual(adj, 0)
+        self.assertFalse(any("churn guard" in r for r in reasons))
+
+    # (c) JOURNAL_RECENT_LOSS_PENALTY=0 -> disabled, no change
+    def test_penalty_disabled_via_env(self):
+        os.environ["JOURNAL_RECENT_LOSS_HOURS"] = "48"
+        os.environ["JOURNAL_RECENT_LOSS_PENALTY"] = "0"
+        jm = self._get_jm()
+
+        import reentry_cooldown
+        loss_info = {"gap_hours": 1.0, "last_ret": -5.0, "last_sell": "2026-06-30 10:00:00"}
+        with patch.object(reentry_cooldown, "recent_loss", return_value=loss_info):
+            adj, reasons = jm.get_score_adjustment("MU")
+
+        self.assertEqual(adj, 0)
+        self.assertFalse(any("churn guard" in r for r in reasons))
+
+    # (d) Recent sell was a WIN -> no penalty (recent_loss returns None for wins)
+    def test_recent_win_no_penalty(self):
+        os.environ["JOURNAL_RECENT_LOSS_HOURS"] = "48"
+        os.environ["JOURNAL_RECENT_LOSS_PENALTY"] = "2"
+        jm = self._get_jm()
+
+        import reentry_cooldown
+        with patch.object(reentry_cooldown, "recent_loss", return_value=None):
+            adj, reasons = jm.get_score_adjustment("NVDA")
+
+        self.assertEqual(adj, 0)
+        self.assertFalse(any("churn guard" in r for r in reasons))
+
+    # (e) Real recent_loss() against a seeded sqlite DB (US table)
+    def test_recent_loss_real_db_us(self):
+        """Exercise reentry_cooldown.recent_loss against a real seeded DB for US."""
+        import reentry_cooldown
+
+        with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+            db_path = f.name
+
+        try:
+            conn = sqlite3.connect(db_path)
+            conn.execute("""
+                CREATE TABLE us_trading_history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ticker TEXT,
+                    sell_date TEXT,
+                    profit_rate REAL
+                )
+            """)
+            from datetime import datetime, timedelta
+            sell_ts = (datetime.now() - timedelta(hours=2)).strftime("%Y-%m-%d %H:%M:%S")
+            conn.execute(
+                "INSERT INTO us_trading_history (ticker, sell_date, profit_rate) VALUES (?, ?, ?)",
+                ("MU", sell_ts, -7.5),
+            )
+            conn.commit()
+            conn.close()
+
+            with patch.dict(os.environ, {"REENTRY_COOLDOWN_DB": db_path}):
+                result = reentry_cooldown.recent_loss("MU", market="US")
+
+            self.assertIsNotNone(result, "Expected a loss dict, got None")
+            self.assertAlmostEqual(result["last_ret"], -7.5)
+            self.assertLess(result["gap_hours"], 3.0)
+
+        finally:
+            os.unlink(db_path)
+
+    # Edge: loss outside the configured window -> no penalty
+    def test_loss_outside_window_no_penalty(self):
+        os.environ["JOURNAL_RECENT_LOSS_HOURS"] = "1"
+        os.environ["JOURNAL_RECENT_LOSS_PENALTY"] = "2"
+        jm = self._get_jm()
+
+        import reentry_cooldown
+        loss_info = {"gap_hours": 5.0, "last_ret": -7.5, "last_sell": "2026-06-30 05:00:00"}
+        with patch.object(reentry_cooldown, "recent_loss", return_value=loss_info):
+            adj, reasons = jm.get_score_adjustment("MU")
+
+        self.assertEqual(adj, 0)
+        self.assertFalse(any("churn guard" in r for r in reasons))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/prism-us/tracking/journal.py
+++ b/prism-us/tracking/journal.py
@@ -7,12 +7,18 @@ Based on tracking/journal.py but adapted for US market with market='US' filter.
 
 import json
 import logging
+import os
+import sys
 import traceback
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
+
+# Recent stop-out churn guard — env-configurable, fail-open
+JOURNAL_RECENT_LOSS_HOURS = float(os.getenv("JOURNAL_RECENT_LOSS_HOURS", "48"))
+JOURNAL_RECENT_LOSS_PENALTY = int(os.getenv("JOURNAL_RECENT_LOSS_PENALTY", "2"))
 
 
 # =============================================================================
@@ -670,6 +676,26 @@ Please review the following completed US stock trade:
                                 f"Trigger '{trigger_type}' high win rate "
                                 f"{t['win_rate']*100:.0f}% (n={t['total']}, actual 30d data)"
                             )
+
+            # Recent stop-out churn guard (US market)
+            # Must come last so it can cancel any net-positive bonus from above.
+            if JOURNAL_RECENT_LOSS_PENALTY > 0:
+                try:
+                    # Import reentry_cooldown from repo root — parent of parent of parent
+                    # (prism-us/tracking -> prism-us -> prism-insight)
+                    _rc_root = str(Path(__file__).resolve().parent.parent.parent)
+                    if _rc_root not in sys.path:
+                        sys.path.insert(0, _rc_root)
+                    import reentry_cooldown as _rc
+                    _loss_info = _rc.recent_loss(ticker, market="US")
+                    if _loss_info is not None and _loss_info["gap_hours"] <= JOURNAL_RECENT_LOSS_HOURS:
+                        adjustment = min(adjustment, 0) - JOURNAL_RECENT_LOSS_PENALTY
+                        reasons.append(
+                            f"Recent stop-out {_loss_info['gap_hours']:.1f}h ago "
+                            f"({_loss_info['last_ret']:.1f}%) — churn guard"
+                        )
+                except Exception:
+                    pass  # fail-open: never raise into the buy path
 
             return max(-3, min(3, adjustment)), reasons
 

--- a/reentry_cooldown.py
+++ b/reentry_cooldown.py
@@ -113,3 +113,51 @@ def reentry_block(market: str, ticker: str, account_key: Optional[str] = None,
         "window_hours": window,
         "after_loss": after_loss,
     }
+
+
+def recent_loss(ticker: str, market: str | None = None) -> Optional[dict]:
+    """Return the most-recent sell's gap info if that sell was a loss, else None.
+
+    Used by the journal score adjustment to penalise fresh stop-outs regardless
+    of whether the (longer) COOLDOWN_LOSS_HOURS window has elapsed.
+
+    Returns: {"gap_hours": float, "last_ret": float, "last_sell": str} or None.
+    Fail-open: returns None on any error.
+    """
+    table = _TABLE.get(((market or "KR") or "KR").upper())
+    if not table or not ticker:
+        return None
+    path = _db_path()
+    try:
+        conn = sqlite3.connect(path, timeout=5)
+        try:
+            row = conn.execute(
+                f"SELECT sell_date, profit_rate FROM {table} "
+                f"WHERE ticker=? AND sell_date IS NOT NULL AND sell_date<>'' "
+                f"ORDER BY sell_date DESC LIMIT 1",
+                (ticker,),
+            ).fetchone()
+        finally:
+            conn.close()
+    except Exception:
+        return None  # fail-open
+
+    if not row or not row[0]:
+        return None
+    sell_dt = _parse_dt(row[0])
+    if sell_dt is None:
+        return None
+    try:
+        last_ret = float(row[1]) if row[1] is not None else 0.0
+    except (TypeError, ValueError):
+        last_ret = 0.0
+    if last_ret >= 0:
+        return None  # not a loss — no penalty
+    gap_hours = (datetime.now() - sell_dt).total_seconds() / 3600.0
+    if gap_hours < 0:
+        return None  # clock skew
+    return {
+        "gap_hours": round(gap_hours, 2),
+        "last_ret": last_ret,
+        "last_sell": row[0],
+    }

--- a/tests/test_journal_recent_loss_penalty.py
+++ b/tests/test_journal_recent_loss_penalty.py
@@ -1,0 +1,223 @@
+"""Tests for the recent stop-out churn-guard penalty in tracking/journal.py (KR).
+
+Cases:
+  (a) recent loss-sell within window + sector "+1" bonus -> net-negative + churn guard reason
+  (b) no recent loss -> adjustment unchanged from baseline
+  (c) JOURNAL_RECENT_LOSS_PENALTY=0 -> disabled, no change
+  (d) recent sell was a WIN -> no penalty
+  (e) real recent_loss() against a tiny seeded sqlite DB
+"""
+import importlib
+import os
+import sqlite3
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Ensure repo root is on path so reentry_cooldown can be imported
+REPO_ROOT = str(Path(__file__).resolve().parent.parent)
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_journal_manager(cursor, conn):
+    """Import JournalManager freshly and return an instance with journal enabled."""
+    # Force re-import so module-level constants re-read env
+    if "tracking.journal" in sys.modules:
+        del sys.modules["tracking.journal"]
+    # Stub out heavy deps before import
+    cores_stub = types.ModuleType("cores")
+    cores_stub.openai_error_logging = types.ModuleType("cores.openai_error_logging")
+    cores_stub.openai_error_logging.log_openai_error = lambda *a, **k: None
+    cores_stub.utils = types.ModuleType("cores.utils")
+    cores_stub.utils.parse_llm_json = lambda *a, **k: None
+    sys.modules.setdefault("cores", cores_stub)
+    sys.modules.setdefault("cores.openai_error_logging", cores_stub.openai_error_logging)
+    sys.modules.setdefault("cores.utils", cores_stub.utils)
+
+    tracking_pkg = types.ModuleType("tracking")
+    sys.modules.setdefault("tracking", tracking_pkg)
+
+    spec = importlib.util.spec_from_file_location(
+        "tracking.journal",
+        Path(REPO_ROOT) / "tracking" / "journal.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.JournalManager(cursor=cursor, conn=conn, enable_journal=True)
+
+
+def _make_db():
+    """Return (conn, cursor) for an in-memory SQLite with minimal schema."""
+    conn = sqlite3.connect(":memory:")
+    cur = conn.cursor()
+    cur.execute("""
+        CREATE TABLE trading_journal (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ticker TEXT, trade_date TEXT, profit_rate REAL,
+            buy_scenario TEXT, market TEXT
+        )
+    """)
+    cur.execute("""
+        CREATE TABLE analysis_performance_tracker (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            trigger_type TEXT, tracking_status TEXT,
+            tracked_30d_return REAL, was_traded INTEGER
+        )
+    """)
+    conn.commit()
+    return conn, cur
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+class TestJournalRecentLossPenaltyKR(unittest.TestCase):
+
+    def setUp(self):
+        self.conn, self.cur = _make_db()
+
+    def tearDown(self):
+        self.conn.close()
+        # Clean up env
+        for k in ("JOURNAL_RECENT_LOSS_HOURS", "JOURNAL_RECENT_LOSS_PENALTY"):
+            os.environ.pop(k, None)
+
+    def _get_jm(self):
+        return _make_journal_manager(self.cur, self.conn)
+
+    # (a) Recent loss within window + sector "+1" -> net-negative + churn guard reason
+    def test_recent_loss_cancels_positive_bonus(self):
+        os.environ["JOURNAL_RECENT_LOSS_HOURS"] = "48"
+        os.environ["JOURNAL_RECENT_LOSS_PENALTY"] = "2"
+        jm = self._get_jm()
+
+        # Patch reentry_cooldown.recent_loss to simulate a loss 1.3h ago
+        loss_info = {"gap_hours": 1.3, "last_ret": -7.5, "last_sell": "2026-06-30 10:00:00"}
+        with patch.dict(sys.modules, {}):
+            import reentry_cooldown
+            with patch.object(reentry_cooldown, "recent_loss", return_value=loss_info):
+                # Inject a sector bonus: insert 3 profitable trades for sector "Tech"
+                for i in range(3):
+                    self.cur.execute(
+                        "INSERT INTO trading_journal (ticker, trade_date, profit_rate, buy_scenario) "
+                        'VALUES (?, ?, ?, ?)',
+                        (f"OTHER{i}", "2026-01-01 00:00:00", 8.0, '{"sector": "Tech"}'),
+                    )
+                self.conn.commit()
+
+                adj, reasons = jm.get_score_adjustment("MU", sector="Tech")
+
+        # sector gave +1, but churn guard should yield net-negative
+        self.assertLess(adj, 0, f"Expected net-negative adjustment, got {adj}")
+        self.assertTrue(
+            any("churn guard" in r for r in reasons),
+            f"Expected churn guard reason, got {reasons}",
+        )
+
+    # (b) No recent loss -> adjustment unchanged from baseline
+    def test_no_recent_loss_no_penalty(self):
+        os.environ["JOURNAL_RECENT_LOSS_HOURS"] = "48"
+        os.environ["JOURNAL_RECENT_LOSS_PENALTY"] = "2"
+        jm = self._get_jm()
+
+        import reentry_cooldown
+        with patch.object(reentry_cooldown, "recent_loss", return_value=None):
+            adj, reasons = jm.get_score_adjustment("AAPL")
+
+        self.assertEqual(adj, 0)
+        self.assertFalse(any("churn guard" in r for r in reasons))
+
+    # (c) JOURNAL_RECENT_LOSS_PENALTY=0 -> disabled, no change
+    def test_penalty_disabled_via_env(self):
+        os.environ["JOURNAL_RECENT_LOSS_HOURS"] = "48"
+        os.environ["JOURNAL_RECENT_LOSS_PENALTY"] = "0"
+        jm = self._get_jm()
+
+        import reentry_cooldown
+        loss_info = {"gap_hours": 1.0, "last_ret": -5.0, "last_sell": "2026-06-30 10:00:00"}
+        with patch.object(reentry_cooldown, "recent_loss", return_value=loss_info):
+            adj, reasons = jm.get_score_adjustment("MU")
+
+        self.assertEqual(adj, 0)
+        self.assertFalse(any("churn guard" in r for r in reasons))
+
+    # (d) Recent sell was a WIN -> no penalty
+    def test_recent_win_no_penalty(self):
+        os.environ["JOURNAL_RECENT_LOSS_HOURS"] = "48"
+        os.environ["JOURNAL_RECENT_LOSS_PENALTY"] = "2"
+        jm = self._get_jm()
+
+        import reentry_cooldown
+        # recent_loss returns None when the sell was a win
+        with patch.object(reentry_cooldown, "recent_loss", return_value=None):
+            adj, reasons = jm.get_score_adjustment("NVDA")
+
+        self.assertEqual(adj, 0)
+        self.assertFalse(any("churn guard" in r for r in reasons))
+
+    # (e) Real recent_loss() against a seeded sqlite DB
+    def test_recent_loss_real_db(self):
+        """Exercise reentry_cooldown.recent_loss against a real seeded DB."""
+        import reentry_cooldown
+
+        with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+            db_path = f.name
+
+        try:
+            conn = sqlite3.connect(db_path)
+            conn.execute("""
+                CREATE TABLE trading_history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ticker TEXT,
+                    sell_date TEXT,
+                    profit_rate REAL
+                )
+            """)
+            # Insert a recent loss sell (2h ago)
+            from datetime import datetime, timedelta
+            sell_ts = (datetime.now() - timedelta(hours=2)).strftime("%Y-%m-%d %H:%M:%S")
+            conn.execute(
+                "INSERT INTO trading_history (ticker, sell_date, profit_rate) VALUES (?, ?, ?)",
+                ("000660", sell_ts, -7.5),
+            )
+            conn.commit()
+            conn.close()
+
+            with patch.dict(os.environ, {"REENTRY_COOLDOWN_DB": db_path}):
+                result = reentry_cooldown.recent_loss("000660", market="KR")
+
+            self.assertIsNotNone(result, "Expected a loss dict, got None")
+            self.assertAlmostEqual(result["last_ret"], -7.5)
+            self.assertLess(result["gap_hours"], 3.0)
+
+        finally:
+            os.unlink(db_path)
+
+    # Edge: loss outside the window -> still get penalised (window check is in journal, not recent_loss)
+    # but gap_hours > JOURNAL_RECENT_LOSS_HOURS -> no penalty
+    def test_loss_outside_window_no_penalty(self):
+        os.environ["JOURNAL_RECENT_LOSS_HOURS"] = "1"  # very short window
+        os.environ["JOURNAL_RECENT_LOSS_PENALTY"] = "2"
+        jm = self._get_jm()
+
+        import reentry_cooldown
+        # gap_hours=5 > window=1 -> no penalty
+        loss_info = {"gap_hours": 5.0, "last_ret": -7.5, "last_sell": "2026-06-30 05:00:00"}
+        with patch.object(reentry_cooldown, "recent_loss", return_value=loss_info):
+            adj, reasons = jm.get_score_adjustment("MU")
+
+        self.assertEqual(adj, 0)
+        self.assertFalse(any("churn guard" in r for r in reasons))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tracking/journal.py
+++ b/tracking/journal.py
@@ -7,15 +7,22 @@ Extracted from stock_tracking_agent.py for LLM context efficiency.
 
 import json
 import logging
+import os
 import re
+import sys
 import traceback
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from cores.openai_error_logging import log_openai_error
 from cores.utils import parse_llm_json
 
 logger = logging.getLogger(__name__)
+
+# Recent stop-out churn guard — env-configurable, fail-open
+JOURNAL_RECENT_LOSS_HOURS = float(os.getenv("JOURNAL_RECENT_LOSS_HOURS", "48"))
+JOURNAL_RECENT_LOSS_PENALTY = int(os.getenv("JOURNAL_RECENT_LOSS_PENALTY", "2"))
 
 
 class JournalManager:
@@ -680,6 +687,25 @@ Please review the following completed trade:
                                 f"Trigger '{trigger_type}' high win rate "
                                 f"{t['win_rate']*100:.0f}% (n={t['total']}, actual 30d data)"
                             )
+
+            # Recent stop-out churn guard (KR market)
+            # Must come last so it can cancel any net-positive bonus from above.
+            if JOURNAL_RECENT_LOSS_PENALTY > 0:
+                try:
+                    # Import reentry_cooldown from repo root (works under both runtimes)
+                    _rc_root = str(Path(__file__).resolve().parent.parent)
+                    if _rc_root not in sys.path:
+                        sys.path.insert(0, _rc_root)
+                    import reentry_cooldown as _rc
+                    _loss_info = _rc.recent_loss(ticker, market="KR")
+                    if _loss_info is not None and _loss_info["gap_hours"] <= JOURNAL_RECENT_LOSS_HOURS:
+                        adjustment = min(adjustment, 0) - JOURNAL_RECENT_LOSS_PENALTY
+                        reasons.append(
+                            f"Recent stop-out {_loss_info['gap_hours']:.1f}h ago "
+                            f"({_loss_info['last_ret']:.1f}%) — churn guard"
+                        )
+                except Exception:
+                    pass  # fail-open: never raise into the buy path
 
             return max(-3, min(3, adjustment)), reasons
 


### PR DESCRIPTION
## Motivation

MU (US) was sold at **-7.5%** then re-bought **1.3h later** with the journal returning `+1` from the sector average bonus. The self-improvement loop was actively encouraging churn: none of the existing same-stock/sector/trigger blocks in `get_score_adjustment` are recency-aware.

## Design

**Cancel positives, then penalise** — the formula is:

```python
adjustment = min(adjustment, 0) - JOURNAL_RECENT_LOSS_PENALTY
```

This guarantees a freshly stopped-out ticker is net-negative regardless of how many historical bonuses it accumulated.

### New: `reentry_cooldown.recent_loss(ticker, market)`

Thin addition to the existing cooldown module (already handles KR/US table routing, DB path resolution, `_parse_dt`). Returns `{"gap_hours", "last_ret", "last_sell"}` iff the most-recent sell was a **loss** (`last_ret < 0`), else `None`. Fail-open on any error. No new DB logic — reuses `_db_path()` / `_TABLE` / `_parse_dt` verbatim.

### Journal penalty block (both markets)

Added at the **end** of `get_score_adjustment()` in `tracking/journal.py` (KR) and `prism-us/tracking/journal.py` (US), after the existing same-stock/sector/trigger blocks:

- Calls `reentry_cooldown.recent_loss(ticker, market=<"KR"/"US">)`
- If `gap_hours <= JOURNAL_RECENT_LOSS_HOURS` (default 48h): applies penalty
- Entire block wrapped in `try/except` — **can never raise into the buy path**
- `reentry_cooldown` imported defensively with repo-root `sys.path` insertion (mirrors US file's existing `_import_from_main_cores` pattern)

### Env knobs (both markets)

| Var | Default | Effect |
|-----|---------|--------|
| `JOURNAL_RECENT_LOSS_HOURS` | `48` | Window in hours to look back |
| `JOURNAL_RECENT_LOSS_PENALTY` | `2` | Penalty magnitude; set `0` to disable |

## MU worked example

Before: sector avg profit → `adjustment = +1`, reasons = ["Technology sector average profit 6.2%"]  
After (1.3h after -7.5% stop-out): `min(+1, 0) - 2 = -2`, reasons include "Recent stop-out 1.3h ago (-7.5%) — churn guard"

## Tests

6 cases per market (12 total), all pass in separate pytest invocations:
- (a) recent loss + sector bonus → net-negative + churn guard reason  
- (b) no recent loss → unchanged  
- (c) `PENALTY=0` → disabled  
- (d) recent WIN → no penalty  
- (e) real seeded sqlite DB exercises actual `recent_loss()`  
- (f) loss outside window → no penalty  

## Scope

This is purely an **additional score nudge** — does not touch cooldown enforcement, existing same-stock/sector/trigger logic, or any order path. Defense-in-depth alongside the now-LIVE `REENTRY_COOLDOWN_LIVE` gate.