### PR TITLE
fix(pulse): 파일럿 재진입을 금액 절반 → 신규진입 수 스로틀로 재설계 (sim/real parity)

### DIFF
--- a/cores/regime_policy.py
+++ b/cores/regime_policy.py
@@ -404,15 +404,16 @@ def _reset_state_cache() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# Post-FTD progressive re-exposure — pilot (half) sizing (env-gated, default OFF) #
+# Post-FTD progressive re-exposure — pilot new-entry throttle (env-gated, OFF)  #
 # --------------------------------------------------------------------------- #
 # After a CORRECTION ends (FTD or price-recovery exit), the first buys back into
 # the market are the riskiest (early re-entry can be a bull trap). PULSE_PILOT_REEXPOSURE
 # ON => for the first PULSE_PILOT_WINDOW_SESSIONS trading sessions after the
-# CORRECTION -> (UPTREND/UNDER_PRESSURE) transition, size new buys at
-# PULSE_PILOT_FACTOR (half). Default OFF = full size (현행 유지). Fail-open: any
-# error -> full size.
-PULSE_PILOT_FACTOR: float = 0.5
+# CORRECTION -> (UPTREND/UNDER_PRESSURE) transition, THROTTLE THE NUMBER of new
+# entries (배치당 신규 진입 1종목 + 중복매수 동결) at the decision layer shared by the
+# simulator and real orders. 금액은 항상 100% 정상 (all-in/all-out per position 계약을
+# 지키기 위해 fractional sizing 은 절대 사용하지 않는다 — sim/real parity). Default OFF =
+# 현행 유지. Fail-open: any error -> 원래 동작(정상 진입).
 PULSE_PILOT_WINDOW_SESSIONS: int = 5
 
 
@@ -458,12 +459,12 @@ def is_pilot_window(sessions_ago: Optional[int], flag_on: Optional[bool] = None)
 
 
 def pilot_reexposure_active(market: str, use_cache: bool = True) -> bool:
-    """Return True when pilot (half) sizing applies for ``market`` ("kr" | "us").
+    """Return True when the pilot new-entry throttle applies for ``market`` ("kr" | "us").
 
     Flag OFF -> False (no replay, zero cost). Otherwise replays MarketPulse over
     ~400d of index bars, finds the last CORRECTION exit, and checks the window.
     Memoized per process (:data:`_PILOT_CACHE`). Fail-open: ANY error -> False
-    (full size), so this never raises into a production buy path.
+    (정상 진입), so this never raises into a production buy path.
     """
     if not pilot_reexposure_enabled():
         return False

--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -3,7 +3,7 @@
 > **단일 진실원(intended state).** 릴리즈가 늘어도 "무엇이 실거래에 적용 중인지" 한눈에 보기 위한 문서.
 > 실제 런타임 상태(서버 .env·crontab 기준)는 `tools/feature_status.py`로 대조 — 이 문서와 어긋나면 그 도구가 진실.
 > 관리 주체 = 코딩 에이전트(cokac-bot). 매 릴리즈/승격 시 갱신.
-> 최종 갱신: 2026-06-25.
+> 최종 갱신: 2026-07-12.
 
 ## 상태 정의
 - **LIVE** = 실거래/실발행에 실제 영향. **SHADOW** = 코드 동작하나 로그/관측만(영향 0). **OFF** = 미실행(코드만 존재). **N/A** = 미구현.
@@ -34,6 +34,7 @@
 | 비전 배관(S1) / 렌더QA(S2) | **ON(log-only)** | `PRISM_FEATURE_VISION=on` | 무손상 인프라 | 렌더QA 비차단 경고만 |
 | 비전 매수 품질검사(S3 + S3.5 오닐 일/주봉·RS) | **SHADOW** | `PRISM_FEATURE_VISION=on` + `PRISM_VISION_SHADOW=true` | **A/B 홀드아웃 측정(승률·손절률·MDD 순효과)** → 미정 | 관측 로그 `[BUY_QUALITY][SHADOW]`. 매매영향 0 |
 | 비전 인사이트 이미지 발행(S6) | **LIVE** | `.env PRISM_FEATURE_INSIGHT_IMAGE=on` **AND** `vision_available()`(`PRISM_FEATURE_VISION=on` + 실 API 키) | 샘플 사용자 승인 후 활성화(06-24) | KR(₩)/US($) 발송 중. 차트에 매수▲/매도▼ 마커·용어설명 포함. 끄기: `PRISM_FEATURE_INSIGHT_IMAGE=off` |
+| Post-FTD 파일럿 재진입(정찰 신규진입 스로틀) | **OFF** | `.env PULSE_PILOT_REEXPOSURE=true` (기본 off) | 파일럿 윈도우 실관측 후 | 조정(CORRECTION) 종료 후 5거래일간 **신규 진입 배치당 1종목(top-down 주도주 우선) + 중복매수(피라미딩) 동결**. **금액은 항상 100% 정상**(all-in/all-out per position 계약 유지, fractional sizing 미사용 → sim/real parity). 시뮬레이터·실주문 공통 결정 레이어에서 적용. fail-open. 구 금액 절반매수(`PULSE_PILOT_FACTOR`)는 sim/real 괴리 결함으로 **제거**. 코드: `cores/regime_policy.py`, `trigger_batch`/`us_trigger_batch._get_regime_slots`, KR/US tracking agents 중복매수 동결 |
 
 ## 자동 승격 정책 (에이전트가 따른다)
 SHADOW→LIVE **자동 승격**은 아래를 **모두** 충족할 때만:
@@ -58,3 +59,4 @@ SHADOW→LIVE **자동 승격**은 아래를 **모두** 충족할 때만:
 - 2026-06-24: **승격·활성화 반영** — Loop B → **LIVE**(`LOOP_B_LIVE=true`+cron, 백테스트 KR/US 통과+승인). Loop C → **SHADOW**(cron 설치, `LOOP_C_LIVE` 미설정; 상세로깅+selftest 추가). S6 발행 → **LIVE**(`PRISM_FEATURE_INSIGHT_IMAGE=on`, 사용자 승인; 매매마커·용어설명 포함).
 - 2026-06-25: **env 키 리네임(코드네임 누수 제거)** — `LOOP_A_*`→`HARDSTOP_*`, `LOOP_B_*`→`TREND_EXIT_*`, `LOOP_C_*`→`FILL_CHASER_*`. **구 키는 deprecated alias로 계속 유효**(코드가 신규 먼저 읽고 구 키 폴백+경고). prod `.env`/crontab 점진 교체 가능. + **Loop C 매수추격 체결우선화**: 예산 `FILL_CHASER_BUY_MAX_PREMIUM_PCT` 0.5%→3%, `FILL_CHASER_BUY_CROSS`(on)로 예산 내 마케터블 cross 즉시체결(예산 초과 시 여전히 CANCEL). SHADOW 유지.
 - 2026-06-25: **재진입 쿨다운 게이트 신설(SHADOW)** — `reentry_cooldown.py` + KR/US 매수 caller 훅. 손실매도 후 같은 종목 24h 재매수 차단(승리후 0h=정당 연속진입 허용). MU 과매매(당일왕복 −5.6% 31건·손절후 재매수) 대응. `REENTRY_COOLDOWN_LIVE` 미설정=SHADOW(로그만). prod 이력검증: 리벤지 재매수 3건 차단·오탐 0.
+- 2026-07-12: **Post-FTD 파일럿 재진입 재설계(sim/real parity 결함 수정)** — 구 `PULSE_PILOT_FACTOR` 금액 절반매수를 **제거**했다. 결함: 실 KIS 주문(`buy_amount`)만 절반이고 시뮬레이터(방송/저널의 진실원)는 전량 기록 → sim-vs-real 괴리. 본 시스템은 포지션당 all-in/all-out이고 포트폴리오 비중은 **중복매수(피라미딩) 허용**으로만 표현하므로 fractional sizing 자체가 계약 위반이었다. 신규 세만틱: `PULSE_PILOT_REEXPOSURE` ON 시 조정 종료 후 5거래일간 **신규 진입 배치당 1종목(주도주 top-down 우선) + 중복매수 동결**을 시뮬레이터/실주문 공통 결정 레이어(`_get_regime_slots` + tracking agents 보유중복 프리체크)에서 적용. **금액은 항상 100% 정상.** 기본 off, fail-open.

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -115,6 +115,10 @@ def _import_from_main_cores(module_name: str, relative_path: str):
     file_path = PROJECT_ROOT / relative_path
     spec = importlib.util.spec_from_file_location(module_name, file_path)
     module = importlib.util.module_from_spec(spec)
+    # py3.14: @dataclass(frozen=True) resolves sys.modules[cls.__module__].__dict__ during
+    # exec, so the module MUST be registered before exec_module (else NoneType.__dict__
+    # AttributeError → fail-open None). Affects cores/regime_policy.py (frozen dataclass).
+    sys.modules[module_name] = module
     spec.loader.exec_module(module)
     return module
 
@@ -1093,6 +1097,22 @@ class USStockTrackingAgent:
         ticker = analysis_result.get("ticker")
         company_name = analysis_result.get("company_name")
         if await self._is_ticker_in_holdings(ticker):
+            # Post-FTD 파일럿 윈도우: 중복매수(피라미딩) 동결. 매수 전 결정 경로에서 차단해
+            # sim/real 이 동일하게 스킵된다. fail-open: 판정 예외 시 기존 로직 유지.
+            try:
+                _rp_pilot = self._regime_policy_mod()
+                _pilot_freeze = _rp_pilot is not None and _rp_pilot.pilot_reexposure_active("us")
+            except Exception:
+                _pilot_freeze = False
+            if _pilot_freeze:
+                logger.info(f"[PULSE_PILOT] 중복매수 동결: {ticker} ({company_name}) already in holdings")
+                return {
+                    "success": True,
+                    "decision": "holding",
+                    "ticker": ticker,
+                    "company_name": company_name,
+                    "current_price": analysis_result.get("current_price", 0),
+                }
             # Pyramiding (#288): allow an additional independent entry only when the
             # strong-bull add-gate passes. Otherwise keep the legacy hard block.
             scenario = analysis_result.get("scenario", {}) or {}
@@ -2821,6 +2841,18 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     # keep the legacy skip. Computed per active account.
                     is_add = False
                     if await self._is_ticker_in_holdings(ticker):
+                        # Post-FTD 파일럿 윈도우: 중복매수(피라미딩) 동결. sim/real 공통 매수 전에
+                        # 차단해 시뮬레이터/실주문이 동일하게 스킵된다. fail-open: 예외 시 기존 로직.
+                        _pilot_freeze = False
+                        try:
+                            _rp_pilot = self._regime_policy_mod()
+                            if _rp_pilot is not None:
+                                _pilot_freeze = _rp_pilot.pilot_reexposure_active("us")
+                        except Exception:
+                            _pilot_freeze = False
+                        if _pilot_freeze:
+                            logger.info(f"[PULSE_PILOT] 중복매수 동결: {ticker} ({company_name}) already in holdings")
+                            continue
                         acct_key = self._account_scope()[0]
                         existing = get_us_existing_position_for_ticker(self.cursor, ticker, account_key=acct_key)
                         allowed, gate_reason = evaluate_us_pyramid_add_gate(
@@ -2939,21 +2971,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                                     except ImportError:
                                         from prism_us.trading.us_stock_trading import AsyncUSTradingContext
                                     async with AsyncUSTradingContext(account_name=account["name"]) as trading:
-                                        # 파일럿 재진입 축소매수(env-gated PULSE_PILOT_REEXPOSURE, 기본 off).
-                                        # CORRECTION 종료 직후 N세션은 buy_amount 를 절반으로. fail-open 정상매수.
-                                        _pilot_buy_amt = None
-                                        try:
-                                            _rp = self._regime_policy_mod()
-                                            if (_rp is not None and _rp.pilot_reexposure_active("us")
-                                                    and getattr(trading, "buy_amount", None)):
-                                                _pilot_buy_amt = round(trading.buy_amount * _rp.PULSE_PILOT_FACTOR, 2)
-                                                logger.info(
-                                                    f"[PULSE_PILOT] {company_name}({ticker}) pilot re-exposure half-size buy: "
-                                                    f"${trading.buy_amount:,.2f}->${_pilot_buy_amt:,.2f} (x{_rp.PULSE_PILOT_FACTOR})"
-                                                )
-                                        except Exception as _pe:
-                                            logger.warning(f"[PULSE_PILOT] fail-open full-size buy: {_pe}")
-                                        trade_result = await trading.async_buy_stock(ticker=ticker, limit_price=current_price, buy_amount=_pilot_buy_amt)
+                                        trade_result = await trading.async_buy_stock(ticker=ticker, limit_price=current_price)
 
                                     if trade_result['success']:
                                         logger.info(f"Actual purchase successful: {trade_result['message']}")

--- a/prism-us/us_trigger_batch.py
+++ b/prism-us/us_trigger_batch.py
@@ -880,6 +880,34 @@ def trigger_contrarian_value(trade_date: str, snapshot: pd.DataFrame,
 
 # === Final Selection ===
 
+# Post-FTD 파일럿 재진입 판정은 root cores/regime_policy.py 에 있다. prism-us/cores 가
+# sys.path 우선이라 `from cores.regime_policy import ...` 는 shadowing 되므로, 파일경로로
+# 직접 1회 로드해 캐시한다(us_stock_tracking_agent._import_from_main_cores 와 동일 패턴).
+_REGIME_POLICY_MOD = "__UNSET__"
+
+
+def _load_root_regime_policy():
+    """root cores/regime_policy.py 를 파일경로로 1회 로드해 캐시. 실패 시 None(호출부 fail-open)."""
+    global _REGIME_POLICY_MOD
+    if _REGIME_POLICY_MOD == "__UNSET__":
+        try:
+            import importlib.util
+            _name = "prism_root_regime_policy_uspilot"
+            _root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            _fp = os.path.join(_root, "cores", "regime_policy.py")
+            spec = importlib.util.spec_from_file_location(_name, _fp)
+            _m = importlib.util.module_from_spec(spec)
+            # py3.14 @dataclass(frozen=True) 는 exec 중 sys.modules[cls.__module__] 를 조회하므로
+            # exec_module 전에 반드시 등록해야 한다(미등록 시 NoneType.__dict__ AttributeError).
+            sys.modules[_name] = _m
+            spec.loader.exec_module(_m)
+            _REGIME_POLICY_MOD = _m
+        except Exception as e:
+            logger.warning("[PULSE_PILOT] regime_policy 로드 실패, fail-open: %s", e)
+            _REGIME_POLICY_MOD = None
+    return _REGIME_POLICY_MOD
+
+
 def _get_regime_slots(market_regime: str) -> tuple:
     """Return (topdown_slots, bottomup_slots) based on market regime."""
     REGIME_SLOTS = {
@@ -890,6 +918,19 @@ def _get_regime_slots(market_regime: str) -> tuple:
         "strong_bear": (0, 3),
     }
     td, bu = REGIME_SLOTS.get(market_regime, (1, 2))  # default: sideways ratios
+    # Post-FTD 정찰(파일럿) 재진입: PULSE_PILOT_REEXPOSURE ON + US 파일럿 윈도우면 배치당
+    # 신규 진입 슬롯을 총 1개로 캡한다. post-FTD 정찰 진입은 주도주(top-down) 우선, 정상 금액
+    # 1종목만. 금액은 절대 건드리지 않는다(sim/real parity). 신규 진입 수만 조인다.
+    # fail-open: 파일럿 판정 중 예외 발생 시 원래 슬롯 유지(기존 약세장 브랜치 스타일).
+    try:
+        _rp = _load_root_regime_policy()
+        if (td + bu) > 1 and _rp is not None and _rp.pilot_reexposure_active("us"):
+            capped = (1, 0) if td >= 1 else (0, min(bu, 1))
+            logger.info("[PULSE_PILOT] 파일럿 신규진입 캡: %s (%d,%d)->(%d,%d)",
+                        market_regime, td, bu, capped[0], capped[1])
+            return capped
+    except Exception as _pe:
+        logger.debug("[PULSE_PILOT] slot-cap fail-open: %s", _pe)
     # 약세·횡보장 모멘텀추격(top-down) 억제 옵션 (env-gated, 기본 off = 현행 유지).
     # ON 시 sideways/moderate_bear의 top-down 슬롯을 0으로 → 급락 휩쏘장에서 momentum chase
     # 매수를 접고 가치형 bottom-up만 남긴다(총 슬롯도 감소 = 매수 절제). strong_bear는 이미 (0,3).

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -714,6 +714,23 @@ class StockTrackingAgent:
 
         is_holding = await self._is_ticker_in_holdings(ticker)
         if is_holding:
+            # Post-FTD 파일럿 윈도우: 중복매수(피라미딩) 동결. 이미 보유 종목에 추가 진입을
+            # 금지한다(신규 정찰 진입만 허용). sim/real 공통 결정 경로에서 매수 전에 차단해
+            # 시뮬레이터와 실주문이 동일하게 스킵된다. fail-open: 판정 예외 시 기존 로직 유지.
+            try:
+                from cores.regime_policy import pilot_reexposure_active
+                _pilot_freeze = pilot_reexposure_active("kr")
+            except Exception:
+                _pilot_freeze = False
+            if _pilot_freeze:
+                logger.info(f"[PULSE_PILOT] 중복매수 동결: {ticker}({company_name}) already in holdings")
+                return {
+                    "success": True,
+                    "decision": "Already holding",
+                    "ticker": ticker,
+                    "company_name": company_name,
+                    "current_price": analysis_result.get("current_price", 0),
+                }
             # Pyramiding (#288): allow an additional independent entry only when the
             # strong-bull add-gate passes. Otherwise keep the legacy hard block.
             scenario = analysis_result.get("scenario", {}) or {}
@@ -1991,23 +2008,7 @@ class StockTrackingAgent:
                             from trading.domestic_stock_trading import AsyncTradingContext
 
                             async with AsyncTradingContext(account_name=account["name"]) as trading:
-                                # 파일럿 재진입 축소매수(env-gated PULSE_PILOT_REEXPOSURE, 기본 off).
-                                # CORRECTION 종료 직후 N세션은 buy_amount 를 절반으로. fail-open 정상매수.
-                                _pilot_buy_amt = None
-                                try:
-                                    from cores.regime_policy import (
-                                        pilot_reexposure_active,
-                                        PULSE_PILOT_FACTOR,
-                                    )
-                                    if pilot_reexposure_active("kr") and getattr(trading, "buy_amount", None):
-                                        _pilot_buy_amt = int(trading.buy_amount * PULSE_PILOT_FACTOR)
-                                        logger.info(
-                                            f"[PULSE_PILOT] {company_name}({ticker}) 파일럿 재진입 축소매수: "
-                                            f"{int(trading.buy_amount):,}->{_pilot_buy_amt:,} KRW (x{PULSE_PILOT_FACTOR})"
-                                        )
-                                except Exception as _pe:
-                                    logger.warning(f"[PULSE_PILOT] fail-open 정상매수: {_pe}")
-                                trade_result = await trading.async_buy_stock(stock_code=ticker, limit_price=current_price, buy_amount=_pilot_buy_amt)
+                                trade_result = await trading.async_buy_stock(stock_code=ticker, limit_price=current_price)
 
                             if trade_result['success']:
                                 logger.info(f"Actual purchase successful: {trade_result['message']}")

--- a/tests/test_pulse_pilot_reexposure.py
+++ b/tests/test_pulse_pilot_reexposure.py
@@ -1,6 +1,10 @@
-"""Post-FTD 파일럿 재진입 축소매수(PULSE_PILOT_REEXPOSURE) 순수 헬퍼 단위테스트.
+"""Post-FTD 파일럿 재진입 신규진입 스로틀(PULSE_PILOT_REEXPOSURE) 순수 단위테스트.
 
-network 없음. 전이후 세션수 계산 / 윈도우 판정 / 플래그 off=항상 정상사이즈 검증.
+network 없음. 전이후 세션수 계산 / 윈도우 판정 / 플래그 off=현행 유지 검증.
++ trigger_batch._get_regime_slots 파일럿 신규진입 캡(배치당 1종목) 검증.
+
+파일럿은 '금액'을 절대 건드리지 않는다(all-in/all-out per position 계약). 신규 진입 '수'만
+조인다: 배치당 신규 진입 슬롯을 총 1개로 캡(top-down 우선) + 중복매수(피라미딩) 동결.
 Run: .venv/bin/python -m pytest tests/test_pulse_pilot_reexposure.py -q
 """
 
@@ -8,21 +12,26 @@ from __future__ import annotations
 
 import pytest
 
+import cores.regime_policy as regime_policy
 from cores.regime_policy import (
     CORRECTION,
     UNDER_PRESSURE,
     UPTREND,
-    PULSE_PILOT_FACTOR,
     PULSE_PILOT_WINDOW_SESSIONS,
     _sessions_since_correction_exit,
     is_pilot_window,
     pilot_reexposure_enabled,
 )
+from trigger_batch import _get_regime_slots
 
 
-def test_factor_and_window_constants():
-    assert PULSE_PILOT_FACTOR == 0.5
+def test_window_constant():
     assert PULSE_PILOT_WINDOW_SESSIONS == 5
+
+
+def test_factor_constant_removed():
+    # 금액 기반 축소매수(defect)는 제거됨 — PULSE_PILOT_FACTOR 존재하면 안 된다.
+    assert not hasattr(regime_policy, "PULSE_PILOT_FACTOR")
 
 
 # --------------------------------------------------------------------------- #
@@ -70,11 +79,11 @@ def test_within_window_true_after_false():
     assert is_pilot_window(PULSE_PILOT_WINDOW_SESSIONS + 3, flag_on=True) is False
 
 
-def test_none_sessions_is_full_size():
+def test_none_sessions_is_inactive():
     assert is_pilot_window(None, flag_on=True) is False
 
 
-def test_flag_off_always_full_size():
+def test_flag_off_always_inactive():
     # Flag OFF -> never pilot, even squarely inside the window.
     for ago in (0, 1, 4, None):
         assert is_pilot_window(ago, flag_on=False) is False
@@ -100,3 +109,49 @@ def test_enabled_parsing(monkeypatch, raw, enabled):
     else:
         monkeypatch.setenv("PULSE_PILOT_REEXPOSURE", raw)
     assert pilot_reexposure_enabled() is enabled
+
+
+# --------------------------------------------------------------------------- #
+# _get_regime_slots — 파일럿 신규진입 캡(배치당 1종목, top-down 우선)               #
+# --------------------------------------------------------------------------- #
+def test_slots_pilot_off_unchanged(monkeypatch):
+    # 파일럿 비활성(윈도우 밖/플래그 off) -> 레짐별 기본 슬롯 그대로.
+    monkeypatch.setattr(regime_policy, "pilot_reexposure_active", lambda market, **kw: False)
+    assert _get_regime_slots("strong_bull") == (2, 1)
+    assert _get_regime_slots("moderate_bull") == (1, 2)
+    assert _get_regime_slots("sideways") == (1, 2)
+    assert _get_regime_slots("moderate_bear") == (1, 2)
+    assert _get_regime_slots("strong_bear") == (0, 3)
+
+
+def test_slots_pilot_active_caps_to_one(monkeypatch):
+    # 파일럿 활성 -> 배치당 신규 진입 총 1종목. top-down >=1 이면 (1,0), 아니면 (0,1).
+    monkeypatch.setattr(regime_policy, "pilot_reexposure_active", lambda market, **kw: True)
+    assert _get_regime_slots("strong_bull") == (1, 0)      # (2,1) -> (1,0)
+    assert _get_regime_slots("moderate_bull") == (1, 0)    # (1,2) -> (1,0)
+    assert _get_regime_slots("sideways") == (1, 0)         # (1,2) -> (1,0)
+    assert _get_regime_slots("moderate_bear") == (1, 0)    # (1,2) -> (1,0)
+    assert _get_regime_slots("strong_bear") == (0, 1)      # (0,3) -> (0,1)
+
+
+def test_slots_pilot_uses_kr_market(monkeypatch):
+    # KR trigger_batch 는 'kr' 시장으로 파일럿을 질의해야 한다.
+    seen = {}
+
+    def _fake(market, **kw):
+        seen["market"] = market
+        return True
+
+    monkeypatch.setattr(regime_policy, "pilot_reexposure_active", _fake)
+    assert _get_regime_slots("strong_bull") == (1, 0)
+    assert seen["market"] == "kr"
+
+
+def test_slots_pilot_exception_fail_open(monkeypatch):
+    # 파일럿 판정 중 예외 -> fail-open: 원래 슬롯 유지.
+    def _boom(market, **kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(regime_policy, "pilot_reexposure_active", _boom)
+    assert _get_regime_slots("strong_bull") == (2, 1)
+    assert _get_regime_slots("strong_bear") == (0, 3)

--- a/trigger_batch.py
+++ b/trigger_batch.py
@@ -1229,6 +1229,19 @@ def _get_regime_slots(market_regime: str) -> tuple:
         "strong_bear": (0, 3),
     }
     td, bu = REGIME_SLOTS.get(market_regime, (1, 2))  # default: sideways ratios
+    # Post-FTD 정찰(파일럿) 재진입: PULSE_PILOT_REEXPOSURE ON + 해당 시장 파일럿 윈도우면
+    # 배치당 신규 진입 슬롯을 총 1개로 캡한다. post-FTD 정찰 진입은 주도주(top-down) 우선,
+    # 정상 금액 1종목만. 금액은 절대 건드리지 않는다(sim/real parity). 신규 진입 수만 조인다.
+    # fail-open: 파일럿 판정 중 예외 발생 시 원래 슬롯 유지(기존 약세장 브랜치 스타일).
+    try:
+        from cores.regime_policy import pilot_reexposure_active
+        if (td + bu) > 1 and pilot_reexposure_active("kr"):
+            capped = (1, 0) if td >= 1 else (0, min(bu, 1))
+            logger.info("[PULSE_PILOT] 파일럿 신규진입 캡: %s (%d,%d)->(%d,%d)",
+                        market_regime, td, bu, capped[0], capped[1])
+            return capped
+    except Exception as _pe:
+        logger.debug("[PULSE_PILOT] slot-cap fail-open: %s", _pe)
     # 약세·횡보장 모멘텀추격(top-down) 억제 옵션 (env-gated, 기본 off = 현행 유지).
     # ON 시 sideways/moderate_bear의 top-down 슬롯을 0으로 → 급락 휩쏘장에서 momentum chase
     # 매수를 접고 가치형 bottom-up만 남긴다(총 슬롯도 감소 = 매수 절제). strong_bear는 이미 (0,3).


### PR DESCRIPTION
## 문제
기존 파일럿 재진입(#429)은 KIS 실주문 금액만 절반으로 줄이고 시뮬레이터(방송·저널의 source of truth)는 정상 금액으로 기록 → 조정 탈출 때마다 시뮬-실계좌 괴리 누적. 본 시스템은 100% 올인-올아웃 + 중복매수로 비중을 표현하는 구조라 금액 축소는 설계와 충돌.

## 재설계
파일럿을 **의사결정 레이어(시뮬·실거래 공통 앞단)**로 이동, 금액은 절대 건드리지 않음:
- **신규 진입 캡**: 파일럿 윈도우(조정 종료 후 5거래일) 동안 배치당 신규 진입 총 1종목 — top-down(주도주) 우선 `(td,bu)→(1,0)`, 없으면 `(0,1)` (`trigger_batch.py:1232`, `us_trigger_batch.py` 미러)
- **중복매수 동결**: 윈도우 중 기보유 종목 추가 진입 차단 — 시뮬 매수 이전 단계 (`stock_tracking_agent.py:726`, US 미러 2곳)
- 금액 절반 코드(`_pilot_buy_amt`, `PULSE_PILOT_FACTOR`) 전면 제거
- fail-open 유지: 파일럿 판정 예외 시 원래 슬롯/정상 진입
- 플래그 `PULSE_PILOT_REEXPOSURE` 이름·윈도우(5세션) 유지 (현재 운영 .env는 false — 머지 후 재활성화 예정)

## 테스트
root 배치 127 passed (pilot/regime_policy/market_pulse/feature_status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)