### PR TITLE
fix(cooldown): enhanced agent 매수 루프가 재진입 쿨다운 우회하던 버그

### DIFF
--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -526,8 +526,28 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
 
                     continue
 
+                # Re-entry cooldown gate. base StockTrackingAgent가 적용하는 쿨다운을
+                # enhanced 매수 루프가 그동안 우회하고 있었다(=삼성전기 익일 재매수 미차단 버그).
+                # 손실/리스크 청산 후 window(기본 loss 24h) 내 재매수를 veto. is_add(피라미딩)는 제외.
+                _cd_block = False
+                if decision == "Enter" and not is_add:
+                    try:
+                        from reentry_cooldown import reentry_block, COOLDOWN_LIVE, COOLDOWN_RISK_EXIT_LIVE
+                        _cd = reentry_block("KR", ticker)
+                    except Exception:
+                        _cd, COOLDOWN_LIVE, COOLDOWN_RISK_EXIT_LIVE = None, False, False
+                    if _cd:
+                        _risk_only = bool(_cd.get("risk_exit")) and not _cd.get("after_loss")
+                        _enforce = COOLDOWN_LIVE and (COOLDOWN_RISK_EXIT_LIVE or not _risk_only)
+                        logger.warning(
+                            "[REENTRY_COOLDOWN][%s] %s ticker=%s last_sell=%s ret=%.1f%% gap=%.1fh<%sh after_loss=%s exit_kind=%s risk_only=%s",
+                            "LIVE" if _enforce else "SHADOW", _cd["action"], ticker,
+                            _cd["last_sell"], _cd["last_ret"], _cd["gap_hours"],
+                            _cd["window_hours"], _cd["after_loss"], _cd.get("exit_kind"), _risk_only)
+                        _cd_block = _enforce
+
                 # Process buy if entry decision
-                if decision == "Enter" and buy_score >= min_score and sector_diverse:
+                if decision == "Enter" and buy_score >= min_score and sector_diverse and not _cd_block:
                     # Process buy (is_add => pyramiding additional independent row, #288)
                     buy_success = await self.buy_stock(ticker, company_name, current_price, scenario, rank_change_msg, is_add=is_add)
 


### PR DESCRIPTION
## 문제
`reentry_cooldown`(손실/리스크 청산 후 window 내 재매수 차단)이 base `StockTrackingAgent`엔 있으나, **KR 오케스트레이터가 실제 쓰는 `EnhancedStockTrackingAgent`의 오버라이드된 매수 루프엔 누락**. .env에 `REENTRY_COOLDOWN_LIVE=true`, `LOSS_HOURS=24`로 활성돼 있는데도 실제 매수경로에서 우회됨.

증거: 서버 `reentry_block('KR','009150')` => WOULD_BLOCK(정상 동작)인데, 삼성전기 07-06 −5.35% 손절 → 07-07 09:49 재매수(gap~23h<24h)가 안 막힘. 오늘 REENTRY_COOLDOWN 로그도 enhanced 경로엔 없음.

## 수정
base와 동일한 쿨다운 게이트를 enhanced 매수 루프에 추가(is_add 피라미딩 제외). 기존 `COOLDOWN_LIVE` 존중 → LIVE면 재매수 veto, 아니면 SHADOW 로깅.

## 영향
COOLDOWN_LIVE=true라 배포 즉시 손실 종목 24h내 재매수가 차단됨(삼성전기류 churn 방지). 24h 단기 window라 장기 재진입엔 영향 적음. 롤백=REENTRY_COOLDOWN_LIVE=false.

## 참고
제주반도체 손절 버그는 별개로 #416에서 이미 해결(loop_a decoupling도 기존 LIVE 경로에 이미 구현됨).

🤖 Generated with [Claude Code](https://claude.com/claude-code)