### PR TITLE
fix(sell): central chokepoint guard in sell_stock (KR+US) — covers all sell cycles

### DIFF
--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -2042,6 +2042,31 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
             account_key = stock_data.get("account_key") or self._account_scope()[0]
             account_name = stock_data.get("account_name") or self._account_scope()[1]
 
+            # ── Cross-cycle sell guard (single source of truth) ──────────────
+            # EVERY sell path routes its real order + signal publish through
+            # sell_stock and gates on this bool return: the batch update_holdings,
+            # loop_a_hardstop, and loop_b_trend_exit (KR + US). A concurrent cycle
+            # may have already closed this position seconds/minutes ago, so refresh
+            # the connection snapshot (commit ends any stale WAL read-txn so other
+            # processes' commits are visible) and abort if the row is gone — no
+            # trading_history row, no delete, no journal, no queued message — so the
+            # caller publishes NO duplicate/ghost SELL and P&L is not double-counted.
+            # Incident 2026-07-01 (MU): loop_a stop-sold 23:50 (+published SELL),
+            # the batch re-hit the same stop off a stale snapshot and re-published a
+            # 2nd SELL 23:55. sell_stock is the chokepoint that closes this for all
+            # paths in both markets. (update_holdings also has an earlier Layer 2
+            # short-circuit; this is the authoritative gate that also covers loops.)
+            self.conn.commit()
+            if get_us_existing_position_for_ticker(
+                self.cursor, ticker, account_key=account_key
+            ).get("row_count", 0) == 0:
+                logger.warning(
+                    f"[SELL-GUARD][US] {ticker} ({company_name}) already closed by "
+                    f"another cycle — sell_stock aborting (no duplicate record/signal)"
+                )
+                return False
+            # ─────────────────────────────────────────────────────────────────
+
             # Calculate profit rate
             profit_rate = ((current_price - buy_price) / buy_price) * 100 if buy_price > 0 else 0
 

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -1122,6 +1122,30 @@ class StockTrackingAgent:
             account_key = stock_data.get('account_key') or self._account_scope()[0]
             account_name = stock_data.get('account_name') or self._account_scope()[1]
 
+            # ── Cross-cycle sell guard (single source of truth) ──────────────
+            # EVERY sell path routes its real order + signal publish through
+            # sell_stock and gates on this bool return: the batch update_holdings,
+            # loop_a_hardstop, and loop_b_trend_exit (KR + US). A concurrent cycle
+            # may have already closed this position seconds/minutes ago, so refresh
+            # the connection snapshot (commit ends any stale WAL read-txn so other
+            # processes' commits are visible) and abort if the row is gone — no
+            # trading_history row, no delete, no journal, no queued message — so the
+            # caller publishes NO duplicate/ghost SELL and P&L is not double-counted.
+            # Incident 2026-07-01 (MU): loop_a stop-sold 23:50 (+published SELL),
+            # the batch re-hit the same stop off a stale snapshot and re-published a
+            # 2nd SELL 23:55. sell_stock is the chokepoint that closes this for all
+            # paths in both markets.
+            self.conn.commit()
+            if get_existing_position_for_ticker(
+                self.cursor, ticker, account_key=account_key
+            ).get("row_count", 0) == 0:
+                logger.warning(
+                    f"[SELL-GUARD][KR] {ticker}({company_name}) already closed by "
+                    f"another cycle — sell_stock aborting (no duplicate record/signal)"
+                )
+                return False
+            # ─────────────────────────────────────────────────────────────────
+
             # Calculate profit rate
             profit_rate = ((current_price - buy_price) / buy_price) * 100
 

--- a/tests/test_layer2_stale_snapshot_guard.py
+++ b/tests/test_layer2_stale_snapshot_guard.py
@@ -48,6 +48,7 @@ get_us_existing_position_for_ticker = _us_db_schema.get_us_existing_position_for
 TABLE_US_STOCK_HOLDINGS = _us_db_schema.TABLE_US_STOCK_HOLDINGS
 
 _AGENT_PATH = os.path.join(PROJECT_ROOT, "prism-us", "us_stock_tracking_agent.py")
+_KR_AGENT_PATH = os.path.join(PROJECT_ROOT, "stock_tracking_agent.py")
 
 _PASS = 0
 _FAIL = 0
@@ -182,11 +183,37 @@ def test_guard_present_in_source():
           "guard runs BEFORE the sell-signal publish (kills duplicate at source)")
 
 
+# ── Test 5: sell_stock chokepoint guard wired into BOTH agents ────────────────
+def test_sell_stock_chokepoint_guard():
+    print("\n[Test 5] sell_stock chokepoint guard (KR + US) — covers loops too")
+    for label, path, marker, insert_tbl in (
+        ("KR", _KR_AGENT_PATH, "[SELL-GUARD][KR]", "INSERT INTO trading_history"),
+        ("US", _AGENT_PATH, "[SELL-GUARD][US]", "INSERT INTO us_trading_history"),
+    ):
+        with open(path, "r", encoding="utf-8") as fh:
+            src = fh.read()
+        sell_idx = src.find("async def sell_stock(")
+        check(sell_idx > 0, f"{label}: sell_stock defined")
+        guard_idx = src.find(marker)
+        insert_idx = src.find(insert_tbl, sell_idx)
+        check(guard_idx > sell_idx, f"{label}: guard marker inside sell_stock")
+        # The guard MUST run BEFORE the trading_history INSERT, else a phantom
+        # sale row is written for an already-closed position.
+        check(0 < guard_idx < insert_idx,
+              f"{label}: guard precedes trading_history INSERT (no phantom P&L row)")
+        # And it must abort via `return False` so callers (orchestrator + loops)
+        # skip the real order + signal publish.
+        seg = src[guard_idx - 400:insert_idx]
+        check("return False" in seg, f"{label}: guard aborts via return False")
+        check('row_count", 0) == 0' in seg, f"{label}: guard predicate row_count == 0")
+
+
 def _run():
     test_guard_detects_concurrent_close()
     test_guard_is_account_scoped()
     test_guard_multirow_still_held()
     test_guard_present_in_source()
+    test_sell_stock_chokepoint_guard()
     print(f"\n===== RESULT: {_PASS} passed, {_FAIL} failed =====")
     return _FAIL
 


### PR DESCRIPTION
## 배경
PR #401(US 오케스트레이터 Layer 2)의 후속. 근본 분석 결과 **중복/유령 SELL은 배치뿐 아니라 모든 매도 경로에서 발생 가능**함을 확인.

## 급소
`sell_stock()`는 `trading_history`를 **무조건 INSERT**, `DELETE`는 **rowcount 미확인**, 이미 청산된 종목이어도 **`return True`**. 호출부는 이 bool로 실주문·신호발행을 게이트하므로, stale/2차 호출이 **중복 SELL 재발행 + P&L 이중계상**을 유발.

## 6개 경로 전부 이 급소를 통과
- 배치 `update_holdings` (KR/US)
- `loop_a_hardstop` (KR/US) → `tools/loop_a_hardstop.py:380` `sim_ok` 게이트
- `loop_b_trend_exit` (KR/US) → `tools/loop_b_trend_exit.py:586` `sim_ok` 게이트

## 수정
`sell_stock` 최상단(trading_history INSERT 전)에서:
1. `self.conn.commit()` — WAL stale read-snapshot 종료해 타 프로세스 커밋을 보이게 함
2. `get_[us_]existing_position_for_ticker(...).row_count == 0` → `return False` (history/삭제/저널/메시지 전부 없음)

→ **단일 급소로 오케스트레이터 + loop_a + loop_b × KR/US 전부 커버.** 루프는 손대지 않음. US `update_holdings`의 Layer 2 가드(#401)는 값싼 조기 단락으로 유지, 이 게이트가 권위적.

## 테스트
- `tests/test_layer2_stale_snapshot_guard.py` 확장 — **22 pass** (양 에이전트에서 가드가 history INSERT 앞에 위치 + `return False` 확인)
- `test_issue_288_pyramiding.py` — **101 pass**
- 양 에이전트 `py_compile` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)