### PR TITLE
fix(loop_a): SHADOW inflight 레코드가 손절 영구 차단하던 버그 + TTL

### DIFF
--- a/tests/test_loop_a_inflight_ttl.py
+++ b/tests/test_loop_a_inflight_ttl.py
@@ -1,0 +1,54 @@
+"""loop_a has_open_inflight 수정 단위테스트.
+
+버그: SHADOW inflight 레코드가 status IN ('OPEN','SHADOW')로 취급돼 3주간 손절을 영구 차단.
+수정: OPEN만 차단 대상 + TTL(오래된 stale OPEN 제외).
+"""
+import os
+import sqlite3
+import sys
+from datetime import timedelta
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tools.loop_a_hardstop import has_open_inflight, INFLIGHT_TTL_SEC, _iso, _now  # noqa: E402
+
+
+def _conn():
+    c = sqlite3.connect(":memory:")
+    c.execute(
+        "CREATE TABLE loop_a_inflight_orders (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "ticker TEXT, market TEXT, side TEXT DEFAULT 'SELL', loop_run_id TEXT, "
+        "order_no TEXT, qty INTEGER, status TEXT, reason TEXT, submitted_ts TEXT)"
+    )
+    return c
+
+
+def _ins(c, ticker, status, ts):
+    c.execute(
+        "INSERT INTO loop_a_inflight_orders(ticker,market,side,loop_run_id,status,submitted_ts) "
+        "VALUES(?,?,?,?,?,?)", (ticker, "KR", "SELL", "run", status, ts))
+    c.commit()
+
+
+def test_shadow_record_does_not_block():
+    # 핵심: SHADOW 레코드는 실주문이 아니므로 LIVE 매도를 막으면 안 됨
+    c = _conn(); _ins(c, "080220", "SHADOW", _iso(_now()))
+    assert has_open_inflight(c, "080220", "KR") is False
+
+
+def test_fresh_open_blocks():
+    c = _conn(); _ins(c, "080220", "OPEN", _iso(_now()))
+    assert has_open_inflight(c, "080220", "KR") is True
+
+
+def test_stale_open_does_not_block():
+    # TTL 지난 OPEN 레코드는 차단 안 함(영구 stuck 방지)
+    c = _conn(); _ins(c, "080220", "OPEN", _iso(_now() - timedelta(seconds=INFLIGHT_TTL_SEC + 60)))
+    assert has_open_inflight(c, "080220", "KR") is False
+
+
+def test_filled_and_rejected_do_not_block():
+    c = _conn()
+    _ins(c, "080220", "FILLED", _iso(_now()))
+    _ins(c, "080220", "REJECTED", _iso(_now()))
+    assert has_open_inflight(c, "080220", "KR") is False

--- a/tools/loop_a_hardstop.py
+++ b/tools/loop_a_hardstop.py
@@ -109,6 +109,10 @@ def _env_flag(suffix, default):
 LOOP_A_ENABLED = _env_flag("ENABLED", True)            # master kill switch
 LOOP_A_LIVE = _env_flag("LIVE", False)                 # False => SHADOW (no real orders)
 LOCK_TTL_SEC = int(_env("LOCK_TTL_SEC", "300"))
+# inflight SELL 레코드 TTL. 이보다 오래된 OPEN 레코드는 stale로 보고 중복방지 대상에서 제외한다.
+# (loop_a 하드스탑은 장중 시장가라 정상 주문은 수 초 내 체결됨. fill-chaser가 SHADOW라
+#  미정리된 레코드가 손절을 영구 차단하던 버그 방지.)
+INFLIGHT_TTL_SEC = int(_env("INFLIGHT_TTL_SEC", "900"))  # 15분
 DB_PATH = _env("DB") or os.getenv("STOCK_TRACKING_DB") \
     or str(PROJECT_ROOT / "stock_tracking_db.sqlite")
 # Reuse the same channel the batch/system already broadcasts to (TELEGRAM_CHANNEL_ID).
@@ -179,10 +183,15 @@ def load_holdings_by_ticker(conn: sqlite3.Connection, market: str) -> Dict[str, 
 
 
 def has_open_inflight(conn: sqlite3.Connection, ticker: str, market: str) -> bool:
+    # 실제 미체결 주문(status='OPEN')만 중복방지 대상. SHADOW 레코드는 실주문이 아니므로
+    # LIVE 매도를 막으면 안 된다(과거 SHADOW 레코드가 3주간 손절을 영구 차단하던 버그).
+    # TTL 지난 stale OPEN 레코드도 차단에서 제외(fill-chaser 미정리로 영구 차단 방지).
+    cutoff = _iso(_now() - timedelta(seconds=INFLIGHT_TTL_SEC))
     row = conn.execute(
         "SELECT 1 FROM loop_a_inflight_orders "
-        "WHERE ticker=? AND market=? AND side='SELL' AND status IN ('OPEN','SHADOW') LIMIT 1",
-        (ticker, market),
+        "WHERE ticker=? AND market=? AND side='SELL' AND status='OPEN' "
+        "AND submitted_ts >= ? LIMIT 1",
+        (ticker, market, cutoff),
     ).fetchone()
     return row is not None
 


### PR DESCRIPTION
## 문제
`has_open_inflight`가 `status IN ('OPEN','SHADOW')`를 시간필터 없이 조회 → loop_a가 SHADOW 모드였을 때(2026-06-18) 기록된 inflight 레코드가 **3주간 해당 종목 손절을 영구 차단**. 제주반도체(080220) 13주가 손절가 이하인데도 매도가 매 사이클 skip되며 방치됨. fill-chaser가 SHADOW라 미정리 레코드도 안 지워짐.

## 수정
`has_open_inflight` → `status='OPEN'` (SHADOW 제외) + `submitted_ts >= now-INFLIGHT_TTL_SEC`(기본 900초). SHADOW 레코드는 실주문이 아니라 LIVE 매도를 막지 않음. stale OPEN도 TTL 후 차단 제외.

운영 DB의 스테일 SHADOW 레코드 4건(082740/080220/443060/028260)은 즉시 정리 완료 → 080220은 다음 loop_a 사이클에 정상 손절 예정.

## 남은 과제(#412)
시뮬레이터 청산+텔레그램을 inflight 가드에서 완전 분리(실체결 무관 즉시 반영)는 #412 리팩토링 범위.

## 테스트
4 passed: SHADOW 미차단 / OPEN 차단 / TTL 만료 미차단 / FILLED·REJECTED 미차단.

🤖 Generated with [Claude Code](https://claude.com/claude-code)