### PR TITLE
docs(.env.example): 신규 env 플래그 동기화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -159,3 +159,16 @@ TELEGRAM_CHANNEL_ID=your_channel_id
 # REENTRY_COOLDOWN_LIVE=false        # false => SHADOW (log only); true => skip the buy
 # REENTRY_COOLDOWN_HOURS=0           # cooldown after a WIN/normal sell (0 = off; wins can re-enter)
 # REENTRY_COOLDOWN_LOSS_HOURS=24     # longer cooldown after a LOSS (revenge-trade prevention)
+# REENTRY_COOLDOWN_RISK_EXIT_LIVE=false  # true => also enforce cooldown for non-loss risk exits(stop)
+
+# Market-regime override / restraint (급락·고변동장 오판 방지 & 약세장 매수 절제)
+# 급락·고변동장을 이동평균 위치만으로 온건강세로 오판하는 것 방지. 값: shadow(기본,판단만
+# 로깅·매매무영향) / active(실제 sideways 강등 적용) / off(비활성). cores/data_prefetch.py.
+# REGIME_HIVOL_OVERRIDE=shadow
+# 약세·횡보장(sideways/moderate_bear)에서 top-down 모멘텀추격 매수 슬롯을 0으로(매수 절제).
+# 기본 off=현행 슬롯 유지. trigger_batch._get_regime_slots.
+# REGIME_WEAK_NO_TOPDOWN=false
+
+# loop_a 하드스탑 inflight SELL 레코드 TTL(초). 이보다 오래된 OPEN 레코드는 stale로 보고
+# 중복방지 대상에서 제외(fill-chaser 미정리로 손절이 영구 차단되던 버그 방지). tools/loop_a_hardstop.py.
+# INFLIGHT_TTL_SEC=900


### PR DESCRIPTION
서버 .env에만 있던/코드에 있던 신규 플래그를 .env.example 템플릿에 반영: REGIME_HIVOL_OVERRIDE, REGIME_WEAK_NO_TOPDOWN, INFLIGHT_TTL_SEC + 누락된 REENTRY_COOLDOWN_RISK_EXIT_LIVE. 기본값·설명 포함, 주석처리(기존 스타일). 런타임 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)