### PR TITLE
feat(btc): 라운드5 게이트 교차셀 검증 — 룰 유지 + 최접근 리포팅

### DIFF
--- a/prism-btc/analysis/round5_gate_cross.py
+++ b/prism-btc/analysis/round5_gate_cross.py
@@ -1,0 +1,204 @@
+# analysis/round5_gate_cross.py — 라운드5: score × ts_4h 교차셀 forward-edge 진단
+#
+# 배경 (2026-07, 라이브 20일 무매매 관찰): score 게이트(|70|)와 ts_4h 게이트(2.0)가
+# 서로 다른 시점에 켜져(ts는 추세 초기, score는 전 TF 정렬 후반) 동시 통과가 드물다는
+# 가설이 제기됨. 기존 H1 연구(h1_signal_power)는 score 버킷과 ts 버킷을 각각
+# marginal 로만 측정했고 교차셀은 본 적 없음.
+#
+# 목적: 고정된 교차셀(score band × ts_4h band)의 방향조정 forward return 을
+# 2020–2026 전체 표본에서 측정해 (1) 현행 게이트의 타당성 재검증,
+# (2) "조기 강추세 레인"(55–70 × ts>=3.5) 가설의 표본 확장 검증.
+# 최적화 스윕 아님 — 셀 경계는 기존 연구(v3_edge_diagnosis §1)의 버킷 그대로.
+#
+# 실행 (prism-btc 패키지 루트에서):
+#   python -m analysis.round5_gate_cross [--db state/btc_market.db]
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import numpy as np
+import pandas as pd
+
+from engine.indicators import add_indicators
+from engine.regime import RegimeSnapshot, build_tf_state, compute_alignment_score
+from engine.signal import (
+    ENTRY_TRIGGER_TF,
+    LONG_ENTRY_POSITIONS,
+    SHORT_ENTRY_POSITIONS,
+    _entry_tf_aligned,
+    _long_tf_direction_negative,
+    _long_tf_direction_positive,
+    trend_strength,
+)
+
+ALL_TFS = ("30m", "1h", "4h", "12h", "1d", "1w")
+EVAL_TF = "4h"
+FWD_TF = "1h"
+HORIZONS = {"3d": 72, "7d": 168, "14d": 336}  # 1h bars
+
+# 셀 경계 — 기존 연구 버킷 고정 (스윕 금지)
+SCORE_BANDS = [(40, 55, "40-55"), (55, 70, "55-70"), (70, 85, "70-85"), (85, 101, "85+")]
+TS_BANDS = [(0.0, 2.0, "ts<2"), (2.0, 3.5, "ts2-3.5"), (3.5, 99.0, "ts3.5+")]
+PERIODS = [("2020", "2021"), ("2022", "2023"), ("2024", "2026")]
+MIN_ABS_SCORE = 40.0  # 표본 하한 — 이보다 약한 정렬은 어떤 가설 셀에도 안 쓰임
+
+
+def load_tf(conn: sqlite3.Connection, tf: str) -> pd.DataFrame:
+    df = pd.read_sql_query(
+        "SELECT open_time, open, high, low, close, volume, turnover "
+        "FROM klines WHERE timeframe=? AND confirmed=1 ORDER BY open_time ASC",
+        conn, params=(tf,))
+    df = add_indicators(df)
+    df["dt"] = pd.to_datetime(df["open_time"], unit="ms", utc=True)
+    return df
+
+
+def extract_signals(db_path: str) -> pd.DataFrame:
+    conn = sqlite3.connect(db_path)
+    data = {tf: load_tf(conn, tf) for tf in ALL_TFS}
+    conn.close()
+    for tf, df in data.items():
+        print(f"[load] {tf}: {len(df)} bars {df['dt'].min()} .. {df['dt'].max()}")
+        # 환경 가드: 일부 로컬 환경(Python 3.14 + pandas 2.3.3 + numpy 1.26)에서
+        # ~1.6만 행 이상 시리즈의 rolling 이 전부 NaN 을 반환하는 버그 확인됨
+        # (2026-07). 조용히 0 신호가 되는 대신 즉시 실패시킨다.
+        if len(df) >= 35 and df["ma10"].isna().all():
+            raise RuntimeError(
+                f"indicator computation broken in this environment "
+                f"({tf}: all-NaN ma10, {len(df)} rows) — pandas rolling bug. "
+                f"Run on a known-good env (e.g. db-server pyenv 3.11).")
+
+    fwd = data[FWD_TF].dropna(subset=["ma10", "ma35", "atr14"]).reset_index(drop=True)
+    fwd_times = fwd["open_time"].values
+    fwd_close = fwd["close"].values
+
+    eval_df = data[EVAL_TF].dropna(subset=["ma10", "ma35", "atr14"]).reset_index(drop=True)
+    tf_arr = {tf: data[tf]["open_time"].values for tf in ALL_TFS}
+
+    rows = []
+    for i in range(len(eval_df)):
+        t = eval_df["open_time"].iloc[i]
+        tf_states = {}
+        ok = True
+        for tf in ALL_TFS:
+            arr = tf_arr[tf]
+            idx = np.searchsorted(arr, t, side="right") - 1
+            if idx < 34:
+                ok = False
+                break
+            try:
+                tf_states[tf] = build_tf_state(data[tf].iloc[:idx + 1])
+            except ValueError:
+                ok = False
+                break
+        if not ok:
+            continue
+
+        score = compute_alignment_score(tf_states)
+        if abs(score) < MIN_ABS_SCORE:
+            continue
+
+        # 진입 경로의 비(非)게이트 조건을 라이브와 동일하게 요구:
+        # 장기TF 가중방향 + 4h 트리거 캔들 위치. 게이트(score/ts)만 셀에서 조건화.
+        if score > 0:
+            if not _long_tf_direction_positive(tf_states):
+                continue
+            if not _entry_tf_aligned(tf_states, ENTRY_TRIGGER_TF, LONG_ENTRY_POSITIONS):
+                continue
+            side, sgn = "long", 1.0
+        else:
+            if not _long_tf_direction_negative(tf_states):
+                continue
+            if not _entry_tf_aligned(tf_states, ENTRY_TRIGGER_TF, SHORT_ENTRY_POSITIONS):
+                continue
+            side, sgn = "short", -1.0
+
+        # 진입가 근사: 이 4h 확정봉 직후의 1h 종가 (H1 연구와 동일)
+        j = np.searchsorted(fwd_times, t, side="right") - 1
+        if j < 0:
+            continue
+        p0 = fwd_close[j]
+        rec = {
+            "t": t, "side": side, "score": score,
+            "ts_4h": trend_strength(tf_states["4h"]),
+            "ts_1d": trend_strength(tf_states["1d"]),
+        }
+        valid = True
+        for name, nbars in HORIZONS.items():
+            k = j + nbars
+            if k >= len(fwd_close):
+                valid = False
+                break
+            rec[f"fwd_{name}"] = sgn * (fwd_close[k] - p0) / p0
+        if valid:
+            rows.append(rec)
+
+    df = pd.DataFrame(rows)
+    df["dt"] = pd.to_datetime(df["t"], unit="ms", utc=True)
+    return df
+
+
+def summarize(d: pd.DataFrame, label: str) -> None:
+    if len(d) == 0:
+        print(f"{label:34s} n=   0")
+        return
+    parts = [f"{label:34s} n={len(d):4d}"]
+    for h in HORIZONS:
+        f = d[f"fwd_{h}"]
+        parts.append(f"{h}: {f.mean() * 100:+.2f}%/{(f > 0).mean() * 100:.0f}%")
+    print("  ".join(parts))
+
+
+def report(df: pd.DataFrame) -> None:
+    df = df.copy()
+    df["abs_score"] = df["score"].abs()
+
+    print(f"\n=== 표본: {df.dt.min():%Y-%m-%d} ~ {df.dt.max():%Y-%m-%d}, n={len(df)} "
+          f"(방향조정 forward, mean%/hit%) ===")
+
+    print("\n--- score × ts_4h 교차셀 ---")
+    for slo, shi, sn in SCORE_BANDS:
+        for tlo, thi, tn in TS_BANDS:
+            d = df[(df.abs_score >= slo) & (df.abs_score < shi)
+                   & (df.ts_4h >= tlo) & (df.ts_4h < thi)]
+            summarize(d, f"score{sn} x {tn}")
+        print()
+
+    print("--- 룰 단위 요약 ---")
+    cur = df[(df.abs_score >= 70) & (df.ts_4h >= 2.0)]
+    summarize(cur, "현행 (|score|>=70 & ts>=2.0)")
+    early = df[(df.abs_score >= 55) & (df.abs_score < 70) & (df.ts_4h >= 3.5)]
+    summarize(early, "조기레인 추가분 (55-70 & ts>=3.5)")
+    two = df[((df.abs_score >= 70) & (df.ts_4h >= 2.0))
+             | ((df.abs_score >= 55) & (df.ts_4h >= 3.5))]
+    summarize(two, "2레인 합계")
+
+    print("\n--- 기간별 안정성 ---")
+    for y0, y1 in PERIODS:
+        p = df[(df.dt >= f"{y0}-01-01") & (df.dt <= f"{y1}-12-31")]
+        summarize(p[(p.abs_score >= 70) & (p.ts_4h >= 2.0)], f"{y0}-{y1} 현행")
+        summarize(p[(p.abs_score >= 55) & (p.abs_score < 70) & (p.ts_4h >= 3.5)],
+                  f"{y0}-{y1} 조기레인 추가분")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db", default=str(Path(__file__).resolve().parents[1]
+                                            / "state" / "btc_market.db"))
+    parser.add_argument("--out", default=None, help="신호 CSV 저장 경로 (선택)")
+    args = parser.parse_args()
+
+    df = extract_signals(args.db)
+    if args.out:
+        df.to_csv(args.out, index=False)
+        print(f"[save] {args.out} ({len(df)} rows)")
+    report(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/prism-btc/engine/config.py
+++ b/prism-btc/engine/config.py
@@ -32,6 +32,11 @@ CANDLE_BONUS_FRAC: float = 0.20  # up to ±20% of each TF weight
 # realized trading (first-gate-crossing entries land at trend saturation; 21 trades,
 # avg -0.5R). 70 keeps the 70–85 bucket (14d +1.78%) and passed 2026H1 OOS.
 # See analysis/round4_attribution.py — attribution cells only, no grid sweep.
+# 라운드5 재검증 (2026-07, 라이브 20일 무매매 관찰 후 게이트 완화 가설 검토):
+# 2020-11~2026-06 전체 표본(n=5,073)의 score×ts_4h 교차셀에서 현행 셀
+# (|score|>=70 & ts>=2.0)은 14d +5.10%/hit 65% (n=793)로 3개 분리 기간 모두 유효.
+# 완화 후보 55-70×ts>=2 (14d -0.05%), 조기레인 55-70×ts>=3.5 (n=10, 3d 음수) 모두
+# 기각 — 게이트 유지. See analysis/round5_gate_cross.py, tasks/btc_round5_gate_review.md.
 ENTRY_SCORE_MIN: float = 70.0
 
 # --- Chop filter: trend-strength gate (라운드2 구조개선 #1) ---
@@ -42,6 +47,8 @@ ENTRY_SCORE_MIN: float = 70.0
 # 1.0 → 2.0 (라운드4, tasks/v3_edge_diagnosis.md §1): 4h ts 1–2 is a proven
 # anti-edge bucket (7d hit 41.0%, mean -0.58%, p=0.0001, n=504); the edge only
 # exists at ts 2+ (2–3.5: 14d hit 64.9%; 3.5+: 77.4%). No parameter sweep.
+# 라운드5 (2026-07): 2020-2026 교차셀에서도 ts<2 는 score 85+ 조차 무엣지
+# (n=1,046, 14d +1.37%/49%) — 게이트 유지 재확인. analysis/round5_gate_cross.py.
 TS_MIN: float = 2.0
 # TFs that must clear TS_MIN before a new entry is allowed.
 # 라운드4: ("4h","1d") → ("4h",). The H1 study measured the *4h* ts buckets;

--- a/prism-btc/live/telegram_reporter.py
+++ b/prism-btc/live/telegram_reporter.py
@@ -153,6 +153,37 @@ def _recent_scores(conn, mode: str, limit: int = 4) -> list[float]:
     return [float(r["score"]) for r in reversed(rows) if r["score"] is not None]
 
 
+def _near_miss_7d(conn, mode: str, score_min: float, ts_min: float,
+                  now: str | None = None) -> dict | None:
+    """최근 7일 중 진입 게이트에 가장 근접했던 평가 1건.
+
+    우선순위: 점수 게이트(|score|>=score_min)를 통과한 행 중 ts_4h 최대
+    → 없으면 |score| 최대 행. 무매매 기간에도 "얼마나 아깝게 관망했는지"를
+    보여주기 위한 것. now 주입으로 결정적 테스트 가능(healthcheck와 동일 원칙).
+    실패는 전부 흡수(None) — 리포트 비중단.
+    """
+    try:
+        rows = conn.execute(
+            "SELECT ts, score, ts_4h FROM btc_signal_log "
+            "WHERE mode=? AND datetime(ts) >= datetime(COALESCE(?, 'now'), '-7 days') "
+            "AND score IS NOT NULL AND ts_4h IS NOT NULL",
+            (mode, now),
+        ).fetchall()
+    except Exception:  # noqa: BLE001
+        return None
+    if not rows:
+        return None
+    passed = [r for r in rows if abs(r["score"]) >= score_min]
+    if passed:
+        best = max(passed, key=lambda r: r["ts_4h"])
+        blocked_by = "ts"
+    else:
+        best = max(rows, key=lambda r: abs(r["score"]))
+        blocked_by = "score"
+    return {"ts": best["ts"], "score": float(best["score"]),
+            "ts_4h": float(best["ts_4h"]), "blocked_by": blocked_by}
+
+
 def _entry_gates() -> tuple[float, float]:
     """진입 게이트 상수 (점수문턱, 추세강도최소). import 실패 시 현행 기본값."""
     try:
@@ -383,6 +414,21 @@ def build_message(conn, mode: str) -> str:
                 else:
                     trend = "큰 변화 없음"
                 lines.append(f"• 최근 점수 흐름: {arrow} ({trend})")
+            # 최근 7일 게이트 최접근 — 무매매여도 시스템이 뭘 보고 참았는지.
+            nm = _near_miss_7d(conn, mode, score_min, ts_min)
+            if nm is not None:
+                when = str(nm["ts"])[5:13].replace("T", " ") + "시(UTC)"
+                if nm["blocked_by"] == "ts":
+                    lines.append(
+                        f"• 최근 7일 최접근: {when} 점수 {nm['score']:+.0f} 통과 · "
+                        f"추세 힘 {nm['ts_4h']:.2f} (최소 {ts_min:.1f}, "
+                        f"{max(ts_min - nm['ts_4h'], 0):.2f} 부족)"
+                    )
+                else:
+                    lines.append(
+                        f"• 최근 7일 최접근: {when} 점수 {nm['score']:+.0f} "
+                        f"(문턱 ±{score_min:.0f}, {max(score_min - abs(nm['score']), 0):.0f}점 부족)"
+                    )
         elif side in ("long", "short"):
             lines.append(f"• 종합 판단: {_side_kr(side)} *신호 포착* — 진입 조건 확인 중")
             if score is not None:

--- a/prism-btc/tests/test_reporter_nearmiss.py
+++ b/prism-btc/tests/test_reporter_nearmiss.py
@@ -1,0 +1,80 @@
+# tests/test_reporter_nearmiss.py — 일일 리포트 "최근 7일 게이트 최접근" 단위 테스트.
+#
+# 원칙: 네트워크 0, in-memory DB, now 주입으로 결정적 (healthcheck 테스트와 동일).
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+from live import tracking
+from live.telegram_reporter import _near_miss_7d
+from live.tracking import ensure_schema
+
+_NOW = datetime(2026, 7, 4, 0, 0, 0, tzinfo=timezone.utc)
+_NOW_STR = _NOW.isoformat()
+
+
+def _conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    ensure_schema(conn)
+    return conn
+
+
+def _sig(conn, *, days_ago: float, score: float, ts_4h: float,
+         mode: str = "shadow") -> str:
+    ts = (_NOW - timedelta(days=days_ago)).isoformat()
+    tracking.log_signal(conn, ts, score=score, ts_4h=ts_4h, ts_1d=1.0,
+                        side="none", reason="test", mode=mode)
+    return ts
+
+
+def test_empty_log_returns_none():
+    conn = _conn()
+    assert _near_miss_7d(conn, "shadow", 70.0, 2.0, now=_NOW_STR) is None
+
+
+def test_score_gate_passed_picks_max_ts4h():
+    conn = _conn()
+    _sig(conn, days_ago=5, score=-80.0, ts_4h=1.2)
+    best_ts = _sig(conn, days_ago=3, score=-95.0, ts_4h=1.98)
+    _sig(conn, days_ago=1, score=-30.0, ts_4h=2.5)  # 점수 미달 — 후보 아님
+    nm = _near_miss_7d(conn, "shadow", 70.0, 2.0, now=_NOW_STR)
+    assert nm is not None
+    assert nm["blocked_by"] == "ts"
+    assert nm["ts"] == best_ts
+    assert nm["ts_4h"] == 1.98
+
+
+def test_no_score_pass_falls_back_to_max_abs_score():
+    conn = _conn()
+    _sig(conn, days_ago=4, score=-55.0, ts_4h=2.2)
+    _sig(conn, days_ago=2, score=40.0, ts_4h=0.5)
+    nm = _near_miss_7d(conn, "shadow", 70.0, 2.0, now=_NOW_STR)
+    assert nm is not None
+    assert nm["blocked_by"] == "score"
+    assert nm["score"] == -55.0
+
+
+def test_window_excludes_older_than_7_days():
+    conn = _conn()
+    _sig(conn, days_ago=8, score=-100.0, ts_4h=3.0)  # 창 밖
+    _sig(conn, days_ago=2, score=-60.0, ts_4h=1.0)
+    nm = _near_miss_7d(conn, "shadow", 70.0, 2.0, now=_NOW_STR)
+    assert nm is not None
+    assert nm["blocked_by"] == "score"
+    assert nm["score"] == -60.0
+
+
+def test_mode_isolation():
+    conn = _conn()
+    _sig(conn, days_ago=1, score=-90.0, ts_4h=1.9, mode="demo")
+    assert _near_miss_7d(conn, "shadow", 70.0, 2.0, now=_NOW_STR) is None
+    nm = _near_miss_7d(conn, "demo", 70.0, 2.0, now=_NOW_STR)
+    assert nm is not None and nm["blocked_by"] == "ts"
+
+
+def test_absorbs_missing_table():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row  # 스키마 없음 → 쿼리 실패 → None
+    assert _near_miss_7d(conn, "shadow", 70.0, 2.0, now=_NOW_STR) is None


### PR DESCRIPTION
## 배경
라이브(shadow+demo) 2026-06-14~07-04 **20일 무매매** 관찰 후 "게이트가 너무 엄격한 것 아닌가" 가설 검토 (Rocky 요청).

## 검증 (analysis/round5_gate_cross.py — 셀 고정, 스윕 없음)
2020-11~2026-06 전체 표본 n=5,073 (4h 평가바, 진입경로 비게이트 조건 동일 적용), score×ts_4h 교차셀 방향조정 forward return:

| 셀 | n | 14d mean/hit |
|---|---|---|
| **현행 (score>=70 & ts>=2.0)** | 793 | **+5.10% / 65%** |
| 55-70 × ts>=2 (완화 후보) | 181 | ~0% |
| 55-70 × ts>=3.5 (조기레인 후보) | 10 | 3d 음수, 표본 부족 |
| score85+ × ts<2 | 1,046 | +1.37% / 49% (무엣지) |

현행 셀은 2020-21 / 2022-23 / 2024-26 3개 분리 기간 모두 유효 → **진입 룰 무변경 (완화 가설 기각)**. 20일 무매매 = 정상 관망 (6/28~30 score −100 구간은 저점, ts 게이트가 바닥 숏 차단. 라이브=백테스트 패리티 서버에서 확인).

## 변경 사항
- `analysis/round5_gate_cross.py` 신설 — 교차셀 진단 재현 스크립트 (+ 로컬 pandas rolling 버그 즉시-실패 가드)
- `engine/config.py` — 라운드5 검증 근거 **주석만** 추가 (상수 무변경)
- `live/telegram_reporter.py` — 일일 리포트에 **"최근 7일 게이트 최접근"** 라인 추가: 무매매 기간에도 시스템이 뭘 보고 얼마나 아깝게 관망했는지 표시 (예: `점수 -95 통과 · 추세 힘 1.98 (최소 2.0, 0.02 부족)`)
- `tests/test_reporter_nearmiss.py` — 신규 6케이스

## 검증
- `pytest prism-btc/tests`: **275 passed**
- build_message 렌더링 수동 확인 (in-memory DB)

## 별건 발견 (이 PR 범위 밖)
맥 로컬 `.venv`(py3.14+pandas2.3.3+numpy1.26.4)에서 ~1.6만행 이상 rolling().mean()이 전부 NaN → 로컬 백테스트 조용히 오염 가능. 당분간 백테스트/분석은 db-server에서 실행 권장, venv 재구축 별도 작업 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)