### PR TITLE
fix(trading): reject malformed sell quantity instead of liquidating full holding

### DIFF
--- a/prism-us/trading/us_stock_trading.py
+++ b/prism-us/trading/us_stock_trading.py
@@ -108,9 +108,11 @@ def _resolve_sell_quantity(holding_quantity: int, quantity: int = None) -> int:
     try:
         q = int(quantity)
     except (TypeError, ValueError):
-        return holding_quantity
+        logger.warning("sell quantity %r invalid; refusing full-liquidation fallback", quantity)
+        return 0
     if q <= 0:
-        return holding_quantity
+        logger.warning("sell quantity %r invalid; refusing full-liquidation fallback", quantity)
+        return 0
     return min(q, holding_quantity)
 
 
@@ -763,6 +765,15 @@ class USStockTrading:
 
         # Determine sell quantity (partial when quantity given, else full holding)
         quantity = _resolve_sell_quantity(holding_quantity, quantity)
+        if quantity <= 0:
+            logger.warning("Rejecting sell for %s: requested quantity resolved to 0 (refusing full-liquidation fallback)", ticker)
+            return {
+                'success': False,
+                'order_no': None,
+                'ticker': ticker,
+                'quantity': 0,
+                'message': 'Sell quantity must be a positive whole number'
+            }
 
         # Fetch current price if not provided
         if not limit_price or limit_price <= 0:
@@ -1163,6 +1174,15 @@ class USStockTrading:
 
         # Determine sell quantity (partial when quantity given, else full holding)
         quantity = _resolve_sell_quantity(holding_quantity, quantity)
+        if quantity <= 0:
+            logger.warning("Rejecting sell for %s: requested quantity resolved to 0 (refusing full-liquidation fallback)", ticker)
+            return {
+                'success': False,
+                'order_no': None,
+                'ticker': ticker,
+                'quantity': 0,
+                'message': 'Sell quantity must be a positive whole number'
+            }
 
         # Reserved order API
         api_url = "/uapi/overseas-stock/v1/trading/order-resv"
@@ -1566,6 +1586,10 @@ class USStockTrading:
 
                         # Resolve partial sell quantity (None = full holding)
                         sell_quantity = _resolve_sell_quantity(target_stock['quantity'], quantity)
+                        if sell_quantity <= 0:
+                            logger.warning("Rejecting sell for %s: requested quantity resolved to 0 (refusing full-liquidation fallback)", ticker)
+                            result['message'] = 'Sell quantity must be a positive whole number'
+                            return result
 
                         logger.info(f"[Async Sell] {ticker} limit_price: ${effective_limit_price:.2f}, use_moo: {effective_use_moo}, qty: {sell_quantity}/{target_stock['quantity']}")
 

--- a/tests/test_sell_quantity_guard.py
+++ b/tests/test_sell_quantity_guard.py
@@ -1,0 +1,115 @@
+"""Tests for the sell-quantity <=0 guard (real-money safety, PR-C).
+
+Covers both `_resolve_sell_quantity` helpers (KR + US) and a focused
+entry-point check that an explicit quantity=0 sell is REJECTED and never
+reaches the broker order API (`self._request`) — i.e. it does NOT silently
+fall back to full liquidation.
+
+Pure-unit: loads the module files directly (no live DB / network / broker).
+
+Run:
+    .venv/bin/python -m pytest tests/test_sell_quantity_guard.py -q
+"""
+
+import importlib.util
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+
+def _load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_kr = _load_module(
+    "kr_trading_for_test",
+    os.path.join(PROJECT_ROOT, "trading", "domestic_stock_trading.py"),
+)
+_us = _load_module(
+    "us_trading_for_test",
+    os.path.join(PROJECT_ROOT, "prism-us", "trading", "us_stock_trading.py"),
+)
+
+kr_resolve = _kr._resolve_sell_quantity
+us_resolve = _us._resolve_sell_quantity
+
+
+# ── Helper unit tests ───────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("resolve", [kr_resolve, us_resolve])
+def test_none_returns_full_holding(resolve):
+    # Unchanged legitimate behavior: None => sell entire holding.
+    assert resolve(100, None) == 100
+    assert resolve(1, None) == 1
+
+
+@pytest.mark.parametrize("resolve", [kr_resolve, us_resolve])
+def test_valid_partial_clamped(resolve):
+    assert resolve(100, 30) == 30          # partial within range
+    assert resolve(100, 100) == 100        # full explicit
+    assert resolve(100, 250) == 100        # clamped down to holding (no over-sell)
+    assert resolve(100, 1) == 1            # min valid
+    assert resolve(100, "40") == 40        # numeric string coerced
+
+
+@pytest.mark.parametrize("resolve", [kr_resolve, us_resolve])
+def test_zero_returns_zero_not_holding(resolve):
+    # CRITICAL: explicit 0 must NOT liquidate the full holding.
+    assert resolve(100, 0) == 0
+
+
+@pytest.mark.parametrize("resolve", [kr_resolve, us_resolve])
+def test_negative_returns_zero_not_holding(resolve):
+    assert resolve(100, -5) == 0
+
+
+@pytest.mark.parametrize("resolve", [kr_resolve, us_resolve])
+def test_non_numeric_returns_zero_not_holding(resolve):
+    assert resolve(100, "abc") == 0
+    assert resolve(100, object()) == 0
+    assert resolve(100, float("nan")) == 0  # int(nan) raises ValueError -> 0
+
+
+# ── Entry-point guard tests (no broker call on quantity=0) ──────────────────
+
+def test_kr_sell_all_market_price_rejects_zero_without_broker_call():
+    self_mock = MagicMock()
+    self_mock.auto_trading = True
+    self_mock.get_holding_quantity.return_value = 10
+
+    result = _kr.DomesticStockTrading.sell_all_market_price(
+        self_mock, stock_code="005930", quantity=0
+    )
+
+    assert result["success"] is False
+    assert result["quantity"] == 0
+    assert result["stock_code"] == "005930"
+    self_mock._request.assert_not_called()
+
+
+def test_us_sell_all_market_price_rejects_zero_without_broker_call():
+    self_mock = MagicMock()
+    self_mock.auto_trading = True
+    self_mock.get_holding_quantity.return_value = 10
+
+    result = _us.USStockTrading.sell_all_market_price(
+        self_mock, ticker="AAPL", exchange="NASDAQ", quantity=0
+    )
+
+    assert result["success"] is False
+    assert result["quantity"] == 0
+    assert result["ticker"] == "AAPL"
+    self_mock._request.assert_not_called()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/trading/domestic_stock_trading.py
+++ b/trading/domestic_stock_trading.py
@@ -83,9 +83,11 @@ def _resolve_sell_quantity(holding_quantity: int, quantity: int = None) -> int:
     try:
         q = int(quantity)
     except (TypeError, ValueError):
-        return holding_quantity
+        logger.warning("sell quantity %r invalid; refusing full-liquidation fallback", quantity)
+        return 0
     if q <= 0:
-        return holding_quantity
+        logger.warning("sell quantity %r invalid; refusing full-liquidation fallback", quantity)
+        return 0
     return min(q, holding_quantity)
 
 
@@ -881,6 +883,15 @@ class DomesticStockTrading:
 
         # Determine sell quantity (partial when quantity given, else full holding)
         buy_quantity = _resolve_sell_quantity(holding_quantity, quantity)
+        if buy_quantity <= 0:
+            logger.warning("Rejecting sell for %s: requested quantity resolved to 0 (refusing full-liquidation fallback)", stock_code)
+            return {
+                'success': False,
+                'order_no': None,
+                'stock_code': stock_code,
+                'quantity': 0,
+                'message': 'Sell quantity must be a positive whole number'
+            }
 
         # Execute sell order
         api_url = "/uapi/domestic-stock/v1/trading/order-cash"
@@ -1027,6 +1038,15 @@ class DomesticStockTrading:
             }
 
         buy_quantity = _resolve_sell_quantity(holding_quantity, quantity)
+        if buy_quantity <= 0:
+            logger.warning("Rejecting sell for %s: requested quantity resolved to 0 (refusing full-liquidation fallback)", stock_code)
+            return {
+                'success': False,
+                'order_no': None,
+                'stock_code': stock_code,
+                'quantity': 0,
+                'message': 'Sell quantity must be a positive whole number'
+            }
 
         # After-hours closing price sell
         api_url = "/uapi/domestic-stock/v1/trading/order-cash"
@@ -1119,6 +1139,15 @@ class DomesticStockTrading:
             }
 
         buy_quantity = _resolve_sell_quantity(holding_quantity, quantity)
+        if buy_quantity <= 0:
+            logger.warning("Rejecting sell for %s: requested quantity resolved to 0 (refusing full-liquidation fallback)", stock_code)
+            return {
+                'success': False,
+                'order_no': None,
+                'stock_code': stock_code,
+                'quantity': 0,
+                'message': 'Sell quantity must be a positive whole number'
+            }
 
         # Set order type and unit price
         if limit_price and limit_price > 0:
@@ -1471,6 +1500,10 @@ class DomesticStockTrading:
 
                         # Resolve partial sell quantity (None = full holding)
                         sell_quantity = _resolve_sell_quantity(holding_quantity, quantity)
+                        if sell_quantity <= 0:
+                            logger.warning("Rejecting sell for %s: requested quantity resolved to 0 (refusing full-liquidation fallback)", stock_code)
+                            result['message'] = 'Sell quantity must be a positive whole number'
+                            return result
 
                         if effective_limit_price:
                             logger.info(f"[Async Sell API] {stock_code} executing sell (qty: {sell_quantity}/{holding_quantity} shares, limit: {effective_limit_price:,} KRW)")


### PR DESCRIPTION
## 개요
외부 PR #433(@tkgo11)이 지적한 **의도치 않은 전량 매도** 위험을 실거래 매도 경로 전반에 안전하게 반영했습니다.

## 문제 (현행 main)
`_resolve_sell_quantity`는 `quantity=None`(정상 전량 청산)뿐 아니라 **명시적으로 잘못된/0/음수 수량**에도 `holding_quantity`(전량)를 반환합니다. 따라서 **피라미딩 부분매도 수량이 0으로 반올림되면 포지션 전량이 매도**되는 잠재 사고가 있습니다.

## 변경
- `_resolve_sell_quantity`(US·KR): `None → 전량`은 **그대로 유지**. 명시적 invalid/`<=0`은 **`0` 반환 + WARNING 로그**(전량 fallback 거부).
- 7개 매도 호출부(US 3 · KR 4) 각각에 resolve 직후 `<=0` 가드 추가 → WARNING 로그 후 해당 함수의 **표준 실패 dict** 반환(전량 청산·침묵 no-op 모두 방지).

## 검증
- 신규 `tests/test_sell_quantity_guard.py` **12 passed**(None→전량 / 유효 부분→클램프 / 0·음수·비수치→0).
- 기존 매도 스위트(`test_issue_288_pyramiding` 포함) 통과. 유일 실패는 main **선존·무관**(`test_update_holdings_masks_sold_account_payload`).
- 헬퍼는 파일 로컬, 7개 호출자 전수 가드 확인. 독립 fresh 리뷰 **APPROVE**(None 경로 보존 / async `result`는 success=False 유지).
- 실 브로커 live 매도는 미검증(수량 결정 로직만 변경).

## 관련
- 원본: #433. #412(주문실행 리팩토링) Phase 1의 순수함수 추출 시 자연 흡수 예정.