### PR TITLE
feat(loops): 루프 매도 메시지 다국어 채널 비동기 브로드캐스트

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -172,3 +172,11 @@ TELEGRAM_CHANNEL_ID=your_channel_id
 # loop_a 하드스탑 inflight SELL 레코드 TTL(초). 이보다 오래된 OPEN 레코드는 stale로 보고
 # 중복방지 대상에서 제외(fill-chaser 미정리로 손절이 영구 차단되던 버그 방지). tools/loop_a_hardstop.py.
 # INFLIGHT_TTL_SEC=900
+
+# loop_b 추세이탈 신규매수 유예(분): buy_date 기준 이보다 어린 포지션은 추세이탈 청산 제외.
+# 매수 배치와 loop 청산이 같은 시간대에 부딪혀 방금 산 종목이 즉시 churn되던 것 방지. 0=off.
+# TREND_EXIT_MIN_HOLD_MIN=30
+
+# 루프(loop_a/b) 매도 메시지를 다국어 채널로도 브로드캐스트할 언어. 미설정 시 en,ja,zh,es 기본.
+# 채널ID는 TELEGRAM_CHANNEL_ID_{LANG}에서 로드. tools/loop_*.py의 _make_agent.
+# LOOP_BROADCAST_LANGUAGES=en,ja,zh,es

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -1944,7 +1944,8 @@ class StockTrackingAgent:
                     raise
 
     async def send_telegram_message(self, chat_id: str, language: str = "ko",
-                                    portfolio_force: bool = False) -> bool:
+                                    portfolio_force: bool = False,
+                                    await_broadcast: bool = False) -> bool:
         """
         Send message via Telegram
 
@@ -2066,10 +2067,19 @@ class StockTrackingAgent:
             if firebase_tasks:
                 await asyncio.gather(*firebase_tasks, return_exceptions=True)
 
-            # Send to broadcast channels if configured (awaited in run() finally block)
+            # Send to broadcast channels if configured (awaited in run() finally block,
+            # or inline here when await_broadcast=True — intraday loops don't call run()
+            # so the task would be cancelled on process exit unless awaited now).
             if hasattr(self, 'telegram_config') and self.telegram_config and self.telegram_config.broadcast_languages:
                 self._broadcast_task = asyncio.create_task(self._send_to_translation_channels(self.message_queue.copy(), self._msg_types.copy()))
                 logger.info("Broadcast channel translation dispatched")
+                if await_broadcast:
+                    try:
+                        await self._broadcast_task
+                    except Exception as e:
+                        logger.warning(f"Broadcast translation await failed (non-critical): {e}")
+                    finally:
+                        self._broadcast_task = None
 
             # Clear message queue
             self.message_queue = []

--- a/tools/loop_a_hardstop.py
+++ b/tools/loop_a_hardstop.py
@@ -275,6 +275,16 @@ async def _make_agent(market: str):
         from us_stock_tracking_agent import USStockTrackingAgent
         agent = USStockTrackingAgent(db_path=DB_PATH)
     await agent.initialize(skip_llm_agent=True)
+    # 루프 매도 메시지도 배치와 동일하게 다국어 채널로 브로드캐스트되게 config 주입.
+    # (미설정 시 send_telegram_message가 KR 채널로만 발송.) 채널ID는 TelegramConfig가
+    # env TELEGRAM_CHANNEL_ID_{LANG}에서 자동 로드. send 시 await_broadcast=True로 완결.
+    try:
+        _langs = [x.strip() for x in os.getenv("LOOP_BROADCAST_LANGUAGES", "en,ja,zh,es").split(",") if x.strip()]
+        if _langs:
+            from telegram_config import TelegramConfig
+            agent.telegram_config = TelegramConfig(use_telegram=True, broadcast_languages=_langs)
+    except Exception as e:
+        logger.warning("loop broadcast config init failed (non-critical): %s", e)
     return agent
 
 
@@ -343,7 +353,7 @@ async def run_market(market: str, run_id: str) -> Dict[str, Any]:
                 # portfolio summary, so do NOT generate+append it here as well —
                 # doing both queued the portfolio twice (the double-send bug). Flush
                 # the queue once; cross-run de-dup lives in portfolio_broadcast.
-                await agent["ref"].send_telegram_message(CHAT_ID)
+                await agent["ref"].send_telegram_message(CHAT_ID, await_broadcast=True)
             except Exception as _e:
                 logger.warning("[%s] run-end portfolio summary failed: %s", market, _e)
         conn.close()
@@ -414,7 +424,7 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
 
         # 3) flush the queued telegram message (instant notification).
         try:
-            await ag.send_telegram_message(CHAT_ID)
+            await ag.send_telegram_message(CHAT_ID, await_broadcast=True)
         except Exception as e:
             logger.warning("[%s] %s telegram flush failed: %s", market, ticker, e)
 

--- a/tools/loop_b_trend_exit.py
+++ b/tools/loop_b_trend_exit.py
@@ -441,6 +441,16 @@ async def _make_agent(market: str):
         from us_stock_tracking_agent import USStockTrackingAgent
         agent = USStockTrackingAgent(db_path=DB_PATH)
     await agent.initialize(skip_llm_agent=True)
+    # 루프 매도 메시지도 배치와 동일하게 다국어 채널로 브로드캐스트되게 config 주입.
+    # (미설정 시 send_telegram_message가 KR 채널로만 발송.) 채널ID는 TelegramConfig가
+    # env TELEGRAM_CHANNEL_ID_{LANG}에서 자동 로드. send 시 await_broadcast=True로 완결.
+    try:
+        _langs = [x.strip() for x in os.getenv("LOOP_BROADCAST_LANGUAGES", "en,ja,zh,es").split(",") if x.strip()]
+        if _langs:
+            from telegram_config import TelegramConfig
+            agent.telegram_config = TelegramConfig(use_telegram=True, broadcast_languages=_langs)
+    except Exception as e:
+        logger.warning("loop broadcast config init failed (non-critical): %s", e)
     return agent
 
 
@@ -545,7 +555,7 @@ async def run_market(market: str, run_id: str) -> Dict[str, Any]:
                 # portfolio summary, so do NOT generate+append it here as well —
                 # doing both queued the portfolio twice (the double-send bug). Flush
                 # the queue once; cross-run de-dup lives in portfolio_broadcast.
-                await agent["ref"].send_telegram_message(CHAT_ID)
+                await agent["ref"].send_telegram_message(CHAT_ID, await_broadcast=True)
             except Exception as _e:
                 logger.warning("[%s] run-end portfolio summary failed: %s", market, _e)
         conn.close()
@@ -635,7 +645,7 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
 
         # 3) flush the queued telegram message (instant notification).
         try:
-            await ag.send_telegram_message(CHAT_ID)
+            await ag.send_telegram_message(CHAT_ID, await_broadcast=True)
         except Exception as e:
             logger.warning("[%s] %s telegram flush failed: %s", market, ticker, e)
 


### PR DESCRIPTION
## 문제
loop_a/b 매도 알림이 KR 채널로만 나가고 다국어 번역을 안 탐. 루프 _make_agent가 telegram_config를 세팅 안 해 send_telegram_message의 브로드캐스트 분기를 우회.

## 수정
- send_telegram_message `await_broadcast` 옵션(True면 브로드캐스트 태스크 inline await — 루프는 run() finally await 경로 없어 태스크 취소되던 것 방지).
- loop_a/b _make_agent에 TelegramConfig(broadcast_languages, env LOOP_BROADCAST_LANGUAGES 기본 en,ja,zh,es) 주입. 채널ID는 TELEGRAM_CHANNEL_ID_{LANG} 자동 로드.
- 루프 send 4곳 await_broadcast=True.
- .env.example 동기화.

## 영향
루프 매도 알림이 배치와 동일하게 다국어 채널로 발송. 비동기 완결. LOOP_BROADCAST_LANGUAGES= (빈값)으로 끄기 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)