### PR TITLE
fix(oauth): derive quota windows from backend telemetry

### DIFF
--- a/docs/OAUTH_HEALTHCHECK.md
+++ b/docs/OAUTH_HEALTHCHECK.md
@@ -1,0 +1,23 @@
+# OAuth 헬스·쿼터 모니터 운영
+
+`tools/oauth_healthcheck.py`는 OAuth 토큰 상태와 최근 인증·쿼터 오류를 읽기 전용으로 점검하고, 필요할 때 지정한 Telegram 운영 채팅으로 알립니다. 매매·DB 데이터는 변경하지 않습니다.
+
+## db-server cron
+
+운영 반영 시 기존 항목을 다음처럼 유지합니다. `--quota`는 상태 메시지를 보내므로 3시간마다만 실행합니다.
+
+```cron
+# OAuth 토큰·로그 오류 감시: 30분마다
+*/30 * * * * cd /root/prism-insight && /root/.pyenv/shims/python tools/oauth_healthcheck.py >> logs/oauth_health.log 2>&1
+
+# 쿼터 현황: 3시간마다 정각
+0 */3 * * * cd /root/prism-insight && /root/.pyenv/shims/python tools/oauth_healthcheck.py --quota >> logs/oauth_health.log 2>&1
+```
+
+`--quota-dry-run`은 Telegram을 전송하지 않고 현재 보고 본문만 표준 출력에 표시합니다.
+
+## 쿼터 창 해석
+
+`x-codex-primary-*`와 `x-codex-secondary-*`는 고정된 “5시간”·“주간” 한도가 아닙니다. 보고서는 각 슬롯의 `x-codex-*-window-minutes`가 양수일 때만 해당 창을 표시하고, 그 길이로 라벨을 만듭니다. 따라서 백엔드가 7일 창을 `primary`에만 제공하고 `secondary`를 `0`으로 제공하면, 보고서는 단일 `주간(7일)` 창만 표시합니다.
+
+제공된 창 중 하나라도 잔량이 `OAUTH_QUOTA_WARN_REMAINING_PCT`(기본 20%) 미만이거나 HTTP 429가 발생하면 경보 상태가 유지됩니다. 제공되지 않은 창은 경보 판단에 포함하지 않습니다.

--- a/docs/RELEASE_NOTES_v2.15.0.md
+++ b/docs/RELEASE_NOTES_v2.15.0.md
@@ -60,7 +60,7 @@ ChatGPT 계정(Codex) 엔드포인트는 일부 모델/파라미터를 거부합
 
 ### 2-3. OAuth 워치독 · 주간 쿼터 모니터 (#348·#355)
 - **OAuth 헬스/사용량 워치독**(`tools/oauth_healthcheck.py`, #348 + 기반 #347): 토큰 건강·로그 에러 버스트 감시, **별도 알림 봇 토큰** 지원(`OAUTH_ALERT_BOT_TOKEN`) + `--test-alert`.
-- **주간 쿼터 모니터(#355)**: Codex 200 응답 헤더(`x-codex-secondary-*`=주간 7일, `x-codex-primary-*`=5시간, `x-codex-plan-type`)를 파싱해 **사용량/잔량/리셋시각**을 테스트 채널로 보고(`--quota`). 잔량 부족·429 시 경보 → 구독 한도 소진을 사전 감지.
+- **주간 쿼터 모니터(#355)**: Codex 200 응답 헤더의 `x-codex-*-window-minutes`를 기준으로 제공되는 쿼터 창만 동적으로 라벨링하여 **사용량/잔량/리셋시각**을 테스트 채널로 보고(`--quota`). `primary`/`secondary`는 고정된 5시간·주간 의미가 아니며, 잔량 부족·429 시 경보로 구독 한도 소진을 사전 감지.
 
 ---
 
@@ -122,7 +122,7 @@ git pull --ff-only origin main
 > **ChatGPT 구독(OAuth) 운용 시(선택)**:
 > - `PRISM_OPENAI_AUTH_MODE=chatgpt_oauth`를 해당 배치 cron에 적용하면 그 프로세스의 LLM 호출이 로컬 OAuth 프록시 경유.
 > - 토큰: `python -m cores.chatgpt_proxy.oauth_login`(브라우저 로그인) → `~/.config/prism-insight/chatgpt_auth.json`. **ChatGPT Plus 이상 계정 필요**(무료 플랜은 쿼터 부족).
-> - 워치독/쿼터: `tools/oauth_healthcheck.py`(헬스 `*/30`), `--quota`(주간/5시간 한도 보고). 알림봇 `OAUTH_ALERT_BOT_TOKEN`/`OAUTH_ALERT_CHAT_ID`.
+> - 워치독/쿼터: `tools/oauth_healthcheck.py`(헬스 `*/30`), `--quota`(헤더가 제공한 쿼터 창만 동적 보고, 권장 cron `0 */3 * * *`). 알림봇 `OAUTH_ALERT_BOT_TOKEN`/`OAUTH_ALERT_CHAT_ID`.
 >
 > **Loop A/B/C(선택)**: 기본 SHADOW(관측 전용, 주문 없음). 실거래 전환은 env 게이트(`LOOP_A_LIVE` 등) + 단계 검증. cron 10분 주기(장중) 권장.
 
@@ -132,7 +132,7 @@ git pull --ff-only origin main
 
 1. **Loop A/B/C는 SHADOW 기본**: Loop A는 env 게이트로 LIVE 전환 가능하나 단계적 모니터링 필요. Loop B(50MA)는 cadence-aware 백테스트 순효과 검증 후, Loop C는 신규 KIS TR **소액 왕복 실주문 검증** 후 LIVE 권장.
 2. **OAuth/Codex 호환은 비공식 표면 의존**: `x-codex-*` 쿼터 헤더·Codex 모델/파라미터 정책은 비공식이라 변경 시 영향 가능. 워치독/쿼터 모니터로 사전 감지하나, 멀티턴 stateless 전환은 매 턴 전체 input 재전송이라 토큰 비용이 소폭 증가합니다(저빈도 결정 경로라 영향 제한적).
-3. **OAuth는 구독 한도 내**: ChatGPT Plus 주간/5시간 한도를 초과하면 429. 전 배치 OAuth 운용 시 쿼터 모니터로 관측 필수.
+3. **OAuth는 구독 한도 내**: ChatGPT 구독 한도는 백엔드가 제공하는 창별로 429를 낼 수 있다. 전 배치 OAuth 운용 시 쿼터 모니터로 관측이 필수이며, 창 길이는 응답 헤더를 기준으로 해석한다.
 4. **#338·#339 US 시즌수익**: KIS 결제 타이밍·환율 반영 기준 변경으로, 과거 표기와 수치가 달라질 수 있습니다.
 
 ---

--- a/tests/test_oauth_healthcheck.py
+++ b/tests/test_oauth_healthcheck.py
@@ -1,0 +1,86 @@
+"""Regression tests for dynamic ChatGPT OAuth quota telemetry.
+
+Run: .venv/bin/python -m pytest tests/test_oauth_healthcheck.py -q
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+_SOURCE = Path(__file__).resolve().parents[1] / "tools" / "oauth_healthcheck.py"
+_SPEC = importlib.util.spec_from_file_location("oauth_healthcheck", _SOURCE)
+assert _SPEC and _SPEC.loader
+oauth_healthcheck = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(oauth_healthcheck)
+
+
+def _quota(**overrides: int | str) -> dict:
+    quota = {
+        "status": 200,
+        "plan_type": "prolite",
+        "active_limit": "premium",
+        "primary_used_pct": 10,
+        "primary_window_min": 300,
+        "primary_reset_at": 0,
+        "primary_reset_after_s": 10_800,
+        "secondary_used_pct": 10,
+        "secondary_window_min": 10_080,
+        "secondary_reset_at": 0,
+        "secondary_reset_after_s": 604_800,
+        "credits_has": "false",
+        "credits_balance": "-",
+        "credits_unlimited": "false",
+    }
+    quota.update(overrides)
+    return quota
+
+
+def test_legacy_five_hour_and_weekly_telemetry_keeps_both_windows():
+    text, danger = oauth_healthcheck._format_quota_report(_quota())
+
+    assert danger is False
+    assert "🗓 주간(7일): 사용 10% · 잔량 90%" in text
+    assert "⏱ 5시간: 사용 10% · 잔량 90%" in text
+
+
+def test_current_single_week_telemetry_uses_primary_window_and_omits_secondary():
+    text, danger = oauth_healthcheck._format_quota_report(_quota(
+        primary_window_min=10_080,
+        primary_reset_after_s=588_000,
+        secondary_window_min=0,
+        secondary_used_pct=0,
+        secondary_reset_after_s=0,
+    ))
+
+    assert danger is False
+    assert "🗓 주간(7일): 사용 10% · 잔량 90%" in text
+    assert "5시간" not in text
+    assert text.count("리셋:") == 1
+
+
+def test_unavailable_window_does_not_trigger_low_quota_warning():
+    text, danger = oauth_healthcheck._format_quota_report(_quota(
+        primary_window_min=10_080,
+        primary_used_pct=10,
+        secondary_window_min=0,
+        secondary_used_pct=100,
+    ))
+
+    assert danger is False
+    assert "⚠️" not in text
+
+
+def test_available_low_quota_and_429_remain_dangerous():
+    low_text, low_danger = oauth_healthcheck._format_quota_report(_quota(
+        primary_used_pct=81,
+    ))
+    exhausted_text, exhausted_danger = oauth_healthcheck._format_quota_report(_quota(
+        status=429,
+        secondary_window_min=0,
+    ))
+
+    assert low_danger is True
+    assert "⏱ 5시간: 사용 81% · 잔량 19% ⚠️" in low_text
+    assert exhausted_danger is True
+    assert "🚨 429 — 쿼터 소진됨" in exhausted_text

--- a/tools/oauth_healthcheck.py
+++ b/tools/oauth_healthcheck.py
@@ -15,11 +15,13 @@ It can ALSO report proactive subscription quota usage (--quota mode):
 
   3. QUOTA  — the ChatGPT/Codex backend returns the same rate-limit telemetry
      Codex CLI displays ("주간 한도 X% 사용") as `x-codex-*` response headers on
-     every successful call. We fire ONE cheap probe and read:
-       primary   window = ~300 min  (the "5h" limit)  -> x-codex-primary-*
-       secondary window = ~10080 min (the WEEKLY limit) -> x-codex-secondary-*
-     plus x-codex-plan-type / x-codex-active-limit. This lets us detect quota
-     exhaustion (429) BEFORE the batch hits it. See tasks/oauth_quota_monitor.md.
+     every successful call. We fire ONE cheap probe and read every *available*
+     primary/secondary window. The backend may change which slot carries a
+     window (for example, current telemetry exposes a 7-day primary window and
+     no secondary window), so labels are derived from `*-window-minutes`, never
+     from the primary/secondary slot name. We also read x-codex-plan-type /
+     x-codex-active-limit. This lets us detect quota exhaustion (429) BEFORE
+     the batch hits it.
 
 On a problem it sends a Telegram alert (to OAUTH_ALERT_CHAT_ID, falling back to
 TELEGRAM_CHANNEL_ID) using TELEGRAM_BOT_TOKEN. A small state file suppresses
@@ -30,8 +32,8 @@ sends a Telegram message. Intended cron lines (db-server):
 
     # health (every 30 min)
     */30 * * * * cd /root/prism-insight && /root/.pyenv/shims/python tools/oauth_healthcheck.py >> logs/oauth_health.log 2>&1
-    # quota status report (hourly; --quota always posts a status line)
-    0 * * * * cd /root/prism-insight && /root/.pyenv/shims/python tools/oauth_healthcheck.py --quota >> logs/oauth_health.log 2>&1
+    # quota status report (every 3 hours; --quota always posts a status line)
+    0 */3 * * * cd /root/prism-insight && /root/.pyenv/shims/python tools/oauth_healthcheck.py --quota >> logs/oauth_health.log 2>&1
 
 Exit code: 0 = healthy, 1 = problem detected (alert attempted).
 """
@@ -210,6 +212,41 @@ def _fmt_reset(reset_at: int, reset_after_s: int) -> str:
     return f"{local} ({rel})"
 
 
+def _quota_window_label(window_min: int) -> tuple[str, str]:
+    """Return a display icon and label derived from a backend window length."""
+    if window_min % (24 * 60) == 0:
+        days = window_min // (24 * 60)
+        return "🗓", f"주간({days}일)" if days == 7 else f"{days}일"
+    if window_min % 60 == 0:
+        return "⏱", f"{window_min // 60}시간"
+    return "⏱", f"{window_min}분"
+
+
+def _available_quota_windows(q: dict) -> list[dict]:
+    """Normalize only quota windows the backend explicitly made available.
+
+    `primary` and `secondary` are transport slot names, not stable 5-hour or
+    weekly semantics. A zero/missing `*-window-minutes` means that slot must
+    not appear in reports or influence low-quota warnings.
+    """
+    windows: list[dict] = []
+    for slot in ("secondary", "primary"):
+        window_min = int(q.get(f"{slot}_window_min", 0) or 0)
+        if window_min <= 0:
+            continue
+        icon, label = _quota_window_label(window_min)
+        used_pct = int(q.get(f"{slot}_used_pct", 0) or 0)
+        windows.append({
+            "icon": icon,
+            "label": label,
+            "used_pct": used_pct,
+            "remaining_pct": max(0, 100 - used_pct),
+            "reset_at": int(q.get(f"{slot}_reset_at", 0) or 0),
+            "reset_after_s": int(q.get(f"{slot}_reset_after_s", 0) or 0),
+        })
+    return windows
+
+
 async def _probe_quota() -> tuple[dict | None, str]:
     """Fire ONE cheap Codex call and read x-codex-* rate-limit headers.
 
@@ -295,31 +332,30 @@ async def _probe_quota() -> tuple[dict | None, str]:
 
 def _format_quota_report(q: dict) -> tuple[str, bool]:
     """Build the Korean Telegram body. Returns (text, danger)."""
-    wk_used = q["secondary_used_pct"]
-    wk_left = max(0, 100 - wk_used)
-    pr_used = q["primary_used_pct"]
-    pr_left = max(0, 100 - pr_used)
-
+    windows = _available_quota_windows(q)
     is_429 = q["status"] == 429
-    low_week = wk_left < QUOTA_WARN_REMAINING_PCT
-    low_5h = pr_left < QUOTA_WARN_REMAINING_PCT
-    danger = is_429 or low_week or low_5h
+    danger = is_429 or any(
+        window["remaining_pct"] < QUOTA_WARN_REMAINING_PCT
+        for window in windows
+    )
 
     head = "⚠️ ChatGPT 쿼터 경고" if danger else "📊 ChatGPT 쿼터 현황"
-    wk_mark = " ⚠️" if (is_429 or low_week) else ""
-    pr_mark = " ⚠️" if (is_429 or low_5h) else ""
 
     lines = [
         head,
         f"플랜: {q['plan_type']} (active={q['active_limit']})",
         "",
-        f"🗓 주간(7일): 사용 {wk_used}% · 잔량 {wk_left}%{wk_mark}",
-        f"   리셋: {_fmt_reset(q['secondary_reset_at'], q['secondary_reset_after_s'])}",
-        f"⏱ 5시간: 사용 {pr_used}% · 잔량 {pr_left}%{pr_mark}",
-        f"   리셋: {_fmt_reset(q['primary_reset_at'], q['primary_reset_after_s'])}",
     ]
+    for window in windows:
+        low_window = window["remaining_pct"] < QUOTA_WARN_REMAINING_PCT
+        mark = " ⚠️" if (is_429 or low_window) else ""
+        lines.extend([
+            f"{window['icon']} {window['label']}: 사용 {window['used_pct']}% · "
+            f"잔량 {window['remaining_pct']}%{mark}",
+            f"   리셋: {_fmt_reset(window['reset_at'], window['reset_after_s'])}",
+        ])
     if is_429:
-        lines.insert(1, "🚨 429 — 쿼터 소진됨. 위 리셋시각까지 대기 필요.")
+        lines.insert(1, "🚨 429 — 쿼터 소진됨. 표시된 리셋시각까지 대기 필요.")
     if str(q.get("credits_unlimited")).lower() == "true":
         lines.append("크레딧: 무제한")
     elif str(q.get("credits_has")).lower() == "true":
@@ -341,8 +377,11 @@ async def _run_quota(force_send: bool) -> int:
         return 0
 
     text, danger = _format_quota_report(quota)
-    print(f"[oauth-health] quota: {detail} "
-          f"week_used={quota['secondary_used_pct']}% 5h_used={quota['primary_used_pct']}% danger={danger}")
+    window_summary = " ".join(
+        f"{window['label']}_used={window['used_pct']}%"
+        for window in _available_quota_windows(quota)
+    ) or "no_quota_windows"
+    print(f"[oauth-health] quota: {detail} {window_summary} danger={danger}")
 
     if danger:
         # Cooldown-suppressed critical alert (so cron does not spam on sustained low).


### PR DESCRIPTION
## Summary
- derive quota labels and warnings from header window lengths
- handle current single 7-day primary window correctly
- document and schedule quota reports every three hours

## Live evidence
- db-server dry-run: primary_window_min=10080, secondary_window_min=0

## Verification
- .venv/bin/python -m pytest tests/test_oauth_healthcheck.py -q
- py_compile, Ruff, diff-check
- current-header-shaped output: one weekly window, no 5-hour label