### PR TITLE
fix(privacy): 슬롯초과 스킵 사유에서 마스킹 계좌번호 공개 노출 제거

### DIFF
--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -2670,8 +2670,10 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
 
                     current_slots = await self._get_current_slots_count()
                     if current_slots >= self.max_slots:
-                        reason = f"Max slots reached for {label}"
-                        logger.info(f"Purchase deferred: {company_name} ({ticker}) - {reason}")
+                        # User-facing reason must NOT include the account label (leaks
+                        # masked account number to broadcast channels). Keep detail in logs only.
+                        reason = "Max slots reached (portfolio full)"
+                        logger.info(f"Purchase deferred: {company_name} ({ticker}) - Max slots reached for {label}")
                         state["should_save_watchlist"] = True
                         state["skip_reason"] = state["skip_reason"] or reason
                         continue

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -1762,8 +1762,10 @@ class StockTrackingAgent:
 
                     current_slots = await self._get_current_slots_count()
                     if current_slots >= self.max_slots:
-                        reason = f"Max slots reached for {label}"
-                        logger.info(f"Purchase deferred: {company_name}({ticker}) - {reason}")
+                        # User-facing reason must NOT include the account label (leaks
+                        # masked account number to broadcast channels). Keep detail in logs only.
+                        reason = "Max slots reached (portfolio full)"
+                        logger.info(f"Purchase deferred: {company_name}({ticker}) - Max slots reached for {label}")
                         state["should_save_watchlist"] = True
                         state["skip_reason"] = state["skip_reason"] or reason
                         continue


### PR DESCRIPTION
## 문제
브로드캐스트 스킵 메시지 `보류 사유: Max slots reached for legacy-real-stock (prod:63****46:01)`에서 로그 전용 함수 `_safe_account_log_label`의 출력(마스킹된 계좌번호)이 공개 채널(en/ja/zh/es)로 노출.

## 위험도
낮음(계좌번호 마스킹 + KIS는 계좌번호만으론 주문 불가) — 그러나 실계좌(prod) 사용·계좌번호 일부·상품코드가 공개되는 정보 위생 문제라 제거.

## 수정
사용자 메시지는 `Max slots reached (portfolio full)`로 일반화, 계좌 라벨은 로그에만 유지. KR+US 동일. 매매 로직 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)