### PR TITLE
feat(us): reduce analysis batches to morning and afternoon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ ENV/
 
 # Internal working docs (handoffs, strategy notes, ops runbooks) — never publish
 tasks/
+!tasks/
+tasks/*
+!tasks/us_two_batch_policy/
+!tasks/us_two_batch_policy/00_VALIDATION_AND_DEPLOYMENT_PLAN.md
 
 # Logs
 *.log

--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -260,7 +260,6 @@ The Docker container includes **built-in cron** for automated stock analysis. Cr
 | Time (KST) | US Time (EST) | Job | Days |
 |------------|---------------|-----|------|
 | 00:15 | 10:15 | **US Morning batch** | Tue-Sat |
-| 02:30 | 12:30 | **US Midday batch** | Tue-Sat |
 | 06:30 | 16:30 | **US Afternoon batch** | Tue-Sat |
 | 07:30 | 17:30 | US Performance tracker | Tue-Sat |
 | 08:00 | 18:00 | US Dashboard refresh | Tue-Sat |

--- a/cores/regime_policy.py
+++ b/cores/regime_policy.py
@@ -11,7 +11,8 @@ production orchestrators. It answers three questions, and nothing else:
   3. :func:`market_pulse_mode` — read the ``MARKET_PULSE_MODE`` env flag
      (``shadow`` | ``live`` | ``off``; default ``shadow``).
 
-Policy rationale (tasks/market_pulse/00_VALIDATION_PLAN.md §7 Rev.5):
+Policy rationale (US two-batch follow-up to
+tasks/market_pulse/00_VALIDATION_PLAN.md §7 Rev.5):
     The V2 trade-sample audit REJECTED the original "CORRECTION = full stop"
     policy — CORRECTION-window buys had a scary 38% stop-out rate but a NET
     +25.3% P&L (the post-crash rebound monsters live in this window). So the
@@ -19,17 +20,13 @@ Policy rationale (tasks/market_pulse/00_VALIDATION_PLAN.md §7 Rev.5):
     the agent to a single daily batch window, cutting exposure to the two noisiest
     micro-structure windows while keeping one shot at the rebound:
 
-        * KR (morning / afternoon): CORRECTION -> afternoon rests, morning runs.
-        * US (morning / midday / afternoon): CORRECTION -> only midday runs;
-          morning (open-hour noise is maximal) and afternoon (overnight gap risk
-          on a late buy) both rest.
+        * KR (morning / afternoon): CORRECTION -> afternoon only.
+        * US (morning / afternoon): CORRECTION -> afternoon only.
 
-    Rev.5 adds a lighter deceleration for the intermediate UNDER_PRESSURE state
-    (4-5 distribution days = market weakening but not yet in correction). Here
-    only US rests its MORNING batch (open-hour gap-strength is the least reliable
-    signal in a softening tape); US midday + afternoon still run, and KR is left
-    UNCHANGED (its two windows already trade the calmer mid/close hours). This is
-    a partial, market-specific brake — strictly weaker than the CORRECTION rest.
+    US now has the same two analysis windows as KR. The 10-minute hardstop and
+    trend-exit loops own intraday downside response, so a third analysis batch
+    is no longer needed. UNDER_PRESSURE therefore keeps both US windows:
+    otherwise it would have the same one-batch result as CORRECTION.
 
     Remaining states — UPTREND and None (unknown / fail-open) — run every batch
     normally, as does KR under UNDER_PRESSURE. Exit/sell loops are NEVER affected
@@ -61,24 +58,18 @@ CORRECTION: str = "CORRECTION"
 _VALID_MODES = ("shadow", "live", "off")
 _DEFAULT_MODE = "shadow"
 
-# Table (§7 Rev.3): batches that REST during CORRECTION, per market. Any batch
-# NOT listed here still runs during CORRECTION (the retained daily window).
+# Table: batches that REST during CORRECTION, per market. Any batch NOT listed
+# here still runs during CORRECTION (the retained daily window).
 _CORRECTION_REST_BATCHES = {
-    # §7 Rev.4: KR keeps the AFTERNOON (14:50, close-confirmation) window and
-    # rests the morning one — in corrections, morning gap-strength fades
-    # intraday (distribution into early hope); buy what HELD through the day,
-    # not what looks like it will rise. Same open-noise principle as US.
-    "kr": frozenset({"morning"}),                 # afternoon runs, morning rests
-    "us": frozenset({"morning", "afternoon"}),    # only midday runs
+    # Both markets retain the close-confirmation afternoon window and rest the
+    # morning one. This keeps correction behavior consistent across KR and US.
+    "kr": frozenset({"morning"}),
+    "us": frozenset({"morning"}),
 }
 
-# Table (§7 Rev.5): batches that REST during UNDER_PRESSURE, per market. A lighter,
-# market-specific brake than CORRECTION. KR is intentionally absent (no rest); only
-# US rests its morning batch (open-hour gap-strength least reliable in a softening
-# tape). Any batch NOT listed here runs normally under UNDER_PRESSURE.
-_UNDER_PRESSURE_REST_BATCHES = {
-    "us": frozenset({"morning"}),                 # midday + afternoon run, morning rests
-}
+# UNDER_PRESSURE has no batch rests. With two scheduled US windows, resting its
+# morning batch would make it operationally identical to CORRECTION.
+_UNDER_PRESSURE_REST_BATCHES: dict[str, frozenset[str]] = {}
 
 # Module-level cache: pulse state is computed once per (short-lived) process and
 # reused by the orchestrator hook and by per-ticker trend-fact injection so we do
@@ -115,17 +106,15 @@ def decide_batch_policy(
 
     Args:
         market:      "kr" or "us" (case-insensitive).
-        batch_mode:  KR: "morning"/"afternoon"; US: "morning"/"midday"/"afternoon".
+        batch_mode:  KR/US: "morning" or "afternoon".
                      ("both" or any unknown mode fails open -> run.)
         pulse_state: UPTREND / UNDER_PRESSURE / CORRECTION / None.
 
-    Rationale (§7 Rev.3, batch choice revised by Rev.4/Rev.5): CORRECTION is not a
-    buy stop; it reduces the agent to a single daily window (KR afternoon-only =
-    close-confirmation entry, US midday-only) to dodge the open-hour noise where
-    gap-strength fades intraday in weak markets, while keeping one shot at the
-    post-crash rebound. Rev.5: UNDER_PRESSURE additionally rests the US morning
-    batch only (KR unchanged). Exit loops are unaffected. Any state/mode not in a
-    rest table runs (fail-open on None/unknown).
+    Rationale: CORRECTION is not a buy stop; it reduces both markets to the
+    afternoon close-confirmation window while keeping one shot at the post-crash
+    rebound. UNDER_PRESSURE keeps the normal morning + afternoon schedule. Exit
+    loops are unaffected. Any state/mode not in a rest table runs (fail-open on
+    None/unknown).
     """
     m = (market or "").strip().lower()
     mode = (batch_mode or "").strip().lower()
@@ -157,7 +146,7 @@ def decide_batch_policy(
                 run_batch=False,
                 reason=(
                     f"UNDER_PRESSURE: {m or '?'} '{mode or '?'}' batch rests "
-                    "(Rev.5 partial brake; exit loops unaffected)"
+                    "(exit loops unaffected)"
                 ),
                 pulse_state=pulse_state,
             )
@@ -165,7 +154,7 @@ def decide_batch_policy(
             run_batch=True,
             reason=(
                 f"UNDER_PRESSURE: {m or '?'} '{mode or '?'}' batch runs "
-                "(Rev.5 partial brake)"
+                "(normal two-batch schedule)"
             ),
             pulse_state=pulse_state,
         )

--- a/docker/crontab
+++ b/docker/crontab
@@ -54,9 +54,6 @@ PYTHONPATH=/app/prism-insight
 # US Morning batch at 00:15 KST (10:15 EST) - Tue-Sat (Mon-Fri US)
 15 0 * * 2-6 cd /app/prism-insight && python3 prism-us/us_stock_analysis_orchestrator.py --mode morning >> /app/prism-insight/logs/us_morning_$(date +\%Y\%m\%d).log 2>&1
 
-# US Midday batch at 02:30 KST (12:30 EST) - Tue-Sat (Mon-Fri US)
-30 2 * * 2-6 cd /app/prism-insight && python3 prism-us/us_stock_analysis_orchestrator.py --mode midday >> /app/prism-insight/logs/us_midday_$(date +\%Y\%m\%d).log 2>&1
-
 # US Afternoon batch at 06:30 KST (16:30 EST) - Tue-Sat (Mon-Fri US)
 30 6 * * 2-6 cd /app/prism-insight && python3 prism-us/us_stock_analysis_orchestrator.py --mode afternoon >> /app/prism-insight/logs/us_afternoon_$(date +\%Y\%m\%d).log 2>&1
 

--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -26,6 +26,7 @@
 | 기능 | 상태 | 게이트 | 승격 기준 | 비고 |
 |---|---|---|---|---|
 | OAuth LLM 백엔드(ChatGPT 구독) | **LIVE** | crontab `PRISM_OPENAI_AUTH_MODE=chatgpt_oauth` | 카나리 검증 완료 | 전 배치 적용 |
+| Market Pulse 배치 정책 | **LIVE** | `.env MARKET_PULSE_MODE=live` | 정책 단위테스트 + 정규장 관측 | KR/US 모두 오전·오후 2회. `UNDER_PRESSURE`는 두 배치 유지, `CORRECTION`은 오후만 실행. 10분 hardstop/trend-exit 및 2분 fill-chaser는 모든 상태에서 유지 |
 | TIER0 이벤트 강제청산(뉴스 자율매도 + KIS 51 관리종목) | **LIVE** | 코드 상시 | 더존 등 실증 | KR+US 매도 프롬프트 핵심-0 |
 | Loop A — 고빈도 하드스톱(−7%/시나리오손절) | **LIVE** | `.env HARDSTOP_LIVE=true` (구 `LOOP_A_LIVE`, alias 유효) + cron 10분 | SHADOW 관측 후 승격(06-20) | KR 9–15 / US 9–16. 킬: `HARDSTOP_ENABLED=false` |
 | Loop B — 50MA 종가확인 추세이탈 | **LIVE** | `.env TREND_EXIT_LIVE=true` (구 `LOOP_B_LIVE`) + cron(KR 9–15 / US 9–16) | 백테스트 KR/US 순효과(휩쏘0·추가DD0) + 사용자 승인(06-24) | 코드: `tools/trend_exit_seller.py` (구 `tools/loop_b_trend_exit.py` shim 유효). 킬: `TREND_EXIT_ENABLED=false` |
@@ -60,3 +61,4 @@ SHADOW→LIVE **자동 승격**은 아래를 **모두** 충족할 때만:
 - 2026-06-25: **env 키 리네임(코드네임 누수 제거)** — `LOOP_A_*`→`HARDSTOP_*`, `LOOP_B_*`→`TREND_EXIT_*`, `LOOP_C_*`→`FILL_CHASER_*`. **구 키는 deprecated alias로 계속 유효**(코드가 신규 먼저 읽고 구 키 폴백+경고). prod `.env`/crontab 점진 교체 가능. + **Loop C 매수추격 체결우선화**: 예산 `FILL_CHASER_BUY_MAX_PREMIUM_PCT` 0.5%→3%, `FILL_CHASER_BUY_CROSS`(on)로 예산 내 마케터블 cross 즉시체결(예산 초과 시 여전히 CANCEL). SHADOW 유지.
 - 2026-06-25: **재진입 쿨다운 게이트 신설(SHADOW)** — `reentry_cooldown.py` + KR/US 매수 caller 훅. 손실매도 후 같은 종목 24h 재매수 차단(승리후 0h=정당 연속진입 허용). MU 과매매(당일왕복 −5.6% 31건·손절후 재매수) 대응. `REENTRY_COOLDOWN_LIVE` 미설정=SHADOW(로그만). prod 이력검증: 리벤지 재매수 3건 차단·오탐 0.
 - 2026-07-12: **Post-FTD 파일럿 재진입 재설계(sim/real parity 결함 수정)** — 구 `PULSE_PILOT_FACTOR` 금액 절반매수를 **제거**했다. 결함: 실 KIS 주문(`buy_amount`)만 절반이고 시뮬레이터(방송/저널의 진실원)는 전량 기록 → sim-vs-real 괴리. 본 시스템은 포지션당 all-in/all-out이고 포트폴리오 비중은 **중복매수(피라미딩) 허용**으로만 표현하므로 fractional sizing 자체가 계약 위반이었다. 신규 세만틱: `PULSE_PILOT_REEXPOSURE` ON 시 조정 종료 후 5거래일간 **신규 진입 배치당 1종목(주도주 top-down 우선) + 중복매수 동결**을 시뮬레이터/실주문 공통 결정 레이어(`_get_regime_slots` + tracking agents 보유중복 프리체크)에서 적용. **금액은 항상 100% 정상.** 기본 off, fail-open.
+- 2026-07-13: **US 분석 배치 3회→2회** — 장중 분석 배치를 제거했다. US는 정상·UNDER_PRESSURE에서 오전+오후를 실행하고, CORRECTION에서는 KR과 동일하게 오전을 쉬고 오후만 실행한다. 고빈도 hardstop/trend-exit/fill-chaser 스케줄은 변경하지 않는다. 상세 검증·배포 체크는 `docs/US_TWO_BATCH_POLICY.md`를 따른다.

--- a/docs/US_TWO_BATCH_POLICY.md
+++ b/docs/US_TWO_BATCH_POLICY.md
@@ -1,0 +1,55 @@
+# US 2회 분석 배치 정책 및 검증 런북
+
+> 최종 갱신: 2026-07-13. 이 문서는 v2.18.0의 Market Pulse 정책을 운영 관찰 결과에 맞춰 후속 정리한 것이다.
+
+## 정책
+
+US 분석 배치는 `morning`과 `afternoon` 두 개만 사용한다. 기존 장중 분석 배치는 제거한다.
+
+- `UPTREND`: 오전 + 오후 실행
+- `UNDER_PRESSURE`: 오전 + 오후 실행
+- `CORRECTION`: 오전 휴식, 오후만 실행
+- 알 수 없는 Pulse 상태: fail-open으로 해당 배치 실행
+
+`UNDER_PRESSURE`에서 오전을 쉬면 CORRECTION과 같은 하루 1회가 되어 상태별 실행 효과가 중복된다. 따라서 이 상태는 매수 품질 게이트의 신호로만 유지하고 분석 빈도를 줄이지 않는다.
+
+## 리스크 대응 범위
+
+분석 빈도 축소는 신규 후보 탐색에만 적용한다. 아래 매도/주문 관리 루프는 Market Pulse 상태와 무관하게 기존 스케줄을 유지한다.
+
+- hardstop: 약 10분 주기
+- trend-exit: 약 10분 주기와 마감 구간
+- fill-chaser: 약 2분 주기
+
+이 루프는 장중 하락 감지 지연을 줄이지만, 다음 정규장 시초가의 갭 변동을 사전에 없애지는 못한다. KR과 US 모두 동일한 제한이므로, CORRECTION의 오후 확인 원칙을 두 시장에 동일하게 적용한다.
+
+## 코드와 cron 계약
+
+- `prism-us/us_stock_analysis_orchestrator.py --mode`는 `morning`, `afternoon`, `both`만 받는다.
+- `docker/crontab` 및 `utils/setup_us_crontab.sh`는 US 분석 두 줄만 생성한다.
+- 운영 db-server의 실제 crontab은 별도 배포 단계에서 기존 장중 실행 한 줄을 삭제해야 한다. 이 저장소 변경만으로 이미 설치된 crontab은 바뀌지 않는다.
+- 실제 db-server의 현재 cron은 오전 10:15 ET, 오후 15:10 ET다. `utils/setup_us_crontab.sh`의
+  범용 설치 템플릿은 오후 16:30 ET를 사용하므로, 새 설치나 재설치 시에는 대상 서버의 cron 시간을
+  별도로 검토해야 한다. DST에 따라 KST 시각만 달라진다.
+
+## 검증 계획
+
+### 로컬 변경 전후 검증
+
+1. `tests/test_regime_policy.py`로 상태 × 시장 × 배치 정책을 검증한다.
+   - US `CORRECTION/morning=False`, `CORRECTION/afternoon=True`
+   - US `UNDER_PRESSURE/morning=True`, `UNDER_PRESSURE/afternoon=True`
+2. `prism-us/tests/test_phase7_orchestrator.py`로 분석 파이프라인의 tracking 실패 로그가 여전히 정확한지 확인한다.
+3. `python prism-us/us_stock_analysis_orchestrator.py --help` 출력에서 두 개의 개별 배치 모드만 허용되는지 확인한다.
+4. `bash -n utils/setup_us_crontab.sh`, `git diff --check`, 그리고 저장소 검색으로 제거된 장중 실행 경로가 남지 않았는지 확인한다.
+
+### 배포 직후 읽기 전용 검증
+
+1. db-server에서 `git branch --show-current`이 `main`이고, `git rev-parse HEAD`가 배포 커밋과 일치하는지 확인한다.
+2. `crontab -l`에서 US 분석은 `--mode morning`, `--mode afternoon` 두 줄만 남고, 제거된 장중 명령·로그 파일명은 없는지 확인한다.
+3. `.env`의 `MARKET_PULSE_MODE=live`를 확인한 뒤, 다음 US 오전/오후 실행 로그에서 `[MARKET_PULSE]` 결정과 모드가 일치하는지 확인한다.
+4. 다음 CORRECTION 및 UNDER_PRESSURE 관측 시에는 정책 로그·휴식 공지·실행 횟수를 위 표와 대조한다. 매도 루프 로그가 계속 생성되는지도 별도로 확인한다.
+
+## 롤백
+
+문제가 생기면 코드와 crontab을 직전 `main` 커밋으로 함께 되돌린다. 코드만 되돌리고 장중 cron을 남기면 새 CLI가 인수를 거부하므로, 두 변경은 한 단위로 롤백한다.

--- a/prism-us/tests/test_phase7_orchestrator.py
+++ b/prism-us/tests/test_phase7_orchestrator.py
@@ -357,11 +357,11 @@ class TestOrchestratorIntegration:
             monkeypatch.setitem(sys.modules, "us_stock_tracking_agent", fake_tracking_module)
 
             caplog.set_level("INFO")
-            await orchestrator.run_full_pipeline("midday", language="en", override_date="20260401")
+            await orchestrator.run_full_pipeline("afternoon", language="en", override_date="20260401")
 
         assert "US tracking system batch execution failed" in caplog.text
-        assert "US full pipeline completed with tracking errors - mode: midday" in caplog.text
-        assert "US full pipeline complete - mode: midday" not in caplog.text
+        assert "US full pipeline completed with tracking errors - mode: afternoon" in caplog.text
+        assert "US full pipeline complete - mode: afternoon" not in caplog.text
 
 
 # =============================================================================

--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -940,9 +940,6 @@ class USStockAnalysisOrchestrator:
             if mode == "morning":
                 title = "🔔 미국주식 오전 프리즘 시그널 얼럿"
                 time_desc = "장 시작 후 10분 시점"
-            elif mode == "midday":
-                title = "🔔 미국주식 장중 프리즘 시그널 얼럿"
-                time_desc = "장중 12시 30분 시점"
             else:
                 title = "🔔 미국주식 오후 프리즘 시그널 얼럿"
                 time_desc = "오후 분석"
@@ -959,9 +956,6 @@ class USStockAnalysisOrchestrator:
             if mode == "morning":
                 title = "🔔 US Stock Morning Prism Signal Alert"
                 time_desc = "10 minutes after market open"
-            elif mode == "midday":
-                title = "🔔 US Stock Midday Prism Signal Alert"
-                time_desc = "at 12:30 PM market time"
             else:
                 title = "🔔 US Stock Afternoon Prism Signal Alert"
                 time_desc = "after market close"
@@ -1203,8 +1197,8 @@ class USStockAnalysisOrchestrator:
 async def main():
     """Main function - command line interface"""
     parser = argparse.ArgumentParser(description="US stock analysis and telegram transmission orchestrator")
-    parser.add_argument("--mode", choices=["morning", "midday", "afternoon", "both"], default="both",
-                        help="Execution mode (morning, midday, afternoon, both)")
+    parser.add_argument("--mode", choices=["morning", "afternoon", "both"], default="both",
+                        help="Execution mode (morning, afternoon, both)")
     parser.add_argument("--language", choices=["ko", "en"], default="ko",
                         help="Analysis language (ko: Korean, en: English)")
     parser.add_argument("--broadcast-languages", type=str, default="",
@@ -1309,9 +1303,6 @@ async def main():
 
     if args.mode == "morning" or args.mode == "both":
         await orchestrator.run_full_pipeline("morning", language=args.language, override_date=args.date)
-
-    if args.mode == "midday":
-        await orchestrator.run_full_pipeline("midday", language=args.language, override_date=args.date)
 
     if args.mode == "afternoon" or args.mode == "both":
         await orchestrator.run_full_pipeline("afternoon", language=args.language, override_date=args.date)

--- a/prism-us/us_trigger_batch.py
+++ b/prism-us/us_trigger_batch.py
@@ -1260,9 +1260,8 @@ def run_batch(trigger_time: str, log_level: str = "INFO", output_file: str = Non
     cap_df = None
     logger.debug("Market cap filter skipped (S&P 500/NASDAQ-100 already large-cap)")
 
-    if trigger_time == "morning" or trigger_time == "midday":
-        label = "Midday" if trigger_time == "midday" else "Morning"
-        logger.info(f"=== {label} Batch Execution ===")
+    if trigger_time == "morning":
+        logger.info("=== Morning Batch Execution ===")
         res1 = trigger_morning_volume_surge(trade_date, snapshot, prev_snapshot, cap_df)
         res2 = trigger_morning_gap_up_momentum(trade_date, snapshot, prev_snapshot, cap_df)
         res3 = trigger_morning_value_to_cap_ratio(trade_date, snapshot, prev_snapshot, cap_df)
@@ -1282,7 +1281,7 @@ def run_batch(trigger_time: str, log_level: str = "INFO", output_file: str = Non
             "Volume Surge Sideways": res3
         }
     else:
-        logger.error("Invalid trigger_time. Use 'morning', 'midday', or 'afternoon'.")
+        logger.error("Invalid trigger_time. Use 'morning' or 'afternoon'.")
         return
 
     # === New triggers: active in all market conditions ===

--- a/tasks/us_two_batch_policy/00_VALIDATION_AND_DEPLOYMENT_PLAN.md
+++ b/tasks/us_two_batch_policy/00_VALIDATION_AND_DEPLOYMENT_PLAN.md
@@ -1,0 +1,52 @@
+# US 2회 분석 배치 — 검증·배포 체크리스트
+
+> 작성일: 2026-07-13 · 범위: US 분석 `morning` + `afternoon` 2회, Market Pulse 정책 정렬
+
+## 1. 로컬 게이트 (배포 전 필수)
+
+- [ ] `python -m pytest tests/test_regime_policy.py -q` 통과
+  - US `CORRECTION`: morning 휴식, afternoon 실행
+  - US `UNDER_PRESSURE`: morning/afternoon 모두 실행
+- [ ] `python -m pytest prism-us/tests/test_phase7_orchestrator.py -q` 통과
+- [ ] `python prism-us/us_stock_analysis_orchestrator.py --force --help`가
+  `morning, afternoon, both`만 표시
+- [ ] 제거된 모드 인수는 argparse가 거부(exit 2)
+- [ ] `bash -n utils/setup_us_crontab.sh`, `python -m compileall` 및
+  `git diff --check` 통과
+- [ ] `docker/crontab` 및 설치 스크립트에 US 분석 명령이 정확히 두 줄인지 확인
+
+## 2. db-server 사전점검 (읽기 전용)
+
+- [ ] SSH 후 `/root/prism-insight`에서 `git branch --show-current` = `main`
+- [ ] `git status --short`를 기록하고, 의도하지 않은 변경이 있으면 pull/cron 변경을 중단
+- [ ] 배포 대상 커밋과 `git log -1 --format=%H`를 기록
+- [ ] `crontab -l`을 백업하고 US 분석·hardstop·trend-exit·fill-chaser 행을 별도 보관
+- [ ] `.env`의 `MARKET_PULSE_MODE`와 고빈도 루프 enable/live 플래그를 읽기 전용으로 확인
+
+## 3. 배포 및 cron 변경
+
+- [ ] 병합된 `main`에서만 `git pull --ff-only origin main`
+- [ ] US 장중 분석 cron 한 줄과 해당 로그 경로만 제거
+- [ ] US morning/afternoon 분석 cron 두 줄은 유지
+- [ ] hardstop, trend-exit, fill-chaser cron 행은 byte-for-byte 변경하지 않음
+- [ ] 변경 후 `crontab -l`에서 `--mode morning` 1줄, `--mode afternoon` 1줄,
+  제거된 모드 0줄인지 확인
+- [ ] `git branch --show-current`, `git rev-parse HEAD`, `git status --short`를 다시 확인
+
+## 4. 첫 실행 관찰
+
+- [ ] 다음 US 오전 실행 로그에 `[MARKET_PULSE]`와 `batch=morning`이 기록되는지 확인
+- [ ] 다음 US 오후 실행 로그에 `[MARKET_PULSE]`와 `batch=afternoon`이 기록되는지 확인
+- [ ] UNDER_PRESSURE일 때 두 분석이 실행되고, CORRECTION일 때 오전만 LIVE 휴식하는지 확인
+- [ ] 같은 거래일에 hardstop/trend-exit/fill-chaser 로그가 계속 생성되는지 확인
+- [ ] argparse 오류, 신규 Telegram 휴식 공지 오류, 누락된 결과 파일이 없는지 확인
+
+## 5. 롤백 조건과 절차
+
+즉시 롤백: cron에 제거된 모드가 남아 CLI 오류가 반복되거나, morning/afternoon 중 하나가
+누락되거나, 매도 루프 행이 변경된 경우.
+
+1. 코드와 cron을 같은 직전 `main` 상태로 되돌린다.
+2. 이전 장중 cron을 복원해야 하는 구 코드라면 해당 cron도 함께 복원한다.
+3. `crontab -l`, `git branch --show-current`, `git rev-parse HEAD` 및 다음 실행 로그로
+   복구를 확인한다.

--- a/telegram_config.py
+++ b/telegram_config.py
@@ -221,11 +221,11 @@ async def send_openai_quota_alert(telegram_config: "TelegramConfig", market: str
 # per-batch variable. dedup: cron runs each (mode, day) exactly once, so a
 # resting batch fires this at most once per language channel — no dedup needed.
 _MP_REST_BATCH_LABELS = {
-    "ko": {"morning": "오전", "midday": "오후(장중)", "afternoon": "오후", "both": "오늘"},
-    "en": {"morning": "morning", "midday": "midday", "afternoon": "afternoon", "both": "today's"},
-    "ja": {"morning": "午前", "midday": "日中", "afternoon": "午後", "both": "本日"},
-    "zh": {"morning": "上午", "midday": "盘中", "afternoon": "下午", "both": "今日"},
-    "es": {"morning": "de la mañana", "midday": "de mediodía", "afternoon": "de la tarde", "both": "de hoy"},
+    "ko": {"morning": "오전", "afternoon": "오후", "both": "오늘"},
+    "en": {"morning": "morning", "afternoon": "afternoon", "both": "today's"},
+    "ja": {"morning": "午前", "afternoon": "午後", "both": "本日"},
+    "zh": {"morning": "上午", "afternoon": "下午", "both": "今日"},
+    "es": {"morning": "de la mañana", "afternoon": "de la tarde", "both": "de hoy"},
 }
 
 _MP_REST_MESSAGES = {

--- a/tests/test_regime_policy.py
+++ b/tests/test_regime_policy.py
@@ -22,13 +22,10 @@ from cores.regime_policy import (
 # --------------------------------------------------------------------------- #
 # decide_batch_policy — table-driven (market, mode, state) -> expected run_batch #
 # --------------------------------------------------------------------------- #
-# §7 Rev.3/Rev.4: CORRECTION reduces to one daily window.
-#   KR: morning rests, afternoon runs.
-#   US: midday runs, morning & afternoon rest.
-# §7 Rev.5: UNDER_PRESSURE partial brake — US morning rests (midday/afternoon run),
-#   KR unchanged (all run). UPTREND / None(unknown) run everything (fail-open).
+# CORRECTION reduces both markets to the afternoon close-confirmation window.
+# UNDER_PRESSURE, UPTREND, and None (unknown) run both scheduled batches.
 _CASES = [
-    # --- KR, CORRECTION (Rev.4: 종가확인 오후 유지, 아침 갭페이드 회피) ---
+    # --- KR, CORRECTION ---
     ("kr", "morning", CORRECTION, False),
     ("kr", "afternoon", CORRECTION, True),
     ("kr", "both", CORRECTION, True),         # unknown mode fails open -> run
@@ -39,22 +36,18 @@ _CASES = [
     ("kr", "afternoon", UNDER_PRESSURE, True),
     ("kr", "morning", None, True),
     ("kr", "afternoon", None, True),
-    # --- US, CORRECTION ---
+    # --- US, CORRECTION: same retained afternoon window as KR ---
     ("us", "morning", CORRECTION, False),
-    ("us", "midday", CORRECTION, True),
-    ("us", "afternoon", CORRECTION, False),
+    ("us", "afternoon", CORRECTION, True),
     ("us", "both", CORRECTION, True),         # unknown mode fails open -> run
     # --- US, non-CORRECTION ---
     ("us", "morning", UPTREND, True),
-    ("us", "midday", UPTREND, True),
     ("us", "afternoon", UPTREND, True),
-    # Rev.5: US morning rests under UNDER_PRESSURE; midday/afternoon run.
-    ("us", "morning", UNDER_PRESSURE, False),
-    ("us", "midday", UNDER_PRESSURE, True),
+    # UNDER_PRESSURE remains a quality-control state, not a batch-rest state.
+    ("us", "morning", UNDER_PRESSURE, True),
     ("us", "afternoon", UNDER_PRESSURE, True),
     ("us", "both", UNDER_PRESSURE, True),      # unknown mode fails open -> run
     ("us", "morning", None, True),
-    ("us", "midday", None, True),
     ("us", "afternoon", None, True),
 ]
 
@@ -71,35 +64,30 @@ def test_decide_batch_policy_table(market, mode, state, expected):
 def test_only_documented_batches_rest():
     """Only the documented (state, market, mode) combos rest; everything else runs.
 
-    Rev.5: rest set = {CORRECTION: kr-morning, us-morning, us-afternoon;
-                       UNDER_PRESSURE: us-morning}. All other combos run.
+    Rest set = {CORRECTION: kr-morning, us-morning}. All other combos run.
     """
     rest = {
         (CORRECTION, "kr", "morning"),
         (CORRECTION, "us", "morning"),
-        (CORRECTION, "us", "afternoon"),
-        (UNDER_PRESSURE, "us", "morning"),
     }
     for market in ("kr", "us"):
-        for mode in ("morning", "midday", "afternoon", "both"):
+        for mode in ("morning", "afternoon", "both", "legacy"):
             for state in (UPTREND, UNDER_PRESSURE, CORRECTION, None):
                 pol = decide_batch_policy(market, mode, state)
                 expected_run = (state, market, mode) not in rest
                 assert pol.run_batch is expected_run, (market, mode, state)
 
 
-def test_under_pressure_rev5_partial_brake():
-    """Rev.5: US morning rests under UNDER_PRESSURE; US midday/afternoon and all KR run."""
-    # US: only morning rests.
-    assert decide_batch_policy("us", "morning", UNDER_PRESSURE).run_batch is False
-    assert decide_batch_policy("us", "midday", UNDER_PRESSURE).run_batch is True
+def test_under_pressure_keeps_both_us_batches():
+    """UNDER_PRESSURE keeps both scheduled US batches distinct from CORRECTION."""
+    assert decide_batch_policy("us", "morning", UNDER_PRESSURE).run_batch is True
     assert decide_batch_policy("us", "afternoon", UNDER_PRESSURE).run_batch is True
     # KR: unchanged — everything runs under UNDER_PRESSURE.
     assert decide_batch_policy("kr", "morning", UNDER_PRESSURE).run_batch is True
     assert decide_batch_policy("kr", "afternoon", UNDER_PRESSURE).run_batch is True
     # None (fail-open) runs everything on both markets.
     for market in ("kr", "us"):
-        for mode in ("morning", "midday", "afternoon"):
+        for mode in ("morning", "afternoon", "legacy"):
             assert decide_batch_policy(market, mode, None).run_batch is True
 
 
@@ -108,19 +96,18 @@ def test_correction_rest_sets():
     assert decide_batch_policy("kr", "morning", CORRECTION).run_batch is False
     assert decide_batch_policy("kr", "afternoon", CORRECTION).run_batch is True
     assert decide_batch_policy("us", "morning", CORRECTION).run_batch is False
-    assert decide_batch_policy("us", "afternoon", CORRECTION).run_batch is False
-    assert decide_batch_policy("us", "midday", CORRECTION).run_batch is True
+    assert decide_batch_policy("us", "afternoon", CORRECTION).run_batch is True
 
 
 def test_decide_is_case_insensitive():
     assert decide_batch_policy("KR", "MORNING", CORRECTION).run_batch is False
-    assert decide_batch_policy("US", "Midday", CORRECTION).run_batch is True
+    assert decide_batch_policy("US", "Afternoon", CORRECTION).run_batch is True
 
 
 def test_decide_fail_open_on_none_state():
     """None (unknown / fail-open) state runs every batch on both markets."""
     for market in ("kr", "us"):
-        for mode in ("morning", "midday", "afternoon"):
+        for mode in ("morning", "afternoon", "legacy"):
             assert decide_batch_policy(market, mode, None).run_batch is True
 
 

--- a/utils/setup_us_crontab.sh
+++ b/utils/setup_us_crontab.sh
@@ -56,13 +56,11 @@ USER_HOME="${HOME:-/home/$(whoami)}"
 # =============================================================================
 # Adjust these if your server is in a different timezone
 # Yahoo Finance has 15-20 min data delay - schedules adjusted accordingly
-# US market has no price limits - 3 runs per day for better coverage
+# US analysis runs twice per day; high-frequency sell loops handle intraday risk.
 
 # === EST (Standard Time: November - March) ===
 # Morning batch: 10:15 EST = 00:15 KST (45 min after open for data delay)
 US_MORNING_BATCH_TIME_EST="15 0"
-# Midday batch: 12:30 EST = 02:30 KST (lunch time monitoring)
-US_MIDDAY_BATCH_TIME_EST="30 2"
 # Afternoon batch: 16:30 EST = 06:30 KST (30 min after close)
 US_AFTERNOON_BATCH_TIME_EST="30 6"
 # Performance tracker: 17:30 EST = 07:30 KST
@@ -73,8 +71,6 @@ US_DASHBOARD_TIME_EST="0 8"
 # === EDT (Daylight Time: March - November) ===
 # Morning batch: 10:15 EDT = 23:15 KST (previous day)
 US_MORNING_BATCH_TIME_EDT="15 23"
-# Midday batch: 12:30 EDT = 01:30 KST
-US_MIDDAY_BATCH_TIME_EDT="30 1"
 # Afternoon batch: 16:30 EDT = 05:30 KST
 US_AFTERNOON_BATCH_TIME_EDT="30 5"
 # Performance tracker: 17:30 EDT = 06:30 KST
@@ -88,13 +84,11 @@ TIMEZONE_MODE="${TIMEZONE_MODE:-EST}"
 
 if [ "$TIMEZONE_MODE" = "EDT" ]; then
     US_MORNING_BATCH_TIME="$US_MORNING_BATCH_TIME_EDT"
-    US_MIDDAY_BATCH_TIME="$US_MIDDAY_BATCH_TIME_EDT"
     US_AFTERNOON_BATCH_TIME="$US_AFTERNOON_BATCH_TIME_EDT"
     US_PERFORMANCE_TRACKER_TIME="$US_PERFORMANCE_TRACKER_TIME_EDT"
     US_DASHBOARD_TIME="$US_DASHBOARD_TIME_EDT"
 else
     US_MORNING_BATCH_TIME="$US_MORNING_BATCH_TIME_EST"
-    US_MIDDAY_BATCH_TIME="$US_MIDDAY_BATCH_TIME_EST"
     US_AFTERNOON_BATCH_TIME="$US_AFTERNOON_BATCH_TIME_EST"
     US_PERFORMANCE_TRACKER_TIME="$US_PERFORMANCE_TRACKER_TIME_EST"
     US_DASHBOARD_TIME="$US_DASHBOARD_TIME_EST"
@@ -214,7 +208,7 @@ PATH=$(generate_path)
 PYTHONPATH=$PROJECT_DIR
 
 # -----------------------------------------------------------------------------
-# US Stock Analysis Batch Jobs (3 runs per day)
+# US Stock Analysis Batch Jobs (2 runs per day)
 # -----------------------------------------------------------------------------
 
 # US Morning batch: 45 min after market open (for Yahoo Finance data delay)
@@ -222,11 +216,6 @@ PYTHONPATH=$PROJECT_DIR
 # EST: 10:15 EST = 00:15 KST | EDT: 10:15 EDT = 23:15 KST
 # Runs Tuesday-Saturday (Mon-Fri US time crosses midnight in KST)
 $US_MORNING_BATCH_TIME * * 2-6 cd $PROJECT_DIR && $PYTHON_PATH prism-us/us_stock_analysis_orchestrator.py --mode morning >> $LOG_DIR/us_morning_\$(date +\%Y\%m\%d).log 2>&1
-
-# US Midday batch: Lunch time monitoring for intraday movements
-# Current mode: $TIMEZONE_MODE
-# EST: 12:30 EST = 02:30 KST | EDT: 12:30 EDT = 01:30 KST
-$US_MIDDAY_BATCH_TIME * * 2-6 cd $PROJECT_DIR && $PYTHON_PATH prism-us/us_stock_analysis_orchestrator.py --mode midday >> $LOG_DIR/us_midday_\$(date +\%Y\%m\%d).log 2>&1
 
 # US Afternoon batch: 30 min after market close
 # Current mode: $TIMEZONE_MODE
@@ -366,10 +355,6 @@ US Market Schedule (in KST):
     - EST: 00:15 KST (10:15 EST)
     - EDT: 23:15 KST (10:15 EDT)
 
-  Midday batch (lunch time):
-    - EST: 02:30 KST (12:30 EST)
-    - EDT: 01:30 KST (12:30 EDT)
-
   Afternoon batch (30 min after close):
     - EST: 06:30 KST (16:30 EST)
     - EDT: 05:30 KST (16:30 EDT)
@@ -424,7 +409,6 @@ interactive_setup() {
     echo "  Python path: $PYTHON_PATH"
     echo "  Timezone: $TIMEZONE_MODE"
     echo "  Morning batch: $US_MORNING_BATCH_TIME (KST)"
-    echo "  Midday batch: $US_MIDDAY_BATCH_TIME (KST)"
     echo "  Afternoon batch: $US_AFTERNOON_BATCH_TIME (KST)"
     echo "  Performance tracker: $US_PERFORMANCE_TRACKER_TIME (KST)"
     echo "  Dashboard refresh: $US_DASHBOARD_TIME (KST)"


### PR DESCRIPTION
## Summary
- remove the US midday analysis batch
- keep both US windows in UNDER_PRESSURE and only afternoon in CORRECTION
- update cron templates, docs, tests, and deployment checklist

## Verification
- .venv/bin/python -m pytest tests/test_regime_policy.py -q
- .venv/bin/python -m pytest prism-us/tests/test_phase7_orchestrator.py -q
- CLI mode contract, compileall, bash -n, git diff --check

## Notes
- Full Ruff retains pre-existing legacy violations in US orchestrator/trigger files.