### PR TITLE
feat(restraint): 약세·횡보장 top-down 매수 억제 옵션 (env-gated, 기본 off)

### DIFF
--- a/tests/test_regime_weak_no_topdown.py
+++ b/tests/test_regime_weak_no_topdown.py
@@ -1,0 +1,42 @@
+"""약세·횡보장 top-down 억제 옵션(REGIME_WEAK_NO_TOPDOWN) 단위테스트.
+
+기본 off = 현행 슬롯 유지. ON 시 sideways/moderate_bear의 top-down 슬롯 0(매수 절제),
+강세장(bull)은 무영향.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# 로컬엔 krx_data_client 미설치 → import 실패 시 스킵. CI/서버에서 실행.
+trigger_batch = pytest.importorskip("trigger_batch")
+
+
+def _slots(regime, flag):
+    if flag is None:
+        os.environ.pop("REGIME_WEAK_NO_TOPDOWN", None)
+    else:
+        os.environ["REGIME_WEAK_NO_TOPDOWN"] = flag
+    try:
+        return trigger_batch._get_regime_slots(regime)
+    finally:
+        os.environ.pop("REGIME_WEAK_NO_TOPDOWN", None)
+
+
+def test_default_off_preserves_current():
+    assert _slots("sideways", None) == (1, 2)
+    assert _slots("moderate_bear", None) == (1, 2)
+    assert _slots("moderate_bull", None) == (1, 2)
+
+
+def test_on_suppresses_topdown_in_weak_regimes():
+    assert _slots("sideways", "true") == (0, 2)
+    assert _slots("moderate_bear", "true") == (0, 2)
+
+
+def test_on_does_not_touch_bull_or_strong_bear():
+    assert _slots("moderate_bull", "true") == (1, 2)
+    assert _slots("strong_bull", "true") == (2, 1)
+    assert _slots("strong_bear", "true") == (0, 3)  # 이미 top-down 0

--- a/trigger_batch.py
+++ b/trigger_batch.py
@@ -7,6 +7,7 @@ import datetime
 import pandas as pd
 import numpy as np
 import logging
+import os
 from typing import Optional
 from krx_data_client import (
     _get_client,
@@ -1227,7 +1228,17 @@ def _get_regime_slots(market_regime: str) -> tuple:
         "moderate_bear": (1, 2),
         "strong_bear": (0, 3),
     }
-    return REGIME_SLOTS.get(market_regime, (1, 2))  # default: sideways ratios
+    td, bu = REGIME_SLOTS.get(market_regime, (1, 2))  # default: sideways ratios
+    # 약세·횡보장 모멘텀추격(top-down) 억제 옵션 (env-gated, 기본 off = 현행 유지).
+    # ON 시 sideways/moderate_bear의 top-down 슬롯을 0으로 → 급락 휩쏘장에서 momentum chase
+    # 매수를 접고 가치형 bottom-up만 남긴다(총 슬롯도 감소 = 매수 절제). strong_bear는 이미 (0,3).
+    if (td > 0 and market_regime in ("sideways", "moderate_bear")
+            and os.getenv("REGIME_WEAK_NO_TOPDOWN", "false").strip().lower()
+            in ("1", "true", "yes", "on")):
+        logger.info("[REGIME_SLOTS] weak-regime top-down 억제: %s (%d,%d)->(0,%d)",
+                    market_regime, td, bu, bu)
+        return (0, bu)
+    return (td, bu)
 
 
 def _build_topdown_pool(trigger_candidates: dict, macro_context: dict, score_column: str) -> list:


### PR DESCRIPTION
## 배경
7월 -42%p(승률 1/9) 손실의 주범 = 약세·휩쏘장의 top-down 모멘텀추격 매수(삼성전기: '시총대비 집중자금' 트리거, sideways에서 score 5로 매수→즉시 손절). `_get_regime_slots`가 sideways/moderate_bear에도 강세장과 동일 top-down 1슬롯 허용 → 절제 안 됨.

## 변경
`REGIME_WEAK_NO_TOPDOWN` env (기본 off = 현행 유지). ON 시 sideways/moderate_bear의 top-down 슬롯 → 0. 급락장 momentum chase 접고 가치형 bottom-up만(총 슬롯도 감소=절제). 강세장 무영향. regime override가 약세장을 sideways로 잡아주므로 그걸 게이트로 활용.

## 검증 방식
env 기본 off라 배포해도 동작 무변화. flip은 별도 승인. 데이터 backtest는 표본(~80건)이 얇아 부정확 → regime override와 동일하게 env-gated로 배포 후 forward 관찰하며 검증.

## 테스트
기본 off 현행유지 / ON 약세장 top-down 0 / 강세·strong_bear 무영향.

🤖 Generated with [Claude Code](https://claude.com/claude-code)