### PR TITLE
feat(screening): KRX 요청 버스트 스로틀

### DIFF
--- a/trigger_batch.py
+++ b/trigger_batch.py
@@ -110,6 +110,33 @@ def get_previous_snapshot(trade_date: str) -> (pd.DataFrame, str):
 
     return df, prev_date
 
+import time as _time
+import random as _random
+import threading as _threading
+
+# --- KRX request throttle ---------------------------------------------------
+# data.krx.co.kr는 IP 차단(403/RST)이 아니라 버스트 요청·장마감 트래픽에 응답이
+# 느려져 Read timeout을 낸다. 요청 사이 최소 간격 + 지터로 연타를 눌러 timeout
+# 빈도를 낮춘다. env로 조절 — KRX_MIN_GAP_SEC=0 이면 스로틀 비활성(기본 0.4s).
+_KRX_THROTTLE_LOCK = _threading.Lock()
+_KRX_LAST_CALL = [0.0]
+
+
+def _krx_throttle() -> None:
+    """Enforce a minimum spacing (+jitter) between consecutive KRX requests."""
+    try:
+        min_gap = float(os.getenv("KRX_MIN_GAP_SEC", "0.4"))
+    except (TypeError, ValueError):
+        min_gap = 0.4
+    if min_gap <= 0:
+        return
+    with _KRX_THROTTLE_LOCK:
+        elapsed = _time.monotonic() - _KRX_LAST_CALL[0]
+        wait = min_gap - elapsed
+        if wait > 0:
+            _time.sleep(wait + _random.uniform(0.0, 0.2))
+        _KRX_LAST_CALL[0] = _time.monotonic()
+
 
 def get_multi_day_ohlcv(ticker: str, end_date: str, days: int = 10) -> pd.DataFrame:
     """
@@ -133,6 +160,7 @@ def get_multi_day_ohlcv(ticker: str, end_date: str, days: int = 10) -> pd.DataFr
 
     krx_failed = False
     try:
+        _krx_throttle()  # 버스트 스로틀: KRX 연타 방지로 read-timeout 빈도↓
         df = get_market_ohlcv_by_date(start_date, end_date, ticker)
         if df.empty:
             logger.warning(f"No {days}-day data for {ticker} from KRX; attempting FinanceDataReader fallback.")


### PR DESCRIPTION
## 배경 (진단)
`data.krx.co.kr` read-timeout이 잦음. 진단 결과 **IP 차단 아님**: 서버→KRX TCP 5/5 성공(3~4ms), 에러 100% 'Read timed out'(refused/403/429 0건), 타임아웃이 배치 시각(14:50~15:16)에만 클러스터. → 버스트 요청·장마감 트래픽에 KRX 포털 응답이 느려지는 스로틀.

## 변경
`get_multi_day_ohlcv`의 KRX 호출 앞에 요청 간 최소간격+지터 스로틀(`_krx_throttle`):
- `KRX_MIN_GAP_SEC` env로 조절 (기본 0.4s, 0이면 비활성)
- behavior-neutral: 데이터 무변경, 지연만 추가
- #440(FDR fallback)과 상호보완 — 스로틀로 빈도↓, 그래도 실패 시 네이버 fallback

## 검증
- py_compile OK
- 기능: 3연속 호출 1.31s 간격 강제 확인 / gap=0 시 즉시(비활성) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)