### PR TITLE
[codex] Keep KR trigger screening alive during KRX name lookup stalls

### DIFF
--- a/tests/test_trigger_batch_enhance_dataframe.py
+++ b/tests/test_trigger_batch_enhance_dataframe.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import os
+import sys
+import types
+
+import pandas as pd
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+krx_stub = types.ModuleType("krx_data_client")
+krx_stub.get_market_ohlcv_by_ticker = lambda *args, **kwargs: pd.DataFrame()
+krx_stub.get_nearest_business_day_in_a_week = lambda *args, **kwargs: "20260703"
+krx_stub.get_market_cap_by_ticker = lambda *args, **kwargs: pd.DataFrame()
+krx_stub.get_market_ticker_name = lambda ticker: ticker
+krx_stub._get_client = lambda: None
+sys.modules.setdefault("krx_data_client", krx_stub)
+
+import trigger_batch as t
+
+
+def setup_function():
+    t._TICKER_NAME_CACHE = None
+
+
+def test_enhance_dataframe_fetches_ticker_names_in_one_batch(monkeypatch):
+    calls = []
+
+    class FakeClient:
+        def get_market_ticker_name(self, market="ALL"):
+            calls.append(market)
+            return {
+                "005930": "SAMSUNG",
+                "000660": "SKHYNIX",
+            }
+
+    monkeypatch.setattr(t, "_get_client", lambda: FakeClient(), raising=False)
+
+    df = pd.DataFrame({"Close": [70000, 120000]}, index=["005930", "000660"])
+
+    result = t.enhance_dataframe(df)
+
+    assert calls == ["ALL"]
+    assert result["stock_name"].to_dict() == {
+        "005930": "SAMSUNG",
+        "000660": "SKHYNIX",
+    }
+
+
+def test_enhance_dataframe_keeps_rows_when_name_lookup_times_out(monkeypatch):
+    class TimeoutClient:
+        def get_market_ticker_name(self, market="ALL"):
+            raise TimeoutError("KRX timeout")
+
+    monkeypatch.setattr(t, "_get_client", lambda: TimeoutClient(), raising=False)
+    monkeypatch.setattr(
+        t.stock_api,
+        "get_market_ticker_name",
+        lambda ticker: (_ for _ in ()).throw(TimeoutError("KRX timeout")),
+    )
+
+    df = pd.DataFrame({"Close": [70000, 120000]}, index=["005930", "000660"])
+
+    result = t.enhance_dataframe(df)
+
+    assert list(result.index) == ["005930", "000660"]
+    assert result["stock_name"].to_dict() == {
+        "005930": "005930",
+        "000660": "000660",
+    }

--- a/tests/test_trigger_batch_enhance_dataframe.py
+++ b/tests/test_trigger_batch_enhance_dataframe.py
@@ -48,16 +48,14 @@ def test_enhance_dataframe_fetches_ticker_names_in_one_batch(monkeypatch):
 
 
 def test_enhance_dataframe_keeps_rows_when_name_lookup_times_out(monkeypatch):
+    calls = []
+
     class TimeoutClient:
         def get_market_ticker_name(self, market="ALL"):
+            calls.append(market)
             raise TimeoutError("KRX timeout")
 
     monkeypatch.setattr(t, "_get_client", lambda: TimeoutClient(), raising=False)
-    monkeypatch.setattr(
-        t.stock_api,
-        "get_market_ticker_name",
-        lambda ticker: (_ for _ in ()).throw(TimeoutError("KRX timeout")),
-    )
 
     df = pd.DataFrame({"Close": [70000, 120000]}, index=["005930", "000660"])
 
@@ -67,4 +65,42 @@ def test_enhance_dataframe_keeps_rows_when_name_lookup_times_out(monkeypatch):
     assert result["stock_name"].to_dict() == {
         "005930": "005930",
         "000660": "000660",
+    }
+    assert calls == ["ALL"]
+
+
+def test_enhance_dataframe_caches_failed_lookup_for_process(monkeypatch):
+    calls = []
+
+    class TimeoutClient:
+        def get_market_ticker_name(self, market="ALL"):
+            calls.append(market)
+            raise TimeoutError("KRX timeout")
+
+    monkeypatch.setattr(t, "_get_client", lambda: TimeoutClient(), raising=False)
+
+    df = pd.DataFrame({"Close": [70000]}, index=["005930"])
+
+    first = t.enhance_dataframe(df)
+    second = t.enhance_dataframe(df)
+
+    assert calls == ["ALL"]
+    assert first["stock_name"].to_dict() == {"005930": "005930"}
+    assert second["stock_name"].to_dict() == {"005930": "005930"}
+
+
+def test_enhance_dataframe_normalizes_numeric_ticker_index(monkeypatch):
+    class FakeClient:
+        def get_market_ticker_name(self, market="ALL"):
+            return {"005930": "SAMSUNG"}
+
+    monkeypatch.setattr(t, "_get_client", lambda: FakeClient(), raising=False)
+
+    df = pd.DataFrame({"Close": [70000, 120000]}, index=[5930, 660])
+
+    result = t.enhance_dataframe(df)
+
+    assert result["stock_name"].to_dict() == {
+        5930: "SAMSUNG",
+        660: "000660",
     }

--- a/trigger_batch.py
+++ b/trigger_batch.py
@@ -35,14 +35,30 @@ logger.addHandler(ch)
 _TICKER_NAME_CACHE: Optional[dict[str, str]] = None
 
 
+def _normalize_ticker_code(ticker) -> str:
+    ticker_code = str(ticker).strip()
+    if ticker_code.isdigit():
+        return ticker_code.zfill(6)
+    return ticker_code
+
+
 def _get_ticker_name_map() -> dict[str, str]:
     """Fetch all ticker names once per process to avoid repeated KRX calls."""
     global _TICKER_NAME_CACHE
     if _TICKER_NAME_CACHE is None:
-        client = _get_client()
-        names = client.get_market_ticker_name(market="ALL")
-        _TICKER_NAME_CACHE = {str(ticker): str(name) for ticker, name in names.items()}
+        try:
+            client = _get_client()
+            names = client.get_market_ticker_name(market="ALL")
+            _TICKER_NAME_CACHE = {_normalize_ticker_code(ticker): str(name) for ticker, name in names.items()}
+        except Exception as e:
+            logger.warning(f"KRX ticker name lookup failed; using ticker codes as names: {e}")
+            _TICKER_NAME_CACHE = {}
     return _TICKER_NAME_CACHE
+
+
+def _get_display_ticker_name(ticker, name_map: dict[str, str]) -> str:
+    ticker_code = _normalize_ticker_code(ticker)
+    return name_map.get(ticker_code, ticker_code)
 
 
 # --- Data collection and caching functions ---
@@ -202,12 +218,8 @@ def enhance_dataframe(df: pd.DataFrame) -> pd.DataFrame:
     """
     if not df.empty:
         df = df.copy()  # Explicitly create copy to prevent SettingWithCopyWarning
-        try:
-            name_map = _get_ticker_name_map()
-        except Exception as e:
-            logger.warning(f"KRX ticker name lookup failed; using ticker codes as names: {e}")
-            name_map = {}
-        df["stock_name"] = df.index.map(lambda ticker: name_map.get(str(ticker), str(ticker)))
+        name_map = _get_ticker_name_map()
+        df["stock_name"] = df.index.map(lambda ticker: _get_display_ticker_name(ticker, name_map))
     return df
 
 

--- a/trigger_batch.py
+++ b/trigger_batch.py
@@ -7,7 +7,9 @@ import datetime
 import pandas as pd
 import numpy as np
 import logging
+from typing import Optional
 from krx_data_client import (
+    _get_client,
     get_market_ohlcv_by_ticker,
     get_nearest_business_day_in_a_week,
     get_market_cap_by_ticker,
@@ -28,6 +30,19 @@ ch = logging.StreamHandler()
 formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
 ch.setFormatter(formatter)
 logger.addHandler(ch)
+
+
+_TICKER_NAME_CACHE: Optional[dict[str, str]] = None
+
+
+def _get_ticker_name_map() -> dict[str, str]:
+    """Fetch all ticker names once per process to avoid repeated KRX calls."""
+    global _TICKER_NAME_CACHE
+    if _TICKER_NAME_CACHE is None:
+        client = _get_client()
+        names = client.get_market_ticker_name(market="ALL")
+        _TICKER_NAME_CACHE = {str(ticker): str(name) for ticker, name in names.items()}
+    return _TICKER_NAME_CACHE
 
 
 # --- Data collection and caching functions ---
@@ -187,7 +202,12 @@ def enhance_dataframe(df: pd.DataFrame) -> pd.DataFrame:
     """
     if not df.empty:
         df = df.copy()  # Explicitly create copy to prevent SettingWithCopyWarning
-        df["stock_name"] = df.index.map(lambda ticker: stock_api.get_market_ticker_name(ticker))
+        try:
+            name_map = _get_ticker_name_map()
+        except Exception as e:
+            logger.warning(f"KRX ticker name lookup failed; using ticker codes as names: {e}")
+            name_map = {}
+        df["stock_name"] = df.index.map(lambda ticker: name_map.get(str(ticker), str(ticker)))
     return df
 
 


### PR DESCRIPTION
## What changed

- Fetch KR ticker-name mappings once per process instead of calling KRX once per selected ticker.
- Keep enhance_dataframe() fail-open when KRX ticker-name lookup times out, using ticker codes as display names.
- Add regression tests for one-shot name loading and timeout fallback behavior.

## Why

The production failure happened after stock selection, during display-name enrichment. get_market_ticker_name(ticker) can reload the full market=ALL ticker-name table internally, so calling it once per ticker amplifies KRX Data Marketplace stalls around market open and can collapse the batch into No stocks selected.

## Validation

- python3 -m pytest tests/test_trigger_batch_enhance_dataframe.py
- PYTHONPYCACHEPREFIX=/private/tmp/prism-pycache python3 -m py_compile trigger_batch.py tests/test_trigger_batch_enhance_dataframe.py

## Risk

Narrow. If ticker-name lookup fails, reports may temporarily show ticker codes instead of company names, but candidate selection can continue.