### PR TITLE
fix(us): 루프 매도 텔레그램 누락 — send_telegram_message await_broadcast 시그니처 정합

### DIFF
--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -3103,13 +3103,23 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
         """Schedule Firebase notification as non-blocking task. Returns the task."""
         return asyncio.create_task(self._notify_firebase(message, chat_id, message_id, msg_type=msg_type))
 
-    async def send_telegram_message(self, chat_id: str, language: str = "ko") -> bool:
+    async def send_telegram_message(self, chat_id: str, language: str = "ko",
+                                    portfolio_force: bool = False,
+                                    await_broadcast: bool = False) -> bool:
         """
         Send message via Telegram.
 
         Args:
             chat_id: Telegram channel ID (no sending if None)
             language: Message language ("ko" or "en")
+            portfolio_force: Bypass portfolio-summary debounce (batch run-end sends
+                the complete final summary; mirrors KR).
+            await_broadcast: Await the broadcast-translation task inline before
+                returning. Intraday loops (trend_exit/hardstop) don't call run(),
+                so without this the translation task is cancelled on process exit
+                and non-KR channels miss the sell notice. (Signature parity with KR —
+                the missing params raised TypeError, dropping ALL US loop-sell
+                Telegram notices, e.g. AVGO/NVDA 2026-07-14.)
 
         Returns:
             bool: Send success status
@@ -3146,7 +3156,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
             # summaries. Other queued messages (sell notices) are unaffected.
             try:
                 from portfolio_broadcast import should_send_portfolio
-                _emit_portfolio = should_send_portfolio("US")
+                _emit_portfolio = should_send_portfolio("US", force=portfolio_force)
             except Exception:
                 _emit_portfolio = True  # fail-open
             if _emit_portfolio:
@@ -3231,10 +3241,19 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
             if firebase_tasks:
                 await asyncio.gather(*firebase_tasks, return_exceptions=True)
 
-            # Send to broadcast channels if configured (awaited in run() finally block)
+            # Send to broadcast channels if configured (awaited in run() finally block,
+            # or inline here when await_broadcast=True — intraday loops don't call run()
+            # so the task would be cancelled on process exit unless awaited now).
             if hasattr(self, 'telegram_config') and self.telegram_config and self.telegram_config.broadcast_languages:
                 self._broadcast_task = asyncio.create_task(self._send_to_translation_channels(self.message_queue.copy(), self._msg_types.copy()))
                 logger.info("US broadcast channel translation dispatched")
+                if await_broadcast:
+                    try:
+                        await self._broadcast_task
+                    except Exception as e:
+                        logger.warning(f"US broadcast translation await failed (non-critical): {e}")
+                    finally:
+                        self._broadcast_task = None
 
             # Clear message queue
             self.message_queue = []


### PR DESCRIPTION
## 증상
2026-07-14 새벽 US 장에서 AVGO·NVDA가 trend_exit 루프로 실제 KIS 매도됐으나(주문번호까지 체결 확인), **텔레그램 채널에 매도 메시지가 안 나감**. Redis/GCP 시그널은 정상 발행.

## 로그 근거 (db-server us_afternoon.log)
```
04:51:00 [LIVE][US] NVDA KIS sell success=True order_no=0030314379 (P/L: -2.60%)
04:51:00 [US] NVDA telegram flush failed: USStockTrackingAgent.send_telegram_message()
         got an unexpected keyword argument 'await_broadcast'
```

## 원인 (KR/US 포크 드리프트)
- KR `stock_tracking_agent.send_telegram_message`: `portfolio_force`, `await_broadcast` 파라미터 있음
- US `us_stock_tracking_agent.send_telegram_message`: 둘 다 **없음**
- 두 루프(trend_exit/hardstop)는 KR/US 공통으로 `send_telegram_message(CHAT_ID, await_broadcast=True)` 호출 → US에서 TypeError → **모든 US 루프 매도의 텔레그램 채널 메시지 누락** (AVGO/NVDA는 가시화된 사례)

## 수정
US 메서드를 KR과 1:1 정합:
1. 시그니처에 `portfolio_force`, `await_broadcast` 추가
2. `should_send_portfolio("US", force=portfolio_force)`
3. `await_broadcast=True` 시 브로드캐스트 번역 태스크 인라인 await (루프는 run()을 안 거쳐 프로세스 종료 시 태스크 취소 방지)

## 검증
- py_compile OK
- AST 시그니처 바인딩: 루프 호출 `(CHAT_ID, await_broadcast=True)` 수용 확인
- `should_send_portfolio` force 인자 지원 확인 (KR도 동일 사용)

## 배포
US 영향 + 공통 루프 경로 → 오후 안전창(KR 15:30 마감 후 ~ US 22:00 개장 전) 배포 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)