### PR TITLE
fix(messaging): keep synchronous Redis/Pub-Sub I/O off the event loop

### DIFF
--- a/messaging/gcp_pubsub_signal_publisher.py
+++ b/messaging/gcp_pubsub_signal_publisher.py
@@ -15,6 +15,7 @@ Usage:
             scenario=scenario_dict
         )
 """
+import asyncio
 import os
 import json
 import logging
@@ -189,7 +190,9 @@ class SignalPublisher:
             message_bytes = message_json.encode("utf-8")
 
             future = self._publisher.publish(self._topic_path, message_bytes)
-            message_id = future.result()
+            # Pub/Sub's future is synchronous; wait in a worker thread so this async
+            # path does not block trading, Telegram, or other event-loop tasks.
+            message_id = await asyncio.to_thread(future.result)
 
             logger.info(
                 f"Signal published: {signal_type} {company_name}({ticker}) "
@@ -328,6 +331,7 @@ async def get_signal_publisher() -> SignalPublisher:
     global _global_publisher
     if _global_publisher is None:
         _global_publisher = SignalPublisher()
+    if _global_publisher._publisher is None:
         await _global_publisher.connect()
     return _global_publisher
 

--- a/messaging/redis_health_check.py
+++ b/messaging/redis_health_check.py
@@ -17,6 +17,7 @@ Usage:
     from messaging.redis_health_check import run_health_check
     asyncio.run(run_health_check())
 """
+import asyncio
 import os
 import logging
 from datetime import datetime
@@ -187,7 +188,9 @@ async def run_health_check_async() -> Dict[str, Any]:
     Returns:
         Dict containing health check results
     """
-    return run_health_check()
+    # The Upstash client is synchronous HTTP. Keep its network operations off
+    # callers' event loop while preserving the existing synchronous API.
+    return await asyncio.to_thread(run_health_check)
 
 
 if __name__ == "__main__":

--- a/messaging/redis_signal_publisher.py
+++ b/messaging/redis_signal_publisher.py
@@ -15,6 +15,7 @@ Usage:
             scenario=scenario_dict
         )
 """
+import asyncio
 import os
 import json
 import logging
@@ -58,6 +59,11 @@ class SignalPublisher:
         self.redis_url = redis_url or os.environ.get("UPSTASH_REDIS_REST_URL")
         self.redis_token = redis_token or os.environ.get("UPSTASH_REDIS_REST_TOKEN")
         self._redis = None
+        # Serializes worker-thread access to the shared synchronous client.
+        # Created lazily inside the running loop (see publish_signal) so it
+        # always binds to the loop that awaits it and construction never
+        # depends on a running event loop.
+        self._publish_lock = None
 
         if not self.redis_url or not self.redis_token:
             logger.warning(
@@ -164,11 +170,16 @@ class SignalPublisher:
             # Publish to Redis Streams (XADD)
             # upstash-redis 1.5.0+ signature: xadd(key, id, data)
             # Use id="*" for auto-generated ID
-            message_id = self._redis.xadd(
-                self.STREAM_NAME,
-                "*",  # auto-generate message ID
-                {"data": json.dumps(signal_data, ensure_ascii=False)}
-            )
+            lock = getattr(self, "_publish_lock", None)
+            if lock is None:
+                lock = self._publish_lock = asyncio.Lock()
+            async with lock:
+                message_id = await asyncio.to_thread(
+                    self._redis.xadd,
+                    self.STREAM_NAME,
+                    "*",  # auto-generate message ID
+                    {"data": json.dumps(signal_data, ensure_ascii=False)},
+                )
 
             market = signal_data.get("market", "KR")
             currency = "USD" if market == "US" else "KRW"
@@ -309,6 +320,7 @@ async def get_signal_publisher() -> SignalPublisher:
     global _global_publisher
     if _global_publisher is None:
         _global_publisher = SignalPublisher()
+    if not _global_publisher._is_connected():
         await _global_publisher.connect()
     return _global_publisher
 

--- a/tests/test_gcp_pubsub_signal_publisher_async.py
+++ b/tests/test_gcp_pubsub_signal_publisher_async.py
@@ -1,0 +1,91 @@
+"""Regression tests for the asynchronous GCP Pub/Sub publisher."""
+
+import asyncio
+import json
+import threading
+
+from messaging.gcp_pubsub_signal_publisher import SignalPublisher
+
+
+class _ImmediateResultFuture:
+    def __init__(self):
+        self.result_thread_id = None
+
+    def result(self):
+        self.result_thread_id = threading.get_ident()
+        return "message-123"
+
+
+class _FailingResultFuture:
+    def __init__(self):
+        self.result_thread_id = None
+
+    def result(self):
+        self.result_thread_id = threading.get_ident()
+        raise RuntimeError("publish acknowledgement failed")
+
+
+class _FakePublisher:
+    def __init__(self, future):
+        self.future = future
+        self.topic_path = None
+        self.message_bytes = None
+
+    def publish(self, topic_path, message_bytes):
+        self.topic_path = topic_path
+        self.message_bytes = message_bytes
+        return self.future
+
+
+def _configured_publisher(future):
+    fake_publisher = _FakePublisher(future)
+    publisher = SignalPublisher(project_id="test-project", topic_id="signals")
+    publisher._publisher = fake_publisher
+    publisher._topic_path = "projects/test-project/topics/signals"
+    return publisher, fake_publisher
+
+
+def test_publish_signal_does_not_block_event_loop():
+    future = _ImmediateResultFuture()
+    publisher, fake_publisher = _configured_publisher(future)
+
+    event_loop_thread_id = threading.get_ident()
+    message_id = asyncio.run(
+        publisher.publish_signal(
+            signal_type="SELL",
+            ticker="AAPL",
+            company_name="Apple",
+            price=210.0,
+            extra_data={"market": "US", "sell_reason": "TEST"},
+        )
+    )
+
+    assert message_id == "message-123"
+    assert future.result_thread_id is not None
+    assert future.result_thread_id != event_loop_thread_id
+    assert fake_publisher.topic_path == "projects/test-project/topics/signals"
+
+    payload = json.loads(fake_publisher.message_bytes.decode("utf-8"))
+    assert payload["type"] == "SELL"
+    assert payload["ticker"] == "AAPL"
+    assert payload["market"] == "US"
+    assert payload["sell_reason"] == "TEST"
+
+
+def test_publish_signal_returns_none_when_acknowledgement_fails():
+    future = _FailingResultFuture()
+    publisher, _ = _configured_publisher(future)
+
+    event_loop_thread_id = threading.get_ident()
+    message_id = asyncio.run(
+        publisher.publish_signal(
+            signal_type="SELL",
+            ticker="AAPL",
+            company_name="Apple",
+            price=210.0,
+        )
+    )
+
+    assert message_id is None
+    assert future.result_thread_id is not None
+    assert future.result_thread_id != event_loop_thread_id

--- a/tests/test_redis_async_boundaries.py
+++ b/tests/test_redis_async_boundaries.py
@@ -1,0 +1,104 @@
+"""Regression tests for synchronous Redis work exposed through async APIs."""
+
+import asyncio
+import json
+import threading
+import time
+import unittest
+from unittest.mock import patch
+
+from messaging.redis_health_check import run_health_check_async
+from messaging.redis_signal_publisher import SignalPublisher
+
+
+class _ThreadRecordingRedis:
+    def __init__(self, *, error=None):
+        self.error = error
+        self.thread_id = None
+        self.args = None
+
+    def xadd(self, *args):
+        self.thread_id = threading.get_ident()
+        self.args = args
+        if self.error:
+            raise self.error
+        return "123-0"
+
+
+class _ConcurrencyRecordingRedis:
+    def __init__(self):
+        self.active = 0
+        self.max_active = 0
+        self._lock = threading.Lock()
+
+    def xadd(self, *args):
+        with self._lock:
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+        time.sleep(0.02)
+        with self._lock:
+            self.active -= 1
+        return "123-0"
+
+
+class RedisAsyncBoundaryTests(unittest.TestCase):
+    def test_publish_signal_runs_xadd_off_event_loop(self):
+        redis = _ThreadRecordingRedis()
+        publisher = SignalPublisher(redis_url="https://example.invalid", redis_token="token")
+        publisher._redis = redis
+        event_loop_thread = threading.get_ident()
+
+        message_id = asyncio.run(
+            publisher.publish_signal("SELL", "AAPL", "Apple", 210.0)
+        )
+
+        self.assertEqual(message_id, "123-0")
+        self.assertNotEqual(redis.thread_id, event_loop_thread)
+        self.assertEqual(redis.args[:2], ("prism:trading-signals", "*"))
+        payload = json.loads(redis.args[2]["data"])
+        self.assertEqual(payload["type"], "SELL")
+        self.assertEqual(payload["ticker"], "AAPL")
+
+    def test_publish_signal_preserves_failure_contract(self):
+        redis = _ThreadRecordingRedis(error=RuntimeError("Redis unavailable"))
+        publisher = SignalPublisher(redis_url="https://example.invalid", redis_token="token")
+        publisher._redis = redis
+
+        self.assertIsNone(
+            asyncio.run(publisher.publish_signal("BUY", "005930", "Samsung", 82000))
+        )
+
+    def test_concurrent_publishes_serialize_shared_client_access(self):
+        redis = _ConcurrencyRecordingRedis()
+        publisher = SignalPublisher(
+            redis_url="https://example.invalid", redis_token="token"
+        )
+        publisher._redis = redis
+
+        async def publish_both():
+            return await asyncio.gather(
+                publisher.publish_signal("BUY", "AAPL", "Apple", 210.0),
+                publisher.publish_signal("SELL", "MSFT", "Microsoft", 510.0),
+            )
+
+        self.assertEqual(asyncio.run(publish_both()), ["123-0", "123-0"])
+        self.assertEqual(redis.max_active, 1)
+
+    def test_async_health_check_runs_sync_client_off_event_loop(self):
+        worker_thread = None
+
+        def fake_health_check():
+            nonlocal worker_thread
+            worker_thread = threading.get_ident()
+            return {"success": True}
+
+        event_loop_thread = threading.get_ident()
+        with patch("messaging.redis_health_check.run_health_check", fake_health_check):
+            result = asyncio.run(run_health_check_async())
+
+        self.assertEqual(result, {"success": True})
+        self.assertNotEqual(worker_thread, event_loop_thread)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 개요
외부 PR #433(@tkgo11)에서 **비동기 논블로킹 개선**만 체리픽했습니다. (원본 hunk 대비 락 생성 방식을 **견고하게 수정**함 — 아래 참조)

## 변경
- Upstash Redis `xadd`, Pub/Sub `future.result()`, Redis health check의 **동기 블로킹 I/O를 `asyncio.to_thread`로 오프로드** → 시그널 발행이 트레이딩/텔레그램/기타 이벤트루프 태스크를 더 이상 멈추지 않음.
- `get_signal_publisher`: 싱글턴이 생성됐지만 미연결 상태면 재연결(복원력).

## 원본 대비 하드닝 (중요)
원본 #433은 공유 동기 클라이언트 직렬화용 `asyncio.Lock()`을 **`__init__`에서 생성**했는데, 이는 (1) 락이 생성 시점 루프에 묶여 크로스루프에서 깨지고, (2) `__init__`를 우회해 만든 인스턴스에서 `_publish_lock` 부재로 `publish_signal`이 실패합니다. **main 대비 baseline 회귀 테스트로 이 문제를 포착** → 락을 **실행 중인 루프 안에서 지연 생성**(getattr 안전망)하도록 변경. 직렬화 동작은 그대로 유지.

## 검증
- 신규 async-boundary 회귀 테스트 포함(작성자 제공): xadd가 워커스레드에서 실행됨/실패 계약/**동시 발행 직렬화(max_active==1)**/health check 오프로드 검증.
- 메시징 스위트 **60 passed, 11 skipped**. 메시지 payload/시그니처 불변.
- 실 Redis/Pub-Sub live 동작은 미검증(오프로드·직렬화 로직만 변경).

## 관련
- 원본: #433 (안전한 조각만 분리 반영, 하드닝 적용)