### PR TITLE
fix(subscriber-monitor): count US-format trade log lines (false zero_success CRITICAL)

### DIFF
--- a/tests/test_subscriber_healthcheck.py
+++ b/tests/test_subscriber_healthcheck.py
@@ -191,6 +191,40 @@ def test_failures_over_threshold_warn(tmp_path, tmp_state, mock_send, mock_alive
 
 
 # ---------------------------------------------------------------------------
+# TEST: US log format (regression for false zero_success CRITICAL)
+#   The subscriber emits US trades as "🇺🇸 US buy successful" / "❌ 🇺🇸 US buy
+#   failed" — NOT the KR "Actual ..." form. The old regexes matched only "Actual",
+#   so every US success/failure went uncounted and a US-only batch with a real
+#   success still tripped zero_success. These lock the US format.
+# ---------------------------------------------------------------------------
+
+def test_us_success_counted_no_alert(tmp_path, tmp_state, mock_send, mock_alive):
+    # US buy attempt + US success (real subscriber format). Success MUST be
+    # counted, so zero_success must NOT fire. (Old regex => false CRITICAL.)
+    log = _make_log(
+        f"{_ts()} INFO 🚀 Executing buy order: 🇺🇸 Alphabet Inc.(GOOGL)",
+        f"{_ts()} INFO ✅ 🇺🇸 US buy successful: Alphabet Inc.(GOOGL) - Buy completed: 2 shares",
+    )
+    mock_send = _run(log, tmp_path, tmp_state, mock_send)
+    mock_send.assert_not_called()
+
+
+def test_us_failures_over_threshold_warn(tmp_path, tmp_state, mock_send, mock_alive):
+    # 1 US success (so zero_success does not fire) + 3 US failures (meets
+    # threshold) => WARN. Old regex counted neither => would mis-fire CRITICAL.
+    log = _make_log(
+        f"{_ts()} INFO 🚀 Executing buy order: 🇺🇸 Alphabet Inc.(GOOGL)",
+        f"{_ts()} INFO ✅ 🇺🇸 US buy successful: Alphabet Inc.(GOOGL) - Buy completed: 2 shares",
+        f"{_ts()} ERROR ❌ 🇺🇸 US sell failed: Micron Technology, Inc.(MU) - MU not found in portfolio",
+        f"{_ts()} ERROR ❌ 🇺🇸 US buy failed: Micron Technology, Inc.(MU) - Buy quantity is 0",
+        f"{_ts()} ERROR ❌ 🇺🇸 US buy failed: NVIDIA Corporation(NVDA) - APBK0952 주문가능금액을 초과",
+    )
+    mock_send = _run(log, tmp_path, tmp_state, mock_send, fail_threshold=3)
+    mock_send.assert_called_once()
+    assert "WARN" in mock_send.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
 # TEST: process down -> DOWN alert
 # ---------------------------------------------------------------------------
 

--- a/tools/subscriber_healthcheck.py
+++ b/tools/subscriber_healthcheck.py
@@ -153,10 +153,16 @@ _IMPORT_FAIL_RE = re.compile(
 )
 _BUY_ATTEMPT_RE = re.compile(r"Executing buy order")
 _SELL_ATTEMPT_RE = re.compile(r"Executing sell order")
-_BUY_SUCCESS_RE = re.compile(r"Actual buy successful|Actual US buy successful")
-_SELL_SUCCESS_RE = re.compile(r"Actual sell successful|Actual US sell successful")
+# Match BOTH log formats the subscriber emits:
+#   KR: "✅ Actual buy successful"      / "❌ Actual buy failed"
+#   US: "✅ 🇺🇸 US buy successful"       / "❌ 🇺🇸 US buy failed"
+# (the older regexes only matched the KR "Actual ..." form, so every US trade —
+#  success AND failure — went uncounted, firing a false zero_success CRITICAL
+#  whenever activity was US-only. See subscriber_20260629 MU/NVDA/GOOGL batch.)
+_BUY_SUCCESS_RE = re.compile(r"(?:Actual|US) buy successful")
+_SELL_SUCCESS_RE = re.compile(r"(?:Actual|US) sell successful")
 _EXEC_ERROR_RE = re.compile(r"Error during buy execution|Error during sell execution|Actual")
-_ACTUAL_FAIL_RE = re.compile(r"❌ Actual")
+_ACTUAL_FAIL_RE = re.compile(r"(?:Actual|US) (?:buy|sell)(?: execution)? failed")
 
 
 def _resolve_log_path(log_path: str | None) -> Path | None:


### PR DESCRIPTION
## 문제
subscriber healthcheck가 `🩺 4 trade attempts, 0 successes` CRITICAL을 오발화. 실제로는 GOOGL 매수가 성공했고 나머지는 정당한 거부였음.

## 근본원인
healthcheck 정규식이 KR 포맷(`Actual buy successful`, `❌ Actual`)만 매칭. subscriber는 US를 `🇺🇸 US buy successful` / `❌ 🇺🇸 US buy failed`로 출력 → **US 거래의 성공·실패가 전부 미집계**. US-only 배치에서 실제 성공이 있어도 zero_success가 뜨고, 실패는 WARN 임계에도 안 닿음. (PR #395에서 유입)

## 수정
- `_BUY_SUCCESS_RE`/`_SELL_SUCCESS_RE`: `(?:Actual|US) buy/sell successful`
- `_ACTUAL_FAIL_RE`: `(?:Actual|US) (?:buy|sell)(?: execution)? failed`
- US 포맷 회귀 테스트 2건 추가

## 검증
- 실로그 `subscriber_20260629.log`: attempts=4 successes=1 fails=3 → zero_success **미발화**
- `pytest tests/test_subscriber_healthcheck.py` 11 passed

런타임 영향: healthcheck cron(맥)만. 매매 로직 무관.