### PR TITLE
fix(auth): atomic, private OAuth token persistence

### DIFF
--- a/cores/chatgpt_proxy/oauth_login.py
+++ b/cores/chatgpt_proxy/oauth_login.py
@@ -9,7 +9,6 @@ import base64
 import hashlib
 import json
 import logging
-import os
 import secrets
 import time
 import webbrowser
@@ -25,9 +24,9 @@ from .constants import (
     OAUTH_SCOPE,
     OAUTH_CALLBACK_PORT,
     OAUTH_REDIRECT_URI,
-    AUTH_DIR,
     AUTH_FILE,
 )
+from .token_manager import save_auth_data
 
 logger = logging.getLogger(__name__)
 
@@ -226,12 +225,7 @@ async def login(force: bool = False) -> dict:
 
 def _save_auth(auth_data: dict) -> None:
     """Save auth data with restricted permissions (atomic write)."""
-    AUTH_DIR.mkdir(parents=True, exist_ok=True)
-    tmp_file = AUTH_FILE.with_suffix(".tmp")
-    with open(tmp_file, "w") as f:
-        json.dump(auth_data, f, indent=2)
-    os.chmod(tmp_file, 0o600)
-    os.rename(tmp_file, AUTH_FILE)
+    save_auth_data(auth_data)
     logger.debug("Auth data saved to %s", AUTH_FILE)
 
 

--- a/cores/chatgpt_proxy/token_manager.py
+++ b/cores/chatgpt_proxy/token_manager.py
@@ -8,6 +8,8 @@ import asyncio
 import json
 import logging
 import os
+import stat
+import tempfile
 import time
 
 import aiohttp
@@ -21,6 +23,48 @@ from .constants import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def save_auth_data(auth_data: dict) -> None:
+    """Atomically replace the OAuth token file with private permissions.
+
+    A unique temporary file avoids collisions between a login and a background
+    refresh in separate processes. ``os.replace`` also works when the target
+    already exists on Windows, unlike ``os.rename``.
+    """
+    AUTH_DIR.mkdir(mode=stat.S_IRWXU, parents=True, exist_ok=True)
+    try:
+        os.chmod(AUTH_DIR, stat.S_IRWXU)
+    except OSError:
+        # Some Windows filesystems do not implement POSIX permission bits.
+        pass
+
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=AUTH_DIR,
+            prefix=f".{AUTH_FILE.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            tmp_path = tmp.name
+            json.dump(auth_data, tmp, indent=2)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        try:
+            os.chmod(tmp_path, 0o600)
+        except OSError:
+            pass
+        os.replace(tmp_path, AUTH_FILE)
+    except Exception:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+        raise
 
 
 class ChatGPTAuthExpiredError(Exception):
@@ -47,12 +91,7 @@ class TokenManager:
 
     def _save_to_disk(self, auth_data: dict) -> None:
         """Save auth data atomically with restricted permissions."""
-        AUTH_DIR.mkdir(parents=True, exist_ok=True)
-        tmp_file = AUTH_FILE.with_suffix(".tmp")
-        with open(tmp_file, "w") as f:
-            json.dump(auth_data, f, indent=2)
-        os.chmod(tmp_file, 0o600)
-        os.rename(tmp_file, AUTH_FILE)
+        save_auth_data(auth_data)
 
     def validate_or_fail(self) -> None:
         """Check that auth file exists and has a refresh token. Call at startup."""

--- a/tests/test_chatgpt_oauth/test_token_manager_storage.py
+++ b/tests/test_chatgpt_oauth/test_token_manager_storage.py
@@ -1,0 +1,35 @@
+"""Cross-platform safety tests for OAuth credential persistence."""
+
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from cores.chatgpt_proxy import token_manager
+
+
+class TokenStorageTests(unittest.TestCase):
+    def test_save_replaces_existing_file_and_leaves_no_temp_credentials(self):
+        with tempfile.TemporaryDirectory() as directory:
+            auth_dir = Path(directory) / "auth"
+            auth_file = auth_dir / "chatgpt_auth.json"
+            with (
+                patch.object(token_manager, "AUTH_DIR", auth_dir),
+                patch.object(token_manager, "AUTH_FILE", auth_file),
+            ):
+                token_manager.save_auth_data({"access_token": "old"})
+                token_manager.save_auth_data({"access_token": "new"})
+
+            self.assertEqual(
+                json.loads(auth_file.read_text(encoding="utf-8")),
+                {"access_token": "new"},
+            )
+            self.assertEqual(list(auth_dir.glob("*.tmp")), [])
+            if os.name != "nt":
+                self.assertEqual(auth_file.stat().st_mode & 0o777, 0o600)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 개요
외부 PR #433(@tkgo11)에서 **격리된 안전 개선만** 체리픽한 첫 조각입니다.

## 변경
- `token_manager.save_auth_data()`: OAuth 토큰 파일을 `NamedTemporaryFile`(생성 시점부터 0600) + `fsync` + `os.replace`로 원자적 교체, 오류 시 임시파일 정리.
  - world-readable 노출 창 제거, login/refresh 동시 실행 충돌 방지, Windows `os.rename` 덮어쓰기 실패 회피.
- `oauth_login._save_auth`: 위 공용 함수로 위임(중복 제거). 검증 로직/인증 흐름 변경 없음.

## 검증
- 신규 `tests/test_chatgpt_oauth/test_token_manager_storage.py` 통과(재교체·잔여 tmp 없음·0600 확인).
- `tests/test_chatgpt_oauth/` 50 passed. 유일한 실패 `test_api_translator::test_basic_text_request`는 **main 선존 실패로 본 변경과 무관**.
- 실 브로커/시장/네트워크 live 동작은 미검증(파일 저장 로직만 변경).

## 관련
- 원본: #433 (직접 병합하지 않고 안전한 조각만 분리 반영)