### PR TITLE
Market Pulse(오닐 M) 상태기계 + CORRECTION 배치휴식 정책 (SHADOW)

### DIFF
--- a/cores/market_pulse.py
+++ b/cores/market_pulse.py
@@ -5,8 +5,13 @@ sequence of index daily bars into one of three states::
 
     UPTREND         — normal; distribution days (DD) <= 3 in the rolling window
     UNDER_PRESSURE  — 4 or 5 accumulated distribution days
-    CORRECTION      — 6+ distribution days, OR repeated failed rally attempts;
-                      exited ONLY by a valid Follow-Through Day (FTD)
+    CORRECTION      — 6+ distribution days, a price drawdown of >=10% below the
+                      rolling reference peak close (edge-trigger, Rev.2), OR
+                      repeated failed rally attempts; exited by a valid
+                      Follow-Through Day (FTD) OR by a price-recovery close above
+                      the pre-correction peak (O'Neil: a new high is by
+                      definition an uptrend; FTD is an early-bottom catch, not the
+                      sole exit). See §7 Rev.1/Rev.2.
 
 The single source of truth for the whole regime/buy/rest policy. It is pure:
 input is a sequence of ``DailyBar`` values, output is a state string. No network,
@@ -22,11 +27,16 @@ history; NOT tuned on our 156 trades). See tasks/market_pulse/00_VALIDATION_PLAN
     | DD expiry               | 25 sessions, or  | IBD standard                             |
     |                         | +5% recovery     |                                          |
     | Correction entry        | DD >= 6          | IBD "market in correction"               |
+    | Correction 진입(가격)   | 롤링 피크 종가   | 시장사 보편 정의(10% correction);        |
+    |                         | 대비 -10%        | edge-trigger, 탈출 시 피크 리셋; Rev.2   |
+    |                         | (edge-trigger)   |                                          |
     | Under-pressure          | DD in {4, 5}     | IBD                                      |
     | Rally attempt Day 1     | first up-close   | O'Neil, "How to Make Money in Stocks"    |
     |                         | after new low    |                                          |
-    | Follow-Through Day      | rally day >= 4 & | O'Neil HTMMIS (1.25–1.7%; conservative   |
-    |                         | +1.7% & vol up   | 1.7 adopted)                             |
+    | Follow-Through Day      | rally day >= 4 & | O'Neil HTMMIS canonical (1.25%+); §7     |
+    |                         | +1.25% & vol up  | Rev.1 (1.7→1.25, was over-conservative)  |
+    | Price-recovery exit     | close > pre-     | O'Neil — a new high IS an uptrend;       |
+    |                         | correction peak  | §7 Rev.1 (added exit besides FTD)        |
     | Rally reset             | close < rally    | O'Neil standard                          |
     |                         | start low        |                                          |
 
@@ -48,7 +58,7 @@ Missing-volume handling summary:
     day cannot be a DD (never counted). Matches IBD.
   * Follow-Through Day: normally requires volume(t) > volume(t-1). If volume data
     is missing for the comparison, FTD falls back to the price condition only
-    (rally day >= 4 AND gain >= +1.7%) — a documented, deliberate degradation so
+    (rally day >= 4 AND gain >= +1.25%) — a documented, deliberate degradation so
     indices without reliable volume still transition out of CORRECTION.
 """
 
@@ -67,8 +77,15 @@ DISTRIBUTION_RECOVERY_PCT: float = 5.0  # DD expires early on +5% recovery (IBD)
 UNDER_PRESSURE_MIN_DD: int = 4         # 4-5 DD => under pressure (IBD)
 CORRECTION_MIN_DD: int = 6             # >=6 DD => market in correction (IBD)
 
+# Rev.2: price-drawdown correction entry. A close >=10% below the rolling
+# reference peak (a standard "10% = correction" market-history definition, not
+# tuned) enters CORRECTION even with zero DDs — waterfall/gap crashes skip the
+# distribution-day (topping) stage. Edge-triggered; the reference peak is reset
+# on CORRECTION exit so a NEW >=10% decline from post-exit levels is required.
+DRAWDOWN_CORRECTION_PCT: float = 10.0  # >=10% below rolling peak => correction
+
 FTD_MIN_RALLY_DAY: int = 4             # follow-through on day 4+ (O'Neil HTMMIS)
-FTD_MIN_GAIN_PCT: float = 1.7          # +1.7% (O'Neil; conservative end of 1.25-1.7)
+FTD_MIN_GAIN_PCT: float = 1.25         # +1.25% (O'Neil HTMMIS canonical; §7 Rev.1, was 1.7)
 
 # PulseState values (enum-ish string constants).
 UPTREND: str = "UPTREND"
@@ -162,6 +179,16 @@ class MarketPulse:
         self._rally_active: bool = False
         self._rally_day: int = 0
         self._rally_start_low: Optional[float] = None
+        # Highest close observed before/at the moment CORRECTION was entered.
+        # A later close above this pre-correction peak = new high = uptrend exit
+        # (§7 Rev.1). Tracked per-episode: re-captured on each _enter_correction.
+        self._pre_correction_peak: Optional[float] = None
+        # Rev.2: rolling reference peak close — max close since machine start OR
+        # since the last CORRECTION exit. Drives the >=10% price-drawdown entry
+        # (edge-trigger) and is reset to the exit close when leaving CORRECTION so
+        # the market must make a NEW >=10% decline from post-exit levels before it
+        # can re-trigger (standard trailing correction/bear labeling; anti-flap).
+        self._reference_peak: Optional[float] = None
 
     @property
     def state(self) -> PulseState:
@@ -177,6 +204,13 @@ class MarketPulse:
         self._closes.append(float(bar.close))
         self._vols.append(None if bar.volume is None else float(bar.volume))
         n = len(self._closes)
+        cur = self._closes[-1]
+
+        # Rev.2: maintain the rolling reference peak (max close since start or the
+        # last CORRECTION exit). Updated every bar, before entry checks so a new
+        # high simply lifts the peak (drawdown 0) and never self-triggers.
+        if self._reference_peak is None or cur > self._reference_peak:
+            self._reference_peak = cur
 
         dd = _count_distribution_days(
             self._closes, self._vols, DISTRIBUTION_WINDOW, self._dd_window_start
@@ -187,8 +221,14 @@ class MarketPulse:
             self._update_correction(n)
         else:
             # UPTREND / UNDER_PRESSURE are re-derived from DD count each day;
-            # only CORRECTION is "sticky" (exited via FTD only).
-            if dd >= CORRECTION_MIN_DD:
+            # only CORRECTION is "sticky" (exited via FTD / price-recovery).
+            drawdown_trigger = (
+                self._reference_peak is not None
+                and cur < self._reference_peak * (1.0 - DRAWDOWN_CORRECTION_PCT / 100.0)
+            )
+            if drawdown_trigger or dd >= CORRECTION_MIN_DD:
+                # Rev.2: a >=10% drawdown from the rolling peak enters CORRECTION
+                # even with zero DDs (waterfall crashes skip the topping stage).
                 self._enter_correction()
             elif dd >= UNDER_PRESSURE_MIN_DD:
                 self._state = UNDER_PRESSURE
@@ -210,6 +250,13 @@ class MarketPulse:
     def _enter_correction(self) -> None:
         self._state = CORRECTION
         self._correction_low = self._closes[-1]
+        # Pre-correction peak = the rolling reference peak at trigger time (max
+        # close since start or the last CORRECTION exit). Identical to the highest
+        # close for a DD-triggered entry, and exactly the drawdown reference for a
+        # price-drawdown entry (Rev.2). Captured fresh per episode, so a later
+        # episode uses its own peak and the new-high recovery exit compares against
+        # the current episode's peak.
+        self._pre_correction_peak = self._reference_peak
         self._rally_active = False
         self._rally_day = 0
         self._rally_start_low = None
@@ -222,6 +269,13 @@ class MarketPulse:
 
         if self._correction_low is None:
             self._correction_low = cur
+
+        # Price-recovery exit (§7 Rev.1): a close above the pre-correction peak
+        # is by definition a new high => uptrend. Checked every day, independent
+        # of any rally attempt. FTD is an early-bottom catch, not the sole exit.
+        if self._pre_correction_peak is not None and cur > self._pre_correction_peak:
+            self._exit_to_uptrend(n)
+            return
 
         if not self._rally_active:
             # Day 1 of a rally attempt = first close up from the prior close.
@@ -254,6 +308,10 @@ class MarketPulse:
 
     def _follow_through(self, n: int) -> None:
         """Valid FTD: return to UPTREND and reset the DD window."""
+        self._exit_to_uptrend(n)
+
+    def _exit_to_uptrend(self, n: int) -> None:
+        """Shared CORRECTION exit (FTD or price-recovery): UPTREND + DD reset."""
         self._state = UPTREND
         self._dd_window_start = n  # exclude all DDs up to and including today
         self._last_dd = 0
@@ -261,3 +319,8 @@ class MarketPulse:
         self._rally_day = 0
         self._rally_start_low = None
         self._correction_low = None
+        self._pre_correction_peak = None
+        # Rev.2 anti-flap: reset the rolling reference peak to today's close so a
+        # NEW >=10% decline from post-exit levels is required to re-trigger a
+        # price-drawdown CORRECTION. Thereafter the peak grows with new highs.
+        self._reference_peak = self._closes[-1]

--- a/cores/market_pulse.py
+++ b/cores/market_pulse.py
@@ -1,0 +1,263 @@
+"""Market Pulse — O'Neil "market direction (M)" state machine (pure, no I/O).
+
+Deterministic finite state machine that classifies overall market health from a
+sequence of index daily bars into one of three states::
+
+    UPTREND         — normal; distribution days (DD) <= 3 in the rolling window
+    UNDER_PRESSURE  — 4 or 5 accumulated distribution days
+    CORRECTION      — 6+ distribution days, OR repeated failed rally attempts;
+                      exited ONLY by a valid Follow-Through Day (FTD)
+
+The single source of truth for the whole regime/buy/rest policy. It is pure:
+input is a sequence of ``DailyBar`` values, output is a state string. No network,
+no filesystem, no clock — fully unit-testable.
+
+Constant provenance (IBD / William O'Neil public methodology — 60y market
+history; NOT tuned on our 156 trades). See tasks/market_pulse/00_VALIDATION_PLAN.md §1:
+
+    | Constant                | Value            | Source                                   |
+    |-------------------------|------------------|------------------------------------------|
+    | Distribution Day        | close <= -0.2% & | IBD standard                             |
+    |                         | volume > prev    |                                          |
+    | DD expiry               | 25 sessions, or  | IBD standard                             |
+    |                         | +5% recovery     |                                          |
+    | Correction entry        | DD >= 6          | IBD "market in correction"               |
+    | Under-pressure          | DD in {4, 5}     | IBD                                      |
+    | Rally attempt Day 1     | first up-close   | O'Neil, "How to Make Money in Stocks"    |
+    |                         | after new low    |                                          |
+    | Follow-Through Day      | rally day >= 4 & | O'Neil HTMMIS (1.25–1.7%; conservative   |
+    |                         | +1.7% & vol up   | 1.7 adopted)                             |
+    | Rally reset             | close < rally    | O'Neil standard                          |
+    |                         | start low        |                                          |
+
+Distribution-day semantics are MIRRORED from the existing deterministic repo
+implementation, ``_count_distribution_days`` in
+``prism-us/cores/data_prefetch.py`` (lines ~1050-1107; constants
+DISTRIBUTION_WINDOW=25, DISTRIBUTION_DROP_PCT=0.2, DISTRIBUTION_RECOVERY_PCT=5.0
+at lines 994-996), which feeds ``index_summary.distribution_days`` in
+production. We reproduce its exact definition and dual expiry (25-session window
++ 5%-recovery) so both code paths agree. The only intentional difference: this
+module never returns ``None`` on missing volume — instead a bar whose volume (or
+its predecessor's) is missing simply *cannot confirm* a DD and is not counted,
+which is the same downstream effect (DD unconfirmed) expressed as a state rather
+than a null. Per IBD, a price drop without a volume increase is NOT a
+distribution day, so missing volume => "cannot confirm" => not a DD.
+
+Missing-volume handling summary:
+  * Distribution day: requires volume(t) > volume(t-1). If either is None the
+    day cannot be a DD (never counted). Matches IBD.
+  * Follow-Through Day: normally requires volume(t) > volume(t-1). If volume data
+    is missing for the comparison, FTD falls back to the price condition only
+    (rally day >= 4 AND gain >= +1.7%) — a documented, deliberate degradation so
+    indices without reliable volume still transition out of CORRECTION.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+# --------------------------------------------------------------------------- #
+# Constants (IBD/O'Neil — see module docstring table; mirror data_prefetch.py)  #
+# --------------------------------------------------------------------------- #
+DISTRIBUTION_WINDOW: int = 25          # rolling sessions (IBD standard)
+DISTRIBUTION_DROP_PCT: float = 0.2     # close change <= -0.2% (IBD)
+DISTRIBUTION_RECOVERY_PCT: float = 5.0  # DD expires early on +5% recovery (IBD)
+
+UNDER_PRESSURE_MIN_DD: int = 4         # 4-5 DD => under pressure (IBD)
+CORRECTION_MIN_DD: int = 6             # >=6 DD => market in correction (IBD)
+
+FTD_MIN_RALLY_DAY: int = 4             # follow-through on day 4+ (O'Neil HTMMIS)
+FTD_MIN_GAIN_PCT: float = 1.7          # +1.7% (O'Neil; conservative end of 1.25-1.7)
+
+# PulseState values (enum-ish string constants).
+UPTREND: str = "UPTREND"
+UNDER_PRESSURE: str = "UNDER_PRESSURE"
+CORRECTION: str = "CORRECTION"
+
+PulseState = str  # semantic alias: one of UPTREND / UNDER_PRESSURE / CORRECTION
+
+
+@dataclass(frozen=True)
+class DailyBar:
+    """A single index daily bar. ``volume`` may be None when unavailable."""
+
+    date: str            # YYYY-MM-DD
+    close: float
+    volume: Optional[float] = None
+
+
+def _count_distribution_days(
+    closes: List[float],
+    vols: List[Optional[float]],
+    window: int = DISTRIBUTION_WINDOW,
+    start_idx: int = 0,
+    drop_threshold_pct: float = DISTRIBUTION_DROP_PCT,
+    recovery_pct: float = DISTRIBUTION_RECOVERY_PCT,
+) -> int:
+    """Count live distribution days over the trailing ``window`` sessions.
+
+    Mirrors ``_count_distribution_days`` in prism-us/cores/data_prefetch.py
+    (deterministic O'Neil count). A DD occurs at index ``i`` when::
+
+        (close[i] - close[i-1]) / close[i-1] * 100 <= -drop_threshold_pct
+        AND vol[i] > vol[i-1]   (volume confirmation; missing => not a DD)
+
+    Expiry: (1) only the last ``window`` comparison-days are considered; (2) a DD
+    is removed if any *later* close is >= its close * (1 + recovery_pct/100)
+    (a +5% recovery above the DD's own close).
+
+    ``start_idx`` lets the caller reset the window after a Follow-Through Day so
+    pre-FTD distribution days no longer count (only DDs at index >= start_idx).
+    """
+    n = len(closes)
+    if n < 2:
+        return 0
+    start = max(1, n - window, start_idx)
+    running_max_after = float("-inf")
+    flags: List[Tuple[int, bool, float]] = []
+    # Reverse pass so ``running_max_after`` is the max close strictly AFTER i.
+    for i in range(n - 1, start - 1, -1):
+        prev_c = closes[i - 1]
+        cur_c = closes[i]
+        if prev_c <= 0:
+            flags.append((i, False, running_max_after))
+            running_max_after = max(running_max_after, cur_c)
+            continue
+        pct = (cur_c - prev_c) / prev_c * 100.0
+        vi = vols[i]
+        vp = vols[i - 1]
+        vol_up = vi is not None and vp is not None and vi > vp
+        is_dist = (pct <= -drop_threshold_pct) and vol_up
+        flags.append((i, is_dist, running_max_after))
+        running_max_after = max(running_max_after, cur_c)
+    kept = 0
+    for i, is_dist, max_after in flags:
+        if not is_dist:
+            continue
+        if max_after >= closes[i] * (1 + recovery_pct / 100.0):
+            continue  # expired by +5% recovery
+        kept += 1
+    return kept
+
+
+class MarketPulse:
+    """Incremental O'Neil market-direction state machine.
+
+    Feed index daily bars in chronological order via :meth:`feed`; it returns the
+    current :data:`PulseState` after each bar. State depends only on the bars fed
+    so far (as-of semantics), so replaying a fixed sequence is deterministic.
+    """
+
+    def __init__(self) -> None:
+        self._closes: List[float] = []
+        self._vols: List[Optional[float]] = []
+        self._dates: List[str] = []
+        self._state: PulseState = UPTREND
+        self._last_dd: int = 0
+        # DD window reset point (absolute bar index); bumped after an FTD.
+        self._dd_window_start: int = 0
+        # Correction / rally-attempt tracking (O'Neil).
+        self._correction_low: Optional[float] = None
+        self._rally_active: bool = False
+        self._rally_day: int = 0
+        self._rally_start_low: Optional[float] = None
+
+    @property
+    def state(self) -> PulseState:
+        return self._state
+
+    @property
+    def distribution_days(self) -> int:
+        return self._last_dd
+
+    def feed(self, bar: DailyBar) -> PulseState:
+        """Ingest one bar (chronological) and return the resulting state."""
+        self._dates.append(bar.date)
+        self._closes.append(float(bar.close))
+        self._vols.append(None if bar.volume is None else float(bar.volume))
+        n = len(self._closes)
+
+        dd = _count_distribution_days(
+            self._closes, self._vols, DISTRIBUTION_WINDOW, self._dd_window_start
+        )
+        self._last_dd = dd
+
+        if self._state == CORRECTION:
+            self._update_correction(n)
+        else:
+            # UPTREND / UNDER_PRESSURE are re-derived from DD count each day;
+            # only CORRECTION is "sticky" (exited via FTD only).
+            if dd >= CORRECTION_MIN_DD:
+                self._enter_correction()
+            elif dd >= UNDER_PRESSURE_MIN_DD:
+                self._state = UNDER_PRESSURE
+            else:
+                self._state = UPTREND
+        return self._state
+
+    def replay(self, bars) -> List[Tuple[str, PulseState, int]]:
+        """Feed a whole sequence; return [(date, state, dd_count), ...]."""
+        out: List[Tuple[str, PulseState, int]] = []
+        for bar in bars:
+            state = self.feed(bar)
+            out.append((bar.date, state, self._last_dd))
+        return out
+
+    # ------------------------------------------------------------------ #
+    # Correction / rally-attempt internals                                #
+    # ------------------------------------------------------------------ #
+    def _enter_correction(self) -> None:
+        self._state = CORRECTION
+        self._correction_low = self._closes[-1]
+        self._rally_active = False
+        self._rally_day = 0
+        self._rally_start_low = None
+
+    def _update_correction(self, n: int) -> None:
+        cur = self._closes[-1]
+        prev = self._closes[-2] if n >= 2 else cur
+        cur_vol = self._vols[-1]
+        prev_vol = self._vols[-2] if n >= 2 else None
+
+        if self._correction_low is None:
+            self._correction_low = cur
+
+        if not self._rally_active:
+            # Day 1 of a rally attempt = first close up from the prior close.
+            if n >= 2 and cur > prev:
+                self._rally_active = True
+                self._rally_day = 1
+                self._rally_start_low = self._correction_low
+            else:
+                if cur < self._correction_low:
+                    self._correction_low = cur
+            return
+
+        # Active rally attempt.
+        if self._rally_start_low is not None and cur < self._rally_start_low:
+            # Undercut the rally-start low => rally fails, reset; new low stands.
+            self._rally_active = False
+            self._rally_day = 0
+            self._correction_low = min(self._correction_low, cur)
+            self._rally_start_low = None
+            return
+
+        self._rally_day += 1
+        gain = (cur - prev) / prev * 100.0 if prev > 0 else 0.0
+        has_vol = cur_vol is not None and prev_vol is not None
+        vol_up = has_vol and cur_vol > prev_vol
+        # Volume confirmation; gain-only fallback when volume data is missing.
+        vol_ok = vol_up if has_vol else True
+        if self._rally_day >= FTD_MIN_RALLY_DAY and gain >= FTD_MIN_GAIN_PCT and vol_ok:
+            self._follow_through(n)
+
+    def _follow_through(self, n: int) -> None:
+        """Valid FTD: return to UPTREND and reset the DD window."""
+        self._state = UPTREND
+        self._dd_window_start = n  # exclude all DDs up to and including today
+        self._last_dd = 0
+        self._rally_active = False
+        self._rally_day = 0
+        self._rally_start_low = None
+        self._correction_low = None

--- a/cores/regime_policy.py
+++ b/cores/regime_policy.py
@@ -1,0 +1,303 @@
+"""Regime policy — single source of truth for Market Pulse batch/rest decisions.
+
+This module glues the pure :mod:`cores.market_pulse` state machine to the
+production orchestrators. It answers three questions, and nothing else:
+
+  1. :func:`decide_batch_policy` — given (market, batch_mode, pulse_state), should
+     THIS analysis batch run, or rest? Pure, table-driven, no I/O, no env reads.
+  2. :func:`get_market_pulse_state` — compute the CURRENT pulse state by replaying
+     :class:`cores.market_pulse.MarketPulse` over the last ~400 calendar days of
+     index bars. Fail-open: ANY error returns ``None`` (never raises).
+  3. :func:`market_pulse_mode` — read the ``MARKET_PULSE_MODE`` env flag
+     (``shadow`` | ``live`` | ``off``; default ``shadow``).
+
+Policy rationale (tasks/market_pulse/00_VALIDATION_PLAN.md §7 Rev.3):
+    The V2 trade-sample audit REJECTED the original "CORRECTION = full stop"
+    policy — CORRECTION-window buys had a scary 38% stop-out rate but a NET
+    +25.3% P&L (the post-crash rebound monsters live in this window). So the
+    revised policy does NOT stop buying during a correction; it merely REDUCES
+    the agent to a single daily batch window, cutting exposure to the two noisiest
+    micro-structure windows while keeping one shot at the rebound:
+
+        * KR (morning / afternoon): CORRECTION -> afternoon rests, morning runs.
+        * US (morning / midday / afternoon): CORRECTION -> only midday runs;
+          morning (open-hour noise is maximal) and afternoon (overnight gap risk
+          on a late buy) both rest.
+
+    Non-CORRECTION states — UPTREND, UNDER_PRESSURE, and None (unknown / fail-open)
+    — run every batch normally. Exit/sell loops are NEVER affected by this policy;
+    only the new-analysis agents rest.
+
+Import safety: this module performs NO heavy imports at module load. All data
+fetching and market_pulse/stock_chart imports are lazy (inside functions) and
+resolved via :func:`_load_root_cores`, which loads the ROOT ``cores/`` sibling by
+file path even when ``sys.path`` shadowing (prism-us/cores) would otherwise win.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# PulseState string values (mirror cores.market_pulse; kept local so
+# decide_batch_policy stays a pure function with zero imports of the state
+# machine — the strings are the contract).
+UPTREND: str = "UPTREND"
+UNDER_PRESSURE: str = "UNDER_PRESSURE"
+CORRECTION: str = "CORRECTION"
+
+# Valid MARKET_PULSE_MODE values and default.
+_VALID_MODES = ("shadow", "live", "off")
+_DEFAULT_MODE = "shadow"
+
+# Table (§7 Rev.3): batches that REST during CORRECTION, per market. Any batch
+# NOT listed here still runs during CORRECTION (the retained daily window).
+_CORRECTION_REST_BATCHES = {
+    "kr": frozenset({"afternoon"}),               # morning runs, afternoon rests
+    "us": frozenset({"morning", "afternoon"}),    # only midday runs
+}
+
+# Module-level cache: pulse state is computed once per (short-lived) process and
+# reused by the orchestrator hook and by per-ticker trend-fact injection so we do
+# not re-fetch the index for every ticker. A None result is cached too, so a
+# failed/network-less run does not retry on every call.
+_STATE_CACHE: dict = {}
+
+
+@dataclass(frozen=True)
+class BatchPolicy:
+    """Decision for a single analysis batch.
+
+    Attributes:
+        run_batch:   True => run this batch normally; False => this batch rests.
+        reason:      Human-readable explanation (goes to logs).
+        pulse_state: The pulse state the decision was based on (may be None).
+    """
+
+    run_batch: bool
+    reason: str
+    pulse_state: Optional[str]
+
+
+def decide_batch_policy(
+    market: str, batch_mode: str, pulse_state: Optional[str]
+) -> BatchPolicy:
+    """Decide whether an analysis batch should run, given the pulse state.
+
+    Pure function — no env reads, no I/O, table-driven (:data:`_CORRECTION_REST_BATCHES`).
+
+    Args:
+        market:      "kr" or "us" (case-insensitive).
+        batch_mode:  KR: "morning"/"afternoon"; US: "morning"/"midday"/"afternoon".
+                     ("both" or any unknown mode fails open -> run.)
+        pulse_state: UPTREND / UNDER_PRESSURE / CORRECTION / None.
+
+    Rationale (§7 Rev.3): CORRECTION is not a buy stop; it reduces the agent to a
+    single daily window (KR morning-only, US midday-only) to dodge the open-hour
+    noise and the overnight-gap-on-late-buy windows, while keeping one shot at the
+    post-crash rebound. Exit loops are unaffected. Any non-CORRECTION or unknown
+    state runs everything (fail-open).
+    """
+    m = (market or "").strip().lower()
+    mode = (batch_mode or "").strip().lower()
+
+    if pulse_state == CORRECTION:
+        rest_batches = _CORRECTION_REST_BATCHES.get(m, frozenset())
+        if mode in rest_batches:
+            return BatchPolicy(
+                run_batch=False,
+                reason=(
+                    f"CORRECTION: {m or '?'} '{mode or '?'}' batch rests "
+                    "(reduce to one daily window; exit loops unaffected)"
+                ),
+                pulse_state=pulse_state,
+            )
+        return BatchPolicy(
+            run_batch=True,
+            reason=(
+                f"CORRECTION: {m or '?'} '{mode or '?'}' batch runs "
+                "(retained daily window)"
+            ),
+            pulse_state=pulse_state,
+        )
+
+    # UPTREND / UNDER_PRESSURE / None(unknown) -> run everything (fail-open).
+    return BatchPolicy(
+        run_batch=True,
+        reason=f"{pulse_state or 'UNKNOWN'}: run all batches",
+        pulse_state=pulse_state,
+    )
+
+
+def market_pulse_mode() -> str:
+    """Return the MARKET_PULSE_MODE env flag: 'shadow' (default) | 'live' | 'off'.
+
+    Unknown/empty values fall back to 'shadow' (the safe, log-only default).
+    """
+    raw = (os.getenv("MARKET_PULSE_MODE") or "").strip().lower()
+    return raw if raw in _VALID_MODES else _DEFAULT_MODE
+
+
+# --------------------------------------------------------------------------- #
+# Pulse-state computation (lazy, fail-open, shadow-safe imports)               #
+# --------------------------------------------------------------------------- #
+def _load_root_cores(name: str):
+    """Import ``cores.<name>`` from the ROOT cores/ dir, defeating sys.path shadowing.
+
+    The US orchestrator/agent runs with prism-us/ ahead of PROJECT_ROOT on
+    sys.path, so a plain ``import cores.<name>`` may resolve to prism-us/cores/.
+    This module lives in the ROOT cores/ dir, so its siblings (market_pulse.py,
+    stock_chart.py) are addressable by file path relative to ``__file__`` — always
+    the correct root module. We try the normal import first (cheap when it already
+    points at the right file, e.g. in the KR process) and only fall back to a
+    by-path load when it is missing or shadowed.
+    """
+    import importlib
+    import importlib.util
+    import pathlib
+
+    target = pathlib.Path(__file__).with_name(f"{name}.py").resolve()
+    try:
+        mod = importlib.import_module(f"cores.{name}")
+        mf = getattr(mod, "__file__", None)
+        if mf and pathlib.Path(mf).resolve() == target:
+            return mod
+    except Exception:  # noqa: BLE001 - shadowed/missing => fall through to by-path
+        pass
+
+    spec = importlib.util.spec_from_file_location(f"prism_root_cores_{name}", target)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+def _df_to_bars(df, close_col: str, vol_col: Optional[str], DailyBar):
+    """Convert an OHLCV frame to a chronological list of ``DailyBar``."""
+    import pandas as pd
+
+    bars = []
+    for idx, row in df.iterrows():
+        c = float(row[close_col])
+        if c <= 0:
+            continue
+        v: Optional[float] = None
+        if vol_col is not None:
+            raw = row[vol_col]
+            if raw is not None and not pd.isna(raw):
+                v = float(raw)
+                if v <= 0:
+                    v = None
+        bars.append(DailyBar(date=idx.strftime("%Y-%m-%d"), close=c, volume=v))
+    return bars
+
+
+def _fetch_kr_bars(DailyBar):
+    """KOSPI index (1001) ~400d daily OHLCV via the authenticated KRX client.
+
+    Mirrors tools/market_pulse_backtest.py:fetch_kr_bars but with a 400-day window
+    (~2 yearly chunks; the KRX API rejects a 6y single request with INVALIDPERIOD2,
+    so we fetch per calendar year and concat). Volume is required for DD detection.
+    """
+    import pandas as pd
+    from datetime import datetime, timedelta
+
+    sc = _load_root_cores("stock_chart")
+    get_index_ohlcv_by_date = sc.get_index_ohlcv_by_date
+
+    end_dt = datetime.now()
+    start_dt = end_dt - timedelta(days=400)
+    chunks = []
+    y = start_dt.year
+    while y <= end_dt.year:
+        s = max(start_dt, datetime(y, 1, 1)).strftime("%Y%m%d")
+        e = min(end_dt, datetime(y, 12, 31)).strftime("%Y%m%d")
+        cdf = get_index_ohlcv_by_date(s, e, "1001")
+        if cdf is not None and len(cdf):
+            chunks.append(cdf)
+        y += 1
+    if not chunks:
+        raise RuntimeError("KOSPI(1001) KRX fetch returned empty for all chunks")
+    df = pd.concat(chunks)
+    df = df[~df.index.duplicated(keep="last")].sort_index()
+    close_col = "종가" if "종가" in df.columns else "Close"
+    vol_col = (
+        "거래량" if "거래량" in df.columns
+        else ("Volume" if "Volume" in df.columns else None)
+    )
+    if vol_col is None:
+        raise RuntimeError("KOSPI(1001) frame has no volume column")
+    return _df_to_bars(df, close_col, vol_col, DailyBar)
+
+
+def _fetch_us_bars(DailyBar):
+    """S&P 500 (^GSPC) daily via yfinance (period=2y ~ the 400d window)."""
+    import pandas as pd
+    import yfinance as yf
+
+    df = yf.download("^GSPC", period="2y", interval="1d",
+                     auto_adjust=True, progress=False)
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = df.columns.get_level_values(0)
+    df = df.dropna(how="all")
+    if df is None or len(df) == 0:
+        raise RuntimeError("^GSPC fetch returned empty")
+    vol_col = "Volume" if "Volume" in df.columns else None
+    return _df_to_bars(df.sort_index(), "Close", vol_col, DailyBar)
+
+
+def get_market_pulse_state(market: str, use_cache: bool = True) -> Optional[str]:
+    """Compute the current Market Pulse state for ``market`` ("kr" | "us").
+
+    Replays :class:`cores.market_pulse.MarketPulse` over ~400 calendar days of
+    index bars and returns the final state string (UPTREND / UNDER_PRESSURE /
+    CORRECTION). Memoized per process (:data:`_STATE_CACHE`).
+
+    NOTE: 400 days is enough for current-state purposes (the rolling peak / DD
+    window reference stays inside this window). A state read near the window edge
+    can differ slightly from a full 6-year replay — acceptable for policy use.
+
+    Fail-open: ANY exception (network, auth, missing data, import) is logged as a
+    warning and returns ``None`` (cached), so this never raises into a production
+    batch or buy path.
+    """
+    m = (market or "").strip().lower()
+    if use_cache and m in _STATE_CACHE:
+        return _STATE_CACHE[m]
+
+    try:
+        mp_mod = _load_root_cores("market_pulse")
+        MarketPulse = mp_mod.MarketPulse
+        DailyBar = mp_mod.DailyBar
+
+        if m == "kr":
+            bars = _fetch_kr_bars(DailyBar)
+        elif m == "us":
+            bars = _fetch_us_bars(DailyBar)
+        else:
+            logger.warning("[MARKET_PULSE] unknown market %r -> None", market)
+            _STATE_CACHE[m] = None
+            return None
+
+        if not bars or len(bars) < 30:
+            raise RuntimeError(f"insufficient index bars: {len(bars) if bars else 0}")
+
+        mp = MarketPulse()
+        state: Optional[str] = None
+        for bar in bars:
+            state = mp.feed(bar)
+        _STATE_CACHE[m] = state
+        return state
+    except Exception as e:  # noqa: BLE001 - fail-open, never raise
+        logger.warning("[MARKET_PULSE] state compute failed for %s, fail-open None: %s",
+                       m or "?", e)
+        _STATE_CACHE[m] = None
+        return None
+
+
+def _reset_state_cache() -> None:
+    """Test/utility hook: clear the memoized pulse-state cache."""
+    _STATE_CACHE.clear()

--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -1220,6 +1220,34 @@ async def main():
 
     args = parser.parse_args()
 
+    # --- Market Pulse (O'Neil M) batch policy hook (SHADOW-first; §7 Rev.3) ---
+    # prism-us/cores shadows root cores/ on sys.path, so regime_policy is loaded
+    # by file path via _import_from_main_cores (same pattern as the translator/
+    # utils modules above). Lazy + guarded: never kills a production batch.
+    try:
+        _rp_mod = _import_from_main_cores(
+            "prism_root_regime_policy", "cores/regime_policy.py"
+        )
+        _mp_mode = _rp_mod.market_pulse_mode()
+        if _mp_mode != "off":
+            _mp_state = _rp_mod.get_market_pulse_state("us")
+            _mp_pol = _rp_mod.decide_batch_policy("us", args.mode, _mp_state)
+            logger.info(
+                f"[MARKET_PULSE] state={_mp_state} batch={args.mode} "
+                f"run={_mp_pol.run_batch} ({_mp_pol.reason}) mode={_mp_mode}"
+            )
+            if not _mp_pol.run_batch:
+                if _mp_mode == "live":
+                    logger.info("[MARKET_PULSE] LIVE: resting this batch "
+                                "(agents rest; exit loops unaffected)")
+                    return
+                else:
+                    logger.info("[MARKET_PULSE][SHADOW] WOULD_SKIP this batch "
+                                "— continuing normally")
+    except Exception as _mp_e:  # fail-open: batch continues on any error
+        logger.warning(f"[MARKET_PULSE] hook failed, fail-open (batch continues): {_mp_e}")
+    # --- end Market Pulse hook ---
+
     # Parse broadcast languages
     broadcast_languages = [lang.strip() for lang in args.broadcast_languages.split(",") if lang.strip()]
 

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -805,6 +805,20 @@ class USStockTrackingAgent:
                 f"- T1_hit(종가<{ma_mid_label}, 오닐 10주선 이탈): {t1_hit} / "
                 f"T2_hit(MA20 하락 and 종가 MA20 대비 -5%↓): {t2_hit}",
             ]
+            # Market Pulse (O'Neil M) 상태를 프롬프트 정보로 주입 (distribution_days 동급).
+            # prism-us/cores 섀도잉을 피해 root cores/ 파일경로로 로드; 프로세스당 1회 캐시; fail-open.
+            try:
+                _rp = _import_from_main_cores(
+                    "prism_root_regime_policy", "cores/regime_policy.py"
+                )
+                _mp_state = _rp.get_market_pulse_state("us")
+                if _mp_state:
+                    lines.append(
+                        f"- Market Pulse: {_mp_state} "
+                        "(오닐 M 상태; CORRECTION=신중, 반등대박도 이 구간에서 나옴)"
+                    )
+            except Exception as _mpe:
+                logger.warning(f"[TrendFacts] market pulse inject failed, fail-open: {_mpe}")
             trend_facts = "\n".join(lines)
             logger.info(f"[TrendFacts] {ticker} T1={t1_hit} T2={t2_hit}")
             return trend_facts

--- a/stock_analysis_orchestrator.py
+++ b/stock_analysis_orchestrator.py
@@ -1299,6 +1299,34 @@ async def main():
 
     args = parser.parse_args()
 
+    # --- Market Pulse (O'Neil M) batch policy hook (SHADOW-first; §7 Rev.3) ---
+    # Lazy + guarded: a broken import/compute can NEVER kill a production batch.
+    try:
+        from cores.regime_policy import (
+            market_pulse_mode,
+            get_market_pulse_state,
+            decide_batch_policy,
+        )
+        _mp_mode = market_pulse_mode()
+        if _mp_mode != "off":
+            _mp_state = get_market_pulse_state("kr")
+            _mp_pol = decide_batch_policy("kr", args.mode, _mp_state)
+            logger.info(
+                f"[MARKET_PULSE] state={_mp_state} batch={args.mode} "
+                f"run={_mp_pol.run_batch} ({_mp_pol.reason}) mode={_mp_mode}"
+            )
+            if not _mp_pol.run_batch:
+                if _mp_mode == "live":
+                    logger.info("[MARKET_PULSE] LIVE: resting this batch "
+                                "(agents rest; exit loops unaffected)")
+                    return
+                else:
+                    logger.info("[MARKET_PULSE][SHADOW] WOULD_SKIP this batch "
+                                "— continuing normally")
+    except Exception as _mp_e:  # fail-open: batch continues on any error
+        logger.warning(f"[MARKET_PULSE] hook failed, fail-open (batch continues): {_mp_e}")
+    # --- end Market Pulse hook ---
+
     # Parse broadcast languages
     broadcast_languages = [lang.strip() for lang in args.broadcast_languages.split(",") if lang.strip()]
 

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -386,6 +386,18 @@ class StockTrackingAgent:
                 f"- T1_hit(종가<{ma_mid_label}, 오닐 10주선 이탈): {t1_hit} / "
                 f"T2_hit(MA20 하락 and 종가 MA20 대비 -5%↓): {t2_hit}",
             ]
+            # Market Pulse (O'Neil M) 상태를 프롬프트 정보로 주입 (distribution_days 동급).
+            # 프로세스당 1회 계산(regime_policy 모듈 캐시); fail-open.
+            try:
+                from cores.regime_policy import get_market_pulse_state
+                _mp_state = get_market_pulse_state("kr")
+                if _mp_state:
+                    lines.append(
+                        f"- Market Pulse: {_mp_state} "
+                        "(오닐 M 상태; CORRECTION=신중, 반등대박도 이 구간에서 나옴)"
+                    )
+            except Exception as _mpe:
+                logger.warning(f"[TrendFacts] market pulse inject failed, fail-open: {_mpe}")
             trend_facts = "\n".join(lines)
             logger.info(f"[TrendFacts] {ticker} T1={t1_hit} T2={t2_hit}")
             return trend_facts

--- a/tests/test_market_pulse.py
+++ b/tests/test_market_pulse.py
@@ -187,6 +187,37 @@ class TestRallyAndFTD:
         st = mp.feed(DailyBar("2026-02-01", c1, 5000.0))
         assert st == CORRECTION
 
+    def test_ftd_fires_at_new_1_25_threshold(self):
+        # §7 Rev.1: threshold lowered 1.7% -> 1.25%. A +1.4% day-4 gain (between
+        # the old and new thresholds) is now a valid FTD. All closes stay well
+        # below the pre-correction peak (100), so price-recovery does not fire.
+        mp = self._into_correction()
+        low = self._low
+        c1 = low * 1.005
+        mp.feed(DailyBar("2026-02-01", c1, 1000.0))
+        c2 = c1 * 1.003
+        mp.feed(DailyBar("2026-02-02", c2, 1100.0))
+        c3 = c2 * 1.002
+        mp.feed(DailyBar("2026-02-03", c3, 1200.0))
+        c4 = c3 * 1.014          # +1.4% >= 1.25% (would fail the old 1.7%)
+        st = mp.feed(DailyBar("2026-02-04", c4, 2000.0))
+        assert st == UPTREND
+        assert mp.distribution_days == 0
+
+    def test_no_ftd_below_1_25_threshold(self):
+        # A +1.0% day-4 gain is below the 1.25% threshold -> not an FTD.
+        mp = self._into_correction()
+        low = self._low
+        c1 = low * 1.005
+        mp.feed(DailyBar("2026-02-01", c1, 1000.0))
+        c2 = c1 * 1.003
+        mp.feed(DailyBar("2026-02-02", c2, 1100.0))
+        c3 = c2 * 1.002
+        mp.feed(DailyBar("2026-02-03", c3, 1200.0))
+        c4 = c3 * 1.01           # +1.0% < 1.25% -> no FTD
+        st = mp.feed(DailyBar("2026-02-04", c4, 2000.0))
+        assert st == CORRECTION
+
     def test_ftd_requires_volume_up_when_volume_present(self):
         mp = self._into_correction()
         low = self._low
@@ -228,6 +259,107 @@ class TestRallyAndFTD:
         c4 = c3 * 1.02        # +2% on day 4, volume missing -> gain-only FTD
         st = mp.feed(DailyBar("2026-02-04", c4, None))
         assert st == UPTREND
+
+
+# --------------------------------------------------------------------------- #
+# Price-recovery exit (§7 Rev.1)                                              #
+# --------------------------------------------------------------------------- #
+class TestPriceRecoveryExit:
+    def _into_correction(self) -> MarketPulse:
+        # 6-DD run from start=100 -> CORRECTION; pre-correction peak = 100.0
+        # (the first close, highest observed before/at entry); low ~= 94.15.
+        closes, vols = _make_dd_run(6)
+        mp = MarketPulse()
+        for i, (c, v) in enumerate(zip(closes, vols)):
+            mp.feed(DailyBar(f"2026-01-{i+1:02d}", c, v))
+        assert mp.state == CORRECTION
+        return mp
+
+    def test_close_above_peak_exits_and_resets_dd(self):
+        mp = self._into_correction()
+        st = mp.feed(DailyBar("2026-02-01", 101.0, 5000.0))  # 101 > peak 100
+        assert st == UPTREND
+        assert mp.distribution_days == 0  # DD window reset (same as FTD exit)
+
+    def test_no_recovery_while_below_peak(self):
+        mp = self._into_correction()
+        # up close but still below the pre-correction peak (100) -> stays CORRECTION
+        st = mp.feed(DailyBar("2026-02-01", 99.0, 5000.0))
+        assert st == CORRECTION
+
+    def test_peak_tracked_per_episode(self):
+        # Episode 1 peak = 100; exit via a new high, climb to a higher high,
+        # then a second episode must use ITS OWN (higher) peak.
+        mp = self._into_correction()
+        assert mp.feed(DailyBar("2026-02-01", 101.0, 5000.0)) == UPTREND  # exit ep1
+        # Climb to a new cumulative high of 110 (up closes, never DDs).
+        mp.feed(DailyBar("2026-02-02", 106.0, 900.0))
+        mp.feed(DailyBar("2026-02-03", 110.0, 900.0))
+        # 6 fresh distribution days from 110 -> episode 2 CORRECTION, peak = 110.
+        c, vol, day = 110.0, 1000.0, 4
+        for _ in range(6):
+            c *= 0.99
+            vol += 100.0
+            mp.feed(DailyBar(f"2026-02-{day:02d}", c, vol))
+            day += 1
+        assert mp.state == CORRECTION
+        # 105 exceeds episode-1's peak (100) but NOT episode-2's peak (110):
+        # must stay CORRECTION -> proves the peak is per-episode.
+        assert mp.feed(DailyBar(f"2026-02-{day:02d}", 105.0, 5000.0)) == CORRECTION
+        day += 1
+        # A close above episode-2's own peak (110) exits.
+        assert mp.feed(DailyBar(f"2026-02-{day:02d}", 111.0, 5000.0)) == UPTREND
+
+
+# --------------------------------------------------------------------------- #
+# Price-drawdown CORRECTION entry (§7 Rev.2)                                   #
+# --------------------------------------------------------------------------- #
+class TestDrawdownEntry:
+    def test_waterfall_crash_falling_volume_enters_correction(self):
+        # A waterfall crash with FALLING volume produces ZERO distribution days
+        # (a DD needs volume > prev). Rev.2: a >=10% drawdown from the rolling
+        # peak must still enter CORRECTION. This is the exact case DD-count
+        # missed (KOSPI 2026-03 −19.1% stayed UPTREND under the old rule).
+        mp = MarketPulse()
+        mp.feed(DailyBar("2026-03-01", 100.0, 5000.0))          # rolling peak
+        prices = [97.0, 94.0, 91.0, 89.0]                       # 89 = -11% vs peak
+        vol = 5000.0
+        st = UPTREND
+        for i, p in enumerate(prices):
+            vol -= 500.0                                        # volume FALLING => no DD
+            st = mp.feed(DailyBar(f"2026-03-{i + 2:02d}", p, vol))
+        assert mp.distribution_days == 0                        # zero DDs (falling vol)
+        assert st == CORRECTION                                 # entered via -10% drawdown
+
+    def test_no_reenter_after_ftd_exit_still_below_old_peak(self):
+        # After an FTD exit the reference peak is RESET to the exit close, so a
+        # day still >10% below the OLD peak — but not below the reset peak — must
+        # NOT immediately re-enter (anti-flap).
+        mp = MarketPulse()
+        mp.feed(DailyBar("2026-04-01", 100.0, 5000.0))          # peak
+        assert mp.feed(DailyBar("2026-04-02", 84.0, 4000.0)) == CORRECTION  # -16%
+        mp.feed(DailyBar("2026-04-03", 84.5, 4100.0))           # rally day 1
+        mp.feed(DailyBar("2026-04-06", 85.0, 4200.0))           # day 2
+        mp.feed(DailyBar("2026-04-07", 85.3, 4300.0))           # day 3
+        # day 4: +1.5% (>=1.25) on rising volume -> FTD -> UPTREND, peak reset ~86.58
+        assert mp.feed(DailyBar("2026-04-08", 86.58, 6000.0)) == UPTREND
+        # 84.0 is still >10% below the OLD peak (100) yet only ~3% below the reset
+        # peak (~86.58) -> stays UPTREND (does NOT re-enter).
+        assert mp.feed(DailyBar("2026-04-09", 84.0, 3000.0)) == UPTREND
+
+    def test_reenter_on_new_decline_from_post_exit_peak(self):
+        # A genuinely NEW >=10% decline measured from the post-exit (reset) peak
+        # DOES re-trigger CORRECTION.
+        mp = MarketPulse()
+        mp.feed(DailyBar("2026-05-01", 100.0, 5000.0))          # peak
+        assert mp.feed(DailyBar("2026-05-04", 84.0, 4000.0)) == CORRECTION
+        mp.feed(DailyBar("2026-05-05", 84.5, 4100.0))
+        mp.feed(DailyBar("2026-05-06", 85.0, 4200.0))
+        mp.feed(DailyBar("2026-05-07", 85.3, 4300.0))
+        # FTD exit -> reference peak reset to ~86.58 (86.58 * 0.90 = 77.92).
+        assert mp.feed(DailyBar("2026-05-08", 86.58, 6000.0)) == UPTREND
+        # 77.0 < 77.92 -> a new >=10% decline from the post-exit peak re-enters.
+        assert mp.feed(DailyBar("2026-05-11", 77.0, 3000.0)) == CORRECTION
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_market_pulse.py
+++ b/tests/test_market_pulse.py
@@ -1,0 +1,250 @@
+"""Unit tests for cores.market_pulse — O'Neil market-direction state machine.
+
+Pure logic, zero network. Table-driven synthetic bar sequences.
+Run with:  .venv/bin/python -m pytest tests/test_market_pulse.py -q
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import pytest
+
+from cores.market_pulse import (
+    CORRECTION,
+    UNDER_PRESSURE,
+    UPTREND,
+    DailyBar,
+    MarketPulse,
+    _count_distribution_days,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                      #
+# --------------------------------------------------------------------------- #
+def _bars(rows: List[tuple]) -> List[DailyBar]:
+    """rows = [(close, volume), ...] -> synthetic bars with sequential dates."""
+    out = []
+    for i, row in enumerate(rows):
+        close, vol = row
+        out.append(DailyBar(date=f"2026-01-{i + 1:02d}", close=float(close), volume=vol))
+    return out
+
+
+def _dd_from_closes(closes: List[float], vols: List[Optional[float]], **kw) -> int:
+    return _count_distribution_days(closes, vols, **kw)
+
+
+def _make_dd_run(n: int, start: float = 100.0):
+    """Produce n distribution days: each -1% close with rising volume."""
+    closes = [start]
+    vols = [1000.0]
+    for i in range(n):
+        closes.append(closes[-1] * 0.99)      # -1% <= -0.2%
+        vols.append(vols[-1] + 100.0)          # volume up
+    return closes, vols
+
+
+# --------------------------------------------------------------------------- #
+# Distribution-day counting + expiry                                          #
+# --------------------------------------------------------------------------- #
+class TestDistributionCount:
+    def test_basic_dd_count(self):
+        closes, vols = _make_dd_run(4)
+        assert _dd_from_closes(closes, vols) == 4
+
+    def test_no_dd_when_volume_not_up(self):
+        # price drops but volume falls -> no distribution day
+        closes = [100, 99, 98, 97]
+        vols = [1000, 900, 800, 700]
+        assert _dd_from_closes(closes, vols) == 0
+
+    def test_no_dd_when_drop_too_small(self):
+        # -0.1% drop is above the -0.2% threshold -> not a DD
+        closes = [100.0, 99.9, 99.8]
+        vols = [1000, 1100, 1200]
+        assert _dd_from_closes(closes, vols) == 0
+
+    def test_missing_volume_cannot_confirm(self):
+        closes = [100, 99, 98]
+        vols = [None, None, None]
+        assert _dd_from_closes(closes, vols) == 0
+
+    def test_25_session_window_expiry(self):
+        # 3 DDs, then 25 flat/up sessions push them out of the window.
+        closes, vols = _make_dd_run(3)               # closes[0..3]
+        base = closes[-1]
+        for k in range(26):                          # many later sessions
+            base *= 1.0005                           # tiny +0.05% (not a DD, <5% recovery slowly)
+            closes.append(base)
+            vols.append(500.0)                        # volume down -> never a DD
+        # The 3 DDs are now >25 comparison-sessions back -> outside window.
+        assert _dd_from_closes(closes, vols) == 0
+
+    def test_5pct_recovery_expiry(self):
+        # 1 DD then price recovers >5% above the DD close -> DD expires.
+        closes = [100.0, 99.0]        # -1% DD at index1 (close 99)
+        vols = [1000.0, 1100.0]
+        closes.append(99.0 * 1.06)    # +6% above the DD close -> recovery expiry
+        vols.append(1200.0)
+        assert _dd_from_closes(closes, vols) == 0
+
+    def test_start_idx_reset(self):
+        closes, vols = _make_dd_run(4)
+        # Ignore everything before the last index -> no countable DD.
+        assert _dd_from_closes(closes, vols, start_idx=len(closes)) == 0
+
+
+# --------------------------------------------------------------------------- #
+# UPTREND -> UNDER_PRESSURE -> CORRECTION transitions                         #
+# --------------------------------------------------------------------------- #
+class TestStateTransitions:
+    def test_starts_uptrend(self):
+        mp = MarketPulse()
+        assert mp.feed(DailyBar("2026-01-01", 100.0, 1000.0)) == UPTREND
+
+    def test_three_dd_stays_uptrend(self):
+        closes, vols = _make_dd_run(3)
+        mp = MarketPulse()
+        states = [mp.feed(DailyBar(f"2026-01-{i+1:02d}", c, v))
+                  for i, (c, v) in enumerate(zip(closes, vols))]
+        assert states[-1] == UPTREND
+        assert mp.distribution_days == 3
+
+    def test_four_dd_under_pressure(self):
+        closes, vols = _make_dd_run(4)
+        mp = MarketPulse()
+        for i, (c, v) in enumerate(zip(closes, vols)):
+            state = mp.feed(DailyBar(f"2026-01-{i+1:02d}", c, v))
+        assert mp.distribution_days == 4
+        assert state == UNDER_PRESSURE
+
+    def test_five_dd_under_pressure(self):
+        closes, vols = _make_dd_run(5)
+        mp = MarketPulse()
+        for i, (c, v) in enumerate(zip(closes, vols)):
+            state = mp.feed(DailyBar(f"2026-01-{i+1:02d}", c, v))
+        assert mp.distribution_days == 5
+        assert state == UNDER_PRESSURE
+
+    def test_six_dd_correction(self):
+        closes, vols = _make_dd_run(6)
+        mp = MarketPulse()
+        for i, (c, v) in enumerate(zip(closes, vols)):
+            state = mp.feed(DailyBar(f"2026-01-{i+1:02d}", c, v))
+        assert mp.distribution_days == 6
+        assert state == CORRECTION
+
+    def test_correction_is_sticky(self):
+        # Enter correction, then flat days (DD would decay) -> still CORRECTION
+        # because only an FTD exits.
+        closes, vols = _make_dd_run(6)
+        mp = MarketPulse()
+        for i, (c, v) in enumerate(zip(closes, vols)):
+            mp.feed(DailyBar(f"2026-01-{i+1:02d}", c, v))
+        # one small down day (no rally, no FTD)
+        last = closes[-1]
+        st = mp.feed(DailyBar("2026-02-01", last * 0.999, 100.0))
+        assert st == CORRECTION
+
+
+# --------------------------------------------------------------------------- #
+# Rally attempts + Follow-Through Day                                         #
+# --------------------------------------------------------------------------- #
+class TestRallyAndFTD:
+    def _into_correction(self) -> MarketPulse:
+        closes, vols = _make_dd_run(6)
+        mp = MarketPulse()
+        for i, (c, v) in enumerate(zip(closes, vols)):
+            mp.feed(DailyBar(f"2026-01-{i+1:02d}", c, v))
+        assert mp.state == CORRECTION
+        self._low = closes[-1]
+        return mp
+
+    def test_ftd_day4_gain_volume_returns_uptrend(self):
+        mp = self._into_correction()
+        low = self._low
+        # Day 1: first up close from prior; days 2-3 hold; day 4 = FTD.
+        c1 = low * 1.005
+        st1 = mp.feed(DailyBar("2026-02-01", c1, 1000.0))       # rally day 1
+        c2 = c1 * 1.003
+        st2 = mp.feed(DailyBar("2026-02-02", c2, 1100.0))       # day 2
+        c3 = c3v = c2 * 1.002
+        st3 = mp.feed(DailyBar("2026-02-03", c3, 1200.0))       # day 3
+        c4 = c3 * 1.02                                          # +2% >= 1.7%
+        st4 = mp.feed(DailyBar("2026-02-04", c4, 2000.0))       # day 4 vol up -> FTD
+        assert st1 == CORRECTION
+        assert st2 == CORRECTION
+        assert st3 == CORRECTION
+        assert st4 == UPTREND
+        assert mp.distribution_days == 0  # DD window reset on FTD
+
+    def test_no_ftd_before_day4(self):
+        mp = self._into_correction()
+        low = self._low
+        c1 = low * 1.02   # big +2% but it's only rally day 1 -> not FTD
+        st = mp.feed(DailyBar("2026-02-01", c1, 5000.0))
+        assert st == CORRECTION
+
+    def test_ftd_requires_volume_up_when_volume_present(self):
+        mp = self._into_correction()
+        low = self._low
+        c1 = low * 1.005
+        mp.feed(DailyBar("2026-02-01", c1, 1000.0))
+        c2 = c1 * 1.003
+        mp.feed(DailyBar("2026-02-02", c2, 1100.0))
+        c3 = c2 * 1.002
+        mp.feed(DailyBar("2026-02-03", c3, 1200.0))
+        c4 = c3 * 1.02        # +2% on day 4 but volume DOWN -> not an FTD
+        st = mp.feed(DailyBar("2026-02-04", c4, 500.0))
+        assert st == CORRECTION
+
+    def test_rally_reset_on_undercut(self):
+        mp = self._into_correction()
+        low = self._low
+        # Start a rally (day 1 up), then undercut the rally-start low -> reset.
+        c1 = low * 1.01
+        mp.feed(DailyBar("2026-02-01", c1, 1000.0))            # rally day 1
+        c2 = c1 * 1.005
+        mp.feed(DailyBar("2026-02-02", c2, 1100.0))            # rally day 2
+        undercut = low * 0.97                                  # below rally-start low
+        mp.feed(DailyBar("2026-02-03", undercut, 1200.0))      # reset rally
+        # Now a fresh day-1 up close; a single +2% here must NOT be an FTD
+        # (rally day count was reset to 0).
+        c_new = undercut * 1.02
+        st = mp.feed(DailyBar("2026-02-04", c_new, 2000.0))
+        assert st == CORRECTION
+
+    def test_ftd_gain_only_when_volume_missing(self):
+        mp = self._into_correction()
+        low = self._low
+        c1 = low * 1.005
+        mp.feed(DailyBar("2026-02-01", c1, None))
+        c2 = c1 * 1.003
+        mp.feed(DailyBar("2026-02-02", c2, None))
+        c3 = c2 * 1.002
+        mp.feed(DailyBar("2026-02-03", c3, None))
+        c4 = c3 * 1.02        # +2% on day 4, volume missing -> gain-only FTD
+        st = mp.feed(DailyBar("2026-02-04", c4, None))
+        assert st == UPTREND
+
+
+# --------------------------------------------------------------------------- #
+# replay() convenience                                                        #
+# --------------------------------------------------------------------------- #
+class TestReplay:
+    def test_replay_shape_and_values(self):
+        closes, vols = _make_dd_run(4)
+        bars = _bars(list(zip(closes, vols)))
+        mp = MarketPulse()
+        out = mp.replay(bars)
+        assert len(out) == len(bars)
+        assert all(len(t) == 3 for t in out)
+        # last row: (date, state, dd_count)
+        assert out[-1][1] == UNDER_PRESSURE
+        assert out[-1][2] == 4
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_regime_policy.py
+++ b/tests/test_regime_policy.py
@@ -1,0 +1,137 @@
+"""Unit tests for cores.regime_policy — pure batch-policy + env-mode parsing.
+
+Pure logic, zero network. Table-driven over every market x mode x state combo.
+Run with:
+    .venv/bin/python -m pytest tests/test_regime_policy.py -q
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cores.regime_policy import (
+    CORRECTION,
+    UNDER_PRESSURE,
+    UPTREND,
+    BatchPolicy,
+    decide_batch_policy,
+    market_pulse_mode,
+)
+
+
+# --------------------------------------------------------------------------- #
+# decide_batch_policy — table-driven (market, mode, state) -> expected run_batch #
+# --------------------------------------------------------------------------- #
+# §7 Rev.3: CORRECTION reduces to one daily window.
+#   KR: morning runs, afternoon rests.
+#   US: midday runs, morning & afternoon rest.
+# All non-CORRECTION / unknown states run everything (fail-open).
+_CASES = [
+    # --- KR, CORRECTION ---
+    ("kr", "morning", CORRECTION, True),
+    ("kr", "afternoon", CORRECTION, False),
+    ("kr", "both", CORRECTION, True),         # unknown mode fails open -> run
+    # --- KR, non-CORRECTION ---
+    ("kr", "morning", UPTREND, True),
+    ("kr", "afternoon", UPTREND, True),
+    ("kr", "morning", UNDER_PRESSURE, True),
+    ("kr", "afternoon", UNDER_PRESSURE, True),
+    ("kr", "morning", None, True),
+    ("kr", "afternoon", None, True),
+    # --- US, CORRECTION ---
+    ("us", "morning", CORRECTION, False),
+    ("us", "midday", CORRECTION, True),
+    ("us", "afternoon", CORRECTION, False),
+    ("us", "both", CORRECTION, True),         # unknown mode fails open -> run
+    # --- US, non-CORRECTION ---
+    ("us", "morning", UPTREND, True),
+    ("us", "midday", UPTREND, True),
+    ("us", "afternoon", UPTREND, True),
+    ("us", "morning", UNDER_PRESSURE, True),
+    ("us", "midday", UNDER_PRESSURE, True),
+    ("us", "afternoon", UNDER_PRESSURE, True),
+    ("us", "morning", None, True),
+    ("us", "midday", None, True),
+    ("us", "afternoon", None, True),
+]
+
+
+@pytest.mark.parametrize("market,mode,state,expected", _CASES)
+def test_decide_batch_policy_table(market, mode, state, expected):
+    pol = decide_batch_policy(market, mode, state)
+    assert isinstance(pol, BatchPolicy)
+    assert pol.run_batch is expected
+    assert pol.pulse_state == state
+    assert isinstance(pol.reason, str) and pol.reason
+
+
+def test_only_correction_ever_rests():
+    """No non-CORRECTION state can ever produce run_batch=False."""
+    for market in ("kr", "us"):
+        for mode in ("morning", "midday", "afternoon", "both"):
+            for state in (UPTREND, UNDER_PRESSURE, None):
+                pol = decide_batch_policy(market, mode, state)
+                assert pol.run_batch is True, (market, mode, state)
+
+
+def test_correction_rest_sets():
+    """Exactly the documented batches rest during CORRECTION."""
+    assert decide_batch_policy("kr", "afternoon", CORRECTION).run_batch is False
+    assert decide_batch_policy("kr", "morning", CORRECTION).run_batch is True
+    assert decide_batch_policy("us", "morning", CORRECTION).run_batch is False
+    assert decide_batch_policy("us", "afternoon", CORRECTION).run_batch is False
+    assert decide_batch_policy("us", "midday", CORRECTION).run_batch is True
+
+
+def test_decide_is_case_insensitive():
+    assert decide_batch_policy("KR", "AFTERNOON", CORRECTION).run_batch is False
+    assert decide_batch_policy("US", "Midday", CORRECTION).run_batch is True
+
+
+def test_decide_fail_open_on_none_state():
+    """None (unknown / fail-open) state runs every batch on both markets."""
+    for market in ("kr", "us"):
+        for mode in ("morning", "midday", "afternoon"):
+            assert decide_batch_policy(market, mode, None).run_batch is True
+
+
+def test_decide_unknown_market_fails_open():
+    """An unknown market has no rest-batches -> runs even in CORRECTION."""
+    assert decide_batch_policy("jp", "morning", CORRECTION).run_batch is True
+    assert decide_batch_policy("", "afternoon", CORRECTION).run_batch is True
+
+
+def test_batchpolicy_is_frozen():
+    pol = decide_batch_policy("kr", "morning", UPTREND)
+    with pytest.raises(Exception):
+        pol.run_batch = False  # frozen dataclass -> FrozenInstanceError
+
+
+# --------------------------------------------------------------------------- #
+# market_pulse_mode — env parsing                                              #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("raw,expected", [
+    (None, "shadow"),          # unset -> default
+    ("", "shadow"),            # empty -> default
+    ("shadow", "shadow"),
+    ("live", "live"),
+    ("off", "off"),
+    ("SHADOW", "shadow"),      # case-insensitive
+    ("  live  ", "live"),      # whitespace trimmed
+    ("bogus", "shadow"),       # unknown -> safe default
+    ("Live", "live"),
+])
+def test_market_pulse_mode_parsing(monkeypatch, raw, expected):
+    if raw is None:
+        monkeypatch.delenv("MARKET_PULSE_MODE", raising=False)
+    else:
+        monkeypatch.setenv("MARKET_PULSE_MODE", raw)
+    assert market_pulse_mode() == expected
+
+
+def test_market_pulse_mode_returns_valid_value_only():
+    """Whatever the env, the returned value is always one of the 3 valid modes."""
+    import os
+    assert market_pulse_mode() in ("shadow", "live", "off")
+    # (does not mutate os.environ here; just a sanity invariant)
+    assert isinstance(os.getenv("PATH"), str)

--- a/tools/market_pulse_backtest.py
+++ b/tools/market_pulse_backtest.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Market Pulse V1 backtest — 6y index replay + pre-registered auto-judgment.
 
-Replays :class:`cores.market_pulse.MarketPulse` over KOSPI (ticker '1001', via
-the repo's authenticated krx_data_client wrapper — the same source production
-uses) and S&P 500 (^GSPC via yfinance), applying the IDENTICAL O'Neil rules to
-both markets (no per-market tuning = robustness evidence).
+Replays :class:`cores.market_pulse.MarketPulse` over KOSPI (^KS11 via yfinance,
+the same fetch tools/regime_backtest.py uses successfully on db-server) and
+S&P 500 (^GSPC via yfinance), applying the IDENTICAL O'Neil rules to both
+markets (no per-market tuning = robustness evidence).
 
 Produces a deterministic markdown report (also printed to console) with:
   (a) per-year state distribution % + transition counts,
@@ -16,7 +16,7 @@ Usage:
     .venv/bin/python tools/market_pulse_backtest.py [--market {kr,us,both}]
                                                      [--years N] [--out PATH]
 
-The heavy 6y data replay is intended to run on db-server (network + krx auth).
+The heavy 6y data replay is intended to run on db-server (network for yfinance).
 Importing this module performs no I/O beyond dotenv; data fetch is lazy.
 """
 
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -60,26 +60,40 @@ C5_END = "2026-07-09"
 # Data fetch (lazy; network/auth only when actually called)                    #
 # --------------------------------------------------------------------------- #
 def fetch_kr_bars(years: int) -> List[DailyBar]:
-    """KOSPI index ('1001') daily OHLCV via the authenticated krx wrapper."""
+    """KOSPI index (1001) daily OHLCV via the authenticated KRX client.
+
+    market_pulse는 거래량이 필수(DD 판정)다. yfinance ^KS11은 거래량이
+    결측/0인 구간이 많아(2026년 등) DD가 전혀 안 잡히는 무의미한 재생이
+    나온다(regime_backtest는 종가만 써서 ^KS11로 충분했던 것과 다름).
+    → 운영과 동일한 krx_data_client 기반 ``get_index_ohlcv_by_date``('1001')를
+    쓰되, 6년 단일요청이 INVALIDPERIOD2로 실패하므로 **연 단위 청크**로 나눠
+    받아 합친다.
+    """
     import pandas as pd
+    from datetime import datetime, timedelta
+    from cores.stock_chart import get_index_ohlcv_by_date
 
-    try:
-        from cores.stock_chart import get_index_ohlcv_by_date
-    except Exception:  # noqa: BLE001
-        from krx_data_client import get_index_ohlcv_by_date
-
-    end = datetime.now()
-    start = end - timedelta(days=int(years * 365.25) + 15)
-    df = get_index_ohlcv_by_date(start.strftime("%Y%m%d"), end.strftime("%Y%m%d"), "1001")
-    if df is None or len(df) == 0:
-        raise RuntimeError("KOSPI index fetch returned empty")
-    if not isinstance(df.index, pd.DatetimeIndex):
-        df.index = pd.to_datetime(df.index)
-    close_col = "종가" if "종가" in df.columns else ("Close" if "Close" in df.columns else None)
-    vol_col = "거래량" if "거래량" in df.columns else ("Volume" if "Volume" in df.columns else None)
-    if close_col is None:
-        raise RuntimeError(f"KOSPI: no close column in {list(df.columns)}")
-    return _df_to_bars(df.sort_index(), close_col, vol_col)
+    end_dt = datetime.now()
+    start_dt = end_dt - timedelta(days=int(years * 365.25) + 10)
+    chunks = []
+    y = start_dt.year
+    while y <= end_dt.year:
+        s = max(start_dt, datetime(y, 1, 1)).strftime("%Y%m%d")
+        e = min(end_dt, datetime(y, 12, 31)).strftime("%Y%m%d")
+        cdf = get_index_ohlcv_by_date(s, e, "1001")
+        if cdf is not None and len(cdf):
+            chunks.append(cdf)
+        y += 1
+    if not chunks:
+        raise RuntimeError("KOSPI(1001) KRX fetch returned empty for all chunks")
+    df = pd.concat(chunks)
+    df = df[~df.index.duplicated(keep="last")].sort_index()
+    close_col = "종가" if "종가" in df.columns else "Close"
+    vol_col = ("거래량" if "거래량" in df.columns
+               else ("Volume" if "Volume" in df.columns else None))
+    if vol_col is None:
+        raise RuntimeError("KOSPI(1001) frame has no volume column — DD 판정 불가")
+    return _df_to_bars(df, close_col, vol_col)
 
 
 def fetch_us_bars(years: int) -> List[DailyBar]:
@@ -222,15 +236,19 @@ def judge(market: str, bars: List[DailyBar], rows) -> Tuple[List[dict], bool]:
                     "pass": c1_pass if c1_months else True,
                     "detail": c1_months, "na": not c1_months})
 
-    # C2: months with return >= +3% -> UPTREND days >= 70%.
+    # C2: months with return >= +3% -> UPTREND days >= 70% (official metric).
+    # 참고: also record the non-CORRECTION day ratio (UPTREND + UNDER_PRESSURE),
+    # since policy allows buys in UNDER_PRESSURE (top-down 0 only) — §7 Rev.2.
+    # This is reported alongside but does NOT affect the official PASS/FAIL.
     c2_months = []
     c2_pass = True
     for m, r in mret:
         if r >= 3.0 and m in spm:
             up = spm[m][UPTREND]
+            non_corr = 100.0 - spm[m][CORRECTION]  # non-CORRECTION ratio (참고)
             ok = up >= 70.0
             c2_pass = c2_pass and ok
-            c2_months.append((m, round(r, 1), round(up, 1), ok))
+            c2_months.append((m, round(r, 1), round(up, 1), round(non_corr, 1), ok))
     results.append({"id": "C2", "desc": "강세월(≥+3%) UPTREND ≥70%",
                     "pass": c2_pass if c2_months else True,
                     "detail": c2_months, "na": not c2_months})
@@ -270,7 +288,7 @@ def render_market(market: str, bars: List[DailyBar]) -> str:
     mp = MarketPulse()
     rows = mp.replay(bars)
     lines: List[str] = []
-    name = {"kr": "KOSPI (1001)", "us": "S&P 500 (^GSPC)"}[market]
+    name = {"kr": "KOSPI (KRX 1001)", "us": "S&P 500 (^GSPC)"}[market]
     lines.append(f"## {name} — {len(rows)} sessions "
                  f"({rows[0][0]} → {rows[-1][0]})")
     lines.append("")
@@ -309,10 +327,15 @@ def render_market(market: str, bars: List[DailyBar]) -> str:
         verdict = "N/A" if r.get("na") else ("PASS" if r["pass"] else "FAIL")
         lines.append(f"- **{r['id']} [{verdict}]** {r['desc']}")
         d = r["detail"]
-        if r["id"] in ("C1", "C2") and d:
+        if r["id"] == "C1" and d:
             for m, ret, val, ok in d:
                 tag = "OK" if ok else "MISS"
-                lines.append(f"    - {m}: 월수익률 {ret}%, 지표 {val}% [{tag}]")
+                lines.append(f"    - {m}: 월수익률 {ret}%, 비-UPTREND {val}% [{tag}]")
+        elif r["id"] == "C2" and d:
+            for m, ret, up, non_corr, ok in d:
+                tag = "OK" if ok else "MISS"
+                lines.append(f"    - {m}: 월수익률 {ret}%, UPTREND {up}% [{tag}] "
+                             f"(참고 비-CORRECTION {non_corr}%)")
         elif r["id"] == "C3":
             lines.append(f"    - 전체 CORRECTION 비율: {d}%")
         elif r["id"] == "C4":

--- a/tools/market_pulse_backtest.py
+++ b/tools/market_pulse_backtest.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Market Pulse V1 backtest — 6y index replay + pre-registered auto-judgment.
+
+Replays :class:`cores.market_pulse.MarketPulse` over KOSPI (ticker '1001', via
+the repo's authenticated krx_data_client wrapper — the same source production
+uses) and S&P 500 (^GSPC via yfinance), applying the IDENTICAL O'Neil rules to
+both markets (no per-market tuning = robustness evidence).
+
+Produces a deterministic markdown report (also printed to console) with:
+  (a) per-year state distribution % + transition counts,
+  (b) CORRECTION episode timeline (start/end/duration/days-to-FTD),
+  (c) pre-registered C1-C5 auto-judgment per
+      tasks/market_pulse/00_VALIDATION_PLAN.md §3 (V1), PASS/FAIL + overall.
+
+Usage:
+    .venv/bin/python tools/market_pulse_backtest.py [--market {kr,us,both}]
+                                                     [--years N] [--out PATH]
+
+The heavy 6y data replay is intended to run on db-server (network + krx auth).
+Importing this module performs no I/O beyond dotenv; data fetch is lazy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+# Insert repo ROOT at sys.path[0] so root `cores` wins (avoid the prism-us cores
+# shadowing trap: we do NOT add prism-us to sys.path).
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) != sys.path[0]:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+try:  # dotenv is optional at import time; must never crash the import.
+    from dotenv import load_dotenv
+
+    load_dotenv(PROJECT_ROOT / ".env")
+except Exception:  # noqa: BLE001
+    pass
+
+from cores.market_pulse import (  # noqa: E402
+    CORRECTION,
+    UNDER_PRESSURE,
+    UPTREND,
+    DailyBar,
+    MarketPulse,
+)
+
+STATES = (UPTREND, UNDER_PRESSURE, CORRECTION)
+
+# C5 window (KR crash the live account bled through — spec §3 V1 C5).
+C5_START = "2026-06-01"
+C5_END = "2026-07-09"
+
+
+# --------------------------------------------------------------------------- #
+# Data fetch (lazy; network/auth only when actually called)                    #
+# --------------------------------------------------------------------------- #
+def fetch_kr_bars(years: int) -> List[DailyBar]:
+    """KOSPI index ('1001') daily OHLCV via the authenticated krx wrapper."""
+    import pandas as pd
+
+    try:
+        from cores.stock_chart import get_index_ohlcv_by_date
+    except Exception:  # noqa: BLE001
+        from krx_data_client import get_index_ohlcv_by_date
+
+    end = datetime.now()
+    start = end - timedelta(days=int(years * 365.25) + 15)
+    df = get_index_ohlcv_by_date(start.strftime("%Y%m%d"), end.strftime("%Y%m%d"), "1001")
+    if df is None or len(df) == 0:
+        raise RuntimeError("KOSPI index fetch returned empty")
+    if not isinstance(df.index, pd.DatetimeIndex):
+        df.index = pd.to_datetime(df.index)
+    close_col = "종가" if "종가" in df.columns else ("Close" if "Close" in df.columns else None)
+    vol_col = "거래량" if "거래량" in df.columns else ("Volume" if "Volume" in df.columns else None)
+    if close_col is None:
+        raise RuntimeError(f"KOSPI: no close column in {list(df.columns)}")
+    return _df_to_bars(df.sort_index(), close_col, vol_col)
+
+
+def fetch_us_bars(years: int) -> List[DailyBar]:
+    """S&P 500 (^GSPC) daily via yfinance (same approach as regime_backtest)."""
+    import pandas as pd
+    import yfinance as yf
+
+    df = yf.download("^GSPC", period=f"{years}y", interval="1d",
+                     auto_adjust=True, progress=False)
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = df.columns.get_level_values(0)
+    df = df.dropna(how="all")
+    if df is None or len(df) == 0:
+        raise RuntimeError("^GSPC fetch returned empty")
+    vol_col = "Volume" if "Volume" in df.columns else None
+    return _df_to_bars(df.sort_index(), "Close", vol_col)
+
+
+def _df_to_bars(df, close_col: str, vol_col: Optional[str]) -> List[DailyBar]:
+    import pandas as pd
+
+    bars: List[DailyBar] = []
+    for idx, row in df.iterrows():
+        c = float(row[close_col])
+        if c <= 0:
+            continue
+        v: Optional[float] = None
+        if vol_col is not None:
+            raw = row[vol_col]
+            if raw is not None and not pd.isna(raw):
+                v = float(raw)
+                if v <= 0:
+                    v = None
+        bars.append(DailyBar(date=idx.strftime("%Y-%m-%d"), close=c, volume=v))
+    return bars
+
+
+# --------------------------------------------------------------------------- #
+# Analysis                                                                     #
+# --------------------------------------------------------------------------- #
+def _year(date: str) -> int:
+    return int(date[:4])
+
+
+def _month(date: str) -> str:
+    return date[:7]
+
+
+def yearly_distribution(rows) -> List[tuple]:
+    """[(year, {state: pct}, transitions), ...]."""
+    by_year: dict = {}
+    for date, state, _dd in rows:
+        by_year.setdefault(_year(date), []).append(state)
+    out = []
+    for y in sorted(by_year):
+        seq = by_year[y]
+        n = len(seq) or 1
+        pct = {s: round(100.0 * seq.count(s) / n, 1) for s in STATES}
+        trans = sum(1 for i in range(1, len(seq)) if seq[i] != seq[i - 1])
+        out.append((y, pct, trans))
+    return out
+
+
+def correction_episodes(rows) -> List[dict]:
+    """Contiguous CORRECTION runs with start/end/duration/days-to-FTD."""
+    episodes: List[dict] = []
+    start_i: Optional[int] = None
+    for i, (date, state, _dd) in enumerate(rows):
+        if state == CORRECTION and start_i is None:
+            start_i = i
+        elif state != CORRECTION and start_i is not None:
+            # exit day i is the Follow-Through Day (only way out).
+            episodes.append({
+                "start": rows[start_i][0],
+                "end": rows[i - 1][0],
+                "duration": i - start_i,
+                "days_to_ftd": i - start_i,   # start..FTD inclusive count
+                "ftd_date": rows[i][0],
+            })
+            start_i = None
+    if start_i is not None:  # still in correction at series end
+        episodes.append({
+            "start": rows[start_i][0],
+            "end": rows[-1][0],
+            "duration": len(rows) - start_i,
+            "days_to_ftd": None,
+            "ftd_date": None,
+        })
+    return episodes
+
+
+def monthly_returns_from_bars(bars: List[DailyBar]) -> List[Tuple[str, float]]:
+    """Month-over-month return using each month's last close. Skips first month."""
+    last_close: dict = {}
+    order: List[str] = []
+    for b in bars:
+        m = b.date[:7]
+        if m not in last_close:
+            order.append(m)
+        last_close[m] = b.close
+    out: List[Tuple[str, float]] = []
+    for i, m in enumerate(order):
+        if i == 0:
+            continue
+        prev = last_close[order[i - 1]]
+        if prev and prev > 0:
+            out.append((m, (last_close[m] - prev) / prev * 100.0))
+    return out
+
+
+def state_pct_by_month(rows) -> dict:
+    """{month: {state: pct, 'n': days}}."""
+    by_month: dict = {}
+    for date, state, _dd in rows:
+        by_month.setdefault(_month(date), []).append(state)
+    out = {}
+    for m, seq in by_month.items():
+        n = len(seq) or 1
+        out[m] = {s: 100.0 * seq.count(s) / n for s in STATES}
+        out[m]["n"] = len(seq)
+    return out
+
+
+def judge(market: str, bars: List[DailyBar], rows) -> Tuple[List[dict], bool]:
+    """Pre-registered C1-C5 auto-judgment. Returns (results, overall_pass)."""
+    results: List[dict] = []
+    mret = monthly_returns_from_bars(bars)
+    spm = state_pct_by_month(rows)
+
+    # C1: months with return <= -5% -> non-UPTREND days >= 50%.
+    c1_months = []
+    c1_pass = True
+    for m, r in mret:
+        if r <= -5.0 and m in spm:
+            non_up = spm[m][UNDER_PRESSURE] + spm[m][CORRECTION]
+            ok = non_up >= 50.0
+            c1_pass = c1_pass and ok
+            c1_months.append((m, round(r, 1), round(non_up, 1), ok))
+    results.append({"id": "C1", "desc": "급락월(≤-5%) 비-UPTREND ≥50%",
+                    "pass": c1_pass if c1_months else True,
+                    "detail": c1_months, "na": not c1_months})
+
+    # C2: months with return >= +3% -> UPTREND days >= 70%.
+    c2_months = []
+    c2_pass = True
+    for m, r in mret:
+        if r >= 3.0 and m in spm:
+            up = spm[m][UPTREND]
+            ok = up >= 70.0
+            c2_pass = c2_pass and ok
+            c2_months.append((m, round(r, 1), round(up, 1), ok))
+    results.append({"id": "C2", "desc": "강세월(≥+3%) UPTREND ≥70%",
+                    "pass": c2_pass if c2_months else True,
+                    "detail": c2_months, "na": not c2_months})
+
+    # C3: overall CORRECTION ratio in [10, 35] %.
+    n = len(rows) or 1
+    corr_pct = 100.0 * sum(1 for _d, s, _dd in rows if s == CORRECTION) / n
+    c3_pass = 10.0 <= corr_pct <= 35.0
+    results.append({"id": "C3", "desc": "전체 CORRECTION 비율 10~35%",
+                    "pass": c3_pass, "detail": round(corr_pct, 1), "na": False})
+
+    # C4: state transitions <= 20 / year (every year).
+    yd = yearly_distribution(rows)
+    c4_bad = [(y, t) for (y, _p, t) in yd if t > 20]
+    c4_pass = not c4_bad
+    results.append({"id": "C4", "desc": "상태전환 ≤20회/년",
+                    "pass": c4_pass, "detail": [(y, t) for (y, _p, t) in yd],
+                    "na": False})
+
+    # C5: KR must hit CORRECTION during 2026-06-01..2026-07-09.
+    if market == "kr":
+        hit = any(s == CORRECTION and C5_START <= d <= C5_END for d, s, _dd in rows)
+        results.append({"id": "C5", "desc": f"KR {C5_START}~{C5_END} CORRECTION 발동",
+                        "pass": hit, "detail": hit, "na": False})
+    else:
+        results.append({"id": "C5", "desc": "KR 전용 (US 해당없음)",
+                        "pass": True, "detail": None, "na": True})
+
+    overall = all(r["pass"] for r in results if not r.get("na"))
+    return results, overall
+
+
+# --------------------------------------------------------------------------- #
+# Report                                                                       #
+# --------------------------------------------------------------------------- #
+def render_market(market: str, bars: List[DailyBar]) -> str:
+    mp = MarketPulse()
+    rows = mp.replay(bars)
+    lines: List[str] = []
+    name = {"kr": "KOSPI (1001)", "us": "S&P 500 (^GSPC)"}[market]
+    lines.append(f"## {name} — {len(rows)} sessions "
+                 f"({rows[0][0]} → {rows[-1][0]})")
+    lines.append("")
+
+    # (a) per-year distribution + transitions
+    lines.append("### (a) 연도별 상태 분포 / 전환 횟수")
+    lines.append("")
+    lines.append("| 연도 | UPTREND% | UNDER_PRESSURE% | CORRECTION% | 전환 |")
+    lines.append("|---|---|---|---|---|")
+    for y, pct, trans in yearly_distribution(rows):
+        lines.append(f"| {y} | {pct[UPTREND]} | {pct[UNDER_PRESSURE]} | "
+                     f"{pct[CORRECTION]} | {trans} |")
+    lines.append("")
+
+    # (b) correction episodes
+    lines.append("### (b) CORRECTION 에피소드")
+    lines.append("")
+    eps = correction_episodes(rows)
+    if not eps:
+        lines.append("_에피소드 없음_")
+    else:
+        lines.append("| 시작 | 종료 | 기간(일) | days-to-FTD | FTD일 |")
+        lines.append("|---|---|---|---|---|")
+        for e in eps:
+            ftd = e["ftd_date"] or "진행중"
+            dtf = e["days_to_ftd"] if e["days_to_ftd"] is not None else "—"
+            lines.append(f"| {e['start']} | {e['end']} | {e['duration']} | "
+                         f"{dtf} | {ftd} |")
+    lines.append("")
+
+    # (c) auto-judgment
+    results, overall = judge(market, bars, rows)
+    lines.append("### (c) 사전등록 기준 자동판정 (V1)")
+    lines.append("")
+    for r in results:
+        verdict = "N/A" if r.get("na") else ("PASS" if r["pass"] else "FAIL")
+        lines.append(f"- **{r['id']} [{verdict}]** {r['desc']}")
+        d = r["detail"]
+        if r["id"] in ("C1", "C2") and d:
+            for m, ret, val, ok in d:
+                tag = "OK" if ok else "MISS"
+                lines.append(f"    - {m}: 월수익률 {ret}%, 지표 {val}% [{tag}]")
+        elif r["id"] == "C3":
+            lines.append(f"    - 전체 CORRECTION 비율: {d}%")
+        elif r["id"] == "C4":
+            lines.append(f"    - 연도별 전환: {d}")
+        elif r["id"] == "C5" and not r.get("na"):
+            lines.append(f"    - 발동 여부: {d}")
+    lines.append("")
+    lines.append(f"### {name} 종합 판정: **{'PASS' if overall else 'FAIL'}**")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Market Pulse V1 backtest")
+    ap.add_argument("--market", choices=["kr", "us", "both"], default="both")
+    ap.add_argument("--years", type=int, default=6)
+    ap.add_argument("--out", default=str(PROJECT_ROOT / "tasks" / "market_pulse" / "results_v1.md"))
+    args = ap.parse_args()
+
+    markets = ["kr", "us"] if args.market == "both" else [args.market]
+    header = [
+        "# Market Pulse V1 — 6년 지수 재생 결과",
+        "",
+        f"_생성: {datetime.now().strftime('%Y-%m-%d %H:%M')} · years={args.years} · "
+        "규칙 무수정 양시장 적용 (사전등록 §3 V1)_",
+        "",
+    ]
+    sections: List[str] = []
+    for m in markets:
+        try:
+            bars = fetch_kr_bars(args.years) if m == "kr" else fetch_us_bars(args.years)
+            if len(bars) < 30:
+                raise RuntimeError(f"insufficient bars: {len(bars)}")
+            sections.append(render_market(m, bars))
+        except Exception as e:  # noqa: BLE001
+            sections.append(f"## {m.upper()} — 데이터 실패 (deferred)\n\n"
+                            f"`{type(e).__name__}: {e}`\n\n"
+                            "6년 데이터 재생은 db-server(네트워크+krx auth)에서 실행. 로컬 지연.\n")
+
+    report = "\n".join(header + sections)
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(report, encoding="utf-8")
+    print(report)
+    print(f"\n[written] {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
사전등록 검증(tasks/market_pulse/00_VALIDATION_PLAN.md, Rev.1~3) 완료. 상태기계(DD+가격 -10%→CORRECTION, FTD/신고가 출구) 6년 재생 C5 PASS. V2 검산으로 매수 전면중단은 기각(-25%p)→CORRECTION시 배치휴식(KR 오전만/US midday만)으로 개정. MARKET_PULSE_MODE=shadow 기본(WOULD_SKIP 로그만, 매매 무영향). 진입점 5종 스모크 통과. 65 유닛테스트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)