### PR TITLE
fix: 배치-loop 충돌 교통정리 (loop_b 신규매수 유예 + 포트폴리오 최종요약 강제발송)

### DIFF
--- a/portfolio_broadcast.py
+++ b/portfolio_broadcast.py
@@ -38,9 +38,13 @@ def _db_path() -> str:
 
 
 def should_send_portfolio(market: str, debounce_sec: int | None = None,
-                          db_path: str | None = None) -> bool:
+                          db_path: str | None = None, force: bool = False) -> bool:
     """Return True iff no portfolio summary was broadcast for `market` within the
     debounce window, recording 'now' atomically when it returns True.
+
+    force=True: 배치 run-end의 '완전한 최종 요약'은 항상 발송(디바운스 우회). 직전에
+    루프 매도가 이른(덜 완전한) 요약을 보내 슬롯을 먹어도 최종 요약이 눌리지 않게 함.
+    발송 시각은 여전히 기록해 이후 루프 요약은 디바운스된다.
 
     Fail-open: returns True on any error (never suppresses on a DB hiccup).
     """
@@ -63,7 +67,7 @@ def should_send_portfolio(market: str, debounce_sec: int | None = None,
                 "SELECT last_sent_ts FROM portfolio_broadcast_log WHERE market=?",
                 (key,),
             ).fetchone()
-            if row is not None and (now - float(row[0])) < window:
+            if not force and row is not None and (now - float(row[0])) < window:
                 conn.execute("ROLLBACK")
                 return False
             conn.execute(

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -1943,7 +1943,8 @@ class StockTrackingAgent:
                 else:
                     raise
 
-    async def send_telegram_message(self, chat_id: str, language: str = "ko") -> bool:
+    async def send_telegram_message(self, chat_id: str, language: str = "ko",
+                                    portfolio_force: bool = False) -> bool:
         """
         Send message via Telegram
 
@@ -1986,7 +1987,8 @@ class StockTrackingAgent:
             # summaries. Other queued messages (sell notices) are unaffected.
             try:
                 from portfolio_broadcast import should_send_portfolio
-                _emit_portfolio = should_send_portfolio("KR")
+                # 배치 run-end(portfolio_force=True)는 완전한 최종 요약이므로 디바운스 우회.
+                _emit_portfolio = should_send_portfolio("KR", force=portfolio_force)
             except Exception:
                 _emit_portfolio = True  # fail-open
             if _emit_portfolio:
@@ -2222,7 +2224,7 @@ class StockTrackingAgent:
 
                 # Send Telegram message (only if chat_id is provided)
                 if chat_id:
-                    message_sent = await self.send_telegram_message(chat_id, language)
+                    message_sent = await self.send_telegram_message(chat_id, language, portfolio_force=True)
                     if message_sent:
                         logger.info("Telegram message sent successfully")
                     else:
@@ -2230,7 +2232,7 @@ class StockTrackingAgent:
                 else:
                     logger.info("Telegram channel ID not provided, skipping message send")
                     # Call even if chat_id is None to clean up message queue
-                    await self.send_telegram_message(None, language)
+                    await self.send_telegram_message(None, language, portfolio_force=True)
 
                 logger.info("Tracking system batch execution complete")
                 return True

--- a/tests/test_portfolio_broadcast.py
+++ b/tests/test_portfolio_broadcast.py
@@ -39,6 +39,15 @@ def test_market_key_case_insensitive(pb):
     assert pb.should_send_portfolio("US", debounce_sec=120) is False
 
 
+def test_force_bypasses_debounce(pb):
+    # 배치 run-end(force=True)는 디바운스를 우회해 항상 발송(완전한 최종 요약 보존).
+    assert pb.should_send_portfolio("KR", debounce_sec=120) is True   # 루프 등 최초 발송
+    assert pb.should_send_portfolio("KR", debounce_sec=120) is False  # 윈도우 내 억제
+    assert pb.should_send_portfolio("KR", debounce_sec=120, force=True) is True  # 강제 통과
+    # force도 발송시각을 기록 -> 이후 비강제 호출은 다시 디바운스
+    assert pb.should_send_portfolio("KR", debounce_sec=120) is False
+
+
 def test_fail_open_on_bad_db(monkeypatch):
     import portfolio_broadcast as m
     importlib.reload(m)

--- a/tools/loop_b_trend_exit.py
+++ b/tools/loop_b_trend_exit.py
@@ -143,6 +143,10 @@ LOOP_B_LIVE = _env_flag("LIVE", False)                  # False => SHADOW (no re
 LOOP_B_CONFIRM_CHECKS = int(_env("CONFIRM_CHECKS", "2"))   # N consecutive day-breaches to act
 LOOP_B_CLOSE_WINDOW = _env_flag("CLOSE_WINDOW", False)     # set true on the close-time cron line
 LOCK_TTL_SEC = int(_env("LOCK_TTL_SEC", "300"))
+# 신규매수 유예(분): buy_date 기준 이보다 어린 포지션은 추세이탈 청산 제외.
+# 매수 배치와 loop 청산이 같은 시간대(마감 윈도우 등)에 부딪혀 20초 만에 churn되던 것 방지.
+# 추세는 갓 산 포지션에서 판정 불가. 0이면 비활성. KR 마감 15:30 고려해 기본 30분.
+MIN_HOLD_MIN = int(_env("MIN_HOLD_MIN", "30"))
 DB_PATH = _env("DB") or os.getenv("STOCK_TRACKING_DB") \
     or str(PROJECT_ROOT / "stock_tracking_db.sqlite")
 # Reuse the same channel the batch/system already broadcasts to (TELEGRAM_CHANNEL_ID).
@@ -554,9 +558,29 @@ async def run_market(market: str, run_id: str) -> Dict[str, Any]:
     return summary
 
 
+def _holding_age_min(buy_date) -> Optional[float]:
+    """보유 나이(분). buy_date='YYYY-MM-DD HH:MM:SS'(KST naive). 실패 시 None(fail-open=제외 안 함)."""
+    if not buy_date:
+        return None
+    try:
+        bd = datetime.strptime(str(buy_date)[:19], "%Y-%m-%d %H:%M:%S")
+        return (datetime.now() - bd).total_seconds() / 60.0
+    except Exception:
+        return None
+
+
 async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, Any],
                           reason: str, streak: int, run_id: str, agent: Dict[str, Any],
                           summary: Dict[str, Any]) -> None:
+    # Grace: 방금 산 포지션은 추세이탈 청산 제외(매수 배치 vs loop 청산 시간대 충돌로
+    # 20초 만에 churn되던 것 방지). buy_date 기준 나이 < MIN_HOLD_MIN 이면 skip.
+    if MIN_HOLD_MIN > 0:
+        _age = _holding_age_min(stock_data.get("buy_date"))
+        if _age is not None and _age < MIN_HOLD_MIN:
+            summary["skipped"] += 1
+            logger.info("[%s] %s gate open but fresh buy (age %.1fm < %dm grace) -> skip (%s)",
+                        market, ticker, _age, MIN_HOLD_MIN, reason)
+            return
     # Guard 1: an inflight SELL for this ticker already exists -> leave it alone.
     if has_open_inflight(conn, ticker, market):
         summary["skipped"] += 1


### PR DESCRIPTION
## 문제(오늘 실증)
- 호텔신라: afternoon 배치 15:14 매수 → 20초 뒤 loop_b가 TIER1.5_MA50(50일선 아래)로 즉시 매도(−0.55% churn). 매수배치 vs loop 마감청산 시간대 충돌.
- 포트폴리오 최종요약 미발송: loop_b 매도가 이른 요약으로 debounce 슬롯을 먹어 배치 run-end 완전요약이 눌림.

## 수정
1) **loop_b 신규매수 유예**(MIN_HOLD_MIN=30분 기본): buy_date 기준 어린 포지션은 추세이탈 청산 제외. 즉시 churn 차단.
2) **포트폴리오 최종요약 강제발송**: `should_send_portfolio(force=True)` — 배치 run-end만 debounce 우회, 루프 요약은 debounce 유지.

## 영향/롤백
매매/알림 동작 변경. 롤백: `TREND_EXIT_MIN_HOLD_MIN=0`(유예 끄기). tests 6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)