### PR TITLE
perf(kr-tracking): skip scenario LLM for held stocks that can't pyramid-add

### DIFF
--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -77,6 +77,7 @@ from tracking import (
     default_scenario,
     get_existing_position_for_ticker,
     evaluate_pyramid_add_gate,
+    pyramid_add_possible_ignoring_regime,
     compute_fractional_sell_quantity,
     JournalManager,
     CompressionManager,
@@ -516,6 +517,46 @@ class StockTrackingAgent:
         Returns:
             Dict: Trading decision result
         """
+        # Cheap pre-gate: skip the per-stock scenario LLM for a held stock that
+        # cannot pyramid-add (#288) regardless of regime. The full add-gate requires
+        # (row_count < max) AND (profit >= min) — both regime-independent and computed
+        # from DB + price only. When they fail, the full path returns "Already holding"
+        # anyway, so we return that here without paying for the ~2.5min scenario LLM.
+        # Winners with room fall through to full analysis (the LLM supplies
+        # market_condition for the regime check), so pyramiding is fully preserved.
+        # Fail-open: any error in the cheap check falls back to full analysis.
+        try:
+            pre_ticker, pre_company = await self._extract_ticker_info(pdf_report_path)
+        except Exception:
+            pre_ticker, pre_company = None, None
+        if pre_ticker and await self._is_ticker_in_holdings(pre_ticker):
+            try:
+                account_key, _ = self._account_scope()
+                existing = get_existing_position_for_ticker(self.cursor, pre_ticker, account_key=account_key)
+                pre_price = await self._get_current_stock_price(pre_ticker)
+                can_add, why = pyramid_add_possible_ignoring_regime(
+                    existing_avg_buy_price=existing.get("avg_buy_price", 0.0),
+                    current_price=pre_price,
+                    existing_row_count=existing.get("row_count", 0),
+                )
+            except Exception as e:
+                logger.warning(
+                    f"{pre_ticker} pyramid pre-gate check failed ({e}); running full analysis"
+                )
+                can_add = True  # fail-open: never skip analysis on uncertainty
+            if not can_add:
+                logger.info(
+                    f"{pre_ticker}({pre_company}) already in holdings — pyramid pre-gate "
+                    f"blocked ({why}); skipping scenario LLM"
+                )
+                return {
+                    "success": True,
+                    "decision": "Already holding",
+                    "ticker": pre_ticker,
+                    "company_name": pre_company,
+                    "current_price": pre_price,
+                }
+
         analysis_result = await self._analyze_report_core(pdf_report_path)
         if not analysis_result.get("success", False):
             return analysis_result

--- a/tests/test_skip_llm_held_nonpyramid.py
+++ b/tests/test_skip_llm_held_nonpyramid.py
@@ -1,0 +1,125 @@
+"""
+tests/test_skip_llm_held_nonpyramid.py
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Tests for the "skip scenario LLM for a held stock that cannot pyramid-add" fast
+path (#288-preserving latency optimization).
+
+Two layers:
+  1. tracking.helpers.pyramid_add_possible_ignoring_regime — the regime-independent
+     cheap pre-gate, and that evaluate_pyramid_add_gate still delegates to it
+     (behavior preserved for the full gate).
+  2. StockTrackingAgent.analyze_report — a held stock that fails the cheap pre-gate
+     returns "Already holding" WITHOUT calling the expensive _analyze_report_core
+     (LLM); a held winner with room, and a non-held stock, still run it.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import stock_tracking_agent as sta_mod
+from stock_tracking_agent import StockTrackingAgent
+from tracking.helpers import (
+    pyramid_add_possible_ignoring_regime,
+    evaluate_pyramid_add_gate,
+    PYRAMID_MIN_PROFIT_PCT,
+    PYRAMID_MAX_ROWS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: cheap pre-gate semantics
+# ---------------------------------------------------------------------------
+
+def test_pregate_winner_with_room_allowed():
+    ok, _ = pyramid_add_possible_ignoring_regime(100.0, 110.0, 1)
+    assert ok is True
+
+
+def test_pregate_flat_or_underwater_blocked():
+    ok, why = pyramid_add_possible_ignoring_regime(100.0, 100.0, 1)
+    assert ok is False and "profit" in why
+    ok2, _ = pyramid_add_possible_ignoring_regime(100.0, 90.0, 1)
+    assert ok2 is False
+
+
+def test_pregate_max_rows_blocked():
+    ok, why = pyramid_add_possible_ignoring_regime(100.0, 200.0, PYRAMID_MAX_ROWS)
+    assert ok is False and "row count" in why
+
+
+def test_pregate_insufficient_price_data_blocked():
+    ok, why = pyramid_add_possible_ignoring_regime(0.0, 110.0, 1)
+    assert ok is False and "insufficient" in why
+
+
+def test_full_gate_still_delegates_and_preserves_outcomes():
+    # regime blocked even when the cheap conditions pass
+    ok, why = evaluate_pyramid_add_gate("sideways", 100.0, 110.0, 1)
+    assert ok is False and "regime" in why
+    # allowed regime + winner + room -> allowed, reason preserves the legacy shape
+    ok2, why2 = evaluate_pyramid_add_gate("strong_bull", 100.0, 110.0, 1)
+    assert ok2 is True
+    assert why2.startswith("add allowed (regime=strong_bull,")
+    # allowed regime but cheap condition fails -> blocked with the cheap reason
+    ok3, why3 = evaluate_pyramid_add_gate("strong_bull", 100.0, 110.0, PYRAMID_MAX_ROWS)
+    assert ok3 is False and "row count" in why3
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: analyze_report skips the LLM for held non-pyramid stocks
+# ---------------------------------------------------------------------------
+
+def _make_agent(*, holding: bool, position: dict, price: float):
+    agent = StockTrackingAgent.__new__(StockTrackingAgent)
+    agent.cursor = MagicMock()
+    agent._extract_ticker_info = AsyncMock(return_value=("009150", "삼성전기"))
+    agent._is_ticker_in_holdings = AsyncMock(return_value=holding)
+    agent._account_scope = MagicMock(return_value=("vps:kr-primary:01", None))
+    agent._get_current_stock_price = AsyncMock(return_value=price)
+    # The expensive call we want to avoid for held non-pyramid stocks:
+    agent._analyze_report_core = AsyncMock(return_value={
+        "success": True, "ticker": "009150", "company_name": "삼성전기",
+        "current_price": price, "scenario": {"market_condition": "strong_bull"},
+        "decision": "Enter", "sector": "IT",
+    })
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_held_nonpyramid_skips_llm(monkeypatch):
+    # Held + flat (profit 0%) => cannot pyramid => must NOT call _analyze_report_core.
+    monkeypatch.setattr(sta_mod, "get_existing_position_for_ticker",
+                        lambda *a, **k: {"avg_buy_price": 100.0, "row_count": 1})
+    agent = _make_agent(holding=True, position={"avg_buy_price": 100.0, "row_count": 1}, price=100.0)
+    result = await agent.analyze_report("reports/009150_삼성전기_20260630_morning.pdf")
+    assert result["decision"] == "Already holding"
+    assert result["ticker"] == "009150"
+    agent._analyze_report_core.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_held_pyramid_candidate_runs_llm(monkeypatch):
+    # Held + winner (+10%) + room => pyramid candidate => MUST run _analyze_report_core.
+    monkeypatch.setattr(sta_mod, "get_existing_position_for_ticker",
+                        lambda *a, **k: {"avg_buy_price": 100.0, "row_count": 1})
+    agent = _make_agent(holding=True, position={"avg_buy_price": 100.0, "row_count": 1}, price=110.0)
+    await agent.analyze_report("reports/009150_삼성전기_20260630_morning.pdf")
+    agent._analyze_report_core.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_not_held_runs_llm(monkeypatch):
+    # Not held => normal full analysis => MUST run _analyze_report_core.
+    monkeypatch.setattr(sta_mod, "get_existing_position_for_ticker",
+                        lambda *a, **k: {"avg_buy_price": 0.0, "row_count": 0})
+    agent = _make_agent(holding=False, position={}, price=110.0)
+    await agent.analyze_report("reports/009150_삼성전기_20260630_morning.pdf")
+    agent._analyze_report_core.assert_awaited_once()

--- a/tracking/__init__.py
+++ b/tracking/__init__.py
@@ -23,6 +23,7 @@ from tracking.helpers import (
     default_scenario,
     get_existing_position_for_ticker,
     evaluate_pyramid_add_gate,
+    pyramid_add_possible_ignoring_regime,
     compute_fractional_sell_quantity,
 )
 from tracking.trading_ops import (
@@ -54,6 +55,7 @@ __all__ = [
     "default_scenario",
     "get_existing_position_for_ticker",
     "evaluate_pyramid_add_gate",
+    "pyramid_add_possible_ignoring_regime",
     "compute_fractional_sell_quantity",
     # Trading ops
     "analyze_sell_decision",

--- a/tracking/helpers.py
+++ b/tracking/helpers.py
@@ -305,6 +305,35 @@ def _regime_label(market_condition: str | None) -> str:
     return text
 
 
+def pyramid_add_possible_ignoring_regime(
+    existing_avg_buy_price: float,
+    current_price: float,
+    existing_row_count: int,
+    min_profit_pct: float = PYRAMID_MIN_PROFIT_PCT,
+    max_rows: int = PYRAMID_MAX_ROWS,
+) -> Tuple[bool, str]:
+    """Regime-independent necessary conditions for a pyramiding add (#288).
+
+    These are exactly conditions (2) row-count and (3) aggregate-profit of
+    ``evaluate_pyramid_add_gate`` — the parts that need NO LLM output (computed
+    from the DB position + current price only). If this returns False, the full
+    gate can never allow an add regardless of regime, so a held stock can be
+    skipped BEFORE its per-stock scenario LLM runs, with the same end result.
+    Single source of truth: ``evaluate_pyramid_add_gate`` delegates here.
+    """
+    if existing_row_count >= max_rows:
+        return False, f"row count {existing_row_count} >= max {max_rows}"
+
+    if not existing_avg_buy_price or existing_avg_buy_price <= 0 or not current_price or current_price <= 0:
+        return False, "insufficient price data for profit check"
+
+    profit_pct = (current_price - existing_avg_buy_price) / existing_avg_buy_price * 100.0
+    if profit_pct < min_profit_pct:
+        return False, f"profit {profit_pct:.2f}% < required {min_profit_pct:.1f}%"
+
+    return True, f"profit={profit_pct:.2f}%, rows={existing_row_count}"
+
+
 def evaluate_pyramid_add_gate(
     market_condition: str | None,
     existing_avg_buy_price: float,
@@ -327,17 +356,15 @@ def evaluate_pyramid_add_gate(
     if regime not in PYRAMID_ALLOWED_REGIMES:
         return False, f"regime '{regime or 'unknown'}' not in {PYRAMID_ALLOWED_REGIMES}"
 
-    if existing_row_count >= max_rows:
-        return False, f"row count {existing_row_count} >= max {max_rows}"
+    # Conditions (2) and (3) are regime-independent — delegate so the cheap
+    # pre-gate that skips the scenario LLM stays in lock-step with this gate.
+    ok, reason = pyramid_add_possible_ignoring_regime(
+        existing_avg_buy_price, current_price, existing_row_count, min_profit_pct, max_rows
+    )
+    if not ok:
+        return False, reason
 
-    if not existing_avg_buy_price or existing_avg_buy_price <= 0 or not current_price or current_price <= 0:
-        return False, "insufficient price data for profit check"
-
-    profit_pct = (current_price - existing_avg_buy_price) / existing_avg_buy_price * 100.0
-    if profit_pct < min_profit_pct:
-        return False, f"profit {profit_pct:.2f}% < required {min_profit_pct:.1f}%"
-
-    return True, f"add allowed (regime={regime}, profit={profit_pct:.2f}%, rows={existing_row_count})"
+    return True, f"add allowed (regime={regime}, {reason})"
 
 
 def compute_fractional_sell_quantity(total_quantity: int, remaining_rows: int) -> int:


### PR DESCRIPTION
## 배경 (실측)
오늘(06-30) 아침 KR 배치 실측: 리포트→매매→포트폴리오 메시지 약 34분. 매수 루프가 분석 픽 전 종목에 시나리오 LLM(~2.5분)을 돌리는데, **이미 보유중인 픽도 LLM을 다 돌린 뒤 add-gate에서 'Already holding'으로 버림**(삼성전기 ~2.7분 낭비).

## 변경 (동작 보존)
`analyze_report`가 **LLM 전에** 싼 사전게이트를 봄: 보유종목이면 피라미딩 add-gate(#288)의 **regime-독립 필요조건**(row수<최대 AND 수익률≥기준)을 DB+현재가만으로 평가. 실패하면 어차피 regime 무관하게 추가매수 불가라, LLM 없이 동일한 'Already holding' 반환. **수익 중 + row 여유(피라미딩 후보)는 그대로 LLM 실행** → regime 확인까지 정상, 피라미딩 100% 보존. 오류 시 fail-open(전체 분석).

## 핵심: 동작 보존
지금도 이런 보유 비후보 종목은 LLM 돌린 뒤 'Already holding'으로 동일 처리됨 → **결과·텔레그램 메시지 동일, 낭비된 LLM 콜만 제거.**

## 변경 파일
- `tracking/helpers.py`: `pyramid_add_possible_ignoring_regime`(조건 2·3 단일소스), `evaluate_pyramid_add_gate`가 위임(출력 바이트 동일 검증).
- `stock_tracking_agent.analyze_report`: 보유 사전스킵.
- `tests/test_skip_llm_held_nonpyramid.py`: 사전게이트 매트릭스 + 보유비후보→LLM스킵 / 보유후보·미보유→LLM실행.

## 검증
- 신규 7 + 기존 #288 게이트 테스트 통과. `evaluate_pyramid_add_gate('strong_bull',100,110,1)`='add allowed (regime=strong_bull, profit=10.00%, rows=1)'(원본 동일).
- ⚠️ 무관 사전존재 실패 2건(`test_agent` async수집, `masks_sold` 테스트픽스처 `id` 컬럼 누락)은 본 변경과 무관.

효과: 분석 픽이 보유종목과 겹칠 때 종목당 ~2.5분 단축(오늘이면 메시지 ~2.7분 빨라짐). 범위: KR. US는 동일 패턴 후속 가능.