### PR TITLE
feat(model): upgrade Sonnet 4.6 -> Sonnet 5 (report_generator + bot docstrings)

### DIFF
--- a/report_generator.py
+++ b/report_generator.py
@@ -730,8 +730,8 @@ async def generate_follow_up_response(ticker, ticker_name, conversation_context,
                     필요한 경우 최신 데이터를 조회하여 정확한 정보를 제공하세요.
                     """,
             request_params=RequestParams(
-                model="claude-sonnet-4-6",
-                maxTokens=2000
+                model="claude-sonnet-5",
+                maxTokens=4000
             )
         )
         app_logger.info(f"추가 질문 응답 생성 결과: {str(response)[:100]}...")
@@ -927,7 +927,7 @@ async def generate_evaluation_response(ticker, ticker_name, avg_price, period, t
                     {report_content if report_content else "관련 보고서가 없습니다. 시장 데이터 조회와 perplexity 검색을 통해 최신 정보를 수집하여 평가해주세요."}
                     """,
             request_params=RequestParams(
-                model="claude-sonnet-4-6",
+                model="claude-sonnet-5",
                 maxTokens=8000
             )
         )
@@ -1124,7 +1124,7 @@ async def generate_us_evaluation_response(ticker, ticker_name, avg_price, period
                     perplexity로 최신 뉴스와 시장 동향을 검색한 후 종합적인 평가를 제공해주세요.
                     """,
             request_params=RequestParams(
-                model="claude-sonnet-4-6",
+                model="claude-sonnet-5",
                 maxTokens=8000
             )
         )
@@ -1221,8 +1221,8 @@ async def generate_us_follow_up_response(ticker, ticker_name, conversation_conte
                     필요한 경우 yahoo_finance를 통해 최신 데이터를 조회하여 정확한 정보를 제공하세요.
                     """,
             request_params=RequestParams(
-                model="claude-sonnet-4-6",
-                maxTokens=2000
+                model="claude-sonnet-5",
+                maxTokens=4000
             )
         )
         app_logger.info(f"US follow-up response generated: {str(response)[:100]}...")
@@ -1339,8 +1339,8 @@ async def generate_journal_conversation_response(
 
 위 메시지에 자연스럽게 응답해주세요. 사용자의 과거 기록(저널, 평가 등)을 참고하여 개인화된 답변을 제공하세요.""",
             request_params=RequestParams(
-                model="claude-sonnet-4-6",
-                maxTokens=2000
+                model="claude-sonnet-5",
+                maxTokens=4000
             )
         )
         app_logger.info(f"Journal conversation response generated: user_id={user_id}, response_len={len(response)}")
@@ -1428,8 +1428,8 @@ async def generate_firecrawl_search_response(search_query: str, analysis_prompt:
         response = await llm.generate_str(
             message=f"다음은 웹 검색 결과입니다:\n\n{context}\n\n---\n\n{analysis_prompt}",
             request_params=RequestParams(
-                model="claude-sonnet-4-6",
-                maxTokens=2000
+                model="claude-sonnet-5",
+                maxTokens=4000
             )
         )
         app.logger.info(f"Firecrawl search+Claude response: {len(response)} chars")
@@ -1535,8 +1535,8 @@ async def generate_firecrawl_followup_response(
         response = await llm.generate_str(
             message=user_question,
             request_params=RequestParams(
-                model="claude-sonnet-4-6",
-                maxTokens=2000,
+                model="claude-sonnet-5",
+                maxTokens=4000,
             ),
         )
         app.logger.info(f"firecrawl_followup ({command}): {len(response)} chars")

--- a/telegram_ai_bot.py
+++ b/telegram_ai_bot.py
@@ -934,7 +934,7 @@ class TelegramAIBot:
         # ==========================================================================
         # Firecrawl AI Research commands — interactive ConversationHandlers
         # Each command first asks for the required parameter, then calls Firecrawl.
-        # Subsequent replies to the bot's response continue via Anthropic Sonnet 4.6.
+        # Subsequent replies to the bot's response continue via Anthropic Sonnet 5.
         # BotFather commands to register:
         #   signal - 이벤트/뉴스 임팩트 분석 (한국)
         #   us_signal - 이벤트/뉴스 임팩트 분석 (미국)
@@ -2746,7 +2746,7 @@ class TelegramAIBot:
 
     async def _run_search_and_claude(self, update: Update, search_query: str, analysis_prompt: str, disclaimer: str):
         """
-        Cost-efficient helper using Firecrawl /search (2 credits) + Claude Sonnet 4.6.
+        Cost-efficient helper using Firecrawl /search (2 credits) + Claude Sonnet 5.
         Uses the same global MCPApp + AnthropicAugmentedLLM pattern as /evaluate.
 
         Returns:
@@ -3422,7 +3422,7 @@ class TelegramAIBot:
     # ==========================================================================
 
     async def _handle_firecrawl_reply(self, update: Update, fc_ctx: FirecrawlConversationContext):
-        """Handle a reply to a Firecrawl bot message — continue via Anthropic Sonnet 4.6."""
+        """Handle a reply to a Firecrawl bot message — continue via Anthropic Sonnet 5."""
         user_question = update.message.text.strip()
         chat_id = update.effective_chat.id
 


### PR DESCRIPTION
## 변경
Claude **Sonnet 5**(`claude-sonnet-5`, 2026-06-30 출시, Opus 4.8 근접 지능·저가)로 업그레이드.

- `report_generator.py`: 텔레그램 봇 분석/답변 경로(Firecrawl 답변 연속·추가 질문 포함)가 쓰는 `RequestParams` 모델 문자열 **7곳** `claude-sonnet-4-6` → `claude-sonnet-5`.
- `telegram_ai_bot.py`: docstring 3곳 "Sonnet 4.6" → "Sonnet 5".

## 동작 변경 처리 (What's new in Sonnet 5)
- Sonnet 5는 **adaptive thinking 기본 ON**이고 thinking이 `max_tokens`를 공유. mcp-agent는 API에 `model/max_tokens/messages/stop_sequences/tools/system`만 넘기고 **`temperature`/`top_p`/`thinking`은 안 보냄** → 400 유발 변경(sampling·manual budget_tokens) **해당 없음**.
- adaptive thinking 여유 확보 및 응답 잘림 방지를 위해 `maxTokens=2000` **5곳 → 4000**. `maxTokens=8000` 2곳은 유지.

## 범위 제외 (미변경)
`prism-btc/live/postmortem.py`(BTC 별개 제품), `cores/archive/insight_agent.py`(archive).

## 검증
양 파일 `py_compile` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)