### PR TITLE
refactor(#412 Phase 1-a): extract pure parsing/normalization into prism_core

### DIFF
--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -634,28 +634,14 @@ class USStockTrackingAgent:
         return f"{account_name} ({ka.mask_account_number(account_key)})"
 
     def _normalize_decision(self, decision: str) -> str:
+        """Normalize decision string for comparison.
+
+        Delegates to prism_core.parsing.normalize_decision_us (issue #412 Phase 1).
+        Lazy import keeps module load independent of sys.path setup order.
+        Behavior unchanged: maps variants to {'entry', 'no_entry'}.
         """
-        Normalize decision string for comparison.
-
-        The agent prompt uses "Enter" or "No Entry" but code checks may use
-        lowercase variants. This method normalizes all variants to a consistent format.
-
-        Args:
-            decision: Raw decision string from agent
-
-        Returns:
-            str: Normalized decision ("entry" or "no_entry")
-        """
-        if not decision:
-            return "no_entry"
-        d = decision.lower().strip()
-        # Handle various entry formats
-        if d in ("enter", "entry", "진입", "yes", "buy"):
-            return "entry"
-        # Handle various no-entry formats
-        elif d in ("no entry", "no_entry", "no-entry", "미진입", "no", "skip", "pass"):
-            return "no_entry"
-        return d
+        from prism_core.parsing import normalize_decision_us
+        return normalize_decision_us(decision)
 
     async def _extract_ticker_info(self, report_path: str) -> Tuple[str, str]:
         """Extract ticker and company name from report path."""

--- a/prism_core/__init__.py
+++ b/prism_core/__init__.py
@@ -1,0 +1,6 @@
+"""prism_core — shared, dependency-free pure functions for the PRISM trading core.
+
+Phase 1 of issue #412 (order-execution architecture refactor). This package holds
+logic-preserving pure functions extracted from the KR/US tracking agents so both
+forks can share one tested implementation. No I/O, no live clock, no DB, no self.
+"""

--- a/prism_core/parsing.py
+++ b/prism_core/parsing.py
@@ -1,0 +1,89 @@
+"""Pure parsing / normalization helpers (issue #412 Phase 1).
+
+Logic-preserving extractions. Each function is a byte-for-byte behavioral copy of
+the inline agent code it replaces; the original methods now delegate here. The KR
+and US decision normalizers are DELIBERATELY separate — their mappings and return
+vocabularies differ (KR: Enter/Watch/Skip 3-state; US: entry/no_entry 2-state) and
+must NOT be unified until the fork is absorbed (Phase 6).
+"""
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_decision_kr(decision: str) -> str:
+    """Normalize a KR AI decision string to canonical English form.
+
+    Extracted from stock_tracking_agent.StockTrackingAgent._normalize_decision.
+    Maps Korean/English variants to {'Enter', 'Watch', 'Skip'}; unknown input is
+    returned stripped but otherwise unchanged.
+    """
+    if not decision:
+        return "Skip"
+    normalized = decision.strip()
+    enter_variants = {"진입", "Entry", "enter", "entry", "Enter", "매수", "Buy", "buy"}
+    watch_variants = {"관망", "Watch", "watch", "Hold", "hold", "보류"}
+    skip_variants = {"미진입", "Skip", "skip", "No entry", "no entry", "패스", "Pass", "pass"}
+    if normalized in enter_variants:
+        return "Enter"
+    if normalized in watch_variants:
+        return "Watch"
+    if normalized in skip_variants:
+        return "Skip"
+    return normalized
+
+
+def normalize_decision_us(decision: str) -> str:
+    """Normalize a US AI decision string for comparison.
+
+    Extracted from prism-us/us_stock_tracking_agent.USStockTrackingAgent
+    ._normalize_decision. Maps variants to {'entry', 'no_entry'}; unknown input is
+    returned lowercased and stripped. NOTE: distinct vocabulary/logic from the KR
+    normalizer above — keep separate.
+    """
+    if not decision:
+        return "no_entry"
+    d = decision.lower().strip()
+    # Handle various entry formats
+    if d in ("enter", "entry", "진입", "yes", "buy"):
+        return "entry"
+    # Handle various no-entry formats
+    elif d in ("no entry", "no_entry", "no-entry", "미진입", "no", "skip", "pass"):
+        return "no_entry"
+    return d
+
+
+def safe_number_conversion(value: Any) -> float:
+    """Safely convert various value types to a float.
+
+    Extracted from stock_tracking_enhanced_agent
+    .StockTrackingEnhancedAgent._safe_number_conversion. Strips thousands
+    separators, spaces and KRW/원 currency markers from strings; returns 0.0 for
+    empty/None/other types and on conversion failure.
+    """
+    try:
+        # If already a numeric type
+        if isinstance(value, (int, float)):
+            return float(value)
+
+        # If string
+        if isinstance(value, str):
+            # Remove commas and spaces
+            cleaned_value = value.replace(',', '').replace(' ', '')
+            # Remove currency symbols (KRW, 원)
+            cleaned_value = cleaned_value.replace('KRW', '').replace('원', '')
+
+            # Check for empty string
+            if not cleaned_value:
+                return 0.0
+
+            # Convert to number
+            return float(cleaned_value)
+
+        # If null or other type
+        return 0.0
+
+    except (ValueError, TypeError) as e:
+        logger.warning(f"Number conversion failed: {value} -> {str(e)}")
+        return 0.0

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -768,22 +768,11 @@ class StockTrackingAgent:
     def _normalize_decision(decision: str) -> str:
         """Normalize AI decision string to canonical English form.
 
-        LLM may return decision in Korean or various English forms.
-        Maps all variants to a consistent set: 'Enter', 'Watch', 'Skip'.
+        Delegates to prism_core.parsing.normalize_decision_kr (issue #412 Phase 1).
+        Behavior unchanged: maps variants to {'Enter', 'Watch', 'Skip'}.
         """
-        if not decision:
-            return "Skip"
-        normalized = decision.strip()
-        enter_variants = {"진입", "Entry", "enter", "entry", "Enter", "매수", "Buy", "buy"}
-        watch_variants = {"관망", "Watch", "watch", "Hold", "hold", "보류"}
-        skip_variants = {"미진입", "Skip", "skip", "No entry", "no entry", "패스", "Pass", "pass"}
-        if normalized in enter_variants:
-            return "Enter"
-        if normalized in watch_variants:
-            return "Watch"
-        if normalized in skip_variants:
-            return "Skip"
-        return normalized
+        from prism_core.parsing import normalize_decision_kr
+        return normalize_decision_kr(decision)
 
     def _parse_price_value(self, value: Any) -> float:
         """Parse price value and convert to number (delegates to tracking.helpers)"""

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -1410,32 +1410,13 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
             logger.error(traceback.format_exc())
 
     def _safe_number_conversion(self, value) -> float:
-        """Safely convert various value types to numbers"""
-        try:
-            # If already a numeric type
-            if isinstance(value, (int, float)):
-                return float(value)
+        """Safely convert various value types to numbers.
 
-            # If string
-            if isinstance(value, str):
-                # Remove commas and spaces
-                cleaned_value = value.replace(',', '').replace(' ', '')
-                # Remove currency symbols (KRW, 원)
-                cleaned_value = cleaned_value.replace('KRW', '').replace('원', '')
-
-                # Check for empty string
-                if not cleaned_value:
-                    return 0.0
-
-                # Convert to number
-                return float(cleaned_value)
-
-            # If null or other type
-            return 0.0
-
-        except (ValueError, TypeError) as e:
-            logger.warning(f"Number conversion failed: {value} -> {str(e)}")
-            return 0.0
+        Delegates to prism_core.parsing.safe_number_conversion (issue #412 Phase 1).
+        Behavior unchanged.
+        """
+        from prism_core.parsing import safe_number_conversion
+        return safe_number_conversion(value)
 
     async def _save_holding_decision(self, ticker: str, current_price: float, decision_json: Dict[str, Any]) -> bool:
         """

--- a/tests/test_prism_core_parsing.py
+++ b/tests/test_prism_core_parsing.py
@@ -1,0 +1,107 @@
+"""Behavior-fixing tests for prism_core.parsing (issue #412 Phase 1).
+
+These lock the exact current behavior of the pure functions extracted from the
+KR/US tracking agents so later refactors cannot silently change them. The KR and
+US decision normalizers are intentionally distinct.
+"""
+import pytest
+
+from prism_core.parsing import (
+    normalize_decision_kr,
+    normalize_decision_us,
+    safe_number_conversion,
+)
+
+
+# --- normalize_decision_kr: {Enter, Watch, Skip}, passthrough otherwise ---
+
+@pytest.mark.parametrize("raw", ["진입", "Entry", "enter", "entry", "Enter", "매수", "Buy", "buy"])
+def test_kr_enter_variants(raw):
+    assert normalize_decision_kr(raw) == "Enter"
+
+
+@pytest.mark.parametrize("raw", ["관망", "Watch", "watch", "Hold", "hold", "보류"])
+def test_kr_watch_variants(raw):
+    assert normalize_decision_kr(raw) == "Watch"
+
+
+@pytest.mark.parametrize("raw", ["미진입", "Skip", "skip", "No entry", "no entry", "패스", "Pass", "pass"])
+def test_kr_skip_variants(raw):
+    assert normalize_decision_kr(raw) == "Skip"
+
+
+def test_kr_empty_returns_skip():
+    assert normalize_decision_kr("") == "Skip"
+    assert normalize_decision_kr(None) == "Skip"
+
+
+def test_kr_strips_whitespace():
+    assert normalize_decision_kr("  진입  ") == "Enter"
+
+
+def test_kr_unknown_passthrough_stripped_not_lowercased():
+    # KR passthrough returns the stripped (NOT lowercased) original
+    assert normalize_decision_kr("  Unknown  ") == "Unknown"
+
+
+# --- normalize_decision_us: {entry, no_entry}, lowercased passthrough otherwise ---
+
+@pytest.mark.parametrize("raw", ["enter", "entry", "ENTER", "Entry", "진입", "yes", "buy", "  BUY  "])
+def test_us_entry_variants(raw):
+    assert normalize_decision_us(raw) == "entry"
+
+
+@pytest.mark.parametrize("raw", ["no entry", "no_entry", "no-entry", "미진입", "no", "skip", "pass", "SKIP"])
+def test_us_no_entry_variants(raw):
+    assert normalize_decision_us(raw) == "no_entry"
+
+
+def test_us_empty_returns_no_entry():
+    assert normalize_decision_us("") == "no_entry"
+    assert normalize_decision_us(None) == "no_entry"
+
+
+def test_us_unknown_passthrough_lowercased_stripped():
+    # US passthrough returns lowercased + stripped original
+    assert normalize_decision_us("  Maybe  ") == "maybe"
+
+
+def test_kr_and_us_are_distinct():
+    # Same input, different vocab — confirms they must stay separate
+    assert normalize_decision_kr("진입") == "Enter"
+    assert normalize_decision_us("진입") == "entry"
+
+
+# --- safe_number_conversion ---
+
+def test_safe_number_numeric_passthrough():
+    assert safe_number_conversion(1000) == 1000.0
+    assert safe_number_conversion(12.5) == 12.5
+    assert safe_number_conversion(0) == 0.0
+
+
+def test_safe_number_strips_separators_and_currency():
+    assert safe_number_conversion("1,000") == 1000.0
+    assert safe_number_conversion("1 000") == 1000.0
+    assert safe_number_conversion("1,000 KRW") == 1000.0
+    assert safe_number_conversion("1000원") == 1000.0
+    assert safe_number_conversion("1,234,567") == 1234567.0
+
+
+def test_safe_number_empty_and_none_and_invalid_return_zero():
+    assert safe_number_conversion("") == 0.0
+    assert safe_number_conversion("   ") == 0.0
+    assert safe_number_conversion(None) == 0.0
+    assert safe_number_conversion("abc") == 0.0
+    assert safe_number_conversion(["not", "a", "number"]) == 0.0
+
+
+def test_safe_number_float_string():
+    assert safe_number_conversion("12.75") == 12.75
+
+
+def test_delegation_wiring_kr_staticmethod():
+    # The KR static method must still work and produce identical output.
+    from stock_tracking_agent import StockTrackingAgent
+    assert StockTrackingAgent._normalize_decision("진입") == "Enter"
+    assert StockTrackingAgent._normalize_decision("관망") == "Watch"


### PR DESCRIPTION
## 개요
이슈 #412(주문실행 아키텍처 리팩토링) **Phase 1-a** — 순수 함수를 `prism_core`로 추출(로직 변화 0). 스코프 (B): import 경로 churn 최소화.

## 변경
새 `prism_core` 패키지 + `prism_core/parsing.py`에 순수 함수 3개 이관:
- `normalize_decision_kr` (Enter/Watch/Skip) — from `stock_tracking_agent`
- `normalize_decision_us` (entry/no_entry) — from `us_stock_tracking_agent`
- `safe_number_conversion` (float 변환) — from `stock_tracking_enhanced_agent`

**KR·US 정규화는 의도적으로 분리** — vocab·매핑이 다름(문서화된 포크 드리프트, 진짜 통합은 Phase 6). 기존 메서드는 **시그니처 유지 + 본문만 lazy-import 위임** → 호출부 0변경, 모듈 로드 순서(US sys.path) 영향 0.

## 검증
- 동작 **byte-for-byte 불변**. 신규 `tests/test_prism_core_parsing.py` **49 passed** (KR 비소문자 passthrough / US 소문자 passthrough / KR·US 구별 / safe_number 엣지 고정).
- root/KR 에이전트 스위트 **97 passed**. 실패 3건은 **main 선존**(async 마커 2 + masks-payload 1, 본 변경 무관).
- US 테스트는 로컬 dual-clone 환경 선존 수집에러(main 동일)라 미실행 — US 모듈 컴파일 OK, 위임은 검증된 순수함수의 2줄 래퍼.
- Fresh 리뷰 **APPROVE**.

## 관련
- #412 Phase 1. 다음: Phase 1-b(`time_windows.py` — KST/ET 세션 판정).