### PR TITLE
fix(subscriber-monitor): exclude benign business rejections from alerts

### DIFF
--- a/tests/test_subscriber_healthcheck.py
+++ b/tests/test_subscriber_healthcheck.py
@@ -210,8 +210,30 @@ def test_us_success_counted_no_alert(tmp_path, tmp_state, mock_send, mock_alive)
 
 
 def test_us_failures_over_threshold_warn(tmp_path, tmp_state, mock_send, mock_alive):
-    # 1 US success (so zero_success does not fire) + 3 US failures (meets
+    # 1 US success (so zero_success does not fire) + 3 REAL US failures (meets
     # threshold) => WARN. Old regex counted neither => would mis-fire CRITICAL.
+    log = _make_log(
+        f"{_ts()} INFO 🚀 Executing buy order: 🇺🇸 Alphabet Inc.(GOOGL)",
+        f"{_ts()} INFO ✅ 🇺🇸 US buy successful: Alphabet Inc.(GOOGL) - Buy completed: 2 shares",
+        f"{_ts()} ERROR ❌ 🇺🇸 US buy failed: Apple Inc.(AAPL) - Buy order failed: APBK1999 시스템 오류",
+        f"{_ts()} ERROR ❌ 🇺🇸 US sell failed: Tesla, Inc.(TSLA) - Connection timeout to KIS",
+        f"{_ts()} ERROR ❌ 🇺🇸 US buy failed: Amazon.com, Inc.(AMZN) - Unexpected broker response",
+    )
+    mock_send = _run(log, tmp_path, tmp_state, mock_send, fail_threshold=3)
+    mock_send.assert_called_once()
+    assert "WARN" in mock_send.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# TEST: benign business rejections must NOT alert (alert-fatigue guard)
+#   "not found in portfolio" (drift), "quantity is 0" (sub-share budget),
+#   "주문가능금액" (no buying power) are expected outcomes, not faults. With a
+#   success present (so zero_success is moot) AND in an all-rejection batch.
+# ---------------------------------------------------------------------------
+
+def test_benign_rejections_no_alert(tmp_path, tmp_state, mock_send, mock_alive):
+    # 1 success + 3 benign rejections meeting the numeric threshold => still NO
+    # WARN, because benign rejections are excluded from actual_failures.
     log = _make_log(
         f"{_ts()} INFO 🚀 Executing buy order: 🇺🇸 Alphabet Inc.(GOOGL)",
         f"{_ts()} INFO ✅ 🇺🇸 US buy successful: Alphabet Inc.(GOOGL) - Buy completed: 2 shares",
@@ -220,8 +242,20 @@ def test_us_failures_over_threshold_warn(tmp_path, tmp_state, mock_send, mock_al
         f"{_ts()} ERROR ❌ 🇺🇸 US buy failed: NVIDIA Corporation(NVDA) - APBK0952 주문가능금액을 초과",
     )
     mock_send = _run(log, tmp_path, tmp_state, mock_send, fail_threshold=3)
-    mock_send.assert_called_once()
-    assert "WARN" in mock_send.call_args[0][0]
+    mock_send.assert_not_called()
+
+
+def test_all_benign_zero_success_no_critical(tmp_path, tmp_state, mock_send, mock_alive):
+    # Account out of cash: every buy attempt benign-rejected, zero successes.
+    # This is an operational state, NOT a broken subscriber => no CRITICAL.
+    log = _make_log(
+        f"{_ts()} INFO 🚀 Executing buy order: 🇺🇸 Micron Technology, Inc.(MU)",
+        f"{_ts()} ERROR ❌ 🇺🇸 US buy failed: Micron Technology, Inc.(MU) - Buy quantity is 0",
+        f"{_ts()} INFO 🚀 Executing buy order: 🇺🇸 NVIDIA Corporation(NVDA)",
+        f"{_ts()} ERROR ❌ 🇺🇸 US buy failed: NVIDIA Corporation(NVDA) - APBK0952 주문가능금액을 초과",
+    )
+    mock_send = _run(log, tmp_path, tmp_state, mock_send)
+    mock_send.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tools/subscriber_healthcheck.py
+++ b/tools/subscriber_healthcheck.py
@@ -163,6 +163,15 @@ _BUY_SUCCESS_RE = re.compile(r"(?:Actual|US) buy successful")
 _SELL_SUCCESS_RE = re.compile(r"(?:Actual|US) sell successful")
 _EXEC_ERROR_RE = re.compile(r"Error during buy execution|Error during sell execution|Actual")
 _ACTUAL_FAIL_RE = re.compile(r"(?:Actual|US) (?:buy|sell)(?: execution)? failed")
+# Benign business rejections — expected outcomes, NOT system faults, so they must
+# not trip WARN/CRITICAL (they only cause alert fatigue):
+#   - "not found in portfolio": sell signal for a stock the subscriber doesn't hold
+#     (portfolio drift) — nothing to sell, correct no-op.
+#   - "quantity is 0": per-trade budget too small for even one share.
+#   - "주문가능금액": insufficient buying power (KIS APBK0952 등) — account out of cash.
+# These are counted separately (benign_rejections) for visibility but excluded from
+# the failure thresholds and from the zero-success fault check.
+_BENIGN_FAIL_RE = re.compile(r"not found in portfolio|quantity is 0|주문가능금액")
 
 
 def _resolve_log_path(log_path: str | None) -> Path | None:
@@ -205,6 +214,7 @@ def _scan_log(log_path: Path, window_min: int, fail_threshold: int) -> dict:
         "sell_successes": 0,
         "exec_errors": 0,
         "actual_failures": 0,
+        "benign_rejections": 0,
         "lines_scanned": 0,
     }
     try:
@@ -225,7 +235,10 @@ def _scan_log(log_path: Path, window_min: int, fail_threshold: int) -> dict:
                 if _SELL_SUCCESS_RE.search(line):
                     counts["sell_successes"] += 1
                 if _ACTUAL_FAIL_RE.search(line):
-                    counts["actual_failures"] += 1
+                    if _BENIGN_FAIL_RE.search(line):
+                        counts["benign_rejections"] += 1
+                    else:
+                        counts["actual_failures"] += 1
                 if _EXEC_ERROR_RE.search(line) and "Error during" in line:
                     counts["exec_errors"] += 1
     except Exception as exc:
@@ -297,7 +310,13 @@ def run_check(
         key = "zero_success"
         total_attempts = counts["buy_attempts"] + counts["sell_attempts"]
         total_successes = counts["buy_successes"] + counts["sell_successes"]
-        zero_success_critical = total_attempts > 0 and total_successes == 0
+        # Benign rejections (no buying power / drift / sub-share budget) are not a
+        # fault: an account that is simply out of cash will log attempts with zero
+        # successes, but that is an operational state, not a broken subscriber. Only
+        # flag zero-success when ≥1 attempt was NOT explained by a benign rejection
+        # (i.e. a real failure or an unexplained/silent no-fill).
+        non_benign_attempts = total_attempts - counts["benign_rejections"]
+        zero_success_critical = total_successes == 0 and non_benign_attempts > 0
         if zero_success_critical:
             if _should_alert(state, key, realert_min):
                 msg = (
@@ -324,7 +343,8 @@ def run_check(
                 msg = (
                     f"{prefix} ⚠️ WARN: execution failures in last {window_min} min: "
                     f"actual_failures={counts['actual_failures']}, exec_errors={counts['exec_errors']} "
-                    f"(threshold={fail_threshold}). Log: {resolved_log}"
+                    f"(benign_rejections={counts['benign_rejections']} excluded; "
+                    f"threshold={fail_threshold}). Log: {resolved_log}"
                 )
                 send_alert(msg, dry_run=dry_run)
                 _record_alert(state, key)
@@ -340,7 +360,7 @@ def run_check(
     status = "DOWN" if not alive else "ALIVE"
     print(
         f"[subscriber-health] status={status} alerts={alerts_sent} clears={clears_sent} "
-        + (f"log_lines={counts['lines_scanned']}" if resolved_log else "no_log")
+        + (f"log_lines={counts['lines_scanned']} benign={counts['benign_rejections']}" if resolved_log else "no_log")
     )
     return 0
 


### PR DESCRIPTION
## 배경
PR #397로 모니터가 US 거래를 제대로 세기 시작하자, 어제 US 배치의 양성 거부 3건(MU 미보유 드리프트 / MU 예산초과 / NVDA 현금부족)이 WARN으로 떴음. 전부 정상 거부지 장애 아님 → 알람 피로.

## 변경
- `_BENIGN_FAIL_RE`: `not found in portfolio` / `quantity is 0` / `주문가능금액` → `benign_rejections`로 분리, `actual_failures`에서 제외
- `zero_success`: 양성거부로만 설명되는 0성공(예: 현금소진)은 운영상태지 장애 아님 → **비양성 시도 ≥1일 때만** CRITICAL
- WARN 메시지·요약 라인에 benign 노출

## 검증
- `pytest` 13 passed (실패→WARN / 양성전용→무알람 / 전부양성+0성공→무CRITICAL)
- 실로그 0629: actual_failures=0, benign=3 → **무알람**

런타임: healthcheck cron(맥)만. 매매 무관.