### PR TITLE
refactor(#412): extract KST order-window classification to prism_core (Phase 1-b)

### DIFF
--- a/prism_core/time_windows.py
+++ b/prism_core/time_windows.py
@@ -1,0 +1,42 @@
+"""Pure order-time-window classification (issue #412 Phase 1-b).
+
+Extracted from ``trading/domestic_stock_trading.py`` so the exchange-session
+calculation lives in a dependency-free core module that can be unit-tested in
+isolation. Behavior is preserved byte-for-byte; ``domestic_stock_trading`` now
+delegates to this function. Only the *calculation* is extracted here — order
+guards, ledger writes and broadcasts stay in the trading adapter (per the
+migration plan, those move no earlier than Phase 2-3).
+"""
+import datetime
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+KST = ZoneInfo("Asia/Seoul")
+
+
+def now_kst() -> datetime.datetime:
+    """Return timezone-aware current time in Korea Standard Time."""
+    return datetime.datetime.now(KST)
+
+
+def domestic_order_window(now: Optional[datetime.datetime] = None) -> str:
+    """Classify the Korean domestic stock order window using KST.
+
+    Returns one of:
+    - regular: 09:00~15:30 market orders
+    - closing: 15:40~16:00 after-hours closing-price orders
+    - reserved: KIS reserved-order window, excluding 23:40~00:10
+    - unavailable: gaps where neither regular/closing nor reserved orders are accepted
+    """
+    now = now or now_kst()
+    current_time = now.astimezone(KST).time() if now.tzinfo else now.time()
+
+    if datetime.time(9, 0) <= current_time <= datetime.time(15, 30):
+        return "regular"
+    if datetime.time(15, 40) <= current_time <= datetime.time(16, 0):
+        return "closing"
+    if datetime.time(16, 0) < current_time <= datetime.time(23, 40):
+        return "reserved"
+    if datetime.time(0, 10) <= current_time <= datetime.time(7, 30):
+        return "reserved"
+    return "unavailable"

--- a/tests/test_prism_core_time_windows.py
+++ b/tests/test_prism_core_time_windows.py
@@ -1,0 +1,69 @@
+"""Unit tests for prism_core.time_windows (issue #412 Phase 1-b).
+
+Pins the KST domestic order-window classification boundaries so the extraction
+from trading/domestic_stock_trading.py is behavior-preserving.
+"""
+import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from prism_core.time_windows import domestic_order_window, KST
+
+
+def _at(h, m, s=0):
+    """Naive datetime carrying a KST wall-clock time (used via .time())."""
+    return datetime.datetime(2026, 7, 20, h, m, s)
+
+
+@pytest.mark.parametrize(
+    "h,m,expected",
+    [
+        # regular: 09:00 ~ 15:30 inclusive
+        (9, 0, "regular"),
+        (12, 0, "regular"),
+        (15, 30, "regular"),
+        # closing: 15:40 ~ 16:00 inclusive
+        (15, 40, "closing"),
+        (16, 0, "closing"),
+        # reserved: 16:00 < t <= 23:40, and 00:10 <= t <= 07:30
+        (16, 1, "reserved"),
+        (20, 0, "reserved"),
+        (23, 40, "reserved"),
+        (0, 10, "reserved"),
+        (3, 0, "reserved"),
+        (7, 30, "reserved"),
+        # unavailable gaps
+        (8, 59, "unavailable"),   # before regular open
+        (8, 15, "unavailable"),   # reserved maintenance gap 07:30~09:00
+        (7, 31, "unavailable"),   # just after reserved morning window
+        (15, 31, "unavailable"),  # between regular and closing
+        (15, 39, "unavailable"),
+        (23, 41, "unavailable"),  # 23:40~00:10 blackout
+        (0, 0, "unavailable"),
+        (0, 9, "unavailable"),
+    ],
+)
+def test_domestic_order_window_boundaries(h, m, expected):
+    assert domestic_order_window(_at(h, m)) == expected
+
+
+def test_tz_aware_input_is_converted_to_kst():
+    # 01:00 UTC == 10:00 KST -> regular
+    utc_dt = datetime.datetime(2026, 7, 20, 1, 0, tzinfo=ZoneInfo("UTC"))
+    assert domestic_order_window(utc_dt) == "regular"
+    # 07:00 UTC == 16:00 KST -> closing
+    utc_closing = datetime.datetime(2026, 7, 20, 7, 0, tzinfo=ZoneInfo("UTC"))
+    assert domestic_order_window(utc_closing) == "closing"
+
+
+def test_default_now_returns_valid_classification():
+    result = domestic_order_window()
+    assert result in {"regular", "closing", "reserved", "unavailable"}
+
+
+def test_delegation_matches_core():
+    """The trading adapter wrapper must return the same value as the core fn."""
+    from trading import domestic_stock_trading as dom
+    for h, m in [(10, 0), (15, 35), (20, 0), (8, 15)]:
+        assert dom._domestic_order_window(_at(h, m)) == domestic_order_window(_at(h, m))

--- a/trading/domestic_stock_trading.py
+++ b/trading/domestic_stock_trading.py
@@ -45,24 +45,18 @@ def _now_kst() -> datetime.datetime:
 def _domestic_order_window(now: Optional[datetime.datetime] = None) -> str:
     """Classify the Korean domestic stock order window using KST.
 
+    Thin wrapper that delegates to ``prism_core.time_windows`` (issue #412
+    Phase 1-b). Kept so existing call sites and tests stay unchanged; the
+    calculation itself now lives in the dependency-free core module.
+
     Returns one of:
     - regular: 09:00~15:30 market orders
     - closing: 15:40~16:00 after-hours closing-price orders
     - reserved: KIS reserved-order window, excluding 23:40~00:10
     - unavailable: gaps where neither regular/closing nor reserved orders are accepted
     """
-    now = now or _now_kst()
-    current_time = now.astimezone(KST).time() if now.tzinfo else now.time()
-
-    if datetime.time(9, 0) <= current_time <= datetime.time(15, 30):
-        return "regular"
-    if datetime.time(15, 40) <= current_time <= datetime.time(16, 0):
-        return "closing"
-    if datetime.time(16, 0) < current_time <= datetime.time(23, 40):
-        return "reserved"
-    if datetime.time(0, 10) <= current_time <= datetime.time(7, 30):
-        return "reserved"
-    return "unavailable"
+    from prism_core.time_windows import domestic_order_window
+    return domestic_order_window(now)
 
 # Load configuration file
 CONFIG_FILE = TRADING_DIR / "config" / "kis_devlp.yaml"


### PR DESCRIPTION
## What (issue #412 Phase 1-b)
Extract the pure KST domestic order-window calculation out of the trading adapter into a dependency-free core module.

- **New `prism_core/time_windows.py`**: `KST`, `now_kst()`, `domestic_order_window()` → `regular` / `closing` / `reserved` / `unavailable`. Logic byte-for-byte identical to the original.
- **`trading/domestic_stock_trading.py`**: `_domestic_order_window` is now a thin lazy-import wrapper delegating to the core fn (same Phase 1-a delegation pattern). Call sites and behavior unchanged.
- **`tests/test_prism_core_time_windows.py`**: pins every boundary (regular 09:00–15:30, closing 15:40–16:00, reserved windows, the unavailable gaps 07:30–09:00 / 15:30–15:40 / 23:40–00:10), tz-aware→KST conversion, and asserts the adapter wrapper == core fn. **22 passed** locally.

## Scope
Calculation-only extraction. Order guards, ledger writes, and broadcasts stay in the adapter (migration plan defers those to Phase 2-3). No call-site changes, no logic changes.

## Notes
`tests/test_domestic_trading_time_windows.py` (existing) validates the delegating path; its behavior is preserved. Under the local `.venv312` it hits a pre-existing pandas-stub collection error that also fails on `main` (unrelated to this diff) — it runs fine in CI.

Phase 1-a was PR #447 (merged). Next: Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)