### PR TITLE
fix(screening): report real change rate for bottom-up triggers

### DIFF
--- a/tests/test_screening_change_rate.py
+++ b/tests/test_screening_change_rate.py
@@ -1,0 +1,87 @@
+"""
+Regression tests for the bottom-up screening triggers' change-rate reporting.
+
+Bug: trigger_macro_sector_leader and trigger_contrarian_value computed the
+daily change into a "DailyChange" column, but the batch dispatch consumer only
+reads "prev_day_change_rate". As a result these two bottom-up triggers reported
+a 0% change rate (e.g. the SK hynix / 000660 case), unlike the top-down triggers
+which populate "prev_day_change_rate" directly.
+
+Fix: both triggers now mirror DailyChange into prev_day_change_rate.
+"""
+import pandas as pd
+import pytest
+
+import trigger_batch
+from trigger_batch import trigger_macro_sector_leader, trigger_contrarian_value
+
+
+def _expected_change(close, prev_close):
+    return (close - prev_close) / prev_close * 100
+
+
+def test_macro_sector_leader_sets_prev_day_change_rate():
+    snapshot = pd.DataFrame(
+        {
+            "Open": [195000, 79000],
+            "Close": [200000, 80000],
+            "Amount": [5e11, 4e11],
+            "Volume": [1_000_000, 1_000_000],
+        },
+        index=["000660", "005930"],
+    )
+    prev_snapshot = pd.DataFrame(
+        {"Close": [194000, 78000]},
+        index=["000660", "005930"],
+    )
+    macro_context = {
+        "leading_sectors": [{"sector": "반도체", "confidence": 0.8}],
+        "sector_map": {"000660": "반도체", "005930": "반도체"},
+    }
+
+    result = trigger_macro_sector_leader(
+        "20260717", snapshot, prev_snapshot, macro_context=macro_context
+    )
+
+    assert not result.empty
+    assert "prev_day_change_rate" in result.columns
+    # Column must equal the computed DailyChange and be non-zero (the bug reported 0).
+    for ticker in result.index:
+        expected = _expected_change(
+            snapshot.loc[ticker, "Close"], prev_snapshot.loc[ticker, "Close"]
+        )
+        assert result.loc[ticker, "prev_day_change_rate"] == pytest.approx(expected)
+        assert result.loc[ticker, "prev_day_change_rate"] != 0
+
+
+def test_contrarian_value_sets_prev_day_change_rate(monkeypatch):
+    # Rising stock today (Close > Open), deep drawdown vs 52w high, profitable.
+    snapshot = pd.DataFrame(
+        {
+            "Open": [190000],
+            "Close": [200000],
+            "Amount": [5e11],
+            "Volume": [1_000_000],
+        },
+        index=["000660"],
+    )
+    prev_snapshot = pd.DataFrame({"Close": [194000]}, index=["000660"])
+
+    # 52-week high => -25% drawdown (inside the -40%..-15% band).
+    high_52w = 200000 / 0.75
+    fake_hist = pd.DataFrame({"High": [high_52w, high_52w * 0.9]})
+    fake_fund = pd.DataFrame({"PER": [10.0], "PBR": [1.0]})
+
+    # trigger_contrarian_value does `from krx_data_client import ...` at call time,
+    # so patching the module attributes is enough.
+    import krx_data_client
+    monkeypatch.setattr(krx_data_client, "get_market_ohlcv_by_date", lambda *a, **k: fake_hist)
+    monkeypatch.setattr(krx_data_client, "get_market_fundamental_by_date", lambda *a, **k: fake_fund)
+
+    result = trigger_contrarian_value("20260717", snapshot, prev_snapshot)
+
+    assert not result.empty
+    assert "prev_day_change_rate" in result.columns
+    expected = _expected_change(200000, 194000)
+    assert result.loc["000660", "prev_day_change_rate"] == pytest.approx(expected)
+    assert result.loc["000660", "prev_day_change_rate"] != 0

--- a/trigger_batch.py
+++ b/trigger_batch.py
@@ -1135,6 +1135,9 @@ def trigger_macro_sector_leader(trade_date: str, snapshot: pd.DataFrame,
     # Calculate daily change for relative strength
     snap_filtered["DailyChange"] = ((snap_filtered["Close"] - prev.loc[matched_rows, "Close"]) /
                                      prev.loc[matched_rows, "Close"]) * 100
+    # Expose as prev_day_change_rate so the downstream dispatch (which only reads
+    # prev_day_change_rate) reports the real change rate instead of 0.
+    snap_filtered["prev_day_change_rate"] = snap_filtered["DailyChange"]
 
     # Market average change for relative strength calculation
     market_avg_change = (
@@ -1264,6 +1267,9 @@ def trigger_contrarian_value(trade_date: str, snapshot: pd.DataFrame,
         return pd.DataFrame()
 
     result_df = pd.DataFrame(rows).set_index("Ticker")
+    # Same fix as trigger_macro_sector_leader: downstream dispatch reads only
+    # prev_day_change_rate, so mirror DailyChange into it (was reported as 0).
+    result_df["prev_day_change_rate"] = result_df["DailyChange"]
 
     def _norm_col(series: pd.Series) -> pd.Series:
         col_min = series.min()


### PR DESCRIPTION
## Problem
`trigger_macro_sector_leader` and `trigger_contrarian_value` (the two bottom-up screening triggers) compute the daily change into a `DailyChange` column, but the batch dispatch consumer (`trigger_batch.py:~1690`) reads **only** `prev_day_change_rate`. As a result these triggers reported a **0% change rate** — e.g. the SK hynix / `000660` macro-sector-leader case flagged in the handoff. The six top-down triggers populate `prev_day_change_rate` directly, so they were unaffected.

## Fix
Mirror `DailyChange` into `prev_day_change_rate` in both triggers:
- `trigger_macro_sector_leader` — right after `DailyChange` is computed
- `trigger_contrarian_value` — right after `result_df` is built (the handoff-flagged "same bug" — confirmed present)

Display-only fix. **No impact on live order execution.**

## Verification
- New regression test `tests/test_screening_change_rate.py` invokes both triggers with synthetic data (contrarian mocks the two `krx_data_client` fetches) and asserts `prev_day_change_rate` is present, equals the computed change, and is non-zero.
- Proven to catch the bug: **fails (2 failed) on pre-fix code, passes (2 passed) after the fix.**
- Existing trigger suites still green (`test_trigger_batch_enhance_dataframe`, `test_trigger_reliability`, `test_regime_weak_no_topdown`, `test_sideways_downtrend_gate` 12/12, `test_issue_289_screening` 59/59).

🤖 Generated with [Claude Code](https://claude.com/claude-code)