### PR TITLE
feat(churn): exit_kind-aware re-entry cooldown (Option A, KR+US, SHADOW-first)

### DIFF
--- a/prism-us/tests/test_journal_recent_loss_penalty.py
+++ b/prism-us/tests/test_journal_recent_loss_penalty.py
@@ -108,7 +108,7 @@ class TestJournalRecentLossPenaltyUS(unittest.TestCase):
 
         loss_info = {"gap_hours": 1.3, "last_ret": -7.5, "last_sell": "2026-06-30 10:00:00"}
         import reentry_cooldown
-        with patch.object(reentry_cooldown, "recent_loss", return_value=loss_info):
+        with patch.object(reentry_cooldown, "recent_risk_exit", return_value=loss_info):
             # Give sector bonus: 3 profitable US trades for sector "Technology"
             for i in range(3):
                 self.cur.execute(
@@ -133,7 +133,7 @@ class TestJournalRecentLossPenaltyUS(unittest.TestCase):
         jm = self._get_jm()
 
         import reentry_cooldown
-        with patch.object(reentry_cooldown, "recent_loss", return_value=None):
+        with patch.object(reentry_cooldown, "recent_risk_exit", return_value=None):
             adj, reasons = jm.get_score_adjustment("AAPL")
 
         self.assertEqual(adj, 0)
@@ -147,7 +147,7 @@ class TestJournalRecentLossPenaltyUS(unittest.TestCase):
 
         import reentry_cooldown
         loss_info = {"gap_hours": 1.0, "last_ret": -5.0, "last_sell": "2026-06-30 10:00:00"}
-        with patch.object(reentry_cooldown, "recent_loss", return_value=loss_info):
+        with patch.object(reentry_cooldown, "recent_risk_exit", return_value=loss_info):
             adj, reasons = jm.get_score_adjustment("MU")
 
         self.assertEqual(adj, 0)
@@ -160,7 +160,7 @@ class TestJournalRecentLossPenaltyUS(unittest.TestCase):
         jm = self._get_jm()
 
         import reentry_cooldown
-        with patch.object(reentry_cooldown, "recent_loss", return_value=None):
+        with patch.object(reentry_cooldown, "recent_risk_exit", return_value=None):
             adj, reasons = jm.get_score_adjustment("NVDA")
 
         self.assertEqual(adj, 0)
@@ -211,7 +211,7 @@ class TestJournalRecentLossPenaltyUS(unittest.TestCase):
 
         import reentry_cooldown
         loss_info = {"gap_hours": 5.0, "last_ret": -7.5, "last_sell": "2026-06-30 05:00:00"}
-        with patch.object(reentry_cooldown, "recent_loss", return_value=loss_info):
+        with patch.object(reentry_cooldown, "recent_risk_exit", return_value=loss_info):
             adj, reasons = jm.get_score_adjustment("MU")
 
         self.assertEqual(adj, 0)

--- a/prism-us/tracking/db_schema.py
+++ b/prism-us/tracking/db_schema.py
@@ -76,7 +76,8 @@ CREATE TABLE IF NOT EXISTS us_trading_history (
     scenario TEXT,                     -- JSON trading scenario
     trigger_type TEXT,
     trigger_mode TEXT,
-    sector TEXT                        -- GICS sector
+    sector TEXT,                       -- GICS sector
+    exit_kind TEXT                     -- churn-guard: stop | trend_exit | target | ai
 )
 """
 
@@ -679,8 +680,31 @@ def create_us_tables(cursor, conn):
 
     migrate_multi_account_schema(cursor, conn)
     migrate_drop_us_holdings_unique_constraint(cursor, conn)
+    migrate_us_trading_history_columns(cursor, conn)
     conn.commit()
     logger.info("US database tables created")
+
+
+def migrate_us_trading_history_columns(cursor, conn):
+    """Add churn-guard columns to us_trading_history if missing (idempotent, no backfill).
+
+    exit_kind: compact exit classification (stop | trend_exit | target | ai) used by
+    the re-entry cooldown / journal churn guard so a stop-out at a marginal profit is
+    treated as churn-risk. Existing rows stay NULL (legacy P&L-sign behaviour).
+    """
+    migrations = [
+        ("us_trading_history", "exit_kind TEXT"),
+    ]
+    for table_name, column_def in migrations:
+        try:
+            cursor.execute(f"ALTER TABLE {table_name} ADD COLUMN {column_def}")
+            conn.commit()
+            logger.info(f"Added column to {table_name}: {column_def}")
+        except Exception as e:
+            if "duplicate column name" in str(e).lower():
+                logger.debug(f"Column already exists in {table_name}: {column_def}")
+            else:
+                logger.warning(f"Migration warning for {table_name}: {e}")
 
 
 def create_us_indexes(cursor, conn):

--- a/prism-us/tracking/journal.py
+++ b/prism-us/tracking/journal.py
@@ -687,7 +687,9 @@ Please review the following completed US stock trade:
                     if _rc_root not in sys.path:
                         sys.path.insert(0, _rc_root)
                     import reentry_cooldown as _rc
-                    _loss_info = _rc.recent_loss(ticker, market="US")
+                    # risk-exit aware (loss OR stop/trend-exit); falls back to
+                    # loss-only on an older reentry_cooldown build.
+                    _loss_info = getattr(_rc, "recent_risk_exit", _rc.recent_loss)(ticker, market="US")
                     if _loss_info is not None and _loss_info["gap_hours"] <= JOURNAL_RECENT_LOSS_HOURS:
                         adjustment = min(adjustment, 0) - JOURNAL_RECENT_LOSS_PENALTY
                         reasons.append(

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -2018,13 +2018,19 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
             logger.error(f"{ticker} US holding decision delete failed: {str(e)}")
             return False
 
-    async def sell_stock(self, stock_data: Dict[str, Any], sell_reason: str) -> bool:
+    async def sell_stock(self, stock_data: Dict[str, Any], sell_reason: str,
+                         exit_kind: Optional[str] = None) -> bool:
         """
         Process stock sale.
 
         Args:
             stock_data: Stock information to sell
             sell_reason: Sell reason
+            exit_kind: Optional explicit exit classification (stop | trend_exit |
+                target | ai). Loops pass it deterministically (loop_a=stop,
+                loop_b=trend_exit); when None it is inferred from sell_reason. Stored
+                in us_trading_history so the re-entry cooldown treats a stop-out at a
+                marginal profit as churn-risk.
 
         Returns:
             bool: Sell success status
@@ -2075,18 +2081,25 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
             holding_days = (datetime.now() - buy_datetime).days
             now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
+            # Classify the exit (stop/trend_exit/target/ai) for the churn guard.
+            try:
+                from reentry_cooldown import classify_exit_kind
+                _exit_kind = classify_exit_kind(sell_reason, exit_kind)
+            except Exception:
+                _exit_kind = exit_kind  # fail-open: store caller hint or None
+
             # Add to trading history
             self.cursor.execute(
                 """
                 INSERT INTO us_trading_history
                 (account_key, account_name, ticker, company_name, buy_price, buy_date, sell_price, sell_date,
-                 profit_rate, holding_days, scenario, trigger_type, trigger_mode, sector)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 profit_rate, holding_days, scenario, trigger_type, trigger_mode, sector, exit_kind)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     account_key, account_name, ticker, company_name, buy_price, buy_date,
                     current_price, now, profit_rate, holding_days,
-                    scenario_json, trigger_type, trigger_mode, sector
+                    scenario_json, trigger_type, trigger_mode, sector, _exit_kind
                 )
             )
 
@@ -2708,17 +2721,21 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     _cd_block = False
                     if normalized_decision == "entry" and not is_add:
                         try:
-                            from reentry_cooldown import reentry_block, COOLDOWN_LIVE
+                            from reentry_cooldown import reentry_block, COOLDOWN_LIVE, COOLDOWN_RISK_EXIT_LIVE
                             _cd = reentry_block("US", ticker)
                         except Exception:
-                            _cd, COOLDOWN_LIVE = None, False
+                            _cd, COOLDOWN_LIVE, COOLDOWN_RISK_EXIT_LIVE = None, False, False
                         if _cd:
+                            # A stop/trend-exit block that is NOT also a loss is the new
+                            # exit-kind branch -> SHADOW unless COOLDOWN_RISK_EXIT_LIVE.
+                            _risk_only = bool(_cd.get("risk_exit")) and not _cd.get("after_loss")
+                            _enforce = COOLDOWN_LIVE and (COOLDOWN_RISK_EXIT_LIVE or not _risk_only)
                             logger.warning(
-                                "[REENTRY_COOLDOWN][%s] %s ticker=%s last_sell=%s ret=%.1f%% gap=%.1fh<%sh after_loss=%s",
-                                "LIVE" if COOLDOWN_LIVE else "SHADOW", _cd["action"], ticker,
+                                "[REENTRY_COOLDOWN][%s] %s ticker=%s last_sell=%s ret=%.1f%% gap=%.1fh<%sh after_loss=%s exit_kind=%s risk_only=%s",
+                                "LIVE" if _enforce else "SHADOW", _cd["action"], ticker,
                                 _cd["last_sell"], _cd["last_ret"], _cd["gap_hours"],
-                                _cd["window_hours"], _cd["after_loss"])
-                            _cd_block = COOLDOWN_LIVE
+                                _cd["window_hours"], _cd["after_loss"], _cd.get("exit_kind"), _risk_only)
+                            _cd_block = _enforce
 
                     if normalized_decision == "entry" and adjusted_score >= min_score and sector_diverse and not _cd_block:
                         # is_add => pyramiding additional independent row (#288)

--- a/reentry_cooldown.py
+++ b/reentry_cooldown.py
@@ -103,19 +103,24 @@ def _query_last_sell(path: str, table: str, ticker: str,
         where += "AND account_key=? "
         params.append(account_key)
     tail = "ORDER BY sell_date DESC LIMIT 1"
+    # `table` is always one of our own fixed constants (never user input) and every
+    # value is bound via ? placeholders; whitelist it so the interpolation is
+    # provably injection-safe.
+    if table not in _TABLE.values():
+        return None
     try:
         conn = sqlite3.connect(path, timeout=5)
         try:
             try:
                 row = conn.execute(
-                    f"SELECT sell_date, profit_rate, exit_kind FROM {table} {where}{tail}",
+                    f"SELECT sell_date, profit_rate, exit_kind FROM {table} {where}{tail}",  # nosec B608
                     params,
                 ).fetchone()
                 return (row[0], row[1], row[2]) if row else None
             except sqlite3.OperationalError:
                 # exit_kind column absent (pre-migration) -> legacy fallback.
                 row = conn.execute(
-                    f"SELECT sell_date, profit_rate FROM {table} {where}{tail}",
+                    f"SELECT sell_date, profit_rate FROM {table} {where}{tail}",  # nosec B608
                     params,
                 ).fetchone()
                 return (row[0], row[1], None) if row else None

--- a/reentry_cooldown.py
+++ b/reentry_cooldown.py
@@ -90,6 +90,21 @@ def _parse_dt(s: str) -> Optional[datetime]:
         return None
 
 
+# Fully static, pre-written queries (no runtime SQL string construction) keyed by
+# (table, account_scoped, want_exit_kind). Selecting a literal by table name is
+# injection-proof by construction — the table can only ever be one we authored.
+_LAST_SELL_SQL = {
+    ("trading_history", False, True): "SELECT sell_date, profit_rate, exit_kind FROM trading_history WHERE ticker=? AND sell_date IS NOT NULL AND sell_date<>'' ORDER BY sell_date DESC LIMIT 1",
+    ("trading_history", True, True): "SELECT sell_date, profit_rate, exit_kind FROM trading_history WHERE ticker=? AND sell_date IS NOT NULL AND sell_date<>'' AND account_key=? ORDER BY sell_date DESC LIMIT 1",
+    ("trading_history", False, False): "SELECT sell_date, profit_rate FROM trading_history WHERE ticker=? AND sell_date IS NOT NULL AND sell_date<>'' ORDER BY sell_date DESC LIMIT 1",
+    ("trading_history", True, False): "SELECT sell_date, profit_rate FROM trading_history WHERE ticker=? AND sell_date IS NOT NULL AND sell_date<>'' AND account_key=? ORDER BY sell_date DESC LIMIT 1",
+    ("us_trading_history", False, True): "SELECT sell_date, profit_rate, exit_kind FROM us_trading_history WHERE ticker=? AND sell_date IS NOT NULL AND sell_date<>'' ORDER BY sell_date DESC LIMIT 1",
+    ("us_trading_history", True, True): "SELECT sell_date, profit_rate, exit_kind FROM us_trading_history WHERE ticker=? AND sell_date IS NOT NULL AND sell_date<>'' AND account_key=? ORDER BY sell_date DESC LIMIT 1",
+    ("us_trading_history", False, False): "SELECT sell_date, profit_rate FROM us_trading_history WHERE ticker=? AND sell_date IS NOT NULL AND sell_date<>'' ORDER BY sell_date DESC LIMIT 1",
+    ("us_trading_history", True, False): "SELECT sell_date, profit_rate FROM us_trading_history WHERE ticker=? AND sell_date IS NOT NULL AND sell_date<>'' AND account_key=? ORDER BY sell_date DESC LIMIT 1",
+}
+
+
 def _query_last_sell(path: str, table: str, ticker: str,
                      account_key: Optional[str]) -> Optional[tuple]:
     """Most recent completed sell -> (sell_date, profit_rate, exit_kind) or None.
@@ -97,32 +112,19 @@ def _query_last_sell(path: str, table: str, ticker: str,
     exit_kind is None when the column does not exist yet (DB not migrated) so
     callers transparently fall back to the legacy P&L-sign behaviour. Fail-open.
     """
-    where = "WHERE ticker=? AND sell_date IS NOT NULL AND sell_date<>'' "
-    params = [ticker]
-    if account_key:
-        where += "AND account_key=? "
-        params.append(account_key)
-    tail = "ORDER BY sell_date DESC LIMIT 1"
-    # `table` is always one of our own fixed constants (never user input) and every
-    # value is bound via ? placeholders; whitelist it so the interpolation is
-    # provably injection-safe.
-    if table not in _TABLE.values():
-        return None
+    scoped = bool(account_key)
+    if (table, scoped, True) not in _LAST_SELL_SQL:
+        return None  # table is always an internal constant; defensive guard
+    params = [ticker, account_key] if scoped else [ticker]
     try:
         conn = sqlite3.connect(path, timeout=5)
         try:
             try:
-                row = conn.execute(
-                    f"SELECT sell_date, profit_rate, exit_kind FROM {table} {where}{tail}",  # nosec B608
-                    params,
-                ).fetchone()
+                row = conn.execute(_LAST_SELL_SQL[(table, scoped, True)], params).fetchone()
                 return (row[0], row[1], row[2]) if row else None
             except sqlite3.OperationalError:
                 # exit_kind column absent (pre-migration) -> legacy fallback.
-                row = conn.execute(
-                    f"SELECT sell_date, profit_rate FROM {table} {where}{tail}",  # nosec B608
-                    params,
-                ).fetchone()
+                row = conn.execute(_LAST_SELL_SQL[(table, scoped, False)], params).fetchone()
                 return (row[0], row[1], None) if row else None
         finally:
             conn.close()

--- a/reentry_cooldown.py
+++ b/reentry_cooldown.py
@@ -35,8 +35,44 @@ COOLDOWN_LIVE = str(os.getenv("REENTRY_COOLDOWN_LIVE", "false")).strip().lower()
 # block: prod showed -5%/-7% sells re-bought within ~24h).
 COOLDOWN_HOURS = float(os.getenv("REENTRY_COOLDOWN_HOURS", "0"))
 COOLDOWN_LOSS_HOURS = float(os.getenv("REENTRY_COOLDOWN_LOSS_HOURS", "24"))
+# Enforce the NEW exit-kind-driven block — a stop/trend-exit re-entry that is NOT a
+# loss (tagged out at a marginal profit) — only when this is ALSO on. Default False
+# = SHADOW for the new branch: it is logged (WOULD_BLOCK … risk_only=True) but not
+# vetoed, while legacy loss-based blocks keep obeying COOLDOWN_LIVE unchanged. Lets
+# the exit-kind churn guard be observed for a few sessions before enforcing.
+COOLDOWN_RISK_EXIT_LIVE = str(os.getenv("REENTRY_COOLDOWN_RISK_EXIT_LIVE", "false")).strip().lower() in ("1", "true", "yes", "on")
 
 _TABLE = {"KR": "trading_history", "US": "us_trading_history"}
+
+# Exit kinds that are churn-risk regardless of realised P&L sign. A stop-loss or
+# trend-exit close that happens to land at a marginal PROFIT (e.g. bought below
+# the stop, tagged out at +0.4%) is still a risk exit — re-buying it immediately
+# is the churn we want to block. These are matched against us_trading_history.exit_kind.
+RISK_EXIT_KINDS = {"stop", "trend_exit"}
+
+
+def classify_exit_kind(sell_reason: str, explicit: Optional[str] = None) -> str:
+    """Normalise a sell into a compact exit_kind: stop | trend_exit | target | ai.
+
+    Callers that know the kind deterministically (loop_a=stop, loop_b=trend_exit)
+    pass `explicit`; otherwise it is inferred from the free-form sell_reason the
+    orchestrator already produces (KR '손절 조건 도달…', US 'Stop-loss condition
+    reached…', tier strings 'TIER1_STOPLOSS'/'TIER1.5_MA50', etc.). Best-effort,
+    never raises; unknown => 'ai' (a deliberate exit, not treated as churn-risk).
+    """
+    if explicit:
+        return explicit
+    r = (sell_reason or "").lower()
+    # Trend-exit tiers first so 'TIER1.5' isn't swallowed by the generic 'tier1' stop match.
+    if ("tier1.5" in r or "ma50" in r or "ma_50" in r or "50-day" in r
+            or "50일선" in r or "trend" in r or "추세" in r):
+        return "trend_exit"
+    if ("stop-loss" in r or "stop_loss" in r or "stoploss" in r or "tier1" in r
+            or "abs7" in r or "-7%" in r or "hard stop" in r or "손절" in r):
+        return "stop"
+    if "target" in r or "목표가" in r:
+        return "target"
+    return "ai"
 
 
 def _db_path() -> str:
@@ -54,6 +90,41 @@ def _parse_dt(s: str) -> Optional[datetime]:
         return None
 
 
+def _query_last_sell(path: str, table: str, ticker: str,
+                     account_key: Optional[str]) -> Optional[tuple]:
+    """Most recent completed sell -> (sell_date, profit_rate, exit_kind) or None.
+
+    exit_kind is None when the column does not exist yet (DB not migrated) so
+    callers transparently fall back to the legacy P&L-sign behaviour. Fail-open.
+    """
+    where = "WHERE ticker=? AND sell_date IS NOT NULL AND sell_date<>'' "
+    params = [ticker]
+    if account_key:
+        where += "AND account_key=? "
+        params.append(account_key)
+    tail = "ORDER BY sell_date DESC LIMIT 1"
+    try:
+        conn = sqlite3.connect(path, timeout=5)
+        try:
+            try:
+                row = conn.execute(
+                    f"SELECT sell_date, profit_rate, exit_kind FROM {table} {where}{tail}",
+                    params,
+                ).fetchone()
+                return (row[0], row[1], row[2]) if row else None
+            except sqlite3.OperationalError:
+                # exit_kind column absent (pre-migration) -> legacy fallback.
+                row = conn.execute(
+                    f"SELECT sell_date, profit_rate FROM {table} {where}{tail}",
+                    params,
+                ).fetchone()
+                return (row[0], row[1], None) if row else None
+        finally:
+            conn.close()
+    except Exception:
+        return None  # fail-open
+
+
 def reentry_block(market: str, ticker: str, account_key: Optional[str] = None,
                   db_path: Optional[str] = None, now: Optional[datetime] = None) -> Optional[dict]:
     """If `ticker` is still inside its re-entry cooldown (relative to its most
@@ -69,24 +140,7 @@ def reentry_block(market: str, ticker: str, account_key: Optional[str] = None,
         return None
     now = now or datetime.now()
     path = db_path or _db_path()
-    try:
-        conn = sqlite3.connect(path, timeout=5)
-        try:
-            sql = (
-                f"SELECT sell_date, profit_rate FROM {table} "
-                f"WHERE ticker=? AND sell_date IS NOT NULL AND sell_date<>'' "
-            )
-            params = [ticker]
-            if account_key:
-                sql += "AND account_key=? "
-                params.append(account_key)
-            sql += "ORDER BY sell_date DESC LIMIT 1"
-            row = conn.execute(sql, params).fetchone()
-        finally:
-            conn.close()
-    except Exception:
-        return None  # fail-open
-
+    row = _query_last_sell(path, table, ticker, account_key)
     if not row or not row[0]:
         return None
     sell_dt = _parse_dt(row[0])
@@ -99,8 +153,13 @@ def reentry_block(market: str, ticker: str, account_key: Optional[str] = None,
         last_ret = float(row[1]) if row[1] is not None else 0.0
     except (TypeError, ValueError):
         last_ret = 0.0
+    exit_kind = (row[2] or "") if len(row) > 2 else ""
+    # A stop/trend-exit is churn-risk even at a marginal PROFIT, so it gets the
+    # (longer) LOSS window regardless of P&L sign. NULL exit_kind (pre-migration
+    # rows) => risk_exit False => legacy sign-based behaviour (backward compatible).
+    risk_exit = exit_kind in RISK_EXIT_KINDS
     after_loss = last_ret < 0
-    window = COOLDOWN_LOSS_HOURS if after_loss else COOLDOWN_HOURS
+    window = COOLDOWN_LOSS_HOURS if (after_loss or risk_exit) else COOLDOWN_HOURS
     if gap_hours >= window:
         return None
     return {
@@ -112,6 +171,8 @@ def reentry_block(market: str, ticker: str, account_key: Optional[str] = None,
         "gap_hours": round(gap_hours, 2),
         "window_hours": window,
         "after_loss": after_loss,
+        "exit_kind": exit_kind or None,
+        "risk_exit": risk_exit,
     }
 
 
@@ -124,24 +185,24 @@ def recent_loss(ticker: str, market: str | None = None) -> Optional[dict]:
     Returns: {"gap_hours": float, "last_ret": float, "last_sell": str} or None.
     Fail-open: returns None on any error.
     """
+    return recent_risk_exit(ticker, market, _loss_only=True)
+
+
+def recent_risk_exit(ticker: str, market: str | None = None,
+                     _loss_only: bool = False) -> Optional[dict]:
+    """Return the most-recent sell's gap info if it was a churn-risk exit, else None.
+
+    A "churn-risk exit" = the sell was a LOSS **or** its exit_kind is a stop/
+    trend-exit (a risk close that may have landed at a marginal profit). NULL
+    exit_kind (pre-migration rows) falls back to loss-only. `_loss_only=True`
+    reproduces the legacy `recent_loss` semantics (loss sign only).
+
+    Returns: {"gap_hours", "last_ret", "last_sell", "exit_kind"} or None. Fail-open.
+    """
     table = _TABLE.get(((market or "KR") or "KR").upper())
     if not table or not ticker:
         return None
-    path = _db_path()
-    try:
-        conn = sqlite3.connect(path, timeout=5)
-        try:
-            row = conn.execute(
-                f"SELECT sell_date, profit_rate FROM {table} "
-                f"WHERE ticker=? AND sell_date IS NOT NULL AND sell_date<>'' "
-                f"ORDER BY sell_date DESC LIMIT 1",
-                (ticker,),
-            ).fetchone()
-        finally:
-            conn.close()
-    except Exception:
-        return None  # fail-open
-
+    row = _query_last_sell(_db_path(), table, ticker, None)
     if not row or not row[0]:
         return None
     sell_dt = _parse_dt(row[0])
@@ -151,8 +212,10 @@ def recent_loss(ticker: str, market: str | None = None) -> Optional[dict]:
         last_ret = float(row[1]) if row[1] is not None else 0.0
     except (TypeError, ValueError):
         last_ret = 0.0
-    if last_ret >= 0:
-        return None  # not a loss — no penalty
+    exit_kind = (row[2] or "") if len(row) > 2 else ""
+    is_risk = (last_ret < 0) if _loss_only else (last_ret < 0 or exit_kind in RISK_EXIT_KINDS)
+    if not is_risk:
+        return None  # not a churn-risk exit — no penalty
     gap_hours = (datetime.now() - sell_dt).total_seconds() / 3600.0
     if gap_hours < 0:
         return None  # clock skew
@@ -160,4 +223,5 @@ def recent_loss(ticker: str, market: str | None = None) -> Optional[dict]:
         "gap_hours": round(gap_hours, 2),
         "last_ret": last_ret,
         "last_sell": row[0],
+        "exit_kind": exit_kind or None,
     }

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -1099,13 +1099,19 @@ class StockTrackingAgent:
             logger.error(f"{stock_data.get('ticker', '') if 'ticker' in locals() else 'Unknown stock'} Error analyzing sell: {str(e)}")
             return False, "Analysis error"
 
-    async def sell_stock(self, stock_data: Dict[str, Any], sell_reason: str) -> bool:
+    async def sell_stock(self, stock_data: Dict[str, Any], sell_reason: str,
+                         exit_kind: Optional[str] = None) -> bool:
         """
         Stock sell processing
 
         Args:
             stock_data: Stock information to sell
             sell_reason: Sell reason
+            exit_kind: Optional explicit exit classification (stop | trend_exit |
+                target | ai). Loops pass it deterministically (loop_a=stop,
+                loop_b=trend_exit); when None it is inferred from sell_reason. Stored
+                in trading_history so the re-entry cooldown treats a stop-out at a
+                marginal profit as churn-risk.
 
         Returns:
             bool: Sell success status
@@ -1157,12 +1163,19 @@ class StockTrackingAgent:
             # Current time
             now = now_datetime.strftime("%Y-%m-%d %H:%M:%S")
 
+            # Classify the exit (stop/trend_exit/target/ai) for the churn guard.
+            try:
+                from reentry_cooldown import classify_exit_kind
+                _exit_kind = classify_exit_kind(sell_reason, exit_kind)
+            except Exception:
+                _exit_kind = exit_kind  # fail-open: store caller hint or None
+
             # Add to trading history table
             self.cursor.execute(
                 """
                 INSERT INTO trading_history
-                (account_key, account_name, ticker, company_name, buy_price, buy_date, sell_price, sell_date, profit_rate, holding_days, scenario, trigger_type, trigger_mode, sector)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                (account_key, account_name, ticker, company_name, buy_price, buy_date, sell_price, sell_date, profit_rate, holding_days, scenario, trigger_type, trigger_mode, sector, exit_kind)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     account_key,
@@ -1179,6 +1192,7 @@ class StockTrackingAgent:
                     trigger_type,
                     trigger_mode,
                     stock_data.get('sector'),
+                    _exit_kind,
                 )
             )
 
@@ -1770,17 +1784,21 @@ class StockTrackingAgent:
                     _cd_block = False
                     if analysis_result.get("decision") == "Enter":
                         try:
-                            from reentry_cooldown import reentry_block, COOLDOWN_LIVE
+                            from reentry_cooldown import reentry_block, COOLDOWN_LIVE, COOLDOWN_RISK_EXIT_LIVE
                             _cd = reentry_block("KR", ticker)
                         except Exception:
-                            _cd, COOLDOWN_LIVE = None, False
+                            _cd, COOLDOWN_LIVE, COOLDOWN_RISK_EXIT_LIVE = None, False, False
                         if _cd:
+                            # A stop/trend-exit block that is NOT also a loss is the new
+                            # exit-kind branch -> SHADOW unless COOLDOWN_RISK_EXIT_LIVE.
+                            _risk_only = bool(_cd.get("risk_exit")) and not _cd.get("after_loss")
+                            _enforce = COOLDOWN_LIVE and (COOLDOWN_RISK_EXIT_LIVE or not _risk_only)
                             logger.warning(
-                                "[REENTRY_COOLDOWN][%s] %s ticker=%s last_sell=%s ret=%.1f%% gap=%.1fh<%sh after_loss=%s",
-                                "LIVE" if COOLDOWN_LIVE else "SHADOW", _cd["action"], ticker,
+                                "[REENTRY_COOLDOWN][%s] %s ticker=%s last_sell=%s ret=%.1f%% gap=%.1fh<%sh after_loss=%s exit_kind=%s risk_only=%s",
+                                "LIVE" if _enforce else "SHADOW", _cd["action"], ticker,
                                 _cd["last_sell"], _cd["last_ret"], _cd["gap_hours"],
-                                _cd["window_hours"], _cd["after_loss"])
-                            _cd_block = COOLDOWN_LIVE
+                                _cd["window_hours"], _cd["after_loss"], _cd.get("exit_kind"), _risk_only)
+                            _cd_block = _enforce
 
                     if analysis_result.get("decision") == "Enter" and not _cd_block:
                         buy_success = await self.buy_stock(ticker, company_name, current_price, scenario, rank_change_msg)

--- a/tests/test_exit_kind_churn_guard.py
+++ b/tests/test_exit_kind_churn_guard.py
@@ -1,0 +1,157 @@
+"""
+exit_kind churn guard (Option A) — re-entry cooldown keyed on exit REASON, not
+just realised P&L sign.
+
+Incident 2026-07-01 (MU, US): a mechanical stop-loss tagged the position out at a
+marginal +0.39% PROFIT, then the orchestrator re-bought it 4 min later. The loss-
+only cooldown did not fire because profit_rate > 0. This test locks in the fix:
+a stop / trend_exit close is churn-risk regardless of P&L sign, while a genuine
+profit-taking (ai/target) re-entry is still allowed. Pre-migration rows (no
+exit_kind column, or NULL) fall back to the legacy sign-based behaviour.
+
+Pure-unit + temp-SQLite; no live DB. Mirrors tests/test_issue_288_pyramiding.py style.
+
+Run:
+    python3 tests/test_exit_kind_churn_guard.py
+"""
+
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+from datetime import datetime, timedelta
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+_spec = importlib.util.spec_from_file_location(
+    "reentry_cooldown_for_exitkind_test",
+    os.path.join(PROJECT_ROOT, "reentry_cooldown.py"),
+)
+rc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rc)
+
+_PASS = 0
+_FAIL = 0
+
+
+def check(cond, msg):
+    global _PASS, _FAIL
+    if cond:
+        _PASS += 1
+        print(f"  PASS: {msg}")
+    else:
+        _FAIL += 1
+        print(f"  FAIL: {msg}")
+
+
+def _mkdb(with_exit_kind=True):
+    fd, path = tempfile.mkstemp(suffix=".sqlite")
+    os.close(fd)
+    conn = sqlite3.connect(path)
+    cols = "account_key TEXT, ticker TEXT, sell_date TEXT, profit_rate REAL"
+    if with_exit_kind:
+        cols += ", exit_kind TEXT"
+    conn.execute(f"CREATE TABLE us_trading_history ({cols})")
+    conn.commit()
+    return path, conn
+
+
+def _recent(hours_ago=0.1):
+    return (datetime.now() - timedelta(hours=hours_ago)).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def test_classifier():
+    print("\n[Test 1] classify_exit_kind")
+    check(rc.classify_exit_kind("손절 조건 도달 (손절가: 1000원)") == "stop", "KR 손절 -> stop")
+    check(rc.classify_exit_kind("Stop-loss condition reached (stop-loss: $10)") == "stop", "US stop -> stop")
+    check(rc.classify_exit_kind("TIER1_STOPLOSS: price<=stop") == "stop", "TIER1 -> stop")
+    check(rc.classify_exit_kind("TIER1.5_MA50 close below 50d") == "trend_exit", "TIER1.5 -> trend_exit")
+    check(rc.classify_exit_kind("목표가 달성 (목표가: 1200원)") == "target", "목표가 -> target")
+    check(rc.classify_exit_kind("AI judgment: weakening") == "ai", "unknown -> ai")
+    check(rc.classify_exit_kind("whatever", explicit="trend_exit") == "trend_exit", "explicit hint wins")
+
+
+def test_stop_at_profit_blocks():
+    print("\n[Test 2] stop/trend exit at a PROFIT still blocks re-entry (the MU fix)")
+    for kind in ("stop", "trend_exit"):
+        path, conn = _mkdb(True)
+        conn.execute("INSERT INTO us_trading_history VALUES (?,?,?,?,?)",
+                     ("A", "MU", _recent(0.1), 0.4, kind))
+        conn.commit(); conn.close()
+        v = rc.reentry_block("US", "MU", db_path=path)
+        check(v is not None and v["risk_exit"] and v["window_hours"] == rc.COOLDOWN_LOSS_HOURS,
+              f"{kind} +0.4% profit -> BLOCK (loss window)")
+        os.remove(path)
+
+
+def test_profit_taking_allowed():
+    print("\n[Test 3] genuine profit-taking (ai/target) re-entry still allowed")
+    for kind in ("ai", "target"):
+        path, conn = _mkdb(True)
+        conn.execute("INSERT INTO us_trading_history VALUES (?,?,?,?,?)",
+                     ("A", "MU", _recent(0.1), 5.0, kind))
+        conn.commit(); conn.close()
+        check(rc.reentry_block("US", "MU", db_path=path) is None,
+              f"{kind} +5% win -> ALLOW (COOLDOWN_HOURS window)")
+        os.remove(path)
+
+
+def test_backward_compatible():
+    print("\n[Test 4] backward compatibility (NULL / pre-migration column)")
+    # NULL exit_kind, loss -> block (legacy sign)
+    path, conn = _mkdb(True)
+    conn.execute("INSERT INTO us_trading_history VALUES (?,?,?,?,?)",
+                 ("A", "MU", _recent(0.1), -3.0, None))
+    conn.commit(); conn.close()
+    check(rc.reentry_block("US", "MU", db_path=path) is not None, "NULL exit_kind + loss -> BLOCK")
+    os.remove(path)
+    # NULL exit_kind, win -> allow
+    path, conn = _mkdb(True)
+    conn.execute("INSERT INTO us_trading_history VALUES (?,?,?,?,?)",
+                 ("A", "MU", _recent(0.1), 0.4, None))
+    conn.commit(); conn.close()
+    check(rc.reentry_block("US", "MU", db_path=path) is None, "NULL exit_kind + profit -> ALLOW")
+    os.remove(path)
+    # No exit_kind column at all (pre-migration) -> fallback still works
+    path, conn = _mkdb(False)
+    conn.execute("INSERT INTO us_trading_history VALUES (?,?,?,?)", ("A", "MU", _recent(0.1), -3.0))
+    conn.commit(); conn.close()
+    check(rc.reentry_block("US", "MU", db_path=path) is not None, "no column + loss -> BLOCK (fallback)")
+    os.remove(path)
+
+
+def test_recent_risk_exit():
+    print("\n[Test 5] recent_risk_exit (journal churn guard source)")
+    # stop at profit -> risk exit dict; recent_loss (loss-only) -> None
+    path, conn = _mkdb(True)
+    conn.execute("INSERT INTO us_trading_history VALUES (?,?,?,?,?)",
+                 ("A", "MU", _recent(1.0), 0.4, "stop"))
+    conn.commit(); conn.close()
+    os.environ["REENTRY_COOLDOWN_DB"] = path
+    try:
+        check(rc.recent_risk_exit("MU", "US") is not None, "recent_risk_exit fires on stop@profit")
+        check(rc.recent_loss("MU", "US") is None, "legacy recent_loss stays loss-only (None on profit)")
+    finally:
+        del os.environ["REENTRY_COOLDOWN_DB"]
+    os.remove(path)
+
+
+def _run():
+    test_classifier()
+    test_stop_at_profit_blocks()
+    test_profit_taking_allowed()
+    test_backward_compatible()
+    test_recent_risk_exit()
+    print(f"\n===== RESULT: {_PASS} passed, {_FAIL} failed =====")
+    return _FAIL
+
+
+def test_exit_kind_churn_guard_pytest():
+    assert _run() == 0
+
+
+if __name__ == "__main__":
+    sys.exit(1 if _run() else 0)

--- a/tests/test_journal_recent_loss_penalty.py
+++ b/tests/test_journal_recent_loss_penalty.py
@@ -104,7 +104,7 @@ class TestJournalRecentLossPenaltyKR(unittest.TestCase):
         loss_info = {"gap_hours": 1.3, "last_ret": -7.5, "last_sell": "2026-06-30 10:00:00"}
         with patch.dict(sys.modules, {}):
             import reentry_cooldown
-            with patch.object(reentry_cooldown, "recent_loss", return_value=loss_info):
+            with patch.object(reentry_cooldown, "recent_risk_exit", return_value=loss_info):
                 # Inject a sector bonus: insert 3 profitable trades for sector "Tech"
                 for i in range(3):
                     self.cur.execute(
@@ -130,7 +130,7 @@ class TestJournalRecentLossPenaltyKR(unittest.TestCase):
         jm = self._get_jm()
 
         import reentry_cooldown
-        with patch.object(reentry_cooldown, "recent_loss", return_value=None):
+        with patch.object(reentry_cooldown, "recent_risk_exit", return_value=None):
             adj, reasons = jm.get_score_adjustment("AAPL")
 
         self.assertEqual(adj, 0)
@@ -144,7 +144,7 @@ class TestJournalRecentLossPenaltyKR(unittest.TestCase):
 
         import reentry_cooldown
         loss_info = {"gap_hours": 1.0, "last_ret": -5.0, "last_sell": "2026-06-30 10:00:00"}
-        with patch.object(reentry_cooldown, "recent_loss", return_value=loss_info):
+        with patch.object(reentry_cooldown, "recent_risk_exit", return_value=loss_info):
             adj, reasons = jm.get_score_adjustment("MU")
 
         self.assertEqual(adj, 0)
@@ -158,7 +158,7 @@ class TestJournalRecentLossPenaltyKR(unittest.TestCase):
 
         import reentry_cooldown
         # recent_loss returns None when the sell was a win
-        with patch.object(reentry_cooldown, "recent_loss", return_value=None):
+        with patch.object(reentry_cooldown, "recent_risk_exit", return_value=None):
             adj, reasons = jm.get_score_adjustment("NVDA")
 
         self.assertEqual(adj, 0)
@@ -212,7 +212,7 @@ class TestJournalRecentLossPenaltyKR(unittest.TestCase):
         import reentry_cooldown
         # gap_hours=5 > window=1 -> no penalty
         loss_info = {"gap_hours": 5.0, "last_ret": -7.5, "last_sell": "2026-06-30 05:00:00"}
-        with patch.object(reentry_cooldown, "recent_loss", return_value=loss_info):
+        with patch.object(reentry_cooldown, "recent_risk_exit", return_value=loss_info):
             adj, reasons = jm.get_score_adjustment("MU")
 
         self.assertEqual(adj, 0)

--- a/tools/loop_a_hardstop.py
+++ b/tools/loop_a_hardstop.py
@@ -377,7 +377,10 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
             agent["ref"] = await _make_agent(market)
         ag = agent["ref"]
         logger.warning("[LIVE][%s] SELLING %s reason=%s", market, ticker, reason)
-        sim_ok = await ag.sell_stock(stock_data, reason)
+        # Loop A is the catastrophic hard-stop => always a 'stop' exit (recorded in
+        # trading_history.exit_kind so the re-entry cooldown treats it as churn-risk
+        # even if it tags out at a marginal profit).
+        sim_ok = await ag.sell_stock(stock_data, reason, exit_kind="stop")
         if not sim_ok:
             logger.error("[%s] %s sell_stock (sim) failed -> aborting, no KIS order", market, ticker)
             release_lock(conn, ticker, market, run_id, new_state="HOLDING")

--- a/tools/loop_b_trend_exit.py
+++ b/tools/loop_b_trend_exit.py
@@ -583,7 +583,10 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
             agent["ref"] = await _make_agent(market)
         ag = agent["ref"]
         logger.warning("[LIVE][%s] SELLING %s streak=%d reason=%s", market, ticker, streak, reason)
-        sim_ok = await ag.sell_stock(stock_data, reason)
+        # Loop B is the trend-exit => always a 'trend_exit' exit (recorded in
+        # trading_history.exit_kind so the re-entry cooldown treats it as churn-risk
+        # regardless of realised P&L sign).
+        sim_ok = await ag.sell_stock(stock_data, reason, exit_kind="trend_exit")
         if not sim_ok:
             logger.error("[%s] %s sell_stock (sim) failed -> aborting, no KIS order", market, ticker)
             release_lock(conn, ticker, market, run_id, new_state="HOLDING")

--- a/tracking/db_schema.py
+++ b/tracking/db_schema.py
@@ -48,7 +48,8 @@ CREATE TABLE IF NOT EXISTS trading_history (
     scenario TEXT,
     trigger_type TEXT,
     trigger_mode TEXT,
-    sector TEXT
+    sector TEXT,
+    exit_kind TEXT
 )
 """
 
@@ -738,6 +739,28 @@ def migrate_analysis_performance_tracker_columns(cursor, conn):
         logger.warning(f"Error updating KR tracking_status: {exc}")
 
 
+def migrate_trading_history_columns(cursor, conn):
+    """Add churn-guard columns to trading_history if missing (idempotent, no backfill).
+
+    exit_kind: compact exit classification (stop | trend_exit | target | ai) used by
+    the re-entry cooldown / journal churn guard so a stop-out at a marginal profit is
+    treated as churn-risk. Existing rows stay NULL (legacy P&L-sign behaviour).
+    """
+    migrations = [
+        ("trading_history", "exit_kind TEXT"),
+    ]
+    for table_name, column_def in migrations:
+        try:
+            cursor.execute(f"ALTER TABLE {table_name} ADD COLUMN {column_def}")
+            conn.commit()
+            logger.info(f"Added column to {table_name}: {column_def}")
+        except Exception as exc:
+            if "duplicate column name" in str(exc).lower():
+                logger.debug(f"Column already exists in {table_name}: {column_def}")
+            else:
+                logger.warning(f"Migration warning for {table_name}: {exc}")
+
+
 def create_all_tables(cursor, conn):
     """
     Create all database tables.
@@ -766,6 +789,7 @@ def create_all_tables(cursor, conn):
     migrate_drop_holdings_unique_constraint(cursor, conn)
     migrate_watchlist_history_columns(cursor, conn)
     migrate_analysis_performance_tracker_columns(cursor, conn)
+    migrate_trading_history_columns(cursor, conn)
     conn.commit()
     logger.info("Database tables created")
 

--- a/tracking/journal.py
+++ b/tracking/journal.py
@@ -697,7 +697,9 @@ Please review the following completed trade:
                     if _rc_root not in sys.path:
                         sys.path.insert(0, _rc_root)
                     import reentry_cooldown as _rc
-                    _loss_info = _rc.recent_loss(ticker, market="KR")
+                    # risk-exit aware (loss OR stop/trend-exit); falls back to
+                    # loss-only on an older reentry_cooldown build.
+                    _loss_info = getattr(_rc, "recent_risk_exit", _rc.recent_loss)(ticker, market="KR")
                     if _loss_info is not None and _loss_info["gap_hours"] <= JOURNAL_RECENT_LOSS_HOURS:
                         adjustment = min(adjustment, 0) - JOURNAL_RECENT_LOSS_PENALTY
                         reasons.append(


### PR DESCRIPTION
## 문제
재진입 쿨다운이 **P&L 부호 기반**이라, 손절/추세이탈이 **소폭 이익(+0.39%)**으로 청산되면 손실로 분류 안 돼 24h 쿨다운이 발동 안 함 → 즉시 재매수(2026-07-01 MU: 손절 +0.39% → 4분 뒤 재매수). 쿨다운 veto·journal 페널티 **둘 다** 부호로 판단해 놓침.

## 수정 (옵션 A — 청산 "사유"로 분류해 매매원장에 저장)
- **스키마**: `trading_history`/`us_trading_history`에 `exit_kind` 컬럼을 **startup idempotent 마이그레이션**으로 추가(`migrate_[us_]trading_history_columns`, `create_all_tables`/`create_us_tables`에 체인). **백필 없음** — 신규 매도부터. 기존 행 NULL → 레거시 부호 동작 fallback.
- **`sell_stock`(KR/US)**: `exit_kind` 파라미터 추가. `classify_exit_kind()`가 호출부 힌트 또는 `sell_reason`(KR '손절 조건 도달…', US 'Stop-loss condition reached…', 'TIER1_*'/'TIER1.5_*')로 `stop|trend_exit|target|ai` 분류. **loop_a→'stop', loop_b→'trend_exit'** 명시 전달.
- **`reentry_block`**: exit_kind가 risk-exit(stop/trend_exit)면 **부호 무관 손실 윈도우(24h)** 적용. NULL/컬럼없음 → 레거시. journal churn guard는 신규 `recent_risk_exit()` 사용(getattr fallback).

## SHADOW-first
신규 exit_kind **하드 veto**는 `REENTRY_COOLDOWN_RISK_EXIT_LIVE`(기본 false)로 게이트 — 로그만 남기고(`[REENTRY_COOLDOWN][SHADOW] … exit_kind=stop risk_only=True`) 차단 안 함. 손실 기반 기존 veto는 `COOLDOWN_LIVE` 그대로. 수 세션 관측 후 플래그 on.

## 테스트
- `tests/test_exit_kind_churn_guard.py`: 분류자 / stop@이익→차단 / 이익실현(ai·target)→허용 / NULL·마이그레이션전 fallback / recent_risk_exit
- 마이그레이션 idempotency, journal 페널티 테스트 recent_risk_exit로 재지정
- **전체 41 pass**, 양 에이전트 py_compile OK

## 배포 안전성
`exit_kind` 컬럼 자동 추가 + 신규 매도부터 기록. 하드 veto는 SHADOW(플래그 off)라 배포 즉시 동작 변화 없음(로그만). journal 소프트 페널티(−score)는 risk-exit로 확장 적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)