### PR TITLE
fix(btc): defer instead of fabricating a price when quote is unavailable

### DIFF
--- a/events/jeoningu_price_fetcher.py
+++ b/events/jeoningu_price_fetcher.py
@@ -133,7 +133,7 @@ def get_kodex_prices(date: str = None) -> dict:
     }
 
 
-def get_current_price(stock_code: str) -> int:
+def get_current_price(stock_code: str) -> int | None:
     """
     Get current closing price (simplified)
 
@@ -141,21 +141,17 @@ def get_current_price(stock_code: str) -> int:
         stock_code: Stock code
 
     Returns:
-        Current closing price (integer)
+        Current closing price (integer), or None if the price is unavailable.
+        Callers MUST guard for None and defer instead of fabricating a price.
     """
     price_info = get_stock_price(stock_code)
 
     if price_info:
         return price_info['close']
     else:
-        # Fallback to mock prices if API fails
-        logger.warning(f"Using mock price for {stock_code}")
-        if stock_code == KODEX_LEVERAGE:
-            return 20000  # Mock for Leverage
-        elif stock_code == KODEX_INVERSE_2X:
-            return 5000  # Mock for Inverse 2X
-        else:
-            return 10000
+        # Do NOT fabricate a price: returning a mock would record fake performance.
+        logger.error("Current price unavailable for %s; deferring instead of fabricating", stock_code)
+        return None
 
 
 # Test function
@@ -176,5 +172,7 @@ if __name__ == "__main__":
     # Get current price
     current_leverage = get_current_price(KODEX_LEVERAGE)
     current_inverse_2x = get_current_price(KODEX_INVERSE_2X)
-    print(f"\nCurrent KODEX Leverage: {current_leverage:,} KRW")
-    print(f"Current KODEX Inverse 2X: {current_inverse_2x:,} KRW")
+    leverage_str = f"{current_leverage:,} KRW" if current_leverage is not None else "unavailable"
+    inverse_2x_str = f"{current_inverse_2x:,} KRW" if current_inverse_2x is not None else "unavailable"
+    print(f"\nCurrent KODEX Leverage: {leverage_str}")
+    print(f"Current KODEX Inverse 2X: {inverse_2x_str}")

--- a/events/jeoningu_trading.py
+++ b/events/jeoningu_trading.py
@@ -657,7 +657,7 @@ click the <b>'Lab'</b> tab!
                     )
                     unrealized_pl = 0  # Unknown; treated as no realized/unrealized change for display
                     message_parts.append(f"┣ Holdings: {position['quantity']:,} shares")
-                    message_parts.append(f"┣ Market Value: unavailable (price fetch failed)")
+                    message_parts.append("┣ Market Value: unavailable (price fetch failed)")
                     message_parts.append(f"┗ Avg Cost: {position['buy_price']:,.0f} KRW")
                 else:
                     current_value = position['quantity'] * current_price

--- a/events/jeoningu_trading.py
+++ b/events/jeoningu_trading.py
@@ -641,9 +641,6 @@ click the <b>'Lab'</b> tab!
             if position:
                 # Holding position
                 current_price = get_current_price(position['stock_code'])
-                current_value = position['quantity'] * current_price
-                unrealized_pl = current_value - position['buy_amount']
-                unrealized_pl_pct = (unrealized_pl / position['buy_amount']) * 100 if position['buy_amount'] > 0 else 0
 
                 # Calculate holding period
                 buy_date = datetime.fromisoformat(position['buy_date'].replace('Z', '+00:00')) if position.get('buy_date') else None
@@ -651,13 +648,29 @@ click the <b>'Lab'</b> tab!
 
                 message_parts.append("📊 **Current Position**\n")
                 message_parts.append(f"🎯 {position['stock_name']}")
-                message_parts.append(f"┣ Holdings: {position['quantity']:,} shares × {current_price:,.0f} KRW")
-                message_parts.append(f"┣ Market Value: {current_value:,.0f} KRW")
-                message_parts.append(f"┣ Avg Cost: {position['buy_price']:,.0f} KRW")
 
-                # Unrealized P&L (emoji for color indication)
-                pl_emoji = "🔴" if unrealized_pl < 0 else "🟢" if unrealized_pl > 0 else "⚪"
-                message_parts.append(f"┗ Unrealized P&L: {pl_emoji} {unrealized_pl:+,.0f} KRW ({unrealized_pl_pct:+.2f}%)")
+                if current_price is None:
+                    # Price unavailable: skip valuation for this position, do not fabricate.
+                    logger.warning(
+                        f"Current price unavailable for {position['stock_code']}; "
+                        f"skipping market valuation in portfolio status"
+                    )
+                    unrealized_pl = 0  # Unknown; treated as no realized/unrealized change for display
+                    message_parts.append(f"┣ Holdings: {position['quantity']:,} shares")
+                    message_parts.append(f"┣ Market Value: unavailable (price fetch failed)")
+                    message_parts.append(f"┗ Avg Cost: {position['buy_price']:,.0f} KRW")
+                else:
+                    current_value = position['quantity'] * current_price
+                    unrealized_pl = current_value - position['buy_amount']
+                    unrealized_pl_pct = (unrealized_pl / position['buy_amount']) * 100 if position['buy_amount'] > 0 else 0
+
+                    message_parts.append(f"┣ Holdings: {position['quantity']:,} shares × {current_price:,.0f} KRW")
+                    message_parts.append(f"┣ Market Value: {current_value:,.0f} KRW")
+                    message_parts.append(f"┣ Avg Cost: {position['buy_price']:,.0f} KRW")
+
+                    # Unrealized P&L (emoji for color indication)
+                    pl_emoji = "🔴" if unrealized_pl < 0 else "🟢" if unrealized_pl > 0 else "⚪"
+                    message_parts.append(f"┗ Unrealized P&L: {pl_emoji} {unrealized_pl:+,.0f} KRW ({unrealized_pl_pct:+.2f}%)")
 
                 if holding_days > 0:
                     message_parts.append(f"\n⏱ Day {holding_days} holding")
@@ -787,6 +800,13 @@ click the <b>'Lab'</b> tab!
                 if current_position:
                     # Sell current position - get real price
                     sell_price = get_current_price(current_position['stock_code'])
+                    if sell_price is None:
+                        # Price unavailable: defer this sell, do NOT fabricate a trade.
+                        logger.warning(
+                            f"Current price unavailable for {current_position['stock_code']}; "
+                            f"deferring SELL (neutral sentiment) this cycle"
+                        )
+                        return
                     sell_amount = current_position['quantity'] * sell_price
                     profit_loss = sell_amount - current_position['buy_amount']
                     profit_loss_pct = (profit_loss / current_position['buy_amount']) * 100
@@ -851,10 +871,30 @@ click the <b>'Lab'</b> tab!
                     logger.warning(f"No target stock for sentiment: {sentiment}")
                     return
 
+                # Fetch the BUY price up-front. A missing price must defer the whole
+                # position change BEFORE any sell executes; otherwise the sell would
+                # commit and the paired buy would be skipped, leaving a half-completed
+                # switch (position sold, balance left uninvested).
+                buy_price = get_current_price(target_code)
+                if buy_price is None:
+                    logger.warning(
+                        f"Current price unavailable for {target_code}; "
+                        f"deferring position change (no SELL/BUY executed) this cycle"
+                    )
+                    return
+
                 # Step 1: Sell current position if different stock
                 if current_position and current_position['stock_code'] != target_code:
                     # Sell different stock - get real price
                     sell_price = get_current_price(current_position['stock_code'])
+                    if sell_price is None:
+                        # Price unavailable: defer the position switch (sell+buy) this cycle,
+                        # do NOT fabricate a sell price.
+                        logger.warning(
+                            f"Current price unavailable for {current_position['stock_code']}; "
+                            f"deferring position switch (SELL then BUY) this cycle"
+                        )
+                        return
                     sell_amount = current_position['quantity'] * sell_price
                     profit_loss = sell_amount - current_position['buy_amount']
                     profit_loss_pct = (profit_loss / current_position['buy_amount']) * 100
@@ -913,8 +953,7 @@ click the <b>'Lab'</b> tab!
                     logger.info(f"Already holding {target_name}")
                     return
 
-                # Step 2: Buy target stock with FULL BALANCE - get real price
-                buy_price = get_current_price(target_code)
+                # Step 2: Buy target stock with FULL BALANCE (buy_price fetched & guarded above)
                 quantity = int(current_balance / buy_price)  # Full balance investment
                 buy_amount = quantity * buy_price
 

--- a/examples/generate_dashboard_json.py
+++ b/examples/generate_dashboard_json.py
@@ -1300,7 +1300,13 @@ class DashboardDataGenerator:
                         if PRICE_FETCHER_AVAILABLE and stock_code:
                             try:
                                 current_price = get_current_price(stock_code)
-                                logger.info(f"실시간 현재가 조회: {stock_code} = {current_price:,}원")
+                                # get_current_price now RETURNS None (does not raise) on failure,
+                                # so guard explicitly and fall back to buy_price.
+                                if current_price is None:
+                                    logger.warning(f"현재가 조회 불가: {stock_code}, 매수가 사용")
+                                    current_price = buy_price
+                                else:
+                                    logger.info(f"실시간 현재가 조회: {stock_code} = {current_price:,}원")
                             except Exception as e:
                                 logger.warning(f"현재가 조회 실패: {e}, 매수가 사용")
                                 current_price = buy_price

--- a/tests/test_jeoningu_price_none_guard.py
+++ b/tests/test_jeoningu_price_none_guard.py
@@ -1,0 +1,130 @@
+"""
+Tests for the BTC/KODEX price None-guard.
+
+Guards against fabricated prices: `get_current_price` must return None (not a
+mock) when the price lookup fails, and every trading/dashboard caller must
+defer instead of trading/computing on a fabricated price.
+"""
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Make the repo root importable (mirrors how the app imports `events.*`).
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import events.jeoningu_price_fetcher as price_fetcher
+import events.jeoningu_trading as trading
+from events.jeoningu_trading import JeoninguTrading
+
+
+def test_get_current_price_returns_none_when_lookup_fails():
+    """When the underlying price fetch fails, we must NOT fabricate a mock price."""
+    with patch.object(price_fetcher, "get_stock_price", return_value=None):
+        result = price_fetcher.get_current_price(price_fetcher.KODEX_LEVERAGE)
+    assert result is None
+
+
+def test_get_current_price_returns_close_on_success():
+    """Successful path is unchanged: returns the close price."""
+    with patch.object(price_fetcher, "get_stock_price", return_value={"close": 12345}):
+        result = price_fetcher.get_current_price("122630")
+    assert result == 12345
+
+
+def _make_trader():
+    """Build a JeoninguTrading without running __init__ (avoids OpenAI/DB setup)."""
+    trader = object.__new__(JeoninguTrading)
+    trader.use_telegram = False
+    trader.db = AsyncMock()
+    return trader
+
+
+@pytest.mark.asyncio
+async def test_buy_deferred_when_price_none_no_trade_executed():
+    """
+    Bullish sentiment with no current position would BUY. If the price is
+    unavailable, the trade-execution boundary (db.insert_trade) must NOT be
+    called and the function must not crash.
+    """
+    trader = _make_trader()
+    trader.db.video_id_exists.return_value = False
+    trader.db.get_current_position.return_value = None
+    trader.db.get_latest_balance.return_value = 1_000_000
+    trader.db.calculate_performance_metrics.return_value = {
+        "win_rate": 0.0,
+        "cumulative_return": 0.0,
+    }
+
+    analysis = {
+        "video_info": {
+            "video_id": "vid1",
+            "title": "t",
+            "video_date": "2026-07-15",
+            "video_url": "http://x",
+        },
+        "jeon_sentiment": "Bullish",
+        "contrarian_action": "buy",
+        "target_stock": {"code": "122630", "name": "KODEX Leverage"},
+    }
+
+    with patch.object(trading, "get_current_price", return_value=None):
+        await trader.execute_trading_strategy(analysis)
+
+    trader.db.insert_trade.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sell_deferred_when_price_none_no_trade_executed():
+    """
+    Neutral sentiment with a held position would SELL. If the price is
+    unavailable, no fabricated SELL trade may be recorded.
+    """
+    trader = _make_trader()
+    trader.db.video_id_exists.return_value = False
+    trader.db.get_current_position.return_value = {
+        "stock_code": "122630",
+        "stock_name": "KODEX Leverage",
+        "quantity": 10,
+        "buy_amount": 100_000,
+        "buy_id": 1,
+    }
+    trader.db.get_latest_balance.return_value = 1_000_000
+
+    analysis = {
+        "video_info": {
+            "video_id": "vid2",
+            "title": "t",
+            "video_date": "2026-07-15",
+            "video_url": "http://x",
+        },
+        "jeon_sentiment": "Neutral",
+        "contrarian_action": "sell",
+        "target_stock": {},
+    }
+
+    with patch.object(trading, "get_current_price", return_value=None):
+        await trader.execute_trading_strategy(analysis)
+
+    trader.db.insert_trade.assert_not_called()
+
+
+def test_dashboard_fallback_to_buy_price_when_price_none():
+    """
+    Dashboard: get_current_price now RETURNS None (does not raise), so the
+    explicit None guard must fall back to buy_price. Replicates the guarded
+    expression against the real (failing) fetcher output.
+    """
+    buy_price = 55_000
+    with patch.object(price_fetcher, "get_stock_price", return_value=None):
+        current_price = price_fetcher.get_current_price("122630")
+
+    if current_price is None:
+        current_price = buy_price
+
+    # Downstream valuation must not crash and must use the fallback.
+    quantity = 3
+    current_value = quantity * current_price
+    assert current_price == buy_price
+    assert current_value == quantity * buy_price


### PR DESCRIPTION
## 개요
외부 PR #433(@tkgo11)의 "가짜 시세 제거" 아이디어를 **크래시 없이 완전하게** 구현했습니다. (작성자는 시세를 None으로 바꿨지만 호출부 산술을 가드하지 않아 크래시 유발 — 이를 완성)

## 변경
- `jeoningu_price_fetcher.get_current_price`: 실패 시 **mock(20000/5000/10000) 대신 None + logger.error** (시뮬레이션 가짜 성과 기록 방지).
- 모든 호출부 가드(가격 없으면 **fabricate/거래하지 않고 defer**):
  - 포트폴리오 평가: 해당 종목 평가 스킵 + "unavailable" 표기
  - 중립 매도 / 스위치 매도 / 매수: 이번 사이클 defer(거래 없음)
  - 대시보드: None은 raise가 아니므로 명시적 None 체크 후 `buy_price` fallback
  - price_fetcher `__main__` 데모: None이면 "unavailable" 출력

## Fresh 리뷰가 잡은 BLOCKER → 수정
포지션 스위치에서 **매도가 먼저 커밋된 뒤 매수가를 조회**하는 구조라, 매수가 None이면 **매도만 되고 매수 스킵(반쪽 스위치, 현금 미투자)**. → **매수가를 매도 실행 전에 미리 조회·가드**하도록 수정.

## 검증
- 신규 `tests/test_jeoningu_price_none_guard.py` **5 passed**(None 반환 / 거래 defer / 대시보드 fallback).
- 기존 jeoningu 테스트 영향 없음. 무관한 3건(trend_exit/hardstop)은 main **선존 실패**.

## 관련
- 원본: #433.