### PR TITLE
feat(translation): gpt-5.4-nano → gpt-5.6-luna

### DIFF
--- a/cores/agents/telegram_translator_agent.py
+++ b/cores/agents/telegram_translator_agent.py
@@ -104,7 +104,7 @@ Only return the translated text without any explanations or metadata.
 
 async def translate_telegram_message(
     message: str,
-    model: str = "gpt-5.4-nano",
+    model: str = "gpt-5.6-luna",
     from_lang: str = "ko",
     to_lang: str = "en"
 ) -> str:
@@ -113,7 +113,7 @@ async def translate_telegram_message(
 
     Args:
         message: Telegram message to translate
-        model: OpenAI model to use (default: gpt-5.4-nano for cost efficiency)
+        model: OpenAI model to use (default: gpt-5.6-luna for cost efficiency)
         from_lang: Source language code (default: "ko" for Korean)
         to_lang: Target language code (default: "en" for English)
 

--- a/examples/generate_dashboard_json.py
+++ b/examples/generate_dashboard_json.py
@@ -96,7 +96,7 @@ class DashboardDataGenerator:
         # Initialize translator
         if self.enable_translation:
             try:
-                self.translator = DashboardTranslator(model="gpt-5.4-nano")
+                self.translator = DashboardTranslator(model="gpt-5.6-luna")
                 logger.info("Translation enabled.")
             except Exception as e:
                 self.enable_translation = False

--- a/examples/generate_us_dashboard_json.py
+++ b/examples/generate_us_dashboard_json.py
@@ -135,7 +135,7 @@ class USDashboardDataGenerator:
         # Initialize translator
         if self.enable_translation:
             try:
-                self.translator = DashboardTranslator(model="gpt-5.4-nano")
+                self.translator = DashboardTranslator(model="gpt-5.6-luna")
                 logger.info("Translation feature enabled.")
             except Exception as e:
                 self.enable_translation = False

--- a/examples/translation_utils.py
+++ b/examples/translation_utils.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 class DashboardTranslator:
     """Dashboard data translation class"""
     
-    def __init__(self, model: str = "gpt-5.4-nano"):
+    def __init__(self, model: str = "gpt-5.6-luna"):
         """
         Initialize translator
 
@@ -444,7 +444,7 @@ if __name__ == "__main__":
     import os
 
     async def test():
-        translator = DashboardTranslator(model="gpt-5.4-nano")
+        translator = DashboardTranslator(model="gpt-5.6-luna")
 
         # Single translation test
         result = await translator.translate_text("The automotive industry outlook is bright.")

--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -671,7 +671,7 @@ class USStockAnalysisOrchestrator:
                         logger.info(f"Translating US telegram message to {lang}")
                         translated_message = await translate_telegram_message(
                             original_message,
-                            model="gpt-5.4-nano",
+                            model="gpt-5.6-luna",
                             from_lang="ko",
                             to_lang=lang
                         )
@@ -728,7 +728,7 @@ class USStockAnalysisOrchestrator:
 
                         translated_report = await translate_telegram_message(
                             text_for_translation,
-                            model="gpt-5.4-nano",
+                            model="gpt-5.6-luna",
                             from_lang="ko",
                             to_lang=lang
                         )
@@ -874,7 +874,7 @@ class USStockAnalysisOrchestrator:
                     logger.info(f"Translating US trigger alert to {lang}")
                     translated_message = await translate_telegram_message(
                         original_message,
-                        model="gpt-5.4-nano",
+                        model="gpt-5.6-luna",
                         from_lang="ko",
                         to_lang=lang
                     )

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -3176,7 +3176,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     translated_queue = []
                     for idx, message in enumerate(self.message_queue, 1):
                         logger.info(f"Translating US message {idx}/{len(self.message_queue)}")
-                        translated = await translate_telegram_message(message, model="gpt-5.4-nano")
+                        translated = await translate_telegram_message(message, model="gpt-5.6-luna")
                         translated_queue.append(translated)
                     self.message_queue = translated_queue
                     logger.info("All US messages translated successfully")
@@ -3298,7 +3298,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                             logger.info(f"Translating US tracking message to {lang}")
                             translated_message = await translate_telegram_message(
                                 message,
-                                model="gpt-5.4-nano",
+                                model="gpt-5.6-luna",
                                 from_lang="ko",
                                 to_lang=lang
                             )

--- a/stock_analysis_orchestrator.py
+++ b/stock_analysis_orchestrator.py
@@ -679,7 +679,7 @@ class StockAnalysisOrchestrator:
                         logger.info(f"Translating telegram message to {lang}")
                         translated_message = await translate_telegram_message(
                             original_message,
-                            model="gpt-5.4-nano",
+                            model="gpt-5.6-luna",
                             from_lang="ko",
                             to_lang=lang
                         )
@@ -737,7 +737,7 @@ class StockAnalysisOrchestrator:
 
                         translated_report = await translate_telegram_message(
                             text_for_translation,
-                            model="gpt-5.4-nano",
+                            model="gpt-5.6-luna",
                             from_lang="ko",
                             to_lang=lang
                         )
@@ -844,7 +844,7 @@ class StockAnalysisOrchestrator:
                 try:
                     logger.info("Translating trigger alert message to English")
                     from cores.agents.telegram_translator_agent import translate_telegram_message
-                    message = await translate_telegram_message(message, model="gpt-5.4-nano")
+                    message = await translate_telegram_message(message, model="gpt-5.6-luna")
                     logger.info("Translation complete")
                 except Exception as e:
                     logger.error(f"Translation failed: {str(e)}. Using original Korean message.")
@@ -903,7 +903,7 @@ class StockAnalysisOrchestrator:
                     logger.info(f"Translating trigger alert to {lang}")
                     translated_message = await translate_telegram_message(
                         original_message,
-                        model="gpt-5.4-nano",
+                        model="gpt-5.6-luna",
                         from_lang="ko",
                         to_lang=lang
                     )

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -2207,7 +2207,7 @@ class StockTrackingAgent:
                     translated_queue = []
                     for idx, message in enumerate(self.message_queue, 1):
                         logger.info(f"Translating message {idx}/{len(self.message_queue)}")
-                        translated = await translate_telegram_message(message, model="gpt-5.4-nano")
+                        translated = await translate_telegram_message(message, model="gpt-5.6-luna")
                         translated_queue.append(translated)
                     self.message_queue = translated_queue
                     logger.info("All messages translated successfully")
@@ -2322,7 +2322,7 @@ class StockTrackingAgent:
                             logger.info(f"Translating tracking message to {lang}")
                             translated_message = await translate_telegram_message(
                                 message,
-                                model="gpt-5.4-nano",
+                                model="gpt-5.6-luna",
                                 from_lang="ko",
                                 to_lang=lang
                             )

--- a/tracking/telegram.py
+++ b/tracking/telegram.py
@@ -112,7 +112,7 @@ class TelegramSender:
             translated = []
             for idx, message in enumerate(messages, 1):
                 logger.info(f"Translating message {idx}/{len(messages)}")
-                result = await translate_telegram_message(message, model="gpt-5.4-nano")
+                result = await translate_telegram_message(message, model="gpt-5.6-luna")
                 translated.append(result)
             logger.info("All messages translated successfully")
             return translated
@@ -143,7 +143,7 @@ class TelegramSender:
                     for message in messages:
                         try:
                             translated = await translate_telegram_message(
-                                message, model="gpt-5.4-nano",
+                                message, model="gpt-5.6-luna",
                                 from_lang="ko", to_lang=lang
                             )
                             await self._send_single_message(channel_id, translated)

--- a/trading/portfolio_telegram_reporter.py
+++ b/trading/portfolio_telegram_reporter.py
@@ -467,7 +467,7 @@ class PortfolioTelegramReporter:
                     # Translate message
                     translated_message = await translate_telegram_message(
                         original_message,
-                        model="gpt-5.4-nano",
+                        model="gpt-5.6-luna",
                         from_lang="ko",
                         to_lang=lang
                     )

--- a/weekly_firecrawl_intelligence.py
+++ b/weekly_firecrawl_intelligence.py
@@ -164,7 +164,7 @@ async def _send_broadcast(message: str, broadcast_languages: list):
 
                 logger.info(f"Translating intelligence report to {lang}")
                 translated = await translate_telegram_message(
-                    message, model="gpt-5.4-nano", from_lang="ko", to_lang=lang
+                    message, model="gpt-5.6-luna", from_lang="ko", to_lang=lang
                 )
                 if len(translated) > 4096:
                     for i in range(0, len(translated), 4096):

--- a/weekly_insight_report.py
+++ b/weekly_insight_report.py
@@ -533,7 +533,7 @@ async def _send_broadcast(message: str, broadcast_languages: list):
 
                 logger.info(f"Translating weekly report to {lang}")
                 translated = await translate_telegram_message(
-                    message, model="gpt-5.4-nano", from_lang="ko", to_lang=lang
+                    message, model="gpt-5.6-luna", from_lang="ko", to_lang=lang
                 )
                 await bot.send_message(chat_id=channel_id, text=translated, parse_mode="HTML")
                 logger.info(f"Weekly report sent to {lang} channel")


### PR DESCRIPTION
## What
Switch all **translation** calls from `gpt-5.4-nano` to **`gpt-5.6-luna`** (20 call sites across 12 files: telegram_translator default + KR/US orchestrators, tracking, portfolio reporter, weekly reports, example DashboardTranslator).

## Not changed (intentional)
- `cores/chatgpt_proxy/api_translator.py` `_MODEL_MAP` — the proxy's `nano→mini` mapping (proxy layer, not model choice).
- `tests/test_chatgpt_oauth/*` — assert proxy passthrough/mapping behavior for `nano`.

## Verified on db-server (real production path)
Ran `translate_telegram_message(..., model=...)` through the actual path (mcp_agent chat.completions → Codex/OAuth proxy):
```
OK  gpt-5.4-nano   3.6s  out='Samsung Electronics rose 3% today, showing strength.'
OK  gpt-5.6-luna   1.4s  out='Samsung Electronics rose 3% today, showing strength.'
```
luna produces a correct translation and is faster. (Also confirmed earlier via the Responses-API Codex probe.) Translation fails safe — returns the original message on any error.

## Risk
Low: background path, graceful fallback. No trading/order impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)