### PR TITLE
매수 집행 게이트: 개별 추세 + 상습손절 (KR+US, ko+en)

### DIFF
--- a/cores/agents/trading_agents.py
+++ b/cores/agents/trading_agents.py
@@ -90,6 +90,26 @@ def create_trading_scenario_agent(language: str = "ko", sector_names: list = Non
 
         Passing the gate = quality baseline established → matrix below is applied with confidence.
 
+        ## Step 1.5 — Individual Stock Trend Gate (mandatory · takes precedence over the matrix)
+
+        O'Neil principle: **never buy a stock below a declining moving average (no falling knives).**
+        Regardless of market regime, momentum, capital inflow, or a bullish report, if the stock's OWN
+        trend matches any below → **No Entry**:
+        - (T1) Close below the 50-day (or 60-day) MA — a break of O'Neil's 10-week line (a pullback above a rising MA is fine; losing the line is trend damage)
+        - (T2) The 20-day MA is sloping down AND close is ≥5% below the 20-day MA — a sharp early breakdown
+        Use the provided '개별 추세 팩트 / Individual Trend Facts' input and report section '1-1 Price'
+        (if facts absent, judge conservatively from the report).
+        **Exception (entry allowed)** only when the stock reclaims/breaks above the declining MA with
+        volume, confirming a trend change. "It looks like it will bounce soon" is NOT an exception.
+        State the trend basis in rejection_reason (No Entry) or rationale (exception entry).
+
+        ## Step 1.6 — Repeat Stop-Out Gate (mandatory)
+
+        If the same stock was **stopped out ≥2 times within the last ~2 weeks** (see provided journal /
+        past experience), **No Entry** unless a clearly NEW structural catalyst — different from the prior
+        failed attempts — is explicitly present in the report. "Good fundamentals" / "oversold" are NOT
+        new catalysts. Repeated stop-outs are a discipline failure; raise the entry bar hard.
+
         ## Step 2 — Market-Regime Entry Matrix (single source of truth)
 
         Apply only after the Fundamental Gate is evaluated.
@@ -152,6 +172,8 @@ def create_trading_scenario_agent(language: str = "ko", sector_names: list = Non
 
         Trigger-type credit: if the trigger is one of "Volume Surge / Gap Up / Daily Rise Top /
         Closing Strength / Capital Inflow Ratio / Volume Surge Flat", count 1 momentum signal automatically.
+        However, **this automatic credit does NOT apply to downtrend stocks caught by the Step 1.5 gate
+        (T1/T2)** — transient inflow/volume during a downtrend is noise, not an entry reason.
 
         ## Step 4 — Extra Confirmations (sideways / bear only)
 
@@ -397,6 +419,24 @@ def create_trading_scenario_agent(language: str = "ko", sector_names: list = Non
 
         게이트 통과 = 종목 품질 베이스라인 확보 → 아래 매트릭스를 자신감 있게 적용하십시오.
 
+        ## 1.5단계 — 개별 종목 추세 게이트 (필수 · 매트릭스보다 우선)
+
+        오닐 원칙: **하락하는 이동평균 아래의 종목은 사지 않는다(떨어지는 칼 금지).**
+        시장 체제·모멘텀·자금 유입·보고서 강세와 무관하게, 종목 자신의 추세가 아래에 해당하면 **미진입**:
+        - (T1) 종가가 50일선(또는 60일선) 아래 — 오닐 10주선 이탈 (상승 이동평균 위 눌림목은 정상, 라인 이탈은 추세 훼손)
+        - (T2) 20일선이 하향이고 종가가 20일선 대비 5% 이상 아래 — 급격한 초기 붕괴
+        입력으로 제공되는 '개별 추세 팩트' 섹션과 보고서 '1-1 가격'을 사용해 판정하십시오
+        (팩트가 없으면 보고서로 보수적으로 판단).
+        **예외(진입 허용)**: 하락 이동평균을 거래량 동반으로 상향 돌파·회복하여 추세 전환이
+        확인된 경우에 한함. "곧 반등할 것 같다"는 기대는 예외가 아니다.
+        미진입 시 rejection_reason에, 예외 진입 시 rationale에 추세 근거를 명시하십시오.
+
+        ## 1.6단계 — 상습 손절 종목 게이트 (필수)
+
+        동일 종목이 **최근 약 2주 내 손절(stop) 2회 이상**(제공된 매매일지 / 과거 경험 참조)이면,
+        직전 실패들과 **명백히 다른 새로운 구조적 촉매**가 보고서에 구체적으로 제시되지 않는 한 **미진입**.
+        "좋은 펀더멘털"·"낙폭 과대"는 새로운 촉매가 아니다. 반복 손절은 규율 실패이므로 진입 문턱을 강하게 높인다.
+
         ## 2단계 — 시장 체제별 진입 매트릭스 (단일 기준점)
 
         펀더 게이트 평가가 끝난 후에만 적용하십시오.
@@ -455,6 +495,7 @@ def create_trading_scenario_agent(language: str = "ko", sector_names: list = Non
         5. 직전 박스 상단 거래량 동반 돌파 (단순 터치 X, 박스 업그레이드 O)
 
         트리거 유형 자동 가산: 트리거가 "거래량 급증 / 갭 상승 / 일중 상승률 / 마감 강도 / 시총 대비 자금 유입 / 거래량 증가 횡보주" 중 하나면 모멘텀 신호 1점을 자동 인정합니다.
+        단, **1.5단계 추세 게이트에 걸리는 하락추세(T1/T2) 종목에는 이 자동 가산을 적용하지 않습니다** — 하락추세 중의 일시적 자금 유입·거래량은 진입 근거가 아니라 노이즈입니다.
 
         ## 4단계 — 추가 확인 요소 (sideways / bear 한정)
 

--- a/prism-us/cores/agents/trading_agents.py
+++ b/prism-us/cores/agents/trading_agents.py
@@ -93,6 +93,24 @@ B) 없으면 S&P 500 (^GSPC) + VIX 최근 20일 데이터(yahoo_finance-get_hist
 
 게이트 통과 = 종목 품질 베이스라인 확보 → 아래 매트릭스를 자신감 있게 적용하십시오.
 
+## 1.5단계 — 개별 종목 추세 게이트 (필수 · 매트릭스보다 우선)
+
+오닐 원칙: **하락하는 이동평균 아래의 종목은 사지 않는다(떨어지는 칼 금지).**
+시장 체제·모멘텀·자금 유입·보고서 강세와 무관하게, 종목 자신의 추세가 아래에 해당하면 **미진입**:
+- (T1) 종가가 50일선(또는 60일선) 아래 — 오닐 10주선 이탈 (상승 이동평균 위 눌림목은 정상, 라인 이탈은 추세 훼손)
+- (T2) 20일선이 하향이고 종가가 20일선 대비 5% 이상 아래 — 급격한 초기 붕괴
+입력으로 제공되는 '개별 추세 팩트' 섹션과 보고서 '1-1 주가'를 사용해 판정하십시오
+(팩트가 없으면 보고서로 보수적으로 판단).
+**예외(진입 허용)**: 하락 이동평균을 거래량 동반으로 상향 돌파·회복하여 추세 전환이
+확인된 경우에 한함. "곧 반등할 것 같다"는 기대는 예외가 아니다.
+미진입 시 rejection_reason에, 예외 진입 시 rationale에 추세 근거를 명시하십시오.
+
+## 1.6단계 — 상습 손절 종목 게이트 (필수)
+
+동일 종목이 **최근 약 2주 내 손절(stop) 2회 이상**(제공된 매매일지 / 과거 경험 참조)이면,
+직전 실패들과 **명백히 다른 새로운 구조적 촉매**가 보고서에 구체적으로 제시되지 않는 한 **미진입**.
+"좋은 펀더멘털"·"낙폭 과대"는 새로운 촉매가 아니다. 반복 손절은 규율 실패이므로 진입 문턱을 강하게 높인다.
+
 ## 2단계 — 시장 체제별 진입 매트릭스 (단일 기준점)
 
 펀더 게이트 평가가 끝난 후에만 적용하십시오.
@@ -150,6 +168,7 @@ B) 없으면 S&P 500 (^GSPC) + VIX 최근 20일 데이터(yahoo_finance-get_hist
 5. 직전 박스 상단 거래량 동반 돌파 (단순 터치 X, 박스 업그레이드 O)
 
 트리거 유형 자동 가산: 트리거가 "Volume Surge / Gap Up / Daily Rise / Closing Strength / Capital Inflow / Volume Surge Flat" 중 하나면 모멘텀 신호 1점을 자동 인정합니다.
+단, **1.5단계 추세 게이트에 걸리는 하락추세(T1/T2) 종목에는 이 자동 가산을 적용하지 않습니다** — 하락추세 중의 일시적 자금 유입·거래량은 진입 근거가 아니라 노이즈입니다.
 
 ## 4단계 — 추가 확인 요소 (sideways / bear 한정)
 
@@ -399,6 +418,26 @@ Four binary checks. Fail any one and the stock is treated as fundamentally weak:
 
 Passing the gate = quality baseline established → matrix below is applied with confidence.
 
+## Step 1.5 — Individual Stock Trend Gate (mandatory · takes precedence over the matrix)
+
+O'Neil principle: **never buy a stock below a declining moving average (no falling knives).**
+Regardless of market regime, momentum, capital inflow, or a bullish report, if the stock's OWN
+trend matches any below → **No Entry**:
+- (T1) Close below the 50-day (or 60-day) MA — a break of O'Neil's 10-week line (a pullback above a rising MA is fine; losing the line is trend damage)
+- (T2) The 20-day MA is sloping down AND close is ≥5% below the 20-day MA — a sharp early breakdown
+Use the provided '개별 추세 팩트 / Individual Trend Facts' input and report section '1-1 Price'
+(if facts absent, judge conservatively from the report).
+**Exception (entry allowed)** only when the stock reclaims/breaks above the declining MA with
+volume, confirming a trend change. "It looks like it will bounce soon" is NOT an exception.
+State the trend basis in rejection_reason (No Entry) or rationale (exception entry).
+
+## Step 1.6 — Repeat Stop-Out Gate (mandatory)
+
+If the same stock was **stopped out ≥2 times within the last ~2 weeks** (see provided journal /
+past experience), **No Entry** unless a clearly NEW structural catalyst — different from the prior
+failed attempts — is explicitly present in the report. "Good fundamentals" / "oversold" are NOT
+new catalysts. Repeated stop-outs are a discipline failure; raise the entry bar hard.
+
 ## Step 2 — Market-Regime Entry Matrix (single source of truth)
 
 Apply only after the Fundamental Gate is evaluated.
@@ -461,6 +500,8 @@ Count each that holds:
 
 Trigger-type credit: if the trigger is one of "Volume Surge / Gap Up / Daily Rise / Closing Strength /
 Capital Inflow / Volume Surge Flat", count 1 momentum signal automatically.
+However, **this automatic credit does NOT apply to downtrend stocks caught by the Step 1.5 gate
+(T1/T2)** — transient inflow/volume during a downtrend is noise, not an entry reason.
 
 ## Step 4 — Extra Confirmations (sideways / bear only)
 

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -692,6 +692,126 @@ class USStockTrackingAgent:
             self.MAX_SAME_SECTOR, self.SECTOR_CONCENTRATION_RATIO, account_key=account_key
         )
 
+    def _get_trend_facts(self, ticker: str) -> str:
+        """Compute deterministic individual-stock trend facts for the buy prompt's trend gate.
+
+        Fail-open: on ANY error returns "" and logs a warning; never raises into the buy path.
+        Reuses the US yfinance data client (cores.us_data_client). RS proxy uses S&P 500 (^GSPC),
+        the module's benchmark index.
+        """
+        try:
+            from cores.us_data_client import get_us_data_client
+
+            client = get_us_data_client()
+
+            # ~6 months of daily bars: enough for MA60 + 60-session RS window (fail-open if short).
+            df = client.get_ohlcv(ticker, period="6mo")
+            if df is None or len(df) < 25 or 'close' not in df.columns:
+                logger.warning(f"[TrendFacts] {ticker} insufficient OHLCV rows; skipping")
+                return ""
+
+            close_s = df['close'].astype(float)
+            close = float(close_s.iloc[-1])
+
+            ma20_s = close_s.rolling(window=20).mean()
+            ma50_s = close_s.rolling(window=50).mean()
+            ma60_s = close_s.rolling(window=60).mean()
+
+            def _val(s):
+                try:
+                    v = s.iloc[-1]
+                    return float(v) if v == v else None  # NaN check
+                except Exception:
+                    return None
+
+            def _slope_up(s, lookback=5):
+                # rising if MA today > MA ~lookback trading days ago
+                try:
+                    if len(s) <= lookback:
+                        return None
+                    cur = s.iloc[-1]
+                    prev = s.iloc[-1 - lookback]
+                    if cur != cur or prev != prev:
+                        return None
+                    return bool(cur > prev)
+                except Exception:
+                    return None
+
+            ma20 = _val(ma20_s)
+            ma50 = _val(ma50_s)
+            ma60 = _val(ma60_s)
+            ma20_up = _slope_up(ma20_s)
+            ma50_up = _slope_up(ma50_s)
+            ma60_up = _slope_up(ma60_s)
+
+            # 50일선 우선, 없으면 60일선 fallback (T1용)
+            ma_mid = ma50 if ma50 is not None else ma60
+            ma_mid_label = "MA50" if ma50 is not None else "MA60"
+
+            def _pct(a, b):
+                if a is None or b is None or b == 0:
+                    return None
+                return (a - b) / b * 100.0
+
+            # RS proxy: 60거래일 종목 수익률 - S&P 500(^GSPC) 60거래일 수익률
+            rs = None
+            stock_ret = None
+            idx_ret = None
+            n = min(60, len(close_s) - 1)
+            if n > 0:
+                base = float(close_s.iloc[-1 - n])
+                if base:
+                    stock_ret = (close / base - 1.0) * 100.0
+                try:
+                    idf = client.get_index_data("^GSPC", period="6mo")
+                    if idf is not None and 'close' in idf.columns and len(idf) > 1:
+                        iclose = idf['close'].astype(float)
+                        m = min(n, len(iclose) - 1)
+                        ibase = float(iclose.iloc[-1 - m])
+                        if ibase:
+                            idx_ret = (float(iclose.iloc[-1]) / ibase - 1.0) * 100.0
+                except Exception as _ie:
+                    logger.warning(f"[TrendFacts] {ticker} index return failed: {_ie}")
+                if stock_ret is not None and idx_ret is not None:
+                    rs = stock_ret - idx_ret
+
+            # 게이트 판정 (deterministic)
+            # T1: 종가가 50일선(오닐 10주선) 아래 = 핵심 라인 이탈. 기울기 무관 —
+            #     라인 아래면 정당한 눌림이 아니라 추세 훼손으로 본다.
+            t1_hit = bool(ma_mid is not None and close < ma_mid)
+            # T2: 20일선 하향 + 종가가 20일선 대비 5% 이상 아래 = 급격한 초기 붕괴.
+            #     (RS 60일은 직전 급등 잔상으로 stale → 게이트 조건에서 제외, 정보로만 표기)
+            t2_hit = bool(ma20 is not None and ma20_up is not None
+                          and ma20_up is False and close <= ma20 * 0.95)
+
+            def _above(a, b):
+                if a is None or b is None:
+                    return "n/a"
+                return "위" if a >= b else "아래"
+
+            def _dir(up):
+                return "n/a" if up is None else ("상승" if up else "하락")
+
+            def _fmt(v, suffix=""):
+                return f"{v:+.1f}{suffix}" if v is not None else "n/a"
+
+            lines = [
+                "### 📉 개별 추세 팩트 (추세 게이트용 · as-of 오늘)",
+                f"- 종가: {close:,.2f}",
+                f"- vs MA20: {_above(close, ma20)} ({_fmt(_pct(close, ma20), '%')}), MA20 기울기: {_dir(ma20_up)}",
+                f"- vs MA50: {_above(close, ma50)} ({_fmt(_pct(close, ma50), '%')}), MA50 기울기: {_dir(ma50_up)}",
+                f"- vs MA60: {_above(close, ma60)} ({_fmt(_pct(close, ma60), '%')}), MA60 기울기: {_dir(ma60_up)}",
+                f"- RS(60일, 종목-S&P500): {_fmt(rs, '%p')} (종목 {_fmt(stock_ret, '%')} / 지수 {_fmt(idx_ret, '%')})",
+                f"- T1_hit(종가<{ma_mid_label}, 오닐 10주선 이탈): {t1_hit} / "
+                f"T2_hit(MA20 하락 and 종가 MA20 대비 -5%↓): {t2_hit}",
+            ]
+            trend_facts = "\n".join(lines)
+            logger.info(f"[TrendFacts] {ticker} T1={t1_hit} T2={t2_hit}")
+            return trend_facts
+        except Exception as e:
+            logger.warning(f"[TrendFacts] {ticker} failed, fail-open: {e}")
+            return ""
+
     async def _extract_trading_scenario(
         self,
         report_content: str,
@@ -777,6 +897,14 @@ class USStockTrackingAgent:
                 - ⚠️ This adjustment is a reference based on past experience.
                 """
 
+            # Individual-stock trend facts for the mandatory Step 1.5 trend gate (fail-open).
+            # Never raises into the buy path; returns "" on any error.
+            trend_facts = ""
+            if ticker:
+                trend_facts = self._get_trend_facts(ticker)
+                if trend_facts:
+                    logger.debug(f"[TrendFacts] US injected for {ticker} ({len(trend_facts)} chars)")
+
             # LLM call to generate trading scenario
             llm = await self.trading_agent.attach_llm(OpenAIAugmentedLLM)
 
@@ -798,6 +926,7 @@ class USStockTrackingAgent:
             ### Trading Value Analysis:
             {rank_change_msg}
             {score_adjustment_info}
+            {trend_facts}
             {journal_context}
 
             ### Report Content:

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -262,6 +262,137 @@ class StockTrackingAgent:
             self.MAX_SAME_SECTOR, self.SECTOR_CONCENTRATION_RATIO, account_key=account_key
         )
 
+    def _get_trend_facts(self, ticker: str) -> str:
+        """Compute deterministic individual-stock trend facts for the buy prompt's trend gate.
+
+        Fail-open: on ANY error returns "" and logs a warning; never raises into the buy path.
+        Reuses the resilient cores.stock_chart wrappers (db-server backed on prod).
+        """
+        try:
+            from datetime import timedelta
+            from cores.stock_chart import (
+                get_market_ohlcv_by_date,
+                get_index_ohlcv_by_date,
+                _detect_index_ticker,
+            )
+
+            end_dt = datetime.now()
+            start_dt = end_dt - timedelta(days=120)
+            end = end_dt.strftime("%Y%m%d")
+            start = start_dt.strftime("%Y%m%d")
+
+            df = get_market_ohlcv_by_date(start, end, ticker, adjusted=True)
+            if df is None or len(df) < 25 or 'Close' not in df.columns:
+                logger.warning(f"[TrendFacts] {ticker} insufficient OHLCV rows; skipping")
+                return ""
+
+            close_s = df['Close'].astype(float)
+            close = float(close_s.iloc[-1])
+
+            ma20_s = close_s.rolling(window=20).mean()
+            ma50_s = close_s.rolling(window=50).mean()
+            ma60_s = close_s.rolling(window=60).mean()
+
+            def _val(s):
+                try:
+                    v = s.iloc[-1]
+                    return float(v) if v == v else None  # NaN check
+                except Exception:
+                    return None
+
+            def _slope_up(s, lookback=5):
+                # rising if MA today > MA ~lookback trading days ago
+                try:
+                    if len(s) <= lookback:
+                        return None
+                    cur = s.iloc[-1]
+                    prev = s.iloc[-1 - lookback]
+                    if cur != cur or prev != prev:
+                        return None
+                    return bool(cur > prev)
+                except Exception:
+                    return None
+
+            ma20 = _val(ma20_s)
+            ma50 = _val(ma50_s)
+            ma60 = _val(ma60_s)
+            ma20_up = _slope_up(ma20_s)
+            ma50_up = _slope_up(ma50_s)
+            ma60_up = _slope_up(ma60_s)
+
+            # 50일선 우선, 없으면 60일선 fallback (T1용)
+            ma_mid = ma50 if ma50 is not None else ma60
+            ma_mid_up = ma50_up if ma50 is not None else ma60_up
+            ma_mid_label = "MA50" if ma50 is not None else "MA60"
+
+            def _pct(a, b):
+                if a is None or b is None or b == 0:
+                    return None
+                return (a - b) / b * 100.0
+
+            # RS proxy: 60거래일 종목 수익률 - 지수 60거래일 수익률
+            rs = None
+            stock_ret = None
+            idx_ret = None
+            n = min(60, len(close_s) - 1)
+            if n > 0:
+                base = float(close_s.iloc[-1 - n])
+                if base:
+                    stock_ret = (close / base - 1.0) * 100.0
+                try:
+                    index_ticker = _detect_index_ticker(ticker)
+                    idf = get_index_ohlcv_by_date(start, end, index_ticker)
+                    if idf is not None and len(idf) > 1:
+                        icol = "종가" if "종가" in idf.columns else (
+                            "Close" if "Close" in idf.columns else None)
+                        if icol:
+                            iclose = idf[icol].astype(float)
+                            m = min(n, len(iclose) - 1)
+                            ibase = float(iclose.iloc[-1 - m])
+                            if ibase:
+                                idx_ret = (float(iclose.iloc[-1]) / ibase - 1.0) * 100.0
+                except Exception as _ie:
+                    logger.warning(f"[TrendFacts] {ticker} index return failed: {_ie}")
+                if stock_ret is not None and idx_ret is not None:
+                    rs = stock_ret - idx_ret
+
+            # 게이트 판정 (deterministic)
+            # T1: 종가가 50일선(오닐 10주선) 아래 = 핵심 라인 이탈. 기울기 무관 —
+            #     라인 아래면 정당한 눌림이 아니라 추세 훼손으로 본다.
+            t1_hit = bool(ma_mid is not None and close < ma_mid)
+            # T2: 20일선 하향 + 종가가 20일선 대비 5% 이상 아래 = 급격한 초기 붕괴.
+            #     (RS 60일은 직전 급등 잔상으로 stale → 게이트 조건에서 제외, 정보로만 표기)
+            t2_hit = bool(ma20 is not None and ma20_up is not None
+                          and ma20_up is False and close <= ma20 * 0.95)
+
+            def _above(a, b):
+                if a is None or b is None:
+                    return "n/a"
+                return "위" if a >= b else "아래"
+
+            def _dir(up):
+                return "n/a" if up is None else ("상승" if up else "하락")
+
+            def _fmt(v, suffix=""):
+                return f"{v:+.1f}{suffix}" if v is not None else "n/a"
+
+            lines = [
+                "### 📉 개별 추세 팩트 (추세 게이트용 · as-of 오늘)",
+                f"- 종가: {close:,.0f}",
+                f"- vs MA20: {_above(close, ma20)} ({_fmt(_pct(close, ma20), '%')}), MA20 기울기: {_dir(ma20_up)}",
+                f"- vs MA50: {_above(close, ma50)} ({_fmt(_pct(close, ma50), '%')}), MA50 기울기: {_dir(ma50_up)}",
+                f"- vs MA60: {_above(close, ma60)} ({_fmt(_pct(close, ma60), '%')}), MA60 기울기: {_dir(ma60_up)}",
+                f"- RS(60일, 종목-지수): {_fmt(rs, '%p')} (종목 {_fmt(stock_ret, '%')} / 지수 {_fmt(idx_ret, '%')})",
+                f"- T1_hit(종가<{ma_mid_label}, 오닐 10주선 이탈): {t1_hit} / "
+                f"T2_hit(MA20 하락 and 종가 MA20 대비 -5%↓): {t2_hit}",
+            ]
+            trend_facts = "\n".join(lines)
+            logger.info(f"[TrendFacts] {ticker} T1={t1_hit} T2={t2_hit}")
+            return trend_facts
+        except Exception as e:
+            logger.warning(f"[TrendFacts] {ticker} failed, fail-open: {e}")
+            return ""
+
     async def _extract_trading_scenario(
         self,
         report_content: str,
@@ -326,9 +457,12 @@ class StockTrackingAgent:
 
             # Get trading journal context for informed decisions
             journal_context = ""
+            trend_facts = ""
             score_adjustment_info = ""
             adjustment, reasons = 0, []
             if ticker:
+                # Deterministic individual-stock trend facts for the 1.5단계 trend gate (fail-open)
+                trend_facts = self._get_trend_facts(ticker)
                 journal_context = self._get_relevant_journal_context(
                     ticker=ticker,
                     sector=sector,
@@ -390,6 +524,7 @@ class StockTrackingAgent:
                 ### Trading Value Analysis:
                 {rank_change_msg}
                 {score_adjustment_info}
+                {trend_facts}
                 {journal_context}
 
                 ### Report Content:
@@ -405,6 +540,7 @@ class StockTrackingAgent:
                 ### Trading Value Analysis:
                 {rank_change_msg}
                 {score_adjustment_info}
+                {trend_facts}
                 {journal_context}
 
                 ### Report Content:


### PR DESCRIPTION
매수 시점에 O'Neil 개별 추세 게이트(T1: 50일선 이탈, T2: MA20 급락)와 상습손절(2주내 2회) 게이트를 프롬프트에 추가. 자금유입/거래량 momentum 자동가산을 하락추세 종목엔 제외. 개별 추세 팩트(_get_trend_facts) 결정론적 주입. KR/US, 한/영 모두 반영. 실데이터 검증: 삼성전기 차단, 하이닉스는 상승 50일선 위(눌림)→상습손절 게이트로 라우팅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)