### PR TITLE
fix(us-sell): guard batch sell against stale-snapshot double-publish (Layer 2)

### DIFF
--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -2202,9 +2202,33 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                 should_sell, sell_reason = await self._analyze_sell_decision(stock)
 
                 if should_sell:
+                    acct_key = stock.get("account_key")
+
+                    # ── Layer 2: fresh holding re-check (cross-cycle stale-snapshot guard) ──
+                    # update_holdings iterates a holdings snapshot taken at pipeline
+                    # start (~40 min earlier). A concurrent intraday loop
+                    # (loop_a_hardstop / loop_b_trend_exit, both */10 on cron) may have
+                    # already closed this position minutes ago. Re-read the live DB row
+                    # right before acting; if it is gone, abort THIS ticker entirely —
+                    # no real order, NO signal publish, no journal — so subscribers never
+                    # receive a duplicate/ghost SELL.
+                    # Incident 2026-07-01: loop_a stop-sold MU 23:50 (+published SELL),
+                    # then the batch re-hit the same stop off its stale snapshot 23:54,
+                    # its real sell no-op'd ("not found in portfolio") yet it still
+                    # published a 2nd SELL 23:55. This guard closes that gap at the source.
+                    self.conn.commit()  # end any read snapshot so other-process commits are visible (WAL)
+                    if get_us_existing_position_for_ticker(
+                        self.cursor, ticker, account_key=acct_key
+                    ).get("row_count", 0) == 0:
+                        logger.warning(
+                            f"[LAYER2][US] {ticker} already closed by another cycle "
+                            f"(stale snapshot) — skipping sell + signal publish"
+                        )
+                        continue
+                    # ── end Layer 2 guard ──
+
                     # Pyramiding (#288): compute remaining row count N for this
                     # (ticker, account) BEFORE any DB row is deleted by sell_stock.
-                    acct_key = stock.get("account_key")
                     remaining_rows = get_us_existing_position_for_ticker(
                         self.cursor, ticker, account_key=acct_key
                     ).get("row_count", 1)

--- a/tests/test_layer2_stale_snapshot_guard.py
+++ b/tests/test_layer2_stale_snapshot_guard.py
@@ -1,0 +1,200 @@
+"""
+Layer 2 — cross-cycle stale-snapshot sell guard (US).
+
+Regression test for the 2026-07-01 MU double-SELL incident:
+  loop_a_hardstop stop-sold MU 23:50 (real close + published SELL), then the
+  morning batch's update_holdings re-hit the same mechanical stop off its
+  pipeline-start snapshot 23:54, its real sell no-op'd ("not found in
+  portfolio") yet it STILL published a 2nd SELL 23:55 -> subscribers saw 2 sells.
+
+The guard (us_stock_tracking_agent.update_holdings, top of `if should_sell:`)
+re-reads the live us_stock_holdings row right before acting; if the position is
+gone (already closed by another cycle) it aborts the ticker entirely — no order,
+no signal publish, no journal. Its decision predicate is exactly:
+
+    get_us_existing_position_for_ticker(cur, ticker, account_key).get("row_count", 0) == 0
+
+These are pure-unit + temp-SQLite tests. They do NOT touch any live DB and mirror
+the style of tests/test_issue_288_pyramiding.py.
+
+Run:
+    python3 tests/test_layer2_stale_snapshot_guard.py
+"""
+
+import importlib.util
+import os
+import re
+import sqlite3
+import sys
+import tempfile
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+
+def _load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_us_db_schema = _load_module(
+    "us_db_schema_for_layer2_test",
+    os.path.join(PROJECT_ROOT, "prism-us", "tracking", "db_schema.py"),
+)
+get_us_existing_position_for_ticker = _us_db_schema.get_us_existing_position_for_ticker
+TABLE_US_STOCK_HOLDINGS = _us_db_schema.TABLE_US_STOCK_HOLDINGS
+
+_AGENT_PATH = os.path.join(PROJECT_ROOT, "prism-us", "us_stock_tracking_agent.py")
+
+_PASS = 0
+_FAIL = 0
+
+
+def check(cond, msg):
+    global _PASS, _FAIL
+    if cond:
+        _PASS += 1
+        print(f"  PASS: {msg}")
+    else:
+        _FAIL += 1
+        print(f"  FAIL: {msg}")
+
+
+def _insert_holding(cur, account_key, ticker, buy_price):
+    cur.execute(
+        """INSERT INTO us_stock_holdings
+            (account_key, account_name, ticker, company_name, buy_price, buy_date)
+            VALUES (?, 'acct', ?, ?, ?, '2026-07-01 09:00:00')""",
+        (account_key, ticker, f"{ticker} Inc", buy_price),
+    )
+
+
+def _guard_would_skip(cur, ticker, account_key):
+    """Exact predicate used by the Layer 2 guard in update_holdings."""
+    return get_us_existing_position_for_ticker(
+        cur, ticker, account_key=account_key
+    ).get("row_count", 0) == 0
+
+
+# ── Test 1: snapshot still valid -> guard proceeds; concurrent close -> guard skips ──
+def test_guard_detects_concurrent_close():
+    print("\n[Test 1] Guard detects a position closed by another cycle after snapshot")
+    fd, path = tempfile.mkstemp(suffix=".sqlite")
+    os.close(fd)
+    try:
+        conn = sqlite3.connect(path)
+        cur = conn.cursor()
+        cur.execute(TABLE_US_STOCK_HOLDINGS)
+        conn.commit()
+
+        # Pipeline-start snapshot: MU is held (1 clean row).
+        _insert_holding(cur, "ACC1", "MU", 1053.54)
+        conn.commit()
+        check(not _guard_would_skip(cur, "MU", "ACC1"),
+              "MU present -> guard proceeds (row_count=1, no skip)")
+
+        # Another cycle (loop_a_hardstop) closes MU between snapshot and the batch's turn.
+        cur.execute("DELETE FROM us_stock_holdings WHERE ticker='MU' AND account_key='ACC1'")
+        conn.commit()
+        check(_guard_would_skip(cur, "MU", "ACC1"),
+              "MU closed by another cycle -> guard SKIPS (row_count=0): no 2nd SELL")
+        conn.close()
+    finally:
+        os.remove(path)
+
+
+# ── Test 2: guard is account-scoped (does not skip a different account's position) ──
+def test_guard_is_account_scoped():
+    print("\n[Test 2] Guard is account-scoped")
+    fd, path = tempfile.mkstemp(suffix=".sqlite")
+    os.close(fd)
+    try:
+        conn = sqlite3.connect(path)
+        cur = conn.cursor()
+        cur.execute(TABLE_US_STOCK_HOLDINGS)
+        conn.commit()
+
+        _insert_holding(cur, "ACC1", "MU", 1053.54)
+        _insert_holding(cur, "ACC2", "MU", 1050.00)
+        conn.commit()
+
+        # Only ACC1's MU is closed by another cycle.
+        cur.execute("DELETE FROM us_stock_holdings WHERE ticker='MU' AND account_key='ACC1'")
+        conn.commit()
+        check(_guard_would_skip(cur, "MU", "ACC1"), "ACC1 MU gone -> skip")
+        check(not _guard_would_skip(cur, "MU", "ACC2"), "ACC2 MU still held -> proceed")
+        conn.close()
+    finally:
+        os.remove(path)
+
+
+# ── Test 3: pyramided (multi-row) position still counts as held ────────────────
+def test_guard_multirow_still_held():
+    print("\n[Test 3] Multi-row (pyramided) position is still 'held' -> guard proceeds")
+    fd, path = tempfile.mkstemp(suffix=".sqlite")
+    os.close(fd)
+    try:
+        conn = sqlite3.connect(path)
+        cur = conn.cursor()
+        cur.execute(TABLE_US_STOCK_HOLDINGS)
+        conn.commit()
+        for bp in (1053.54, 1060.00):
+            _insert_holding(cur, "ACC1", "MU", bp)
+        conn.commit()
+        check(not _guard_would_skip(cur, "MU", "ACC1"), "2 rows -> proceed")
+
+        # Only one row removed (partial) -> still held.
+        cur.execute("SELECT id FROM us_stock_holdings WHERE ticker='MU' ORDER BY id LIMIT 1")
+        one_id = cur.fetchone()[0]
+        cur.execute("DELETE FROM us_stock_holdings WHERE id=?", (one_id,))
+        conn.commit()
+        check(not _guard_would_skip(cur, "MU", "ACC1"), "1 row remains -> still proceed")
+
+        # Last row removed -> now closed -> skip.
+        cur.execute("DELETE FROM us_stock_holdings WHERE ticker='MU' AND account_key='ACC1'")
+        conn.commit()
+        check(_guard_would_skip(cur, "MU", "ACC1"), "all rows gone -> skip")
+        conn.close()
+    finally:
+        os.remove(path)
+
+
+# ── Test 4: the guard actually exists in the source with the abort semantics ───
+def test_guard_present_in_source():
+    print("\n[Test 4] Guard is wired into update_holdings source")
+    with open(_AGENT_PATH, "r", encoding="utf-8") as fh:
+        src = fh.read()
+    check("[LAYER2][US]" in src, "LAYER2 guard log marker present")
+    # The guard must `continue` (abort the ticker) on row_count == 0, and must sit
+    # BEFORE the sell-signal publish so no ghost SELL is emitted.
+    m = re.search(r"# ── Layer 2:.*?# ── end Layer 2 guard ──", src, re.DOTALL)
+    check(m is not None, "Layer 2 guard block delimited in source")
+    if m:
+        block = m.group(0)
+        check('row_count", 0) == 0' in block, "guard predicate: row_count == 0")
+        check("continue" in block, "guard aborts ticker via continue (no order/publish/journal)")
+    guard_idx = src.find("[LAYER2][US]")
+    publish_idx = src.find("from messaging.redis_signal_publisher import publish_sell_signal")
+    check(0 < guard_idx < publish_idx,
+          "guard runs BEFORE the sell-signal publish (kills duplicate at source)")
+
+
+def _run():
+    test_guard_detects_concurrent_close()
+    test_guard_is_account_scoped()
+    test_guard_multirow_still_held()
+    test_guard_present_in_source()
+    print(f"\n===== RESULT: {_PASS} passed, {_FAIL} failed =====")
+    return _FAIL
+
+
+# pytest entrypoints
+def test_layer2_guard_pytest():
+    assert _run() == 0
+
+
+if __name__ == "__main__":
+    sys.exit(1 if _run() else 0)


### PR DESCRIPTION
## 문제 (2026-07-01 MU 중복 매도 사고)

퍼블리셔(db-server)에서 MU에 **매도 2 + 매수 1** 신호가 발행돼 구독자에게 그대로 전파됨.

**타임라인 (KST):**
- `23:50:09` `loop_a_hardstop`(10분 배치) → MU -8.37%, stop-loss 이탈 → 실매도 체결 + **SELL 신호 #1**
- `23:54:40` `morning 오케스트레이터`(23:15 시작) → **23:15 스냅샷** 기준 MU를 아직 보유로 판단 → 동일 mechanical stop → 실매도는 `not found in portfolio` 실패했지만 **SELL 신호 #2 발행** (발행이 실체결과 분리됨)
- `23:58:37` 오케스트레이터 매수 패스가 MU 신규 픽 재매수 → **BUY 신호**

## 근본 원인

`update_holdings`가 파이프라인 시작 시점의 보유 **스냅샷**으로 ~40분 뒤 매도 판단을 함(TOCTOU). 동시에 도는 `loop_a_hardstop`/`loop_b_trend_exit`(둘 다 cron `*/10`)가 그 사이 청산해도 배치는 모름. 게다가 매도 신호 발행이 실청산 성공/보유 존재 여부와 무관하게 실행됨.

## 수정 (Layer 2 — 실행 직전 보유 재조회)

`if should_sell:` 진입 직후:
1. `self.conn.commit()` — WAL read-snapshot 종료해 타 프로세스 커밋을 보이게 함
2. `get_us_existing_position_for_ticker(...).row_count == 0` 이면 → `continue` (실주문 X, 신호 발행 X, 저널 X)

기존 피라미딩에 쓰는 신뢰된 헬퍼 재사용. 공유락 불필요(저트래픽). 매도 신호 발행 **이전**에 위치해 유령 매도를 원천 차단.

## 테스트
- `tests/test_layer2_stale_snapshot_guard.py` — **12 pass** (동시청산 감지, 계정 스코핑, 멀티행, 소스 배선=발행 앞 위치)
- `tests/test_issue_288_pyramiding.py` 회귀 — **101 pass** (동일 매도 경로 영향 없음)

## 범위
US(`prism-us`)만. KR(`stock_tracking_agent.py`)도 동일 구조라 후속 적용 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)