### PR TITLE
feat(oneil): 약세·횡보장 '기다림' 원칙 최적화 4종 (US 억제 미러 + 하드 게이트)

### DIFF
--- a/cores/regime_policy.py
+++ b/cores/regime_policy.py
@@ -86,6 +86,10 @@ _UNDER_PRESSURE_REST_BATCHES = {
 # failed/network-less run does not retry on every call.
 _STATE_CACHE: dict = {}
 
+# Item 4: post-FTD pilot re-exposure cache (per-process). True/False memoized so
+# the ~400d index replay runs at most once per market per process. Fail-open False.
+_PILOT_CACHE: dict = {}
+
 
 @dataclass(frozen=True)
 class BatchPolicy:
@@ -394,5 +398,103 @@ def get_market_pulse_state(market: str, use_cache: bool = True) -> Optional[str]
 
 
 def _reset_state_cache() -> None:
-    """Test/utility hook: clear the memoized pulse-state cache."""
+    """Test/utility hook: clear the memoized pulse-state + pilot caches."""
     _STATE_CACHE.clear()
+    _PILOT_CACHE.clear()
+
+
+# --------------------------------------------------------------------------- #
+# Post-FTD progressive re-exposure — pilot (half) sizing (env-gated, default OFF) #
+# --------------------------------------------------------------------------- #
+# After a CORRECTION ends (FTD or price-recovery exit), the first buys back into
+# the market are the riskiest (early re-entry can be a bull trap). PULSE_PILOT_REEXPOSURE
+# ON => for the first PULSE_PILOT_WINDOW_SESSIONS trading sessions after the
+# CORRECTION -> (UPTREND/UNDER_PRESSURE) transition, size new buys at
+# PULSE_PILOT_FACTOR (half). Default OFF = full size (현행 유지). Fail-open: any
+# error -> full size.
+PULSE_PILOT_FACTOR: float = 0.5
+PULSE_PILOT_WINDOW_SESSIONS: int = 5
+
+
+def pilot_reexposure_enabled() -> bool:
+    """Return True when PULSE_PILOT_REEXPOSURE is truthy (1/true/yes/on). Default OFF."""
+    return os.getenv("PULSE_PILOT_REEXPOSURE", "false").strip().lower() in (
+        "1", "true", "yes", "on"
+    )
+
+
+def _sessions_since_correction_exit(states) -> Optional[int]:
+    """Pure. Given a chronological list of pulse-state strings, return the number
+    of trading sessions since the most recent CORRECTION -> non-CORRECTION
+    transition (0 on the exit session itself, 1 the next session, ...).
+
+    Returns ``None`` when the series currently ends in CORRECTION (no re-exposure
+    window active yet) or no such transition exists in the series.
+    """
+    if not states:
+        return None
+    if states[-1] == CORRECTION:
+        return None
+    exit_idx = None
+    for i in range(1, len(states)):
+        if states[i - 1] == CORRECTION and states[i] != CORRECTION:
+            exit_idx = i
+    if exit_idx is None:
+        return None
+    return (len(states) - 1) - exit_idx
+
+
+def is_pilot_window(sessions_ago: Optional[int], flag_on: Optional[bool] = None) -> bool:
+    """Pure. True iff the flag is ON and ``0 <= sessions_ago < PULSE_PILOT_WINDOW_SESSIONS``.
+
+    ``flag_on`` defaults to :func:`pilot_reexposure_enabled` when not supplied
+    (injectable for tests). ``sessions_ago is None`` -> False (full size).
+    """
+    if flag_on is None:
+        flag_on = pilot_reexposure_enabled()
+    if not flag_on or sessions_ago is None:
+        return False
+    return 0 <= sessions_ago < PULSE_PILOT_WINDOW_SESSIONS
+
+
+def pilot_reexposure_active(market: str, use_cache: bool = True) -> bool:
+    """Return True when pilot (half) sizing applies for ``market`` ("kr" | "us").
+
+    Flag OFF -> False (no replay, zero cost). Otherwise replays MarketPulse over
+    ~400d of index bars, finds the last CORRECTION exit, and checks the window.
+    Memoized per process (:data:`_PILOT_CACHE`). Fail-open: ANY error -> False
+    (full size), so this never raises into a production buy path.
+    """
+    if not pilot_reexposure_enabled():
+        return False
+    m = (market or "").strip().lower()
+    if use_cache and m in _PILOT_CACHE:
+        return _PILOT_CACHE[m]
+    try:
+        mp_mod = _load_root_cores("market_pulse")
+        MarketPulse = mp_mod.MarketPulse
+        DailyBar = mp_mod.DailyBar
+
+        if m == "kr":
+            bars = _fetch_kr_bars(DailyBar)
+        elif m == "us":
+            bars = _fetch_us_bars(DailyBar)
+        else:
+            logger.warning("[PULSE_PILOT] unknown market %r -> full size", market)
+            _PILOT_CACHE[m] = False
+            return False
+
+        if not bars or len(bars) < 30:
+            raise RuntimeError(f"insufficient index bars: {len(bars) if bars else 0}")
+
+        mp = MarketPulse()
+        states = [mp.feed(bar) for bar in bars]
+        ago = _sessions_since_correction_exit(states)
+        active = is_pilot_window(ago, flag_on=True)
+        _PILOT_CACHE[m] = active
+        return active
+    except Exception as e:  # noqa: BLE001 - fail-open, never raise
+        logger.warning("[PULSE_PILOT] active-check failed for %s, fail-open full-size: %s",
+                       m or "?", e)
+        _PILOT_CACHE[m] = False
+        return False

--- a/cores/regime_policy.py
+++ b/cores/regime_policy.py
@@ -184,6 +184,60 @@ def market_pulse_mode() -> str:
 
 
 # --------------------------------------------------------------------------- #
+# Regime-adaptive hard min_score floor (env-gated, default OFF)               #
+# --------------------------------------------------------------------------- #
+# 7월 -42%p 손실 재발 방지책의 하나: 매수 임계(min_score)는 지금 LLM이 시나리오마다
+# 자유롭게 정한다(약세장에서 낮아질 수 있음). 아래 표는 시장 레짐별 "절대 하한선"을
+# 강제해, 약세장에서는 LLM이 무슨 값을 주더라도 그 밑으로는 못 사게 한다(안전 게이트).
+# 기본 OFF(REGIME_MIN_SCORE_FLOOR 미설정) = 현행 유지(LLM 값 그대로).
+_REGIME_MIN_SCORE_FLOORS = {
+    "strong_bear": 9,
+    "moderate_bear": 8,
+    "sideways": 8,
+    "moderate_bull": 0,
+    "strong_bull": 0,
+    "unknown": 0,
+}
+
+
+def regime_min_score_floor_enabled() -> bool:
+    """Return True when REGIME_MIN_SCORE_FLOOR is truthy (1/true/yes/on). Default OFF.
+
+    Same truthy parsing as trigger_batch's REGIME_WEAK_NO_TOPDOWN gate.
+    """
+    return os.getenv("REGIME_MIN_SCORE_FLOOR", "false").strip().lower() in (
+        "1", "true", "yes", "on"
+    )
+
+
+def min_score_floor(market_regime: Optional[str]) -> int:
+    """Hard buy-score floor for ``market_regime`` (0 for bullish / unknown regimes).
+
+    Tolerant of decorated labels (e.g. ``"strong_bear (하락)"`` -> ``strong_bear``):
+    only the leading whitespace-delimited token is matched. Unmapped -> 0.
+    """
+    raw = (market_regime or "").strip().lower()
+    key = raw.split()[0] if raw else "unknown"
+    return _REGIME_MIN_SCORE_FLOORS.get(key, 0)
+
+
+def effective_min_score(llm_min_score, market_regime: Optional[str]) -> int:
+    """Return ``max(llm_min_score, regime_floor)`` when the flag is ON; else the
+    LLM value unchanged.
+
+    NEVER lowers the LLM threshold (floor is a one-way raise). Pure, no I/O beyond
+    the single env read. ``llm_min_score`` non-int/None is treated as 0.
+    """
+    try:
+        base = int(llm_min_score or 0)
+    except (TypeError, ValueError):
+        base = 0
+    if not regime_min_score_floor_enabled():
+        return base
+    return max(base, min_score_floor(market_regime))
+
+
+# --------------------------------------------------------------------------- #
 # Pulse-state computation (lazy, fail-open, shadow-safe imports)               #
 # --------------------------------------------------------------------------- #
 def _load_root_cores(name: str):

--- a/cores/regime_policy.py
+++ b/cores/regime_policy.py
@@ -11,7 +11,7 @@ production orchestrators. It answers three questions, and nothing else:
   3. :func:`market_pulse_mode` — read the ``MARKET_PULSE_MODE`` env flag
      (``shadow`` | ``live`` | ``off``; default ``shadow``).
 
-Policy rationale (tasks/market_pulse/00_VALIDATION_PLAN.md §7 Rev.3):
+Policy rationale (tasks/market_pulse/00_VALIDATION_PLAN.md §7 Rev.5):
     The V2 trade-sample audit REJECTED the original "CORRECTION = full stop"
     policy — CORRECTION-window buys had a scary 38% stop-out rate but a NET
     +25.3% P&L (the post-crash rebound monsters live in this window). So the
@@ -24,9 +24,16 @@ Policy rationale (tasks/market_pulse/00_VALIDATION_PLAN.md §7 Rev.3):
           morning (open-hour noise is maximal) and afternoon (overnight gap risk
           on a late buy) both rest.
 
-    Non-CORRECTION states — UPTREND, UNDER_PRESSURE, and None (unknown / fail-open)
-    — run every batch normally. Exit/sell loops are NEVER affected by this policy;
-    only the new-analysis agents rest.
+    Rev.5 adds a lighter deceleration for the intermediate UNDER_PRESSURE state
+    (4-5 distribution days = market weakening but not yet in correction). Here
+    only US rests its MORNING batch (open-hour gap-strength is the least reliable
+    signal in a softening tape); US midday + afternoon still run, and KR is left
+    UNCHANGED (its two windows already trade the calmer mid/close hours). This is
+    a partial, market-specific brake — strictly weaker than the CORRECTION rest.
+
+    Remaining states — UPTREND and None (unknown / fail-open) — run every batch
+    normally, as does KR under UNDER_PRESSURE. Exit/sell loops are NEVER affected
+    by this policy; only the new-analysis agents rest.
 
 Import safety: this module performs NO heavy imports at module load. All data
 fetching and market_pulse/stock_chart imports are lazy (inside functions) and
@@ -65,6 +72,14 @@ _CORRECTION_REST_BATCHES = {
     "us": frozenset({"morning", "afternoon"}),    # only midday runs
 }
 
+# Table (§7 Rev.5): batches that REST during UNDER_PRESSURE, per market. A lighter,
+# market-specific brake than CORRECTION. KR is intentionally absent (no rest); only
+# US rests its morning batch (open-hour gap-strength least reliable in a softening
+# tape). Any batch NOT listed here runs normally under UNDER_PRESSURE.
+_UNDER_PRESSURE_REST_BATCHES = {
+    "us": frozenset({"morning"}),                 # midday + afternoon run, morning rests
+}
+
 # Module-level cache: pulse state is computed once per (short-lived) process and
 # reused by the orchestrator hook and by per-ticker trend-fact injection so we do
 # not re-fetch the index for every ticker. A None result is cached too, so a
@@ -100,12 +115,13 @@ def decide_batch_policy(
                      ("both" or any unknown mode fails open -> run.)
         pulse_state: UPTREND / UNDER_PRESSURE / CORRECTION / None.
 
-    Rationale (§7 Rev.3, batch choice revised by Rev.4): CORRECTION is not a buy
-    stop; it reduces the agent to a single daily window (KR afternoon-only =
+    Rationale (§7 Rev.3, batch choice revised by Rev.4/Rev.5): CORRECTION is not a
+    buy stop; it reduces the agent to a single daily window (KR afternoon-only =
     close-confirmation entry, US midday-only) to dodge the open-hour noise where
     gap-strength fades intraday in weak markets, while keeping one shot at the
-    post-crash rebound. Exit loops are unaffected. Any non-CORRECTION or unknown
-    state runs everything (fail-open).
+    post-crash rebound. Rev.5: UNDER_PRESSURE additionally rests the US morning
+    batch only (KR unchanged). Exit loops are unaffected. Any state/mode not in a
+    rest table runs (fail-open on None/unknown).
     """
     m = (market or "").strip().lower()
     mode = (batch_mode or "").strip().lower()
@@ -130,7 +146,27 @@ def decide_batch_policy(
             pulse_state=pulse_state,
         )
 
-    # UPTREND / UNDER_PRESSURE / None(unknown) -> run everything (fail-open).
+    if pulse_state == UNDER_PRESSURE:
+        rest_batches = _UNDER_PRESSURE_REST_BATCHES.get(m, frozenset())
+        if mode in rest_batches:
+            return BatchPolicy(
+                run_batch=False,
+                reason=(
+                    f"UNDER_PRESSURE: {m or '?'} '{mode or '?'}' batch rests "
+                    "(Rev.5 partial brake; exit loops unaffected)"
+                ),
+                pulse_state=pulse_state,
+            )
+        return BatchPolicy(
+            run_batch=True,
+            reason=(
+                f"UNDER_PRESSURE: {m or '?'} '{mode or '?'}' batch runs "
+                "(Rev.5 partial brake)"
+            ),
+            pulse_state=pulse_state,
+        )
+
+    # UPTREND / None(unknown) -> run everything (fail-open).
     return BatchPolicy(
         run_batch=True,
         reason=f"{pulse_state or 'UNKNOWN'}: run all batches",

--- a/prism-us/tests/test_regime_weak_no_topdown_us.py
+++ b/prism-us/tests/test_regime_weak_no_topdown_us.py
@@ -1,0 +1,40 @@
+"""약세·횡보장 top-down 억제 옵션(REGIME_WEAK_NO_TOPDOWN) 단위테스트 — US.
+
+KR tests/test_regime_weak_no_topdown.py 의 US 미러(bug-fix parity). 기본 off = 현행
+슬롯 유지. ON 시 sideways/moderate_bear 의 top-down 슬롯 0(매수 절제), 강세장(bull)은 무영향.
+prism-us/tests/conftest.py 가 prism-us 를 sys.path 우선 등록하므로 cores=prism-us/cores 로 해석된다.
+"""
+import os
+
+import pytest
+
+# 서버 전용 의존성 미설치 시 import 실패 → 스킵(KR 미러와 동일 정책).
+us_trigger_batch = pytest.importorskip("us_trigger_batch")
+
+
+def _slots(regime, flag):
+    if flag is None:
+        os.environ.pop("REGIME_WEAK_NO_TOPDOWN", None)
+    else:
+        os.environ["REGIME_WEAK_NO_TOPDOWN"] = flag
+    try:
+        return us_trigger_batch._get_regime_slots(regime)
+    finally:
+        os.environ.pop("REGIME_WEAK_NO_TOPDOWN", None)
+
+
+def test_default_off_preserves_current():
+    assert _slots("sideways", None) == (1, 2)
+    assert _slots("moderate_bear", None) == (1, 2)
+    assert _slots("moderate_bull", None) == (1, 2)
+
+
+def test_on_suppresses_topdown_in_weak_regimes():
+    assert _slots("sideways", "true") == (0, 2)
+    assert _slots("moderate_bear", "true") == (0, 2)
+
+
+def test_on_does_not_touch_bull_or_strong_bear():
+    assert _slots("moderate_bull", "true") == (1, 2)
+    assert _slots("strong_bull", "true") == (2, 1)
+    assert _slots("strong_bear", "true") == (0, 3)  # 이미 top-down 0

--- a/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
+++ b/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
@@ -91,7 +91,9 @@ class _FakeAsyncUSTradingContext:
     async def __aexit__(self, exc_type, exc, tb):
         return False
 
-    async def async_buy_stock(self, ticker, limit_price=None):
+    async def async_buy_stock(self, ticker, limit_price=None, buy_amount=None):
+        # buy_amount mirrors the real USStockTrading.async_buy_stock signature
+        # (None = full size; set only under PULSE_PILOT_REEXPOSURE pilot sizing).
         return {
             "success": True,
             "message": f"bought for {self.account_name}",

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -2939,7 +2939,21 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                                     except ImportError:
                                         from prism_us.trading.us_stock_trading import AsyncUSTradingContext
                                     async with AsyncUSTradingContext(account_name=account["name"]) as trading:
-                                        trade_result = await trading.async_buy_stock(ticker=ticker, limit_price=current_price)
+                                        # 파일럿 재진입 축소매수(env-gated PULSE_PILOT_REEXPOSURE, 기본 off).
+                                        # CORRECTION 종료 직후 N세션은 buy_amount 를 절반으로. fail-open 정상매수.
+                                        _pilot_buy_amt = None
+                                        try:
+                                            _rp = self._regime_policy_mod()
+                                            if (_rp is not None and _rp.pilot_reexposure_active("us")
+                                                    and getattr(trading, "buy_amount", None)):
+                                                _pilot_buy_amt = round(trading.buy_amount * _rp.PULSE_PILOT_FACTOR, 2)
+                                                logger.info(
+                                                    f"[PULSE_PILOT] {company_name}({ticker}) pilot re-exposure half-size buy: "
+                                                    f"${trading.buy_amount:,.2f}->${_pilot_buy_amt:,.2f} (x{_rp.PULSE_PILOT_FACTOR})"
+                                                )
+                                        except Exception as _pe:
+                                            logger.warning(f"[PULSE_PILOT] fail-open full-size buy: {_pe}")
+                                        trade_result = await trading.async_buy_stock(ticker=ticker, limit_price=current_price, buy_amount=_pilot_buy_amt)
 
                                     if trade_result['success']:
                                         logger.info(f"Actual purchase successful: {trade_result['message']}")

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -1781,6 +1781,30 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
             logger.warning(f"[sell] live regime fetch failed, using stale market_condition: {e}")
             return None
 
+    def _buy_floor_regime(self) -> Optional[str]:
+        """레짐 하한선 게이트(REGIME_MIN_SCORE_FLOOR)용 '현재' 시장 레짐을 프로세스당 1회
+        캐시한다. _get_live_regime_safe 재사용(OpenAI 무관, fail-open None → 하한 0)."""
+        _c = getattr(self, "_buy_floor_regime_cache", "__UNSET__")
+        if _c == "__UNSET__":
+            _c = self._get_live_regime_safe()
+            self._buy_floor_regime_cache = _c
+        return _c
+
+    def _regime_policy_mod(self):
+        """root cores/regime_policy.py 를 파일경로로 1회 로드해 캐시(prism-us/cores 섀도잉 회피).
+        실패 시 None → 호출부 fail-open."""
+        _m = getattr(self, "_regime_policy_mod_cache", "__UNSET__")
+        if _m == "__UNSET__":
+            try:
+                _m = _import_from_main_cores(
+                    "prism_root_regime_policy_floor", "cores/regime_policy.py"
+                )
+            except Exception as e:
+                logger.warning(f"[REGIME_MIN_SCORE_FLOOR] regime_policy 로드 실패, fail-open: {e}")
+                _m = None
+            self._regime_policy_mod_cache = _m
+        return _m
+
     async def _fallback_sell_decision(self, stock_data: Dict[str, Any]) -> Tuple[bool, str]:
         """Rule-based sell decision (fallback when AI unavailable).
 
@@ -2828,6 +2852,25 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
 
                     buy_score = scenario.get("buy_score", 0)
                     min_score = scenario.get("min_score", 0)
+
+                    # 레짐 적응 하한선(env-gated REGIME_MIN_SCORE_FLOOR, 기본 off). 플래그 ON 시
+                    # 약세장 하한(strong_bear 9 / bear·sideways 8)을 강제해 min_score 를 끌어올린다.
+                    # 진입 게이트(아래 adjusted_score >= min_score)가 그대로 차단을 수행한다.
+                    # 기본 off = 현행 유지. fail-open: 레짐/모듈 로드 실패 시 LLM min_score 유지.
+                    # prism-us/cores 섀도잉 회피: root cores/regime_policy.py 를 파일경로로 로드.
+                    try:
+                        _rp = self._regime_policy_mod()
+                        if _rp is not None and _rp.regime_min_score_floor_enabled():
+                            _fr = self._buy_floor_regime()
+                            _eff = _rp.effective_min_score(min_score, _fr)
+                            if _eff > min_score:
+                                logger.info(
+                                    f"[REGIME_MIN_SCORE_FLOOR] {company_name}({ticker}) "
+                                    f"min_score {min_score}->{_eff} (regime={_fr})"
+                                )
+                                min_score = _eff
+                    except Exception as _fe:
+                        logger.warning(f"[REGIME_MIN_SCORE_FLOOR] fail-open, LLM min_score 유지: {_fe}")
 
                     score_adjustment = 0
                     adjustment_reasons = []

--- a/prism-us/us_trigger_batch.py
+++ b/prism-us/us_trigger_batch.py
@@ -889,7 +889,18 @@ def _get_regime_slots(market_regime: str) -> tuple:
         "moderate_bear": (1, 2),
         "strong_bear": (0, 3),
     }
-    return REGIME_SLOTS.get(market_regime, (1, 2))  # default: sideways ratios
+    td, bu = REGIME_SLOTS.get(market_regime, (1, 2))  # default: sideways ratios
+    # 약세·횡보장 모멘텀추격(top-down) 억제 옵션 (env-gated, 기본 off = 현행 유지).
+    # ON 시 sideways/moderate_bear의 top-down 슬롯을 0으로 → 급락 휩쏘장에서 momentum chase
+    # 매수를 접고 가치형 bottom-up만 남긴다(총 슬롯도 감소 = 매수 절제). strong_bear는 이미 (0,3).
+    # KR trigger_batch._get_regime_slots 와 동일 로직/동일 env var (bug-fix parity).
+    if (td > 0 and market_regime in ("sideways", "moderate_bear")
+            and os.getenv("REGIME_WEAK_NO_TOPDOWN", "false").strip().lower()
+            in ("1", "true", "yes", "on")):
+        logger.info("[REGIME_SLOTS] weak-regime top-down 억제: %s (%d,%d)->(0,%d)",
+                    market_regime, td, bu, bu)
+        return (0, bu)
+    return (td, bu)
 
 
 def _build_topdown_pool(trigger_candidates: dict, macro_context: dict, score_column: str, sector_map: dict = None) -> list:

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -1991,7 +1991,23 @@ class StockTrackingAgent:
                             from trading.domestic_stock_trading import AsyncTradingContext
 
                             async with AsyncTradingContext(account_name=account["name"]) as trading:
-                                trade_result = await trading.async_buy_stock(stock_code=ticker, limit_price=current_price)
+                                # 파일럿 재진입 축소매수(env-gated PULSE_PILOT_REEXPOSURE, 기본 off).
+                                # CORRECTION 종료 직후 N세션은 buy_amount 를 절반으로. fail-open 정상매수.
+                                _pilot_buy_amt = None
+                                try:
+                                    from cores.regime_policy import (
+                                        pilot_reexposure_active,
+                                        PULSE_PILOT_FACTOR,
+                                    )
+                                    if pilot_reexposure_active("kr") and getattr(trading, "buy_amount", None):
+                                        _pilot_buy_amt = int(trading.buy_amount * PULSE_PILOT_FACTOR)
+                                        logger.info(
+                                            f"[PULSE_PILOT] {company_name}({ticker}) 파일럿 재진입 축소매수: "
+                                            f"{int(trading.buy_amount):,}->{_pilot_buy_amt:,} KRW (x{PULSE_PILOT_FACTOR})"
+                                        )
+                                except Exception as _pe:
+                                    logger.warning(f"[PULSE_PILOT] fail-open 정상매수: {_pe}")
+                                trade_result = await trading.async_buy_stock(stock_code=ticker, limit_price=current_price, buy_amount=_pilot_buy_amt)
 
                             if trade_result['success']:
                                 logger.info(f"Actual purchase successful: {trade_result['message']}")

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -1128,6 +1128,15 @@ class StockTrackingAgent:
             logger.warning(f"[sell] live regime fetch failed, using stale market_condition: {e}")
             return None
 
+    def _buy_floor_regime(self) -> Optional[str]:
+        """레짐 하한선 게이트(REGIME_MIN_SCORE_FLOOR)용 '현재' 시장 레짐을 프로세스당 1회
+        캐시한다. _get_live_regime_safe 재사용(OpenAI 무관, fail-open None → 하한 0)."""
+        _c = getattr(self, "_buy_floor_regime_cache", "__UNSET__")
+        if _c == "__UNSET__":
+            _c = self._get_live_regime_safe()
+            self._buy_floor_regime_cache = _c
+        return _c
+
     async def _analyze_sell_decision(self, stock_data: Dict[str, Any]) -> Tuple[bool, str]:
         """
         Sell decision analysis
@@ -1929,6 +1938,31 @@ class StockTrackingAgent:
                     min_score = scenario.get("min_score", 0)
                     logger.info(f"Buy score check: {company_name}({ticker}) - Score: {buy_score}")
 
+                    # 레짐 적응 하한선 게이트(env-gated REGIME_MIN_SCORE_FLOOR, 기본 off).
+                    # KR 진입은 LLM decision=="Enter" 로만 결정되고 min_score 는 정보용이었다.
+                    # 플래그 ON 시 약세장 하한(strong_bear 9 / bear·sideways 8)을 강제해,
+                    # buy_score 가 하한 미만이면 LLM 이 Enter 라 해도 매수를 차단한다(안전 게이트).
+                    # 기본 off = 현행 유지(하한 계산·차단 없음). fail-open: 레짐 조회 실패 시 하한 0.
+                    _regime_floor_block = False
+                    try:
+                        from cores.regime_policy import (
+                            effective_min_score,
+                            regime_min_score_floor_enabled,
+                        )
+                        if regime_min_score_floor_enabled():
+                            _fr = self._buy_floor_regime()
+                            _eff = effective_min_score(min_score, _fr)
+                            if _eff > min_score:
+                                logger.info(
+                                    f"[REGIME_MIN_SCORE_FLOOR] {company_name}({ticker}) "
+                                    f"min_score {min_score}->{_eff} (regime={_fr})"
+                                )
+                                min_score = _eff
+                            if buy_score < min_score:
+                                _regime_floor_block = True
+                    except Exception as _fe:
+                        logger.warning(f"[REGIME_MIN_SCORE_FLOOR] fail-open, LLM min_score 유지: {_fe}")
+
                     # Re-entry cooldown gate (SHADOW logs only; LIVE vetoes a churn
                     # re-entry into a name just sold — longer cooldown after a loss).
                     _cd_block = False
@@ -1950,7 +1984,7 @@ class StockTrackingAgent:
                                 _cd["window_hours"], _cd["after_loss"], _cd.get("exit_kind"), _risk_only)
                             _cd_block = _enforce
 
-                    if analysis_result.get("decision") == "Enter" and not _cd_block:
+                    if analysis_result.get("decision") == "Enter" and not _cd_block and not _regime_floor_block:
                         buy_success = await self.buy_stock(ticker, company_name, current_price, scenario, rank_change_msg)
 
                         if buy_success:

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -411,6 +411,28 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                 # Check entry decision
                 buy_score = scenario.get("buy_score", 0)
                 min_score = scenario.get("min_score", 0)
+
+                # 레짐 적응 하한선(env-gated REGIME_MIN_SCORE_FLOOR, 기본 off). 플래그 ON 시
+                # 약세장 하한(strong_bear 9 / bear·sideways 8)을 강제해 min_score 를 끌어올린다.
+                # 아래 진입 게이트(buy_score < min_score → Skip)가 그대로 차단을 수행한다.
+                # 레짐은 시나리오의 market_condition 라벨(strong_bear 등) 선두 토큰을 사용.
+                try:
+                    from cores.regime_policy import (
+                        effective_min_score,
+                        regime_min_score_floor_enabled,
+                    )
+                    if regime_min_score_floor_enabled():
+                        _fr = scenario.get("market_condition") or ""
+                        _eff = effective_min_score(min_score, _fr)
+                        if _eff > min_score:
+                            logger.info(
+                                f"[REGIME_MIN_SCORE_FLOOR] {company_name}({ticker}) "
+                                f"min_score {min_score}->{_eff} (regime={_fr})"
+                            )
+                            min_score = _eff
+                except Exception as _fe:
+                    logger.warning(f"[REGIME_MIN_SCORE_FLOOR] fail-open, LLM min_score 유지: {_fe}")
+
                 decision = analysis_result.get("decision")
                 rationale = scenario.get("rationale", "") or ""
                 logger.info(f"Buy score check: {company_name}({ticker}) - Score: {buy_score}, Min required score: {min_score}")

--- a/tests/test_pulse_pilot_reexposure.py
+++ b/tests/test_pulse_pilot_reexposure.py
@@ -1,0 +1,102 @@
+"""Post-FTD 파일럿 재진입 축소매수(PULSE_PILOT_REEXPOSURE) 순수 헬퍼 단위테스트.
+
+network 없음. 전이후 세션수 계산 / 윈도우 판정 / 플래그 off=항상 정상사이즈 검증.
+Run: .venv/bin/python -m pytest tests/test_pulse_pilot_reexposure.py -q
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cores.regime_policy import (
+    CORRECTION,
+    UNDER_PRESSURE,
+    UPTREND,
+    PULSE_PILOT_FACTOR,
+    PULSE_PILOT_WINDOW_SESSIONS,
+    _sessions_since_correction_exit,
+    is_pilot_window,
+    pilot_reexposure_enabled,
+)
+
+
+def test_factor_and_window_constants():
+    assert PULSE_PILOT_FACTOR == 0.5
+    assert PULSE_PILOT_WINDOW_SESSIONS == 5
+
+
+# --------------------------------------------------------------------------- #
+# _sessions_since_correction_exit — pure transition counting                  #
+# --------------------------------------------------------------------------- #
+def test_exit_day_is_zero_sessions_ago():
+    # CORRECTION ... then first non-CORRECTION session = exit day (ago == 0).
+    assert _sessions_since_correction_exit([CORRECTION, CORRECTION, UPTREND]) == 0
+
+
+def test_counts_sessions_after_exit():
+    states = [CORRECTION, CORRECTION, UPTREND, UPTREND, UPTREND]  # exit at idx 2
+    assert _sessions_since_correction_exit(states) == 2
+
+
+def test_exit_to_under_pressure_also_counts():
+    # A CORRECTION -> UNDER_PRESSURE transition is still an exit.
+    assert _sessions_since_correction_exit([CORRECTION, UNDER_PRESSURE]) == 0
+
+
+def test_currently_in_correction_returns_none():
+    assert _sessions_since_correction_exit([UPTREND, CORRECTION, CORRECTION]) is None
+
+
+def test_no_transition_returns_none():
+    assert _sessions_since_correction_exit([UPTREND, UPTREND, UNDER_PRESSURE]) is None
+    assert _sessions_since_correction_exit([]) is None
+
+
+def test_uses_most_recent_transition():
+    # Two episodes: exit#1 (idx1), re-enter, exit#2 (idx4). Latest exit is idx4.
+    states = [CORRECTION, UPTREND, CORRECTION, CORRECTION, UPTREND, UPTREND]
+    # len 6, exit_idx 4 -> ago = 5 - 4 = 1
+    assert _sessions_since_correction_exit(states) == 1
+
+
+# --------------------------------------------------------------------------- #
+# is_pilot_window — flag gating + window boundaries                           #
+# --------------------------------------------------------------------------- #
+def test_within_window_true_after_false():
+    # Within 5 sessions (0..4) -> True; 5+ -> False.
+    for ago in range(0, PULSE_PILOT_WINDOW_SESSIONS):
+        assert is_pilot_window(ago, flag_on=True) is True, ago
+    assert is_pilot_window(PULSE_PILOT_WINDOW_SESSIONS, flag_on=True) is False
+    assert is_pilot_window(PULSE_PILOT_WINDOW_SESSIONS + 3, flag_on=True) is False
+
+
+def test_none_sessions_is_full_size():
+    assert is_pilot_window(None, flag_on=True) is False
+
+
+def test_flag_off_always_full_size():
+    # Flag OFF -> never pilot, even squarely inside the window.
+    for ago in (0, 1, 4, None):
+        assert is_pilot_window(ago, flag_on=False) is False
+
+
+def test_flag_defaults_to_env(monkeypatch):
+    monkeypatch.setenv("PULSE_PILOT_REEXPOSURE", "true")
+    assert is_pilot_window(0) is True
+    monkeypatch.delenv("PULSE_PILOT_REEXPOSURE", raising=False)
+    assert is_pilot_window(0) is False
+
+
+# --------------------------------------------------------------------------- #
+# pilot_reexposure_enabled — env parsing                                      #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("raw,enabled", [
+    (None, False), ("", False), ("false", False), ("0", False), ("off", False),
+    ("1", True), ("true", True), ("YES", True), ("on", True), ("  On  ", True),
+])
+def test_enabled_parsing(monkeypatch, raw, enabled):
+    if raw is None:
+        monkeypatch.delenv("PULSE_PILOT_REEXPOSURE", raising=False)
+    else:
+        monkeypatch.setenv("PULSE_PILOT_REEXPOSURE", raw)
+    assert pilot_reexposure_enabled() is enabled

--- a/tests/test_regime_min_score_floor.py
+++ b/tests/test_regime_min_score_floor.py
@@ -1,0 +1,85 @@
+"""레짐 적응 하한선(REGIME_MIN_SCORE_FLOOR) 순수 헬퍼 단위테스트.
+
+network 없음. 표 매핑 / max() 동작 / 플래그 off=무보정 / 라벨 관용성 검증.
+Run: .venv/bin/python -m pytest tests/test_regime_min_score_floor.py -q
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cores.regime_policy import (
+    effective_min_score,
+    min_score_floor,
+    regime_min_score_floor_enabled,
+)
+
+
+# --------------------------------------------------------------------------- #
+# min_score_floor — regime -> floor mapping                                    #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("regime,expected", [
+    ("strong_bear", 9),
+    ("moderate_bear", 8),
+    ("sideways", 8),
+    ("moderate_bull", 0),
+    ("strong_bull", 0),
+    ("unknown", 0),
+    (None, 0),
+    ("", 0),
+    ("bogus_regime", 0),          # unmapped -> 0
+    ("STRONG_BEAR", 9),           # case-insensitive
+    ("strong_bear (하락 추세)", 9),  # decorated label -> leading token
+    ("  sideways  ", 8),          # whitespace trimmed
+])
+def test_min_score_floor_mapping(regime, expected):
+    assert min_score_floor(regime) == expected
+
+
+# --------------------------------------------------------------------------- #
+# effective_min_score — flag gating + max() behavior                          #
+# --------------------------------------------------------------------------- #
+def test_flag_off_is_noop(monkeypatch):
+    monkeypatch.delenv("REGIME_MIN_SCORE_FLOOR", raising=False)
+    assert not regime_min_score_floor_enabled()
+    # Flag off: LLM value returned unchanged even in the harshest regime.
+    assert effective_min_score(3, "strong_bear") == 3
+    assert effective_min_score(0, "sideways") == 0
+    assert effective_min_score(10, "strong_bear") == 10
+
+
+def test_flag_on_applies_max(monkeypatch):
+    monkeypatch.setenv("REGIME_MIN_SCORE_FLOOR", "true")
+    assert regime_min_score_floor_enabled()
+    # Floor raises when LLM value is below the regime floor.
+    assert effective_min_score(3, "strong_bear") == 9   # floor 9 wins
+    assert effective_min_score(3, "sideways") == 8      # floor 8 wins
+    # LLM value already >= floor -> unchanged (never lowers).
+    assert effective_min_score(9, "strong_bear") == 9
+    assert effective_min_score(10, "strong_bear") == 10
+    # Bullish / unknown regimes have floor 0 -> LLM value passes through.
+    assert effective_min_score(5, "strong_bull") == 5
+    assert effective_min_score(2, "unknown") == 2
+    assert effective_min_score(4, None) == 4
+
+
+@pytest.mark.parametrize("raw,enabled", [
+    (None, False), ("", False), ("false", False), ("0", False), ("no", False),
+    ("off", False), ("bogus", False),
+    ("1", True), ("true", True), ("TRUE", True), ("yes", True), ("on", True),
+    ("  On  ", True),
+])
+def test_flag_parsing(monkeypatch, raw, enabled):
+    if raw is None:
+        monkeypatch.delenv("REGIME_MIN_SCORE_FLOOR", raising=False)
+    else:
+        monkeypatch.setenv("REGIME_MIN_SCORE_FLOOR", raw)
+    assert regime_min_score_floor_enabled() is enabled
+
+
+def test_effective_handles_non_int_llm(monkeypatch):
+    monkeypatch.setenv("REGIME_MIN_SCORE_FLOOR", "true")
+    assert effective_min_score(None, "strong_bear") == 9
+    assert effective_min_score("bad", "sideways") == 8
+    monkeypatch.delenv("REGIME_MIN_SCORE_FLOOR", raising=False)
+    assert effective_min_score(None, "strong_bear") == 0

--- a/tests/test_regime_policy.py
+++ b/tests/test_regime_policy.py
@@ -22,10 +22,11 @@ from cores.regime_policy import (
 # --------------------------------------------------------------------------- #
 # decide_batch_policy — table-driven (market, mode, state) -> expected run_batch #
 # --------------------------------------------------------------------------- #
-# §7 Rev.3: CORRECTION reduces to one daily window.
-#   KR: morning runs, afternoon rests.
+# §7 Rev.3/Rev.4: CORRECTION reduces to one daily window.
+#   KR: morning rests, afternoon runs.
 #   US: midday runs, morning & afternoon rest.
-# All non-CORRECTION / unknown states run everything (fail-open).
+# §7 Rev.5: UNDER_PRESSURE partial brake — US morning rests (midday/afternoon run),
+#   KR unchanged (all run). UPTREND / None(unknown) run everything (fail-open).
 _CASES = [
     # --- KR, CORRECTION (Rev.4: 종가확인 오후 유지, 아침 갭페이드 회피) ---
     ("kr", "morning", CORRECTION, False),
@@ -47,9 +48,11 @@ _CASES = [
     ("us", "morning", UPTREND, True),
     ("us", "midday", UPTREND, True),
     ("us", "afternoon", UPTREND, True),
-    ("us", "morning", UNDER_PRESSURE, True),
+    # Rev.5: US morning rests under UNDER_PRESSURE; midday/afternoon run.
+    ("us", "morning", UNDER_PRESSURE, False),
     ("us", "midday", UNDER_PRESSURE, True),
     ("us", "afternoon", UNDER_PRESSURE, True),
+    ("us", "both", UNDER_PRESSURE, True),      # unknown mode fails open -> run
     ("us", "morning", None, True),
     ("us", "midday", None, True),
     ("us", "afternoon", None, True),
@@ -65,13 +68,39 @@ def test_decide_batch_policy_table(market, mode, state, expected):
     assert isinstance(pol.reason, str) and pol.reason
 
 
-def test_only_correction_ever_rests():
-    """No non-CORRECTION state can ever produce run_batch=False."""
+def test_only_documented_batches_rest():
+    """Only the documented (state, market, mode) combos rest; everything else runs.
+
+    Rev.5: rest set = {CORRECTION: kr-morning, us-morning, us-afternoon;
+                       UNDER_PRESSURE: us-morning}. All other combos run.
+    """
+    rest = {
+        (CORRECTION, "kr", "morning"),
+        (CORRECTION, "us", "morning"),
+        (CORRECTION, "us", "afternoon"),
+        (UNDER_PRESSURE, "us", "morning"),
+    }
     for market in ("kr", "us"):
         for mode in ("morning", "midday", "afternoon", "both"):
-            for state in (UPTREND, UNDER_PRESSURE, None):
+            for state in (UPTREND, UNDER_PRESSURE, CORRECTION, None):
                 pol = decide_batch_policy(market, mode, state)
-                assert pol.run_batch is True, (market, mode, state)
+                expected_run = (state, market, mode) not in rest
+                assert pol.run_batch is expected_run, (market, mode, state)
+
+
+def test_under_pressure_rev5_partial_brake():
+    """Rev.5: US morning rests under UNDER_PRESSURE; US midday/afternoon and all KR run."""
+    # US: only morning rests.
+    assert decide_batch_policy("us", "morning", UNDER_PRESSURE).run_batch is False
+    assert decide_batch_policy("us", "midday", UNDER_PRESSURE).run_batch is True
+    assert decide_batch_policy("us", "afternoon", UNDER_PRESSURE).run_batch is True
+    # KR: unchanged — everything runs under UNDER_PRESSURE.
+    assert decide_batch_policy("kr", "morning", UNDER_PRESSURE).run_batch is True
+    assert decide_batch_policy("kr", "afternoon", UNDER_PRESSURE).run_batch is True
+    # None (fail-open) runs everything on both markets.
+    for market in ("kr", "us"):
+        for mode in ("morning", "midday", "afternoon"):
+            assert decide_batch_policy(market, mode, None).run_batch is True
 
 
 def test_correction_rest_sets():

--- a/tests/test_stock_tracking_agent_process_reports.py
+++ b/tests/test_stock_tracking_agent_process_reports.py
@@ -23,7 +23,9 @@ class _FakeAsyncTradingContext:
     async def __aexit__(self, exc_type, exc, tb):
         return False
 
-    async def async_buy_stock(self, stock_code, limit_price=None):
+    async def async_buy_stock(self, stock_code, limit_price=None, buy_amount=None):
+        # buy_amount mirrors the real DomesticStockTrading.async_buy_stock signature
+        # (None = full size; set only under PULSE_PILOT_REEXPOSURE pilot sizing).
         return {
             "success": True,
             "message": f"bought for {self.account_name}",


### PR DESCRIPTION
## 배경
오닐 원칙('확실한 기회가 없으면 기다려라') 정합성 검토에서 발견된 누수 4건을 보완합니다.

## 변경 (커밋별)
1. **fix(restraint): US 약세장 top-down 억제 미러** — `REGIME_WEAK_NO_TOPDOWN`이 KR `trigger_batch.py`에만 있고 US에는 없어, 운영 플래그가 켜져 있어도 미국장은 횡보약세에서 모멘텀추격을 계속하던 비대칭 수정 (`prism-us/us_trigger_batch.py:898`)
2. **feat(pulse): UNDER_PRESSURE US 아침 배치 감속 (Rev.5)** — 조정 판정 전 압박 구간에서 US morning 배치만 휴식 (KR 무변경, 매도 루프 무영향, fail-open 유지)
3. **feat(restraint): 레짐 적응 매수 하한선** — `REGIME_MIN_SCORE_FLOOR` (기본 OFF): strong_bear≥9, moderate_bear/sideways≥8 하드 게이트. LLM min_score와 max() 결합. KR/US/enhanced 공통 헬퍼(`cores/regime_policy.py`)
4. **feat(pulse): CORRECTION 종료 후 파일럿 재진입** — `PULSE_PILOT_REEXPOSURE` (기본 OFF): FTD/회복 이탈 후 5거래일간 매수금액 0.5배 (오닐 점진 재노출)

## 테스트
- root: 150 passed (regime_policy/market_pulse/min_score_floor/pilot_reexposure/feature_status)
- prism-us: 3 passed (weak_no_topdown US 미러)
- 신규 플래그 2종은 기본 OFF — 머지 즉시 행동 변화는 항목 1(기존 플래그 ON)과 항목 2(MARKET_PULSE_MODE=live)만

🤖 Generated with [Claude Code](https://claude.com/claude-code)