### PR TITLE
fix(tracking): KRX 순단 시 KIS 시세 fallback + 매수 후보 분석 실패 알림

### DIFF
--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 from stock_tracking_agent import StockTrackingAgent
 import logging
 import json
+import os
 import traceback
 
 from mcp_agent.workflows.llm.augmented_llm import RequestParams
@@ -384,12 +385,16 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                 logger.info("No stocks sold")
 
             # 2. Analyze new reports and make buy decisions
+            analysis_failures = []
             for pdf_report_path in pdf_report_paths:
                 # Analyze report
                 analysis_result = await self.analyze_report(pdf_report_path)
 
                 if not analysis_result.get("success", False):
                     logger.error(f"Report analysis failed: {pdf_report_path} - {analysis_result.get('error', 'Unknown error')}")
+                    analysis_failures.append(
+                        f"{os.path.basename(pdf_report_path)}: {analysis_result.get('error', 'Unknown error')}"
+                    )
                     continue
 
                 # Skip if already holding this stock (no telegram message for already held stocks)
@@ -620,6 +625,20 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                         logger.info(f"Purchase complete: {company_name}({ticker}) @ {current_price:,.0f} KRW")
                     else:
                         logger.warning(f"Purchase failed: {company_name}({ticker})")
+
+            # A silently skipped candidate is a buy decision that never ran —
+            # surface it to the channel (2026-07-13: KRX outage skipped all 3
+            # candidates and nobody was notified).
+            if analysis_failures:
+                try:
+                    if getattr(self, "telegram_config", None):
+                        from telegram_config import send_buy_analysis_failure_alert
+                        await send_buy_analysis_failure_alert(
+                            self.telegram_config, len(analysis_failures), len(pdf_report_paths),
+                            market="KR", detail="; ".join(analysis_failures[:3])
+                        )
+                except Exception as alert_err:
+                    logger.error(f"Buy-analysis failure alert send failed: {alert_err}")
 
             logger.info(f"Report processing complete - Purchased: {buy_count} items, Sold: {sell_count} items")
             return buy_count, sell_count

--- a/telegram_config.py
+++ b/telegram_config.py
@@ -214,6 +214,41 @@ async def send_openai_quota_alert(telegram_config: "TelegramConfig", market: str
         logger.error(f"[{market}] Failed to send OpenAI quota alert: {e}")
 
 
+async def send_buy_analysis_failure_alert(telegram_config: "TelegramConfig", failed: int, total: int,
+                                          market: str = "KR", detail: str = ""):
+    """Alert the main channel when buy-candidate report analyses failed.
+
+    Without this the batch stays silent when e.g. a KRX outage kills the price
+    query for every candidate (2026-07-13): subscribers see no buy messages and
+    the operator only notices by absence.
+    """
+    if not telegram_config or not telegram_config.use_telegram:
+        return
+
+    try:
+        from telegram import Bot
+        from telegram.request import HTTPXRequest
+
+        request = HTTPXRequest(connect_timeout=10.0, read_timeout=10.0)
+        bot = Bot(token=telegram_config.bot_token, request=request)
+
+        alert_message = (
+            f"⚠️ [{market}] 매수 후보 분석 실패\n\n"
+            f"이번 배치의 매수 후보 {total}종목 중 {failed}종목의 분석이 실패해 "
+            f"해당 종목의 매수 판단이 이루어지지 않았습니다.\n"
+            + (f"\n• 사유: {detail}\n" if detail else "")
+            + "• 조치: 서버 로그(stock_analysis_*.log)에서 원인 확인"
+        )
+
+        await bot.send_message(
+            chat_id=telegram_config.channel_id,
+            text=alert_message
+        )
+        logger.info(f"[{market}] Buy-analysis failure alert sent ({failed}/{total})")
+    except Exception as e:
+        logger.error(f"[{market}] Failed to send buy-analysis failure alert: {e}")
+
+
 # --- Market Pulse "batch resting" subscriber notice (static, no LLM) -----------
 # When the Market Pulse hook rests a LIVE batch, subscribers would otherwise see
 # silence. These pre-translated notices explain the pause. Deterministic /

--- a/tracking/helpers.py
+++ b/tracking/helpers.py
@@ -94,7 +94,35 @@ async def get_current_stock_price(cursor, ticker: str, account_key: str | None =
                 await asyncio.sleep(wait)
             else:
                 logger.error(traceback.format_exc())
+                # KRX exhausted — try KIS before the DB fallback. A new buy
+                # candidate has no stock_holdings row, so the DB fallback
+                # returns 0 and the whole report analysis is silently skipped
+                # (2026-07-13 KRX outage dropped all 3 afternoon candidates).
+                kis_price = await _get_price_from_kis(ticker)
+                if kis_price > 0:
+                    return kis_price
                 return _get_last_price_from_db(cursor, ticker, account_key=account_key)
+
+
+async def _get_price_from_kis(ticker: str) -> float:
+    """KIS quote fallback for when KRX (data.krx.co.kr) is down.
+
+    KIS is an independent provider whose credentials are already configured
+    wherever the tracking agents run (same creds the order path uses).
+    Returns 0.0 on any failure — caller falls back to the last DB price.
+    """
+    import asyncio
+    try:
+        from trading.domestic_stock_trading import AsyncTradingContext
+        async with AsyncTradingContext() as trading:
+            info = await asyncio.to_thread(trading.get_current_price, ticker)
+        price = float((info or {}).get("current_price") or 0)
+        if price > 0:
+            logger.warning(f"{ticker} current price via KIS fallback: {price:,.0f} KRW (KRX unavailable)")
+        return price
+    except Exception as e:
+        logger.error(f"{ticker} KIS price fallback failed: {e}")
+        return 0.0
 
 
 def _get_last_price_from_db(cursor, ticker: str, account_key: str | None = None) -> float:


### PR DESCRIPTION
## 배경
2026-07-13 오후 배치에서 KRX(data.krx.co.kr) read timeout이 14:50~15:20 간헐 발생(30건). 매수 후보 3종목(SK이터닉스·한국콜마·한진칼) 전부 `Current price query failed`로 리포트 분석이 스킵되어 매수 판단이 이루어지지 않았고, 아무 알림도 없었음.

## 변경
1. **KIS 시세 fallback** (`tracking/helpers.py`): KRX 3회 재시도 소진 시 KIS `get_current_price`로 조회 (독립 프로바이더, 주문 경로와 동일 자격증명 — `cores/corporate_status.py`의 기존 ATC 시세 조회 패턴 재사용). KIS도 실패하면 기존 DB fallback 그대로.
2. **매수 후보 분석 실패 알림** (`telegram_config.py` + `stock_tracking_enhanced_agent.py`): 분석 실패 집계 후 1건 이상이면 메인 채널로 ⚠️ 알림 (기존 `send_openai_quota_alert` 패턴).

## 검증
- `py_compile` 3파일 통과
- stub 테스트: KRX 다운 → KIS fallback 12,345원 반환 확인 / KRX+KIS 동시 다운 → 기존 DB fallback(0.0) 동작 불변 확인
- 실주문/원장 로직 무변경 (시세 조회와 알림만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)