### PR TITLE
fix(subscriber-monitor): treat 'Order window unavailable' as benign rejection

### DIFF
--- a/tests/test_subscriber_healthcheck.py
+++ b/tests/test_subscriber_healthcheck.py
@@ -258,6 +258,21 @@ def test_all_benign_zero_success_no_critical(tmp_path, tmp_state, mock_send, moc
     mock_send.assert_not_called()
 
 
+def test_order_window_and_drift_no_critical(tmp_path, tmp_state, mock_send, mock_alive):
+    # Real 2026-06-30 case: a late-batch sell hits portfolio drift and a buy lands
+    # in the KST 15:30–16:00 dead zone ("Order window unavailable"). Both are
+    # deterministic both-sides timing/operational rejections, so zero successes
+    # here must NOT raise CRITICAL.
+    log = _make_log(
+        f"{_ts()} INFO 🚀 Executing sell order: 🇰🇷 삼성E&A(028050)",
+        f"{_ts()} ERROR ❌ Actual sell failed: 삼성E&A(028050) - Stock 028050 not found in portfolio",
+        f"{_ts()} INFO 🚀 Executing buy order: 🇰🇷 이오테크닉스(039030)",
+        f"{_ts()} ERROR ❌ Actual buy failed: 이오테크닉스(039030) - Buy failed: Order window unavailable in KST (reserved orders are accepted 16:00~23:40 and 00:10~07:30)",
+    )
+    mock_send = _run(log, tmp_path, tmp_state, mock_send)
+    mock_send.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # TEST: process down -> DOWN alert
 # ---------------------------------------------------------------------------

--- a/tools/subscriber_healthcheck.py
+++ b/tools/subscriber_healthcheck.py
@@ -169,9 +169,12 @@ _ACTUAL_FAIL_RE = re.compile(r"(?:Actual|US) (?:buy|sell)(?: execution)? failed"
 #     (portfolio drift) — nothing to sell, correct no-op.
 #   - "quantity is 0": per-trade budget too small for even one share.
 #   - "주문가능금액": insufficient buying power (KIS APBK0952 등) — account out of cash.
+#   - "Order window unavailable": signal arrived in the post-close / pre-reserved-window
+#     dead zone (KST 15:30–16:00). The publisher hits the SAME KIS window rule and also
+#     fails, so it is a deterministic both-sides timing limitation, not a subscriber fault.
 # These are counted separately (benign_rejections) for visibility but excluded from
 # the failure thresholds and from the zero-success fault check.
-_BENIGN_FAIL_RE = re.compile(r"not found in portfolio|quantity is 0|주문가능금액")
+_BENIGN_FAIL_RE = re.compile(r"not found in portfolio|quantity is 0|주문가능금액|Order window unavailable")
 
 
 def _resolve_log_path(log_path: str | None) -> Path | None:


### PR DESCRIPTION
## 배경
06-30 15:32(마감 후 데드존) 매수가 `Order window unavailable`로 실패 → zero_success CRITICAL이 떴고 07-01 05:15까지 stale 재발. db-server 확인 결과 **퍼블리셔도 동일 실패 + 미보유 = 패리티(드리프트 아님)**. 결정적·양쪽동일·예상되는 타이밍 거부.

## 변경
`_BENIGN_FAIL_RE`에 `Order window unavailable` 추가 → benign_rejections로 분류, WARN/zero_success에서 제외 (#398과 동일 패턴).

## 검증
- 14 tests pass (실 시나리오 회귀: 매도 드리프트 + 데드존 매수 → 무알람)
- 실로그 0630: actual_failures=0 (이전엔 stale CRITICAL)

런타임: healthcheck cron(맥)만. 매매 무관.