### PR TITLE
feat(trading): route real orders through ExecutionService

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,4 +45,4 @@ jobs:
             tests/test_layer2_stale_snapshot_guard.py -q
           python -m pytest tests/test_sell_claim_concurrency.py -q
           python -m pytest tests/test_fill_chaser.py -q
-          python -m pytest prism-us/tests/test_fill_chaser_us.py -q
+          python -m pytest --noconftest prism-us/tests/test_fill_chaser_us.py -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,16 @@ jobs:
             pytest-asyncio
 
       - name: Run tests
-        run: python -m pytest cores/llm/tests/ -q
+        run: |
+          python -m pytest cores/llm/tests/ -q
+          # Lightweight real-order boundary gates. Keep KR/US fill-chaser in
+          # separate processes because their runtime packages intentionally
+          # shadow one another.
+          python -m pytest tests/test_execution_service.py -q \
+            -k "not transient_empty_portfolio"
+          python -m pytest \
+            tests/test_issue_288_pyramiding.py \
+            tests/test_layer2_stale_snapshot_guard.py -q
+          python -m pytest tests/test_sell_claim_concurrency.py -q
+          python -m pytest tests/test_fill_chaser.py -q
+          python -m pytest prism-us/tests/test_fill_chaser_us.py -q

--- a/prism-us/tests/test_fill_chaser_us.py
+++ b/prism-us/tests/test_fill_chaser_us.py
@@ -123,7 +123,13 @@ def _fast_defaults(monkeypatch):
 
 
 def _patch_ctx(monkeypatch, trader):
-    monkeypatch.setattr(lc, "_open_context", lambda market, account_name=None: FakeCtx(trader))
+    from prism_core.execution_service import ExecutionService
+
+    monkeypatch.setattr(
+        lc,
+        "_open_context",
+        lambda market, account_name=None: ExecutionService(FakeCtx(trader)),
+    )
 
 
 def _logs(db, action=None):
@@ -311,11 +317,15 @@ def test_inquiry_failure_degrades_to_noop(tmp_db, monkeypatch):
 def test_dry_run_payload_has_required_us_fields(tmp_db, monkeypatch):
     """dry_run=True returns the exact US amend body incl. the TODO(live-validate)
     fields (PDNO/ORD_SVR_DVSN_CD/OVRS_EXCG_CD/OVRS_ORD_UNPR) — no network/order."""
+    from prism_core.execution_service import ExecutionService
+
     trader = FakeTrader([], {})
     order = {"ticker": "AAPL", "side": "SELL", "order_no": "O1",
              "ord_unpr": 190.00, "unfilled_qty": 10, "exchange": "NASD",
              "krx_fwdg_ord_orgno": ""}
-    payload = lc._build_dry_run_payload(trader, "US", order, "AMEND", 189.50)
+    payload = lc._build_dry_run_payload(
+        ExecutionService(trader), "US", order, "AMEND", 189.50
+    )
     assert payload["tr_id"] and "order-rvsecncl" in payload["api_url"]
     p = payload["params"]
     for k in ("CANO", "ACNT_PRDT_CD", "OVRS_EXCG_CD", "PDNO", "ORGN_ODNO",

--- a/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
+++ b/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
@@ -1,8 +1,11 @@
+import asyncio
 import importlib.util
 import logging
 import sqlite3
 import sys
+import threading
 import types
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -142,6 +145,116 @@ class _FakeAsyncUSTradingContext:
             "success": True,
             "message": f"sold for {self.account_name}",
         }
+
+
+@pytest.mark.parametrize("pyramiding", [False, True], ids=["single", "pyramiding"])
+def test_concurrent_sell_guard_allows_one_us_order_and_publish(tmp_path, pyramiding):
+    from prism_core.execution_service import ExecutionService
+
+    db_path = tmp_path / "us-concurrent-sell.sqlite"
+    setup = sqlite3.connect(db_path)
+    setup.execute("PRAGMA journal_mode=WAL")
+    setup.execute(
+        """CREATE TABLE us_stock_holdings (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               account_key TEXT NOT NULL, account_name TEXT, ticker TEXT NOT NULL,
+               company_name TEXT NOT NULL, buy_price REAL NOT NULL,
+               buy_date TEXT NOT NULL, current_price REAL, scenario TEXT,
+               trigger_type TEXT, trigger_mode TEXT, sector TEXT
+           )"""
+    )
+    setup.execute(
+        """CREATE TABLE us_trading_history (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               account_key TEXT NOT NULL, account_name TEXT, ticker TEXT NOT NULL,
+               company_name TEXT NOT NULL, buy_price REAL NOT NULL,
+               buy_date TEXT NOT NULL, sell_price REAL NOT NULL,
+               sell_date TEXT NOT NULL, profit_rate REAL NOT NULL,
+               holding_days INTEGER NOT NULL, scenario TEXT, trigger_type TEXT,
+               trigger_mode TEXT, sector TEXT, exit_kind TEXT
+           )"""
+    )
+    target_row_id = setup.execute(
+        """INSERT INTO us_stock_holdings
+           (account_key, account_name, ticker, company_name, buy_price, buy_date)
+           VALUES ('ACC1', 'us-primary', 'AAPL', 'Apple', 180,
+                   '2026-07-01 09:00:00')"""
+    ).lastrowid
+    if pyramiding:
+        setup.execute(
+            """INSERT INTO us_stock_holdings
+               (account_key, account_name, ticker, company_name, buy_price, buy_date)
+               VALUES ('ACC1', 'us-primary', 'AAPL', 'Apple', 175,
+                       '2026-06-15 09:00:00')"""
+        )
+    setup.commit()
+    setup.close()
+
+    barrier = threading.Barrier(2)
+
+    effects = {"broker": 0, "publish": 0}
+    effects_lock = threading.Lock()
+
+    class Broker:
+        async def async_sell_stock(self, *args, **kwargs):
+            with effects_lock:
+                effects["broker"] += 1
+            return {"success": True}
+
+    stock = {
+        "ticker": "AAPL",
+        "company_name": "Apple",
+        "buy_price": 180,
+        "buy_date": "2026-07-01 09:00:00",
+        "current_price": 185,
+        "account_key": "ACC1",
+        "account_name": "us-primary",
+        "sector": "Technology",
+        "id": target_row_id,
+    }
+
+    def run_competitor():
+        conn = sqlite3.connect(db_path, timeout=1, check_same_thread=False)
+        conn.execute("PRAGMA busy_timeout=1000")
+        agent = USStockTrackingAgent.__new__(USStockTrackingAgent)
+        agent.conn = conn
+        agent.cursor = conn.cursor()
+        agent.message_queue = []
+        agent._msg_types = []
+        agent.enable_journal = False
+        agent.journal_manager = None
+        agent._account_scope = lambda: ("ACC1", "us-primary")
+        agent._get_trigger_win_rate = lambda _trigger: ""
+
+        async def exercise():
+            barrier.wait(timeout=5)
+            sold = await agent.sell_stock(dict(stock), "concurrency regression")
+            if sold:
+                await ExecutionService(Broker()).execute_sell("AAPL", quantity=1)
+                with effects_lock:
+                    effects["publish"] += 1
+            return sold, len(agent.message_queue)
+
+        try:
+            return asyncio.run(exercise())
+        finally:
+            conn.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(lambda _index: run_competitor(), range(2)))
+
+    verify = sqlite3.connect(db_path)
+    history_count = verify.execute("SELECT COUNT(*) FROM us_trading_history").fetchone()[0]
+    remaining_prices = verify.execute(
+        "SELECT buy_price FROM us_stock_holdings ORDER BY id"
+    ).fetchall()
+    verify.close()
+
+    assert sorted(sold for sold, _messages in results) == [False, True]
+    assert sum(messages for _sold, messages in results) == 1
+    assert history_count == 1
+    assert remaining_prices == ([(175.0,)] if pyramiding else [])
+    assert effects == {"broker": 1, "publish": 1}
 
 
 def _install_signal_modules(monkeypatch, redis_calls, gcp_calls):

--- a/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
+++ b/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
@@ -52,6 +52,41 @@ def _load_us_agent_module():
         tracking_db_schema.migrate_us_watchlist_history_columns = lambda *args, **kwargs: None
         tracking_db_schema.is_us_ticker_in_holdings = lambda *args, **kwargs: False
         tracking_db_schema.get_us_holdings_count = lambda *args, **kwargs: 0
+        def get_us_existing_position_for_ticker(cursor, ticker, account_key=None):
+            try:
+                if account_key:
+                    cursor.execute(
+                        "SELECT buy_price FROM us_stock_holdings "
+                        "WHERE ticker = ? AND account_key = ?",
+                        (ticker, account_key),
+                    )
+                else:
+                    cursor.execute(
+                        "SELECT buy_price FROM us_stock_holdings WHERE ticker = ?",
+                        (ticker,),
+                    )
+                prices = [float(row[0]) for row in cursor.fetchall()]
+            except sqlite3.Error:
+                prices = []
+            return {
+                "row_count": len(prices),
+                "avg_buy_price": sum(prices) / len(prices) if prices else 0.0,
+            }
+
+        tracking_db_schema.get_us_existing_position_for_ticker = (
+            get_us_existing_position_for_ticker
+        )
+        tracking_db_schema.evaluate_us_pyramid_add_gate = (
+            lambda *args, **kwargs: (False, "no existing position")
+        )
+        tracking_db_schema.compute_us_fractional_sell_quantity = (
+            lambda total, rows: int(total) if int(rows) <= 1 else int(total) // int(rows)
+        )
+        tracking_db_schema.decide_us_sell_plan = (
+            lambda rows, will_queue: (
+                "single_full" if int(rows) <= 1 else "full_exit" if will_queue else "fractional"
+            )
+        )
         sys.modules["tracking.db_schema"] = tracking_db_schema
 
         tracking_journal = types.ModuleType("tracking.journal")
@@ -102,7 +137,7 @@ class _FakeAsyncUSTradingContext:
             "failed_accounts": ["us-secondary"],
         }
 
-    async def async_sell_stock(self, ticker, limit_price=None):
+    async def async_sell_stock(self, ticker, limit_price=None, quantity=None):
         return {
             "success": True,
             "message": f"sold for {self.account_name}",
@@ -188,11 +223,13 @@ async def test_process_reports_analyzes_once_and_dedupes_signals(monkeypatch, ca
         slot_checks.append(agent.active_account["name"])
         return 0
 
-    async def fake_check_sector_diversity(sector):
+    async def fake_check_sector_diversity(sector, is_pyramiding_add=False):
         sector_checks.append((agent.active_account["name"], sector))
         return True
 
-    async def fake_buy_stock(ticker, company_name, current_price, scenario, rank_change_msg):
+    async def fake_buy_stock(
+        ticker, company_name, current_price, scenario, rank_change_msg, is_add=False
+    ):
         buy_calls.append((agent.active_account["name"], ticker))
         return True
 
@@ -266,7 +303,7 @@ async def test_process_reports_saves_watchlist_once_when_not_traded(monkeypatch)
     async def fake_get_current_slots_count():
         return 0
 
-    async def fake_check_sector_diversity(sector):
+    async def fake_check_sector_diversity(sector, is_pyramiding_add=False):
         return True
 
     async def fake_buy_stock(*args, **kwargs):
@@ -317,6 +354,7 @@ async def test_update_holdings_masks_sold_account_payload(monkeypatch):
     agent.cursor.execute(
         """
         CREATE TABLE us_stock_holdings (
+            id INTEGER PRIMARY KEY,
             ticker TEXT,
             company_name TEXT,
             buy_price REAL,
@@ -369,7 +407,7 @@ async def test_update_holdings_masks_sold_account_payload(monkeypatch):
     async def fake_analyze_sell_decision(stock):
         return True, "Take profit"
 
-    async def fake_sell_stock(stock, reason):
+    async def fake_sell_stock(stock, reason, exit_kind=None):
         return True
 
     agent._get_current_stock_price = fake_get_current_stock_price

--- a/prism-us/us_pending_order_batch.py
+++ b/prism-us/us_pending_order_batch.py
@@ -30,6 +30,8 @@ _project_root = str(Path(__file__).resolve().parent.parent)
 sys.path.insert(0, _project_root)
 sys.path.insert(0, _prism_us_dir)
 
+from prism_core.execution_service import ExecutionService  # noqa: E402
+
 import pytz
 
 # Logging
@@ -153,15 +155,16 @@ def process_pending_orders(dry_run: bool = False):
 
         try:
             trader = USStockTrading(mode=mode, account_name=account_name, product_code=product_code)
+            execution = ExecutionService(trader)
             if order_type == 'buy':
-                result = trader.buy_reserved_order(
+                result = execution.execute_reserved_buy(
                     ticker=ticker,
                     limit_price=limit_price,
                     buy_amount=buy_amount,
                     exchange=exchange
                 )
             elif order_type == 'sell':
-                result = trader.sell_reserved_order(
+                result = execution.execute_reserved_sell(
                     ticker=ticker,
                     limit_price=limit_price if limit_price > 0 else None,
                     exchange=exchange

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -2239,13 +2239,29 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
             # paths in both markets. (update_holdings also has an earlier Layer 2
             # short-circuit; this is the authoritative gate that also covers loops.)
             self.conn.commit()
-            if get_us_existing_position_for_ticker(
-                self.cursor, ticker, account_key=account_key
-            ).get("row_count", 0) == 0:
+            # Acquire the SQLite writer lock BEFORE the authoritative guard read.
+            # This makes the guard + history INSERT + holding DELETE one atomic
+            # claim across batch and loop processes. A competing seller waits,
+            # then observes the committed deletion and aborts without publishing.
+            self.conn.execute("BEGIN IMMEDIATE")
+            row_id = stock_data.get('id')
+            if row_id is not None:
+                self.cursor.execute(
+                    "SELECT 1 FROM us_stock_holdings "
+                    "WHERE id = ? AND ticker = ? AND account_key = ? LIMIT 1",
+                    (row_id, ticker, account_key),
+                )
+                position_exists = self.cursor.fetchone() is not None
+            else:
+                position_exists = get_us_existing_position_for_ticker(
+                    self.cursor, ticker, account_key=account_key
+                ).get("row_count", 0) > 0
+            if not position_exists:
                 logger.warning(
                     f"[SELL-GUARD][US] {ticker} ({company_name}) already closed by "
                     f"another cycle — sell_stock aborting (no duplicate record/signal)"
                 )
+                self.conn.rollback()
                 return False
             # ─────────────────────────────────────────────────────────────────
 
@@ -2284,7 +2300,6 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
             # than one row for this account, delete ONLY that row (preserving the
             # remaining independent entries). Single-row tickers keep the legacy
             # ticker-scoped delete + adjustment-log cleanup (zero behavior change).
-            row_id = stock_data.get('id')
             existing = get_us_existing_position_for_ticker(self.cursor, ticker, account_key=account_key)
             is_partial = row_id is not None and existing.get("row_count", 0) > 1
             if is_partial:
@@ -2344,6 +2359,8 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
             return True
 
         except Exception as e:
+            if self.conn.in_transaction:
+                self.conn.rollback()
             logger.error(f"Error during sell: {str(e)}")
             logger.error(traceback.format_exc())
             return False

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -37,6 +37,8 @@ from typing import List, Dict, Any, Tuple, Optional
 # Add parent directory to path for imports
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
+from prism_core.execution_service import ExecutionService  # noqa: E402
+
 _openai_debug_spec = _ilu.spec_from_file_location("cores.openai_debug", PROJECT_ROOT / "cores" / "openai_debug.py")
 if _openai_debug_spec and _openai_debug_spec.loader:
     _openai_debug_mod = _ilu.module_from_spec(_openai_debug_spec)
@@ -2454,11 +2456,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     will_queue = False
                     if remaining_rows > 1 and current_price > 0:
                         try:
-                            try:
-                                from trading.us_stock_trading import AsyncUSTradingContext
-                            except ImportError:
-                                from prism_us.trading.us_stock_trading import AsyncUSTradingContext
-                            async with AsyncUSTradingContext(account_name=stock.get("account_name")) as _probe:
+                            async with ExecutionService.us(account_name=stock.get("account_name")) as _probe:
                                 # Order gets queued when market is closed AND the
                                 # reserved-order window is unavailable (pre-10:00 KST).
                                 will_queue = (not _probe.is_market_open()) and (not _probe.is_reserved_order_available())
@@ -2508,11 +2506,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                         # Only execute trading if we have a valid price
                         if current_price > 0:
                             try:
-                                try:
-                                    from trading.us_stock_trading import AsyncUSTradingContext
-                                except ImportError:
-                                    from prism_us.trading.us_stock_trading import AsyncUSTradingContext
-                                async with AsyncUSTradingContext(account_name=stock.get("account_name")) as trading:
+                                async with ExecutionService.us(account_name=stock.get("account_name")) as trading:
                                     # Determine sell quantity.
                                     # FIX 1: full_exit -> quantity=None (sell whole position).
                                     # FIX 2: fractional -> distribute from a per-pass snapshot
@@ -2541,7 +2535,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                                     # the ticker was already added to fully_exited_tickers above.
                                     # Pass limit_price for reserved orders (required for US market)
                                     # If limit_price is 0, trading module will use MOO (Market On Open)
-                                    trade_result = await trading.async_sell_stock(ticker=ticker, limit_price=current_price, quantity=sell_quantity)
+                                    trade_result = await trading.execute_sell(ticker=ticker, limit_price=current_price, quantity=sell_quantity)
 
                                 if trade_result['success']:
                                     logger.info(f"Actual sell successful: {trade_result['message']}")
@@ -2953,12 +2947,8 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
 
                             if current_price > 0:
                                 try:
-                                    try:
-                                        from trading.us_stock_trading import AsyncUSTradingContext
-                                    except ImportError:
-                                        from prism_us.trading.us_stock_trading import AsyncUSTradingContext
-                                    async with AsyncUSTradingContext(account_name=account["name"]) as trading:
-                                        trade_result = await trading.async_buy_stock(ticker=ticker, limit_price=current_price)
+                                    async with ExecutionService.us(account_name=account["name"]) as trading:
+                                        trade_result = await trading.execute_buy(ticker=ticker, limit_price=current_price)
 
                                     if trade_result['success']:
                                         logger.info(f"Actual purchase successful: {trade_result['message']}")

--- a/prism_core/execution_service.py
+++ b/prism_core/execution_service.py
@@ -10,11 +10,22 @@ regression tests.
 from __future__ import annotations
 
 import asyncio
+import sys
+from pathlib import Path
 from typing import Any
 
 
 class ExecutionService:
     """Wrap an existing trader or async trading context without changing it."""
+
+    _DIRECT_ORDER_METHODS = {
+        "async_buy_stock",
+        "async_sell_stock",
+        "amend_order",
+        "cancel_order",
+        "buy_reserved_order",
+        "sell_reserved_order",
+    }
 
     def __init__(self, context_or_trader: Any):
         self._resource = context_or_trader
@@ -31,11 +42,21 @@ class ExecutionService:
     def us(cls, account_name: str | None = None) -> "ExecutionService":
         try:
             from trading.us_stock_trading import AsyncUSTradingContext
-        except ImportError:
-            try:
-                from us_stock_trading import AsyncUSTradingContext
-            except ImportError:
-                from prism_us.trading.us_stock_trading import AsyncUSTradingContext
+        except ModuleNotFoundError as exc:
+            if exc.name != "trading.us_stock_trading":
+                raise
+            # Some long-lived processes import the root ``trading`` package
+            # before switching to the US runtime. Python then keeps that package
+            # cached and cannot discover ``prism-us/trading`` as a subpackage.
+            # Import the existing standalone module path used by the loop tools
+            # instead of deleting or replacing the process-wide package cache.
+            us_trading_dir = Path(__file__).resolve().parents[1] / "prism-us" / "trading"
+            if not us_trading_dir.is_dir():
+                raise
+            path = str(us_trading_dir)
+            if path not in sys.path:
+                sys.path.insert(0, path)
+            from us_stock_trading import AsyncUSTradingContext
 
         return cls(AsyncUSTradingContext(account_name=account_name))
 
@@ -60,6 +81,10 @@ class ExecutionService:
 
     def __getattr__(self, name: str) -> Any:
         """Preserve read-only/query calls while order calls move explicitly."""
+        if name in self._DIRECT_ORDER_METHODS:
+            raise AttributeError(
+                f"direct order method {name!r} is blocked; use ExecutionService methods"
+            )
         return getattr(self._active_trader, name)
 
     async def execute_buy(self, *args, **kwargs):

--- a/prism_core/execution_service.py
+++ b/prism_core/execution_service.py
@@ -1,0 +1,93 @@
+"""Transitional single entry point for broker order execution.
+
+Phase 2 of issue #412 is intentionally a behaviour-preserving strangler step.
+This wrapper owns no retry, persistence, locking, or idempotency policy; it only
+forwards the existing trading-context calls behind explicit order methods.
+Those policies belong to later phases after the current behaviour is covered by
+regression tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+
+class ExecutionService:
+    """Wrap an existing trader or async trading context without changing it."""
+
+    def __init__(self, context_or_trader: Any):
+        self._resource = context_or_trader
+        self._trader: Any | None = None
+        self._entered_context = False
+
+    @classmethod
+    def domestic(cls, account_name: str | None = None) -> "ExecutionService":
+        from trading.domestic_stock_trading import AsyncTradingContext
+
+        return cls(AsyncTradingContext(account_name=account_name))
+
+    @classmethod
+    def us(cls, account_name: str | None = None) -> "ExecutionService":
+        try:
+            from trading.us_stock_trading import AsyncUSTradingContext
+        except ImportError:
+            try:
+                from us_stock_trading import AsyncUSTradingContext
+            except ImportError:
+                from prism_us.trading.us_stock_trading import AsyncUSTradingContext
+
+        return cls(AsyncUSTradingContext(account_name=account_name))
+
+    async def __aenter__(self) -> "ExecutionService":
+        enter = getattr(self._resource, "__aenter__", None)
+        if enter is not None:
+            self._trader = await enter()
+            self._entered_context = True
+        else:
+            self._trader = self._resource
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        if not self._entered_context:
+            return None
+        exit_context = getattr(self._resource, "__aexit__")
+        return await exit_context(exc_type, exc, tb)
+
+    @property
+    def _active_trader(self) -> Any:
+        return self._trader if self._trader is not None else self._resource
+
+    def __getattr__(self, name: str) -> Any:
+        """Preserve read-only/query calls while order calls move explicitly."""
+        return getattr(self._active_trader, name)
+
+    async def execute_buy(self, *args, **kwargs):
+        return await self._active_trader.async_buy_stock(*args, **kwargs)
+
+    async def execute_sell(self, *args, **kwargs):
+        return await self._active_trader.async_sell_stock(*args, **kwargs)
+
+    async def amend_or_cancel(self, action: str, *args, **kwargs):
+        return await asyncio.to_thread(
+            self.amend_or_cancel_sync, action, *args, **kwargs
+        )
+
+    def amend_or_cancel_sync(self, action: str, *args, **kwargs):
+        """Forward synchronous amend/cancel calls, including dry-run payloads."""
+        if action == "amend":
+            method = self._active_trader.amend_order
+        elif action == "cancel":
+            method = self._active_trader.cancel_order
+        else:
+            raise ValueError(f"unsupported order action: {action}")
+        return method(*args, **kwargs)
+
+    def execute_reserved_buy(self, *args, **kwargs):
+        return self._active_trader.buy_reserved_order(*args, **kwargs)
+
+    def execute_reserved_sell(self, *args, **kwargs):
+        return self._active_trader.sell_reserved_order(*args, **kwargs)
+
+
+__all__ = ["ExecutionService"]

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -48,6 +48,7 @@ from cores.llm.openai_responses_llm import OpenAIResponsesLLM as OpenAIAugmented
 from cores.openai_error_logging import log_openai_error
 from cores.agents.trading_agents import create_trading_scenario_agent
 from cores.utils import parse_llm_json
+from prism_core.execution_service import ExecutionService
 
 # O'Neil 룰베이스 매도 (2026-06-04 US quota 사고 동일 룰 결함 KR에도 적용).
 # 방어적 import: 실패 시 _ONEIL_FALLBACK_AVAILABLE=False 로 기존 레거시 룰 유지.
@@ -1682,8 +1683,7 @@ class StockTrackingAgent:
 
                     if sell_success:
                         # Call actual account trading function (async)
-                        from trading.domestic_stock_trading import AsyncTradingContext
-                        async with AsyncTradingContext(account_name=stock.get("account_name")) as trading:
+                        async with ExecutionService.domestic(account_name=stock.get("account_name")) as trading:
                             # Determine fractional sell quantity for multi-row tickers.
                             # FIX 2: snapshot total qty once per ticker per pass and
                             # distribute from (snapshot - already_ordered), so fills
@@ -1711,7 +1711,7 @@ class StockTrackingAgent:
                                     f"remaining rows={remaining_rows})"
                                 )
                             # Execute async sell with limit price for reserved orders
-                            trade_result = await trading.async_sell_stock(
+                            trade_result = await trading.execute_sell(
                                 stock_code=ticker, limit_price=current_price, quantity=sell_quantity
                             )
 
@@ -2051,10 +2051,8 @@ class StockTrackingAgent:
                         buy_success = await self.buy_stock(ticker, company_name, current_price, scenario, rank_change_msg)
 
                         if buy_success:
-                            from trading.domestic_stock_trading import AsyncTradingContext
-
-                            async with AsyncTradingContext(account_name=account["name"]) as trading:
-                                trade_result = await trading.async_buy_stock(stock_code=ticker, limit_price=current_price)
+                            async with ExecutionService.domestic(account_name=account["name"]) as trading:
+                                trade_result = await trading.execute_buy(stock_code=ticker, limit_price=current_price)
 
                             if trade_result['success']:
                                 logger.info(f"Actual purchase successful: {trade_result['message']}")

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -1363,13 +1363,30 @@ class StockTrackingAgent:
             # 2nd SELL 23:55. sell_stock is the chokepoint that closes this for all
             # paths in both markets.
             self.conn.commit()
-            if get_existing_position_for_ticker(
-                self.cursor, ticker, account_key=account_key
-            ).get("row_count", 0) == 0:
+            # Acquire the SQLite writer lock BEFORE the authoritative guard read.
+            # Without this, two processes can both observe the row, both write a
+            # history record, and both return True (TOCTOU duplicate SELL).
+            # The transaction contains synchronous DB work only and commits before
+            # journal/publish/order continuations, so the lock is held briefly.
+            self.conn.execute("BEGIN IMMEDIATE")
+            row_id = stock_data.get('id')
+            if row_id is not None:
+                self.cursor.execute(
+                    "SELECT 1 FROM stock_holdings "
+                    "WHERE id = ? AND ticker = ? AND account_key = ? LIMIT 1",
+                    (row_id, ticker, account_key),
+                )
+                position_exists = self.cursor.fetchone() is not None
+            else:
+                position_exists = get_existing_position_for_ticker(
+                    self.cursor, ticker, account_key=account_key
+                ).get("row_count", 0) > 0
+            if not position_exists:
                 logger.warning(
                     f"[SELL-GUARD][KR] {ticker}({company_name}) already closed by "
                     f"another cycle — sell_stock aborting (no duplicate record/signal)"
                 )
+                self.conn.rollback()
                 return False
             # ─────────────────────────────────────────────────────────────────
 
@@ -1422,7 +1439,6 @@ class StockTrackingAgent:
             # than one row for this account, delete ONLY that row so the remaining
             # independent entries are preserved. Single-row tickers keep the legacy
             # ticker-scoped delete (zero behavior change).
-            row_id = stock_data.get('id')
             existing = get_existing_position_for_ticker(self.cursor, ticker, account_key=account_key)
             if row_id is not None and existing.get("row_count", 0) > 1:
                 self.cursor.execute(
@@ -1473,6 +1489,8 @@ class StockTrackingAgent:
             return True
 
         except Exception as e:
+            if self.conn.in_transaction:
+                self.conn.rollback()
             logger.error(f"Error during sell: {str(e)}")
             logger.error(traceback.format_exc())
             return False

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -18,6 +18,7 @@ from cores.llm.openai_responses_llm import OpenAIResponsesLLM as OpenAIAugmented
 # Import core agents
 from cores.agents.trading_agents import create_sell_decision_agent
 from cores.utils import parse_llm_json
+from prism_core.execution_service import ExecutionService
 
 logging.basicConfig(
     level=logging.INFO,
@@ -637,10 +638,9 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
 
                     if buy_success:
                         # Call actual account trading function (async)
-                        from trading.domestic_stock_trading import AsyncTradingContext
-                        async with AsyncTradingContext() as trading:
+                        async with ExecutionService.domestic() as trading:
                             # Execute async buy with limit price for reserved orders
-                            trade_result = await trading.async_buy_stock(stock_code=ticker, limit_price=current_price)
+                            trade_result = await trading.execute_buy(stock_code=ticker, limit_price=current_price)
 
                         if trade_result['success']:
                             logger.info(f"Actual purchase successful: {trade_result['message']}")

--- a/tasks/issue-412/01-current-state.md
+++ b/tasks/issue-412/01-current-state.md
@@ -1,4 +1,9 @@
-# 01. 현재 아키텍처 분석 (2026-07-06 main 기준)
+# 01. 현재 아키텍처 분석
+
+> 2026-07-06 작성 (당시 main #411 기준) → **2026-07-13 main(#432, `7e9c94eb`) 기준 전면 재검증.**
+> 재검증에서 확인된 주요 변화: KR 중복 SELL 가드 이식 완료, 루프 3종(구 loop_a/b/c)의
+> 리네임과 크로스 프로세스 owner_lock 도입, US 코드의 `prism-us/` 패키지 이동,
+> market-pulse 레짐 정책 도입. 상세는 각 절의 앵커와 §6 참고.
 
 ## 1. 실제 주문 경로 (검증 완료)
 
@@ -8,16 +13,43 @@
 Buy/Sell Agent (LLM 판단만)
   → StockTrackingAgent / EnhancedStockTrackingAgent  (원장 + 실주문 + 알림 + publish)
   → AsyncTradingContext → DomesticStockTrading       (KIS adapter)
-  → kis_auth._url_fetch() → KIS REST API
+  → trading/kis_auth._url_fetch() → KIS REST API
   → Redis Streams / GCP Pub/Sub publish (optional, non-critical)
 ```
 
-## 2. 핵심 결함: 원장 선커밋 + 주문 fire-and-forget
+단, **2026-07 현재 주문 진입점은 batch 에이전트만이 아니다.** 실주문 진입점은
+총 9곳 (설계 최초 작성 시점의 "4곳" 전제는 폐기). 컨텍스트 클래스는 KR
+`AsyncTradingContext` / US `AsyncUSTradingContext`로 **문자열이 다르며**, #9는
+컨텍스트 없이 `USStockTrading`을 직접 쓴다 — grep 기반 검사 시 세 패턴 모두 필요:
 
-### 매수 (stock_tracking_enhanced_agent.py:531-544)
+| # | 경로 | 위치 | 주문 종류 |
+|---|------|------|----------|
+| 1 | KR batch 매도 | `stock_tracking_agent.py:1640-1668` | 지정가/분할 매도 |
+| 2 | KR batch 매수 | `stock_tracking_agent.py:2008-2011` | 지정가 매수 |
+| 3 | KR enhanced 매수 | `stock_tracking_enhanced_agent.py:578-581` | 지정가 매수 |
+| 4 | 하드스탑 루프 (구 loop_a) | `tools/hardstop_seller.py:260-263,417` | 시장가 손절 매도 (KR/US 양시장) |
+| 5 | 추세이탈 루프 (구 loop_b) | `tools/trend_exit_seller.py:426-429,638` | 시장가 매도 (KR/US 양시장) |
+| 6 | 미체결 추격 루프 (구 loop_c) | `tools/fill_chaser.py:300-303` | **정정/취소** (KR/US, SHADOW 기본) |
+| 7 | US batch 매도 | `prism-us/us_stock_tracking_agent.py:2557` | 지정가/예약 매도 |
+| 8 | US batch 매수 | `prism-us/us_stock_tracking_agent.py:2974` | 지정가/예약 매수 |
+| 9 | US 예약주문 지연 제출 배치 | `prism-us/us_pending_order_batch.py:88,157,164` (204줄) | **큐잉된 예약주문의 실제 제출** |
+
+4~6은 batch와 **별도 cron 프로세스**로 도는 LLM-free 루프다. #9는 KIS 예약주문
+API 시간창(10:00~23:20 KST) 밖에서 큐잉된 주문을 10:05 KST cron이 꺼내
+`buy_reserved_order()`/`sell_reserved_order()`로 제출하는 **지연 제출(deferred
+submission) 경로**다 — "익일 체결 확인"이 아니다. 목표 설계의 ExecutionService
+chokepoint는 이 9곳 전부를 감싸야 한다.
+
+각주: `cores/corporate_status.py:87-95`도 `AsyncTradingContext`를 열지만 시세/종목
+상태코드 조회 전용(실주문 없음)이다. grep 검사의 제외 목록에 명시하고, 장기적으로는
+MarketDataPort로 이관할 사용처다.
+
+## 2. 핵심 결함: 원장 선커밋 + 주문 fire-and-forget (여전히 유효)
+
+### 매수 (stock_tracking_enhanced_agent.py:574-581)
 
 ```python
-if decision == "Enter" and buy_score >= min_score and sector_diverse:
+if decision == "Enter" and buy_score >= min_score and sector_diverse and not _cd_block:
     buy_success = await self.buy_stock(...)          # ① 로컬 원장 먼저 커밋
     if buy_success:
         async with AsyncTradingContext() as trading:
@@ -28,7 +60,7 @@ if decision == "Enter" and buy_score >= min_score and sector_diverse:
             logger.error(...)                        # ③ 실패해도 로그만. 롤백 없음
 ```
 
-### 매도 (stock_tracking_agent.py:1461-1500)
+### 매도 (stock_tracking_agent.py:1627-1668)
 
 ```python
 sell_success = await self.sell_stock(stock, sell_reason)   # ① 원장에서 행 삭제
@@ -38,6 +70,11 @@ if sell_success:
     # 실패 시 역시 로그만
 ```
 
+### 루프도 같은 패턴 (tools/hardstop_seller.py:405-425)
+
+sim/원장 close를 먼저 확정한 뒤 KIS 주문을 넣는다. 에러 메시지가 구조를 자백한다:
+`"KIS sell failed after sim close"` — 주문 실패 시 원장은 이미 닫혀 있고 보상이 없다.
+
 **결과**: KIS 주문이 실패하면 로컬 원장과 실계좌가 조용히 어긋난다.
 - 매수: 원장에는 보유 중, 실계좌에는 없음 → 이후 매도 판단이 유령 포지션에 대해 돈다.
 - 매도: 원장에서는 삭제됨, 실계좌에는 남음 → 시스템 관리 밖의 실물 포지션 발생.
@@ -45,14 +82,17 @@ if sell_success:
 
 추가 문제: **매도는 원장 행을 delete한다.** 상태 이력이 없어 사후 reconciliation이
 구조적으로 불가능하다 (무엇이 있었는지 원장이 기억하지 못함).
+US도 동일 (`prism-us/us_stock_tracking_agent.py:2303-2315`의 DELETE 3연타).
 
-## 3. God class: StockTrackingAgent 상속 체인
+## 3. God class: StockTrackingAgent 상속 체인 (계속 성장 중)
 
-- `stock_tracking_agent.py` — `StockTrackingAgent` 2,297줄
-- `stock_tracking_enhanced_agent.py` — `EnhancedStockTrackingAgent(StockTrackingAgent)` 1,497줄
-- `prism-us/us_stock_tracking_agent.py` — **KR 클래스의 통째 포크** 약 2,900줄+
+- `stock_tracking_agent.py` — `StockTrackingAgent` **2,510줄** (07-06 시점 2,297줄)
+- `stock_tracking_enhanced_agent.py` — `EnhancedStockTrackingAgent(StockTrackingAgent)` **1,539줄**
+- `prism-us/us_stock_tracking_agent.py` — **KR 클래스의 통째 포크 3,600줄** (07-06 시점 ~2,900줄)
 
-한 상속 체인이 담고 있는 책임 12가지:
+일주일 사이 +350줄/+700줄. 포크 비대화는 가속 중이며, 이식성 문제의 실증이다.
+
+한 상속 체인이 담고 있는 책임 12가지 (07-13 기준 계속 유효, 일부는 심화):
 
 1. DB 스키마 관리 (`_create_tables`, 마이그레이션)
 2. 계좌 설정 (`_get_trading_accounts`, `_account_scope`)
@@ -60,6 +100,7 @@ if sell_success:
 4. LLM 매수 판단 (`_extract_trading_scenario`, `analyze_report`)
 5. LLM 매도 판단 (`_analyze_sell_decision`, `_fallback_sell_decision`)
 6. 포트폴리오 정책 — `MAX_SLOTS=10`, `MAX_SAME_SECTOR=3`, 점수 임계값이 **클래스 상수로 하드코딩**
+   (+ 07-13: market-pulse 레짐 게이트 `pilot_reexposure_active`, 재진입 cooldown이 추가로 얽힘)
 7. 원장 CRUD (`buy_stock`, `sell_stock`, `update_holdings`, watchlist)
 8. 매매일지/교훈 (`_create_journal_entry`, `compress_old_journal_entries`)
 9. KIS 실주문 (루프 안 inline import로 `AsyncTradingContext` 호출)
@@ -67,45 +108,100 @@ if sell_success:
 11. Telegram/Firebase 알림 (`send_telegram_message`, `_notify_firebase`, 번역 채널)
 12. 실행 루프 (`run`, `process_reports`)
 
+`sell_stock`은 07-13 현재 중복 SELL 가드 + exit_kind 분류(churn 가드) + 재진입
+cooldown 입력 기록 + 다국어 브로드캐스트 큐잉까지 흡수해 더 무거워졌다 —
+Phase 1 순수 함수 추출의 난도가 그만큼 올라갔다.
+
 LLM 출력 계약이 없어 방어적 파싱이 흩어져 있다:
 `_normalize_decision`, `_parse_price_value`, `_safe_number_conversion`.
-
-**이식성이 깨졌다는 실증**: 미국 시장 진출 시 이 클래스를 복사해 prism-us 포크를
-만들었다. 다음 프로젝트도 같은 방식이 될 것.
 
 ## 4. 이미 잘 되어 있는 것 (건드리지 않거나 승격할 것)
 
 ### 4.1 시그널 publish는 이미 약결합
-`stock_tracking_agent.py:1505` 부근, enhanced:548 부근 — Redis/GCP publish는
+`stock_tracking_agent.py:1680-1704`, enhanced `:591-620` — Redis/GCP publish는
 optional·auto-skip·non-critical. 이 패턴을 시스템 전체 규칙(이벤트 버스)으로 승격한다.
 
 ### 4.2 KIS adapter 내부 안전장치 (trading/domestic_stock_trading.py, 2,179줄)
 - `:225` 전역 `asyncio.Lock`, `:1204` 종목별 lock — 단, **프로세스 내부용**.
-  cron으로 도는 별도 프로세스 간에는 무력하다.
-- 실/모의 TR ID 분기: 매수 `TTTC0012U`/`VTTC0012U`(:383), 매도 `TTTC0011U`/`VTTC0011U`(:890),
-  예약주문 `CTSC0008U`(:771, :1134)
+  cron으로 도는 별도 프로세스 간에는 무력하다 (루프 쪽 owner_lock은 §4.5).
+- 실/모의 TR ID 분기: 매수 `TTTC0012U`/`VTTC0012U`(:383, :517, :667),
+  매도 `TTTC0011U`/`VTTC0011U`(:890, :1035), 예약주문 `CTSC0008U`(:771, :1134)
 - `:1431` — get_portfolio()의 일시적 빈 응답을 보유 없음으로 확정하지 않는 재확인 가드
+  (빈 응답 3회 재시도 + 최초 확인 수량 fallback)
 
-### 4.3 kis_auth.py (1,741줄)
+### 4.3 trading/kis_auth.py (1,741줄 — 루트에서 trading/으로 이동)
 - `:163-166` real/prod/live vs demo/paper/vps 모드 정규화, 불일치 시 예외
-- `:220` `account_key = svr:account:product` 단위 credential 바인딩
+- `account_key = svr:account:product` 단위 credential 바인딩
 - 단, 인증 컨텍스트가 전역 가변 상태라 다중 계좌에서 lock으로 보호하는 구조 —
   근본 해결은 lock 추가가 아니라 인증 컨텍스트의 객체 스코프화.
 
-### 4.4 사고에서 나온 회귀 방어 (반드시 보존·이식할 것)
-- **중복 SELL 가드** (`prism-us/us_stock_tracking_agent.py:2050-2075`):
-  2026-07-01 MU 사고(loop_a가 23:50 손절 매도+publish 후, batch가 stale snapshot으로
-  23:55 두 번째 SELL publish) 이후, 모든 매도 경로가 `sell_stock` 단일 chokepoint를
-  지나고, fresh WAL snapshot(`conn.commit()` 후 재조회)으로 행 부재 시 abort.
-  **KR 쪽에는 아직 이 가드가 없다.**
-- **피라미딩 분할매도 over-sell 방지** (#288 FIX 2, `stock_tracking_agent.py:1465-1497`):
-  pass당 보유수량 스냅샷에서 이미 주문한 수량을 차감해 분배. 미체결 지정가가
-  있을 때 마지막 행이 broker 재조회로 전량 매도하는 버그를 막는다.
+### 4.4 사고에서 나온 회귀 방어 (반드시 보존할 것 — KR 이식은 완료됨)
+- **중복 SELL 가드 — 이제 KR/US 양쪽에 존재**:
+  - US: `prism-us/us_stock_tracking_agent.py:2242-2261` (`[SELL-GUARD][US]`) +
+    **Layer 2 fresh holding re-check** `:2432-2445` (update_holdings의 stale snapshot 선차단)
+  - KR: `stock_tracking_agent.py:1300-1327` (`[SELL-GUARD][KR]`) — **07-06 문서의
+    "KR에는 아직 없다"는 서술은 무효.** 이식이 main에 반영됐다.
+  - 시맨틱: 2026-07-01 MU 사고(하드스탑 루프가 23:50 손절 매도+publish 후, batch가
+    stale snapshot으로 23:55 두 번째 SELL publish) 이후, 모든 매도 경로(batch
+    update_holdings, hardstop_seller, trend_exit_seller)가 `sell_stock` 단일
+    chokepoint를 지나고, fresh WAL snapshot(`conn.commit()` 후 재조회)으로 행 부재 시 abort.
+  - 남은 일: 이 가드를 ExecutionService로 이관할 때 시맨틱을 1:1 보존하고,
+    동시 2-프로세스 회귀 테스트를 CI에 고정하는 것 (05 문서 L2-1).
+- **피라미딩 분할매도 over-sell 방지** (#288 FIX 2, `stock_tracking_agent.py:1575-1668`):
+  pass당 보유수량 스냅샷(`pass_total_qty`)에서 이미 주문한 수량을 차감해 분배.
+  미체결 지정가가 있을 때 마지막 행이 broker 재조회로 전량 매도하는 버그를 막는다.
+  (07-06 문서의 :1465-1497 앵커는 라인 이동)
 
-## 5. 현재 없는 것
+### 4.5 루프 계층의 안전장치 (07-13 신규 — 설계가 흡수·승격할 선례)
 
-- 주문 접수 이후의 체결/미체결 추적 (예약주문은 `us_pending_order_batch.py`가 부분적으로 담당)
-- 로컬 원장 ↔ 실계좌 reconciliation job
-- 주문 intent의 영속화 / idempotency 키
-- 크로스 프로세스 lock
-- shadow 실행 모드 (demo 계좌 모드는 있음)
+설계 최초 작성 이후 파악된, 루프 3종이 이미 갖춘 것들:
+
+- **크로스 프로세스 owner_lock — 단, 부분적**: `loop_a_position_state` 테이블에
+  SQLite `BEGIN IMMEDIATE`로 티커 단위 lock + 만료 시각을 공유하는 것은
+  **hardstop(`tools/hardstop_seller.py:200-235`)과 fill_chaser(`tools/fill_chaser.py:165-240`)
+  둘뿐이다.** trend_exit는 자체 `loop_b_position_state`/`loop_b_inflight_orders`
+  테이블을 쓴다 (`tools/trend_exit_seller.py:200-289`) — 즉 **hardstop↔trend_exit는
+  상호 직렬화되지 않으며** (둘 다 SELL 주체인데도), 이 경합은 sell_stock
+  fresh-snapshot 가드에만 의존한다. fill_chaser docstring의 "all loops serialise
+  on the SAME lock"(:38-39)은 코드 현실과 어긋난 stale 주석이니 믿지 말 것.
+  batch 에이전트도 lock 밖이다. 목표 설계의 크로스 프로세스 lock은 loop_a_*/loop_b_*
+  테이블을 통합·일반화해 루프 전체 + batch를 포괄해야 한다.
+- **SHADOW/LIVE env 게이트**: `HARDSTOP_LIVE`, `TREND_EXIT_LIVE`, `FILL_CHASER_LIVE`
+  3종 (기본 SHADOW — 실주문 없이 "WOULD SELL/AMEND" 로그만). 목표 설계의 shadow
+  실행 모드가 요구하는 시맨틱의 축소판이 이미 운영 중이다.
+- **미체결 주문 관리의 단일 소유자**: `fill_chaser`가 KIS 실시간 미체결 조회
+  (KR `get_revisable_orders`(:322) / US `get_unfilled_orders`(:336))를 source of truth로
+  정정(추격)/취소를 수행하고 partial fill을 `loop_c_chase_log`로 대사한다.
+  BrokerAdapter의 `list_open_orders`/`amend_order`가 흡수할 대상이자 참조 구현.
+  ⚠️ 정정/취소 TR wrapper는 라이브 검증 전 (`tasks/loop_c_design.md` 체크리스트).
+- **루프 매도 publish 경로**: `sell_broadcast.py`(구 loop_publish)가 루프 매도를
+  batch와 같은 Redis/GCP 스트림으로 발행한다. 시맨틱 주의: **publish는 sim 커밋
+  기준**(sim = 방송 source of truth)이며 자사 KIS 체결 여부와 무관 — 이벤트 버스
+  통합 시 발행 시점 계약을 명시적으로 결정해야 한다 (03 §6).
+
+관련 문서: `tasks/loop_architecture_design.md`, `tasks/mu_double_sell_safety_design.md`.
+
+## 5. 현재 없는 것 (07-13 재평가)
+
+- 주문 접수 이후의 체결/미체결 추적 — **부분 존재로 격상**: fill_chaser가 미체결
+  조회·정정·취소를 담당하고, `us_pending_order_batch.py`는 시간창 밖 큐잉 예약주문의
+  지연 제출을 담당한다 (`us_pending_orders` 큐 — **order_intents 영속화의 기존 실물
+  선례**). 단 둘 다 국지적이며, 주문 수명주기의 영속 기록(order state store)은 없다.
+- 로컬 원장 ↔ 실계좌 reconciliation job — 없음 (변동 없음)
+- 주문 intent의 영속화 / idempotency 키 — 없음 (변동 없음)
+- 크로스 프로세스 lock — **루프 간에는 존재** (§4.5), batch는 미포괄
+- shadow 실행 모드 — **루프에는 env 게이트로 존재** (§4.5), 코어 batch의
+  `execution_mode` 격리는 없음 (demo 계좌 모드는 있음)
+
+## 6. 07-06 → 07-13 사이 설계에 영향을 준 main 변경 요약
+
+- #422~#423: 루프 grace/portfolio 수정, 루프 매도 다국어 브로드캐스트
+- #424: buy-gate (개별 추세 게이트 + 반복 손절 게이트가 매수 프롬프트에)
+- #425~#427, #429~#430: market-pulse — O'Neil M 상태기계, batch-rest 정책,
+  CORRECTION 후 파일럿 재진입 축소매수/스로틀 (`cores/regime_policy.py` 신설,
+  buy 경로에 `pilot_reexposure_active` 게이트 추가)
+- #428: loop_a/b/c → hardstop_seller / trend_exit_seller / fill_chaser 리네임
+  (구 경로는 deprecation shim), loop_publish.py → sell_broadcast.py
+- #431: US 분석 배치 아침/오후 2회로 축소 (cron 스케줄 변경)
+- KR 중복 SELL 가드 이식 (`[SELL-GUARD][KR]`)
+- US 코드 전체가 `prism-us/` 패키지로 이동 (us_stock_trading.py 어댑터 포크 포함)

--- a/tasks/issue-412/01-current-state.md
+++ b/tasks/issue-412/01-current-state.md
@@ -1,0 +1,111 @@
+# 01. 현재 아키텍처 분석 (2026-07-06 main 기준)
+
+## 1. 실제 주문 경로 (검증 완료)
+
+이슈 #412가 서술한 경로는 정확하다:
+
+```
+Buy/Sell Agent (LLM 판단만)
+  → StockTrackingAgent / EnhancedStockTrackingAgent  (원장 + 실주문 + 알림 + publish)
+  → AsyncTradingContext → DomesticStockTrading       (KIS adapter)
+  → kis_auth._url_fetch() → KIS REST API
+  → Redis Streams / GCP Pub/Sub publish (optional, non-critical)
+```
+
+## 2. 핵심 결함: 원장 선커밋 + 주문 fire-and-forget
+
+### 매수 (stock_tracking_enhanced_agent.py:531-544)
+
+```python
+if decision == "Enter" and buy_score >= min_score and sector_diverse:
+    buy_success = await self.buy_stock(...)          # ① 로컬 원장 먼저 커밋
+    if buy_success:
+        async with AsyncTradingContext() as trading:
+            trade_result = await trading.async_buy_stock(...)  # ② 실주문
+        if trade_result['success']:
+            logger.info(...)
+        else:
+            logger.error(...)                        # ③ 실패해도 로그만. 롤백 없음
+```
+
+### 매도 (stock_tracking_agent.py:1461-1500)
+
+```python
+sell_success = await self.sell_stock(stock, sell_reason)   # ① 원장에서 행 삭제
+if sell_success:
+    async with AsyncTradingContext(...) as trading:
+        trade_result = await trading.async_sell_stock(...)  # ② 실주문
+    # 실패 시 역시 로그만
+```
+
+**결과**: KIS 주문이 실패하면 로컬 원장과 실계좌가 조용히 어긋난다.
+- 매수: 원장에는 보유 중, 실계좌에는 없음 → 이후 매도 판단이 유령 포지션에 대해 돈다.
+- 매도: 원장에서는 삭제됨, 실계좌에는 남음 → 시스템 관리 밖의 실물 포지션 발생.
+- 보상(compensation) 로직, ERROR 상태, 재시도, 알림 어느 것도 없다.
+
+추가 문제: **매도는 원장 행을 delete한다.** 상태 이력이 없어 사후 reconciliation이
+구조적으로 불가능하다 (무엇이 있었는지 원장이 기억하지 못함).
+
+## 3. God class: StockTrackingAgent 상속 체인
+
+- `stock_tracking_agent.py` — `StockTrackingAgent` 2,297줄
+- `stock_tracking_enhanced_agent.py` — `EnhancedStockTrackingAgent(StockTrackingAgent)` 1,497줄
+- `prism-us/us_stock_tracking_agent.py` — **KR 클래스의 통째 포크** 약 2,900줄+
+
+한 상속 체인이 담고 있는 책임 12가지:
+
+1. DB 스키마 관리 (`_create_tables`, 마이그레이션)
+2. 계좌 설정 (`_get_trading_accounts`, `_account_scope`)
+3. 시세/거래량 조회 (`_get_current_stock_price`, `_get_trading_value_rank_change`)
+4. LLM 매수 판단 (`_extract_trading_scenario`, `analyze_report`)
+5. LLM 매도 판단 (`_analyze_sell_decision`, `_fallback_sell_decision`)
+6. 포트폴리오 정책 — `MAX_SLOTS=10`, `MAX_SAME_SECTOR=3`, 점수 임계값이 **클래스 상수로 하드코딩**
+7. 원장 CRUD (`buy_stock`, `sell_stock`, `update_holdings`, watchlist)
+8. 매매일지/교훈 (`_create_journal_entry`, `compress_old_journal_entries`)
+9. KIS 실주문 (루프 안 inline import로 `AsyncTradingContext` 호출)
+10. 시그널 publish (Redis/GCP, try/except non-critical)
+11. Telegram/Firebase 알림 (`send_telegram_message`, `_notify_firebase`, 번역 채널)
+12. 실행 루프 (`run`, `process_reports`)
+
+LLM 출력 계약이 없어 방어적 파싱이 흩어져 있다:
+`_normalize_decision`, `_parse_price_value`, `_safe_number_conversion`.
+
+**이식성이 깨졌다는 실증**: 미국 시장 진출 시 이 클래스를 복사해 prism-us 포크를
+만들었다. 다음 프로젝트도 같은 방식이 될 것.
+
+## 4. 이미 잘 되어 있는 것 (건드리지 않거나 승격할 것)
+
+### 4.1 시그널 publish는 이미 약결합
+`stock_tracking_agent.py:1505` 부근, enhanced:548 부근 — Redis/GCP publish는
+optional·auto-skip·non-critical. 이 패턴을 시스템 전체 규칙(이벤트 버스)으로 승격한다.
+
+### 4.2 KIS adapter 내부 안전장치 (trading/domestic_stock_trading.py, 2,179줄)
+- `:225` 전역 `asyncio.Lock`, `:1204` 종목별 lock — 단, **프로세스 내부용**.
+  cron으로 도는 별도 프로세스 간에는 무력하다.
+- 실/모의 TR ID 분기: 매수 `TTTC0012U`/`VTTC0012U`(:383), 매도 `TTTC0011U`/`VTTC0011U`(:890),
+  예약주문 `CTSC0008U`(:771, :1134)
+- `:1431` — get_portfolio()의 일시적 빈 응답을 보유 없음으로 확정하지 않는 재확인 가드
+
+### 4.3 kis_auth.py (1,741줄)
+- `:163-166` real/prod/live vs demo/paper/vps 모드 정규화, 불일치 시 예외
+- `:220` `account_key = svr:account:product` 단위 credential 바인딩
+- 단, 인증 컨텍스트가 전역 가변 상태라 다중 계좌에서 lock으로 보호하는 구조 —
+  근본 해결은 lock 추가가 아니라 인증 컨텍스트의 객체 스코프화.
+
+### 4.4 사고에서 나온 회귀 방어 (반드시 보존·이식할 것)
+- **중복 SELL 가드** (`prism-us/us_stock_tracking_agent.py:2050-2075`):
+  2026-07-01 MU 사고(loop_a가 23:50 손절 매도+publish 후, batch가 stale snapshot으로
+  23:55 두 번째 SELL publish) 이후, 모든 매도 경로가 `sell_stock` 단일 chokepoint를
+  지나고, fresh WAL snapshot(`conn.commit()` 후 재조회)으로 행 부재 시 abort.
+  **KR 쪽에는 아직 이 가드가 없다.**
+- **피라미딩 분할매도 over-sell 방지** (#288 FIX 2, `stock_tracking_agent.py:1465-1497`):
+  pass당 보유수량 스냅샷에서 이미 주문한 수량을 차감해 분배. 미체결 지정가가
+  있을 때 마지막 행이 broker 재조회로 전량 매도하는 버그를 막는다.
+
+## 5. 현재 없는 것
+
+- 주문 접수 이후의 체결/미체결 추적 (예약주문은 `us_pending_order_batch.py`가 부분적으로 담당)
+- 로컬 원장 ↔ 실계좌 reconciliation job
+- 주문 intent의 영속화 / idempotency 키
+- 크로스 프로세스 lock
+- shadow 실행 모드 (demo 계좌 모드는 있음)

--- a/tasks/issue-412/02-issue-412-review.md
+++ b/tasks/issue-412/02-issue-412-review.md
@@ -1,0 +1,85 @@
+# 02. 이슈 #412 설계 검토
+
+결론: **방향 동의, 실행 계획 수정 필요.** 이슈의 현재 코드 서술은 정확하다
+(라인 참조, TR ID, 운영 주의점 모두 실제 코드와 일치). 다만 목표 설계는
+이 프로젝트가 사고로 배운 교훈이 빠진 일반론이며, 가장 어려운 세 문제
+(체결 추적, 진짜 idempotency, 마이그레이션)가 비어 있다.
+
+## A. 그대로 채택
+
+- Buy/Sell Agent 역할 분리 + "매수 시나리오는 매도 Agent의 입력" 데이터 계약
+  (현재 코드도 `stock_holdings.scenario` JSON으로 이미 이렇게 동작)
+- Agent 판단 → OrderIntent 변환 → Broker Adapter 실행의 3계층
+- demo/shadow/live 모드 구분, 프롬프트 버전 관리
+- "KIS 주문번호는 체결 보장이 아니라 접수 확인" 원칙
+- 운영 주의점 목록 (예약주문 fallback 금지, 미국 시장가 매도 제약, 빈 portfolio 응답 등)
+
+## B. 채택하되 보완 (설계 허점)
+
+### B-1. BrokerAdapter에 체결/미체결 조회가 없다 — 치명적
+이슈 초안의 인터페이스는 `buy / sell / get_position / get_portfolio / cancel_order`뿐.
+**주문 상태 조회(get_order_status)와 체결 내역 조회(list_executions)가 없다.**
+
+- 이러면 reconciliation job이 포지션 수준 비교밖에 못 해서 불일치의 원인
+  (부분체결? 미체결? 유령주문?)을 특정할 수 없다.
+- "주문번호는 접수 확인일 뿐"이라 스스로 정의해놓고, 접수 이후를 추적할 수단이 없다.
+- 예약주문(오늘 접수 → 내일 체결)은 특히 치명적. 기존 `us_pending_order_batch.py`가
+  푸는 문제를 설계가 무시한다.
+
+→ 보완: `get_order_status()`, `list_executions()` (KIS 주문체결조회
+`inquire-daily-ccld` 계열) 추가, pending order 추적을 adapter 책임으로 흡수.
+
+### B-2. idempotency_key가 체크박스 수준
+- 키 생성 규칙(무엇이 "같은 주문"인가), 저장/검사 지점, unique 제약 여부 미정의.
+- **KIS API에는 client-order-id가 없다.** 타임아웃 후 "나갔는지 모르는 주문"은
+  intent 중복 차단으로 해결되지 않는다.
+
+→ 보완: `idempotency_key = decision_id` (Agent 판단 시점에 UUID 부여) +
+`order_intents.idempotency_key` unique 제약 + 주문 상태기계
+`CREATED → SUBMITTING → SUBMITTED | FAILED | UNKNOWN` +
+UNKNOWN은 체결내역 조회로 복구.
+
+### B-3. 원장-주문 쓰기 순서를 결정하지 않음
+현재 코드의 실제 버그(원장 선커밋 → 주문 fire-and-forget)에 대해
+"주문 실패 시 position 복구 또는 ERROR_RETRY"라는 체크박스 한 줄뿐.
+
+→ 보완: **intent 먼저 영속화, 포지션 전이는 broker 접수 확인 후.**
+03-target-design.md의 상태기계로 확정.
+
+### B-4. lock 개념이 프로세스 내/간을 구분하지 않음
+`asyncio.Lock`은 이미 존재하지만 프로세스 내부용. orchestrator/tracking/batch가
+별도 프로세스(cron)로 도는 현실에서 필요한 것은 **크로스 프로세스 lock**
+(SQLite 트랜잭션 or flock). 또한 "전역 KIS env를 lock으로 보호"는 전역 가변
+인증 상태라는 결함을 영속화한다 — 근본 해결은 인증 컨텍스트의 객체 스코프화.
+
+### B-5. shadow 모드 시맨틱 미정의
+shadow 포지션과 실포지션이 한 positions 테이블에 섞이면 매도 판단이 무엇을
+보고 도는지 불명확. → `execution_mode` 컬럼 + 엄격한 필터링으로 정의 (03 참고).
+
+## C. 대체
+
+### C-1. Greenfield 파일 구조 → Strangler 단계 전환
+이슈는 `trading/kis/...` 신규 구조 + 일괄 구현을 제안하지만:
+- 기존 `trading/` 모듈과 충돌하고, 라이브 데이터(`stock_holdings`,
+  `trading_history` 등)와 운영 중인 cron 배치에서 새 스키마로 가는
+  마이그레이션 경로가 전혀 없다.
+- 이슈가 참조하는 기준 문서 2개(`docs/BUY_SELL_AGENT_SPLIT_DESIGN.md`,
+  `docs/BROKER_ORDER_EXECUTION_DESIGN.md`)는 repo에 존재하지 않는다
+  (작성자 로컬 트리에만 존재).
+
+→ 대체: 04-migration-plan.md의 Phase 0~6. 각 Phase는 독립 배포·독립 롤백.
+
+### C-2. "타 프로젝트 이식용 기준 구현" → "prism-us 흡수로 이식성 증명"
+이식 가능한 코어가 진짜인지는 문서가 아니라 코드로 증명한다:
+**prism-us 포크가 프로파일+어댑터 조합으로 대체되면** 제3 프로젝트 이식은
+부산물로 달성된다.
+
+## D. 이슈 범위 밖 추가 (이 계획의 확장)
+
+- `StockTrackingAgent` god class 해체 자체 — 이슈는 주문 실행 계층만 다루고,
+  판단~원장~알림이 엉킨 2,300줄 클래스는 건드리지 않는다.
+- 도메인 이벤트 버스 (Telegram/Redis/GCP/일지를 구독자로)
+- `MarketProfile` (KR/US 시장 차이를 데이터로), `PortfolioPolicy` (하드코딩 상수 제거)
+- 상속(`Enhanced extends Base`) → 합성(Strategy 플러그인) 전환
+- 사고 회귀 케이스의 자동화 테스트 고정 (MU 중복 SELL, #288 over-sell, 빈 portfolio)
+- KR에 아직 없는 중복 SELL chokepoint 가드의 이식

--- a/tasks/issue-412/02-issue-412-review.md
+++ b/tasks/issue-412/02-issue-412-review.md
@@ -1,5 +1,8 @@
 # 02. 이슈 #412 설계 검토
 
+> 2026-07-13 재검증: 검토 결론은 유지. 단 B-4(lock)와 마지막 D 항목(KR 가드)은
+> 이후 main 변경으로 상태가 바뀌었다 — 해당 절의 갱신 주석 참고.
+
 결론: **방향 동의, 실행 계획 수정 필요.** 이슈의 현재 코드 서술은 정확하다
 (라인 참조, TR ID, 운영 주의점 모두 실제 코드와 일치). 다만 목표 설계는
 이 프로젝트가 사고로 배운 교훈이 빠진 일반론이며, 가장 어려운 세 문제
@@ -23,8 +26,10 @@
 - 이러면 reconciliation job이 포지션 수준 비교밖에 못 해서 불일치의 원인
   (부분체결? 미체결? 유령주문?)을 특정할 수 없다.
 - "주문번호는 접수 확인일 뿐"이라 스스로 정의해놓고, 접수 이후를 추적할 수단이 없다.
-- 예약주문(오늘 접수 → 내일 체결)은 특히 치명적. 기존 `us_pending_order_batch.py`가
-  푸는 문제를 설계가 무시한다.
+- 예약주문은 특히 치명적. US는 KIS 예약주문 API 시간창(10:00~23:20 KST) 제약
+  때문에 `us_pending_order_batch.py`가 **시간창 밖 주문을 큐잉했다가 지연 제출**하는
+  구조인데(07-13 정정: "익일 체결 확인"이 아님), 이슈 설계는 이 주문 수명주기
+  전체(큐잉→제출→체결 확인)를 다루지 않는다.
 
 → 보완: `get_order_status()`, `list_executions()` (KIS 주문체결조회
 `inquire-daily-ccld` 계열) 추가, pending order 추적을 adapter 책임으로 흡수.
@@ -51,6 +56,12 @@ UNKNOWN은 체결내역 조회로 복구.
 별도 프로세스(cron)로 도는 현실에서 필요한 것은 **크로스 프로세스 lock**
 (SQLite 트랜잭션 or flock). 또한 "전역 KIS env를 lock으로 보호"는 전역 가변
 인증 상태라는 결함을 영속화한다 — 근본 해결은 인증 컨텍스트의 객체 스코프화.
+
+> 07-13 갱신: SQLite `BEGIN IMMEDIATE` 티커 단위 owner_lock이 이미 존재하나
+> **부분적이다** — hardstop과 fill_chaser만 `loop_a_position_state`를 공유하고,
+> trend_exit는 자체 `loop_b_position_state`를 써서 hardstop↔trend_exit는
+> 직렬화되지 않는다 (01 문서 §4.5). 남은 요구는 이 lock을 **루프 전체 +
+> batch 에이전트까지 포괄하도록 통합·일반화**하는 것 — 새로 발명할 필요 없음.
 
 ### B-5. shadow 모드 시맨틱 미정의
 shadow 포지션과 실포지션이 한 positions 테이블에 섞이면 매도 판단이 무엇을
@@ -82,4 +93,8 @@ shadow 포지션과 실포지션이 한 positions 테이블에 섞이면 매도 
 - `MarketProfile` (KR/US 시장 차이를 데이터로), `PortfolioPolicy` (하드코딩 상수 제거)
 - 상속(`Enhanced extends Base`) → 합성(Strategy 플러그인) 전환
 - 사고 회귀 케이스의 자동화 테스트 고정 (MU 중복 SELL, #288 over-sell, 빈 portfolio)
-- KR에 아직 없는 중복 SELL chokepoint 가드의 이식
+- ~~KR에 아직 없는 중복 SELL chokepoint 가드의 이식~~ → **완료됨 (07-13 확인:
+  `stock_tracking_agent.py:1300-1327` `[SELL-GUARD][KR]`).** 남은 것은 CI 회귀 고정과
+  ExecutionService 이관 시 시맨틱 보존.
+- (07-13 추가) 이슈의 주문 경로 인벤토리는 batch 4곳 기준 — 현재는 루프 3종 +
+  US 포함 **9곳**이다 (01 문서 §1 표). chokepoint 범위 산정 시 이 표를 기준으로 한다.

--- a/tasks/issue-412/03-target-design.md
+++ b/tasks/issue-412/03-target-design.md
@@ -39,14 +39,21 @@ prism_us = US MarketProfile + yfinance MarketData + KIS overseas BrokerAdapter (
 class ExecutionService:
     """모든 매수/매도 주문이 지나는 유일한 경로.
     - intent 영속화 (idempotency unique 제약)
-    - 중복 SELL 가드 (fresh snapshot, US 사고 2026-07-01 교훈)
+    - 중복 SELL 가드 (fresh snapshot — 현 KR/US sell_stock 가드의 시맨틱 1:1 이관)
     - 분할매도 수량 계산 (#288 스냅샷 로직 이관)
-    - 크로스 프로세스 lock (계좌 단위)
+    - 크로스 프로세스 lock (loop_a_position_state owner_lock의 계승·일반화)
     - execution_mode 라우팅 (live / demo / shadow)
     """
     async def execute_buy(self, intent: BuyOrderIntent) -> OrderResult: ...
     async def execute_sell(self, intent: SellOrderIntent) -> OrderResult: ...
+    async def amend_or_cancel(self, intent: AmendOrderIntent) -> OrderResult: ...
 ```
+
+**커버리지 (07-13 기준)**: chokepoint가 감싸야 할 실주문 진입점은 batch 4곳이
+아니라 **9곳**이다 — KR batch 매수/매도, enhanced 매수, 루프 3종(hardstop /
+trend_exit / fill_chaser), US batch 매수/매도, US 예약주문 확인 배치.
+전체 표는 01 문서 §1. 루프는 LLM-free·별도 cron이므로 ExecutionService는
+LLM 판단 없이 intent만 받아도 동작해야 한다 (DecisionPort 비의존).
 
 ### 2.2 BrokerAdapter — 이슈 #412 초안 + 누락 메서드 추가
 
@@ -61,11 +68,18 @@ class BrokerAdapter(Protocol):
     async def get_order_status(self, order_id: str, account_id: str) -> OrderStatus: ...
     async def list_executions(self, account_id: str, date: date) -> list[Execution]: ...
     async def list_open_orders(self, account_id: str) -> list[OpenOrder]: ...
+    async def amend_order(self, order_id: str, new_price: Decimal) -> OrderResult: ...  # 07-13 추가
 ```
 
 - KIS 구현: 주문체결조회(`inquire-daily-ccld`), 해외 체결내역 조회 사용.
-- 예약주문의 익일 체결 확인(`us_pending_order_batch.py` 역할)을 adapter +
-  reconciliation job으로 흡수.
+- `list_open_orders`/`amend_order`의 참조 구현이 이미 있다: `tools/fill_chaser.py`가
+  KR `get_revisable_orders` / US `get_unfilled_orders`를 source of truth로 정정/취소를
+  수행한다 (07-13 확인). adapter는 이 wrapper들을 흡수한다. ⚠️ 해당 TR wrapper는
+  아직 라이브 검증 전 (`tasks/loop_c_design.md` 체크리스트 선행).
+- US 예약주문의 **시간창 밖 큐잉 → 지연 제출**(`prism-us/us_pending_order_batch.py`,
+  `us_pending_orders` 큐)을 order_intents 상태기계로 흡수한다 — 이 큐는 사실상
+  CREATED→SUBMITTING 전이의 기존 실물 선례이므로, §3.1 상태기계의 마이그레이션
+  대상으로 명시한다. 제출 후 체결 확인은 reconciliation job 담당.
 - get_portfolio의 일시적 빈 응답 가드(현 `domestic_stock_trading.py:1431`)는
   adapter 내부 책임으로 유지.
 
@@ -132,15 +146,26 @@ PENDING_ENTRY ──► OPEN ──► PENDING_EXIT ──► CLOSED
 - shadow intent는 broker 호출 없이 SUBMITTED(가상) 처리, 시세 기준 가상 체결 기록.
 - positions.execution_mode='shadow' 행은 매도 판단 루프에서 shadow 전용 계좌
   스코프로만 조회된다. live 판단 경로와 절대 섞이지 않는다 (쿼리 필터 강제).
+- 선례 (07-13): 루프의 `HARDSTOP_LIVE`/`TREND_EXIT_LIVE`/`FILL_CHASER_LIVE` env
+  게이트가 이미 "기본 SHADOW, 명시적 opt-in으로만 LIVE" 시맨틱을 운영 중이다.
+  execution_mode 라우팅은 이 규칙을 계승한다 (기본값은 항상 비실주문 쪽).
+- 주의 (hardstop 사례에서 배운 것): 과거 SHADOW 레코드가 LIVE 매도를 3주간
+  차단한 버그가 있었다 (`tools/hardstop_seller.py:186-187` 주석). shadow 기록은
+  live 경로의 중복 판정에 **절대 입력되지 않아야 한다** — 격리는 양방향이다.
 
 ## 5. 크로스 프로세스 동시성
 
-- 계좌 단위 lock: SQLite `BEGIN IMMEDIATE` 트랜잭션 또는 flock 파일 lock.
-  (asyncio.Lock은 보조 수단으로 유지)
+- 티커/계좌 단위 lock: **기존 `loop_a_position_state` owner_lock(SQLite
+  `BEGIN IMMEDIATE` + 만료 시각, `tools/hardstop_seller.py:200-235`)을 계승·일반화**해
+  루프 전체 + batch 에이전트를 포괄한다. 새 메커니즘 발명 금지. 주의: 현재는
+  hardstop+fill_chaser만 이 lock을 공유하고 **trend_exit는 별도 `loop_b_position_state`를
+  쓴다** — hardstop↔trend_exit 미직렬화 상태이므로 통합 시 loop_b_* 테이블 흡수가
+  필수 작업이다 (01 §4.5). (asyncio.Lock은 보조 수단으로 유지)
 - 중복 SELL 가드는 ExecutionService 안에서 fresh snapshot(commit 후 재조회)으로
-  수행 — US 구현(`us_stock_tracking_agent.py:2050`)의 시맨틱을 그대로 이관.
-- kis_auth의 전역 가변 인증 상태 → `KisSession` 객체 스코프로 전환
-  (계좌별 세션 인스턴스, 전역 env 오염 제거).
+  수행 — 현행 KR(`stock_tracking_agent.py:1300-1327`)·US(`prism-us/
+  us_stock_tracking_agent.py:2242-2261` + Layer 2 `:2432-2445`)의 시맨틱을 1:1 이관.
+- kis_auth(현 `trading/kis_auth.py`)의 전역 가변 인증 상태 → `KisSession` 객체
+  스코프로 전환 (계좌별 세션 인스턴스, 전역 env 오염 제거).
 
 ## 6. 이벤트 버스
 
@@ -149,3 +174,11 @@ PENDING_ENTRY ──► OPEN ──► PENDING_EXIT ──► CLOSED
   non-critical 패턴을 규칙으로 승격.
 - 이벤트 페이로드에 decision_id, intent_id 포함 → 외부 구독자(GCP 수신측)도
   중복 처리 가능해짐.
+- **발행 시점 계약 (07-13 추가 — 결정 필요)**: 현행 publish는 batch 인라인 3곳 +
+  `sell_broadcast.py`(루프 매도) 총 4곳이며, 시맨틱은 "**sim 커밋 = 방송 source of
+  truth**" (자사 KIS 체결 여부와 무관하게 sim_ok 기준 발행 — Rocky 규칙). §3.1의
+  쓰기 순서 교정(broker 접수 확인 후 포지션 확정)과 그대로 합치면 발행 시점이
+  뒤로 밀린다. 확정: **구독자 향 시그널 이벤트는 sim 커밋 시점 유지**(구독자 계약
+  불변), **원장/reconciliation 향 이벤트(OrderSubmitted 등)는 broker 접수 기준** —
+  두 종류를 다른 이벤트로 분리해 발행한다. `sell_broadcast.publish_loop_sell`은
+  Phase 6에서 이벤트 버스 구독자로 흡수.

--- a/tasks/issue-412/03-target-design.md
+++ b/tasks/issue-412/03-target-design.md
@@ -1,0 +1,151 @@
+# 03. 목표 아키텍처
+
+## 1. 전체 그림
+
+```
+┌─────────────────────────── prism_core (시장/브로커/알림 무지식) ───────────────────────────┐
+│                                                                                            │
+│  TrackingEngine (흐름만: Sell Phase → Buy Phase → Report)                                   │
+│    │                                                                                       │
+│    ├── DecisionPort        ← LLM Buy/Sell Agent (Pydantic 출력 계약)                        │
+│    ├── MarketDataPort      ← 시세/거래량/지수/변동성                                          │
+│    ├── PositionRepository  ← 원장 (상태 전이, delete 금지)                                    │
+│    ├── ExecutionService    ← 주문 단일 chokepoint (intent 영속화, idempotency, 가드)          │
+│    │     └── BrokerAdapter ← KIS 국내/해외, (미래: 타 증권사)                                 │
+│    ├── PortfolioPolicy     ← 슬롯/섹터/점수 임계값 (설정 객체)                                 │
+│    ├── MarketProfile       ← timezone/장시간/통화/호가단위/섹터분류                            │
+│    └── EventBus            ← 도메인 이벤트 발행                                              │
+│                                                                                            │
+└────────────────────────────────────────────────────────────────────────────────────────────┘
+        ▲ 구독자 (adapter 계층): TelegramNotifier, RedisPublisher, GcpPublisher,
+                                 FirebaseNotifier, JournalWriter, ReconciliationAlerter
+
+prism_kr = KR MarketProfile + pykrx MarketData + KIS domestic BrokerAdapter
+prism_us = US MarketProfile + yfinance MarketData + KIS overseas BrokerAdapter (포크 삭제)
+```
+
+원칙:
+- 코어는 어떤 시장·브로커·알림 채널도 모른다. 전부 생성자 주입.
+- 상속 대신 합성: Enhanced의 동적 손절/목표가·시장상황 분석은 Strategy 플러그인.
+- 알림/publish는 인라인 호출 금지. 엔진은 이벤트만 발행한다
+  (`PositionOpened`, `PositionClosed`, `OrderSubmitted`, `OrderFailed`,
+  `OrderUnknown`, `ReconciliationMismatch`).
+
+## 2. 포트 인터페이스
+
+### 2.1 ExecutionService — 모든 주문의 단일 chokepoint
+
+```python
+class ExecutionService:
+    """모든 매수/매도 주문이 지나는 유일한 경로.
+    - intent 영속화 (idempotency unique 제약)
+    - 중복 SELL 가드 (fresh snapshot, US 사고 2026-07-01 교훈)
+    - 분할매도 수량 계산 (#288 스냅샷 로직 이관)
+    - 크로스 프로세스 lock (계좌 단위)
+    - execution_mode 라우팅 (live / demo / shadow)
+    """
+    async def execute_buy(self, intent: BuyOrderIntent) -> OrderResult: ...
+    async def execute_sell(self, intent: SellOrderIntent) -> OrderResult: ...
+```
+
+### 2.2 BrokerAdapter — 이슈 #412 초안 + 누락 메서드 추가
+
+```python
+class BrokerAdapter(Protocol):
+    async def buy(self, intent: BuyOrderIntent) -> OrderResult: ...
+    async def sell(self, intent: SellOrderIntent) -> OrderResult: ...
+    async def get_position(self, symbol: str, account_id: str) -> BrokerPosition | None: ...
+    async def get_portfolio(self, account_id: str) -> list[BrokerPosition]: ...
+    async def cancel_order(self, order_id: str) -> OrderResult: ...
+    # ↓ 이슈 초안에 없던 필수 추가분
+    async def get_order_status(self, order_id: str, account_id: str) -> OrderStatus: ...
+    async def list_executions(self, account_id: str, date: date) -> list[Execution]: ...
+    async def list_open_orders(self, account_id: str) -> list[OpenOrder]: ...
+```
+
+- KIS 구현: 주문체결조회(`inquire-daily-ccld`), 해외 체결내역 조회 사용.
+- 예약주문의 익일 체결 확인(`us_pending_order_batch.py` 역할)을 adapter +
+  reconciliation job으로 흡수.
+- get_portfolio의 일시적 빈 응답 가드(현 `domestic_stock_trading.py:1431`)는
+  adapter 내부 책임으로 유지.
+
+### 2.3 DecisionPort — LLM 출력 계약 고정
+
+```python
+class BuyDecision(BaseModel):
+    decision: Literal["Enter", "No Entry"]
+    buy_score: int = Field(ge=0, le=10)
+    scenario: TradingScenario        # target_price, stop_loss, invalidation 포함
+    rationale: str
+    decision_id: str                 # UUID, 생성 시점 부여 → idempotency_key의 원천
+    prompt_version: str
+
+class SellDecision(BaseModel):
+    decision: Literal["Hold", "Full Exit"]
+    exit_kind: Literal["stop", "trend_exit", "target", "ai", "manual"] | None
+    rationale: str
+    decision_id: str
+    prompt_version: str
+```
+
+현재 흩어져 있는 방어적 파싱(`_normalize_decision`, `_parse_price_value`,
+`_safe_number_conversion`)은 이 경계 한 곳으로 수렴한다.
+프롬프트와 스키마는 함께 버저닝한다 (이슈 #412 제안 채택).
+
+## 3. 상태기계
+
+### 3.1 주문 (order_intents)
+
+```
+CREATED ──► SUBMITTING ──► SUBMITTED ──► FILLED | PARTIALLY_FILLED | CANCELLED | REJECTED
+                │
+                ├──► FAILED    (broker가 명시적 거부 — 보상 실행)
+                └──► UNKNOWN   (타임아웃/네트워크 — 체결내역 조회로 복구, 사람 알림)
+```
+
+- KIS에 client-order-id가 없으므로, UNKNOWN 상태의 복구는
+  `list_executions()` 대조로만 가능하다. 이것이 idempotency의 실체다.
+
+### 3.2 포지션 (positions) — delete 금지
+
+```
+PENDING_ENTRY ──► OPEN ──► PENDING_EXIT ──► CLOSED
+      │                        │
+      └──► ENTRY_FAILED        └──► EXIT_UNKNOWN (사람 개입)
+```
+
+- **쓰기 순서 확정**: ① intent 영속화(CREATED) → ② 포지션 PENDING_* 전이 →
+  ③ broker 호출 → ④ 접수 확인 시 OPEN/CLOSED 확정, 실패 시 보상 전이.
+  현재의 "원장 선커밋 후 fire-and-forget"을 제거한다.
+- 매도 시 행 삭제 금지 → CLOSED 전이. reconciliation의 전제 조건.
+
+## 4. DB 모델 (이슈 #412 채택 + 보강)
+
+- `order_intents`: idempotency_key UNIQUE, decision_id, status, execution_mode,
+  created_at, submitted_at, raw_request
+- `broker_orders`: intent_id FK, broker_order_no, status, filled_qty, avg_price,
+  last_checked_at, raw_response
+- `positions`: 상태기계 컬럼 + execution_mode 컬럼 (shadow/demo/live 격리)
+- 기존 `stock_holdings`/`trading_history`는 Phase 4까지 병행 유지 (04 참고)
+
+### shadow 모드 시맨틱 (이슈 미정의분 확정)
+- shadow intent는 broker 호출 없이 SUBMITTED(가상) 처리, 시세 기준 가상 체결 기록.
+- positions.execution_mode='shadow' 행은 매도 판단 루프에서 shadow 전용 계좌
+  스코프로만 조회된다. live 판단 경로와 절대 섞이지 않는다 (쿼리 필터 강제).
+
+## 5. 크로스 프로세스 동시성
+
+- 계좌 단위 lock: SQLite `BEGIN IMMEDIATE` 트랜잭션 또는 flock 파일 lock.
+  (asyncio.Lock은 보조 수단으로 유지)
+- 중복 SELL 가드는 ExecutionService 안에서 fresh snapshot(commit 후 재조회)으로
+  수행 — US 구현(`us_stock_tracking_agent.py:2050`)의 시맨틱을 그대로 이관.
+- kis_auth의 전역 가변 인증 상태 → `KisSession` 객체 스코프로 전환
+  (계좌별 세션 인스턴스, 전역 env 오염 제거).
+
+## 6. 이벤트 버스
+
+- 최초 구현은 in-process 동기 dispatch (외부 브로커 불필요).
+- 구독자 실패는 격리(try/except + 로그) — 현 Redis/GCP publish의
+  non-critical 패턴을 규칙으로 승격.
+- 이벤트 페이로드에 decision_id, intent_id 포함 → 외부 구독자(GCP 수신측)도
+  중복 처리 가능해짐.

--- a/tasks/issue-412/04-migration-plan.md
+++ b/tasks/issue-412/04-migration-plan.md
@@ -1,0 +1,91 @@
+# 04. 단계별 마이그레이션 계획 (Strangler)
+
+원칙: 각 Phase는 **독립 배포 가능, 독립 롤백 가능, 서버 demo 검증 통과 후 다음 단계 진입.**
+검증 절차의 상세는 05-verification-plan.md.
+
+---
+
+## Phase 0 — 합의 (코드 변경 없음)
+
+- [x] 이 디렉토리의 계획/설계/검증 문서 작성
+- [ ] 이슈 #412에 검토 코멘트 게시, 방향 합의
+- 완료 조건: 이슈 코멘트에 방향 합의 (또는 이견 반영해 문서 수정)
+
+## Phase 1 — 순수 함수 추출 (무위험)
+
+대상: 로직 변화 없이 옮기기만 하면 되는 것들.
+- `_normalize_decision`, `_parse_price_value`, `_safe_number_conversion`
+  → `prism_core/parsing.py`
+- `compute_fractional_sell_quantity` 및 #288 스냅샷 분배 로직 → 순수 함수화
+- 주문 시간대 판정 (KST/ET 거래소 timezone 기준) → `time_windows.py`
+- 완료 조건:
+  - 추출된 함수 전부에 단위 테스트 (기존 동작 고정, #288 over-sell 케이스 포함)
+  - 기존 호출부는 import 경로만 변경, diff에 로직 변화 없음
+  - 서버 demo 1일 운영에서 기존과 동일 동작
+
+## Phase 2 — ExecutionService chokepoint (동작 불변 래핑)
+
+- `AsyncTradingContext` 직접 호출 4곳(KR 매수/매도 × base/enhanced)을
+  `ExecutionService.execute_buy/execute_sell` 뒤로 이동. **내부는 기존 코드 그대로 위임.**
+- 이때 함께: US의 중복 SELL 가드(fresh snapshot)를 ExecutionService에 구현해
+  KR에도 적용 (현재 KR에는 없음 — 2026-07-01 MU 사고의 KR 재발 방지)
+- 완료 조건:
+  - 주문 경로 grep 검사: `AsyncTradingContext` 사용처가 ExecutionService 내부 1곳뿐
+  - 중복 SELL 회귀 테스트 (동시 2 프로세스 시나리오) 통과
+  - 서버 demo 3일 운영: 주문 결과가 리팩토링 전과 동일 패턴
+
+## Phase 3 — OrderIntent 영속화 + 쓰기 순서 교정
+
+- `order_intents`, `broker_orders` 테이블 신설 (기존 테이블 무변경)
+- ExecutionService가 ① intent 저장(CREATED, idempotency unique) → ② broker 호출
+  → ③ 결과로 상태 갱신 (SUBMITTED/FAILED/UNKNOWN)
+- 주문 실패 시: 매수는 원장 보상 삭제(현행 buy_stock 커밋 취소), 매도는 원장 복원
+  + `OrderFailed` 이벤트로 Telegram 알림 (**현재는 로그만 남기고 침묵 — 이걸 제거**)
+- UNKNOWN 처리: `list_executions` 대조 후 확정, 미확정 시 사람 알림
+- 완료 조건:
+  - 강제 실패 주입 테스트(모의 broker 예외/타임아웃)에서 원장-intent 정합 유지
+  - idempotency: 같은 decision_id 재실행 시 두 번째 주문이 차단되는 테스트
+  - 서버 demo에서 정상 매수/매도 + 인위적 실패 시나리오 각 1회 검증
+
+## Phase 4 — 포지션 상태기계 (가장 위험, shadow 병행 검증)
+
+- `positions` 신설, PENDING_ENTRY→OPEN→PENDING_EXIT→CLOSED 전이
+- **병행 기록 기간**: 기존 `stock_holdings`(insert/delete)와 신규 `positions`를
+  동시에 기록하되, 판단 루프는 여전히 기존 테이블을 읽는다.
+- 매일 두 테이블 대조 스크립트 실행 → N일(최소 5 거래일) 무불일치 후 읽기 전환.
+- 읽기 전환 후에도 기존 테이블 기록은 1주 유지 (즉시 롤백 경로).
+- 완료 조건: 5 거래일 연속 대조 무불일치 → 읽기 전환 → 3 거래일 정상 → 구기록 중단
+
+## Phase 5 — BrokerAdapter 추출 + Reconciliation (alert-only)
+
+- KIS 국내 어댑터를 BrokerAdapter Protocol로 정리, **체결 조회 메서드 구현**
+- 예약주문 익일 체결 확인 로직 흡수
+- reconciliation job: positions(OPEN) vs `get_portfolio()` 대조.
+  빈 응답 가드 필수. **자동 수정 금지, 불일치는 `ReconciliationMismatch` 이벤트
+  → Telegram 알림만** (자동 보정은 운영 신뢰 쌓인 뒤 별도 결정)
+- `kis_auth` 전역 상태 → `KisSession` 객체 스코프 전환
+- 완료 조건: 인위적 불일치(demo 계좌에서 수동 주문)를 job이 탐지·알림
+
+## Phase 6 — 코어/어댑터 패키지 분리 + prism-us 흡수
+
+- 이벤트 버스 도입, Telegram/Redis/GCP/일지/Firebase를 구독자로 이동
+- `prism_core` / `prism_kr` / `prism_us` 패키지 분리
+- MarketProfile, PortfolioPolicy 도입 (하드코딩 상수 제거)
+- Enhanced 상속 → Strategy 합성 전환
+- **prism-us의 us_stock_tracking_agent 포크를 코어+어댑터 조합으로 대체**
+- 완료 조건 (= 이식성 합격 기준):
+  - prism-us 전용 tracking 코드가 프로파일/어댑터/전략 등록 수준으로 축소
+  - KR/US 모두 코어 엔진 하나로 서버 demo 5 거래일 무사고
+  - 이 시점에 이슈 #412의 "타 프로젝트 이식" 요구는 문서가 아니라
+    동작하는 코어 패키지로 충족된다
+
+---
+
+## Phase 간 공통 규칙
+
+- 한 Phase = 한 PR. PR에는 해당 Phase 문서 갱신 포함.
+- 배포는 항상 demo 계좌 모드 먼저. live 전환은 Phase별 완료 조건 + Rocky 승인.
+- 회귀 케이스 3종(MU 중복 SELL, #288 over-sell, 빈 portfolio)은 Phase 2부터
+  CI에 상주.
+- 문제 발생 시: 해당 Phase revert → 이전 Phase 상태로 복귀 (각 Phase가
+  이전 상태와 호환되도록 DB 변경은 additive-only).

--- a/tasks/issue-412/04-migration-plan.md
+++ b/tasks/issue-412/04-migration-plan.md
@@ -1,5 +1,8 @@
 # 04. 단계별 마이그레이션 계획 (Strangler)
 
+> 2026-07-13 갱신: Phase 2의 전제(주문 경로 4곳, KR 가드 부재)가 main 변경으로
+> 깨져서 재작성. Phase 5에 amend/미체결 조회 흡수 추가. Phase 6 수치 갱신.
+
 원칙: 각 Phase는 **독립 배포 가능, 독립 롤백 가능, 서버 demo 검증 통과 후 다음 단계 진입.**
 검증 절차의 상세는 05-verification-plan.md.
 
@@ -17,7 +20,11 @@
 - `_normalize_decision`, `_parse_price_value`, `_safe_number_conversion`
   → `prism_core/parsing.py`
 - `compute_fractional_sell_quantity` 및 #288 스냅샷 분배 로직 → 순수 함수화
+  (현 위치 `stock_tracking_agent.py:1575-1655`)
 - 주문 시간대 판정 (KST/ET 거래소 timezone 기준) → `time_windows.py`
+- 주의 (07-13): `sell_stock`에 exit_kind 분류·재진입 cooldown 기록·브로드캐스트
+  큐잉이 추가돼 07-06 시점보다 무겁다. 추출 대상을 "계산"으로 한정하고
+  가드/원장/알림은 Phase 2~3까지 건드리지 않는다.
 - 완료 조건:
   - 추출된 함수 전부에 단위 테스트 (기존 동작 고정, #288 over-sell 케이스 포함)
   - 기존 호출부는 import 경로만 변경, diff에 로직 변화 없음
@@ -25,13 +32,30 @@
 
 ## Phase 2 — ExecutionService chokepoint (동작 불변 래핑)
 
-- `AsyncTradingContext` 직접 호출 4곳(KR 매수/매도 × base/enhanced)을
-  `ExecutionService.execute_buy/execute_sell` 뒤로 이동. **내부는 기존 코드 그대로 위임.**
-- 이때 함께: US의 중복 SELL 가드(fresh snapshot)를 ExecutionService에 구현해
-  KR에도 적용 (현재 KR에는 없음 — 2026-07-01 MU 사고의 KR 재발 방지)
+(07-13 재작성 — 구버전의 "4곳, KR 가드 이식" 전제 폐기)
+
+- `AsyncTradingContext` 직접 호출 **9곳**(01 문서 §1 표: KR batch 매수/매도,
+  enhanced 매수, hardstop/trend_exit/fill_chaser 루프, US batch 매수/매도,
+  US 예약주문 배치)을 `ExecutionService.execute_buy/execute_sell/amend_or_cancel`
+  뒤로 이동. **내부는 기존 코드 그대로 위임.**
+  - 순서 제안: KR batch 3곳 → 루프 3곳 → US 3곳 (루프는 LLM-free이므로
+    ExecutionService의 DecisionPort 비의존이 이 단계에서 강제 검증된다)
+- ~~US의 중복 SELL 가드를 KR에 적용~~ → **이미 main에 이식 완료**
+  (`stock_tracking_agent.py:1300-1327`). 이 Phase에서 할 일은:
+  - 기존 KR/US 가드 시맨틱을 ExecutionService로 **1:1 이관** (동작 불변)
+  - 동시 2-프로세스 중복 SELL 회귀 테스트를 CI에 고정 (지금은 코드에만 존재,
+    테스트 부재 — 이관 중 시맨틱 훼손을 잡을 안전망이 없다)
+- 루프의 owner_lock(`loop_a_position_state`)은 이 Phase에서 **건드리지 않는다**
+  (제거·통합은 Phase 5에서 lock 일반화와 함께).
 - 완료 조건:
-  - 주문 경로 grep 검사: `AsyncTradingContext` 사용처가 ExecutionService 내부 1곳뿐
-  - 중복 SELL 회귀 테스트 (동시 2 프로세스 시나리오) 통과
+  - 주문 경로 grep 검사 (07-13 정정 — US는 `AsyncUSTradingContext`로 문자열이 다르고
+    #9는 컨텍스트 없이 직접 호출이므로 단일 패턴으로는 US가 통째로 빠진다):
+    `AsyncTradingContext|AsyncUSTradingContext|buy_reserved_order|sell_reserved_order`
+    사용처가 ExecutionService 내부뿐일 것. 제외 목록: `tests/`, `prism-us/tests/`,
+    `examples/`, `cores/corporate_status.py`(시세 조회 전용 — Phase 6에서
+    MarketDataPort로 이관). 구 loop shim(`tools/loop_*.py`)은 runpy 셸이라 애초에
+    안 잡힘 — 제외 불필요.
+  - 중복 SELL 회귀 테스트 (동시 2 프로세스 시나리오, KR+US) 통과
   - 서버 demo 3일 운영: 주문 결과가 리팩토링 전과 동일 패턴
 
 ## Phase 3 — OrderIntent 영속화 + 쓰기 순서 교정
@@ -59,7 +83,15 @@
 ## Phase 5 — BrokerAdapter 추출 + Reconciliation (alert-only)
 
 - KIS 국내 어댑터를 BrokerAdapter Protocol로 정리, **체결 조회 메서드 구현**
-- 예약주문 익일 체결 확인 로직 흡수
+- `amend_order`/`list_open_orders`는 fill_chaser의 기존 TR wrapper를 흡수
+  (라이브 검증 체크리스트 `tasks/loop_c_design.md` 선행 — 07-13 추가)
+- 크로스 프로세스 lock 일반화: `loop_a_position_state` owner_lock을 batch까지
+  포괄하는 형태로 승격 (테이블명 중립화 포함). **trend_exit의 별도
+  `loop_b_position_state`/`loop_b_inflight_orders`도 이때 통합** — 현재
+  hardstop↔trend_exit 미직렬화 갭을 닫는 것이 이 작업의 실질 가치다 (01 §4.5)
+- US 예약주문 지연 제출 큐(`prism-us/us_pending_order_batch.py`,
+  `us_pending_orders`)를 order_intents 상태기계로 흡수 (03 §2.2 — Phase 3에서
+  테이블이 생기면 이 큐가 첫 마이그레이션 후보)
 - reconciliation job: positions(OPEN) vs `get_portfolio()` 대조.
   빈 응답 가드 필수. **자동 수정 금지, 불일치는 `ReconciliationMismatch` 이벤트
   → Telegram 알림만** (자동 보정은 운영 신뢰 쌓인 뒤 별도 결정)
@@ -69,10 +101,14 @@
 ## Phase 6 — 코어/어댑터 패키지 분리 + prism-us 흡수
 
 - 이벤트 버스 도입, Telegram/Redis/GCP/일지/Firebase를 구독자로 이동
+  (`sell_broadcast.publish_loop_sell` 포함 — 발행 시점 계약은 03 §6 결정 준수.
+  `cores/corporate_status.py`의 ATC 시세 조회는 MarketDataPort로 이관)
 - `prism_core` / `prism_kr` / `prism_us` 패키지 분리
 - MarketProfile, PortfolioPolicy 도입 (하드코딩 상수 제거)
 - Enhanced 상속 → Strategy 합성 전환
-- **prism-us의 us_stock_tracking_agent 포크를 코어+어댑터 조합으로 대체**
+- **prism-us의 us_stock_tracking_agent 포크(07-13 기준 3,600줄, 일주일에 +700줄로
+  성장 중)를 코어+어댑터 조합으로 대체.** `prism-us/trading/us_stock_trading.py`
+  어댑터 포크도 흡수 대상.
 - 완료 조건 (= 이식성 합격 기준):
   - prism-us 전용 tracking 코드가 프로파일/어댑터/전략 등록 수준으로 축소
   - KR/US 모두 코어 엔진 하나로 서버 demo 5 거래일 무사고

--- a/tasks/issue-412/05-verification-plan.md
+++ b/tasks/issue-412/05-verification-plan.md
@@ -27,12 +27,25 @@ L1  단위 테스트 (순수 함수, payload builder, 상태 전이)
 1. **MU 중복 SELL (2026-07-01)**: 두 실행 경로가 같은 포지션을 초 단위 간격으로
    매도 시도 → 두 번째는 chokepoint에서 abort, SELL publish 정확히 1회.
    (동시 프로세스 시뮬레이션: 별도 커넥션 2개, WAL 모드)
+   *07-13 갱신: 가드는 이미 KR/US 코드에 존재한다 (`stock_tracking_agent.py:1300-1327`,
+   `prism-us/us_stock_tracking_agent.py:2242-2261`). 이 테스트의 역할은 새 동작
+   구현이 아니라 **기존 가드를 회귀로 고정**해 ExecutionService 이관(Phase 2) 중
+   시맨틱 훼손을 잡는 것 — 따라서 Phase 2 착수 전에 먼저 작성한다.*
 2. **#288 over-sell**: 피라미딩 3행, 첫 2행 지정가 미체결 상태에서 마지막 행 매도
    → 스냅샷 잔량 기준 수량, broker 재조회 금지.
 3. **빈 portfolio 응답**: get_portfolio 1회 빈 리스트 → 보유 없음 확정 금지, 재확인.
 4. **주문 실패 보상**: broker 예외/타임아웃 주입 → 매수 원장 보상, 매도 원장 복원,
    OrderFailed 알림 발생, UNKNOWN 경로는 체결조회 대조.
-5. **shadow/live 격리**: shadow 포지션이 live 매도 판단 쿼리에 절대 잡히지 않음.
+5. **shadow/live 격리 (양방향)**: shadow 포지션이 live 매도 판단 쿼리에 절대
+   잡히지 않음 **+ shadow 기록이 live 주문의 중복 판정에 입력되지 않음**
+   (hardstop에서 과거 SHADOW 레코드가 LIVE 손절을 3주간 차단한 실사고 —
+   `tools/hardstop_seller.py:186-187`).
+6. **크로스 프로세스 owner_lock (07-13 추가)**: 두 프로세스가 같은 티커의 lock을
+   경합 → 한쪽만 획득, 만료 시각 경과 후 재획득 가능. Phase 5의 lock 일반화 시
+   기존 루프 동작(`loop_a_position_state`)이 깨지지 않음을 고정. **특히
+   hardstop↔trend_exit 동시 경합 케이스 포함** — 현재 둘은 서로 다른 lock 테이블
+   (`loop_a_*` vs `loop_b_*`)이라 직렬화되지 않는 상태이므로, 통합 후 이 케이스가
+   새로 막히는지가 핵심 검증점이다.
 
 모의 broker(fake adapter)로 구현. 실제 KIS 호출 없음.
 
@@ -51,6 +64,17 @@ L1  단위 테스트 (순수 함수, payload builder, 상태 전이)
    runtime env flag 동시 충족 — 이슈 #412 채택)
 2. 실제 장 시간에 정규 cron 스케줄로 최소 N 거래일 운영
    (Phase 1: 1일, Phase 2: 3일, Phase 4: 5일+3일, Phase 6: 5일)
+   — batch뿐 아니라 **루프 cron(hardstop/trend_exit/fill_chaser, */10)도 포함**해서
+   돌린다. Phase 2부터는 루프 경로도 chokepoint를 지나므로 루프 없는 검증은 무효.
+   - **선행 실사 (07-13)**: 루프 3종의 서버 crontab 설치 상태를 먼저 확인할 것.
+     코드 주석 기준 셋 다 "Intended cron (SHADOW until reviewed)"이고 특히
+     fill_chaser는 "NOT installed" 명시 (`tools/fill_chaser.py:47`) — 미설치
+     루프는 검증 시작 전 SHADOW로 설치한다.
+   - **게이트 일수 정의 (07-13)**: market-pulse batch-rest(`cores/regime_policy.py`)가
+     CORRECTION/UNDER_PRESSURE 레짐에서 배치를 통째로 쉬게 하므로, "N 거래일"은
+     달력이 아니라 **주문 경로가 실제 실행된 거래일 N일**로 센다 (batch-rest로
+     쉰 날은 카운트 제외). 나쁜 레짐 주간에 무실행 통과를 막기 위함.
+   (참고: #431로 US 분석 배치는 아침/오후 2회 — 검증 일정 산정 시 반영)
 3. 매일 확인 항목:
    - `order_intents` ↔ `broker_orders` ↔ KIS demo 계좌 잔고 3자 대조
    - 에러 로그 grep: `Actual purchase failed`, `Actual sell failed`, UNKNOWN 상태 잔존

--- a/tasks/issue-412/05-verification-plan.md
+++ b/tasks/issue-412/05-verification-plan.md
@@ -1,0 +1,79 @@
+# 05. 검증 계획
+
+핵심 전제: **단위 테스트만으로는 "버그 없음"을 말할 수 없다.**
+최종 검증은 운영 서버에 demo 계좌 모드로 배포해 실제 장 시간에 돌려보는 것이다.
+
+## 1. 검증 피라미드
+
+```
+L4  운영 서버 배포 검증 (demo 계좌, 실제 장 시간, Phase별 필수 게이트)
+L3  Shadow 병행 기록 대조 (Phase 4)
+L2  회귀/시나리오 테스트 (사고 케이스 고정, 동시성)
+L1  단위 테스트 (순수 함수, payload builder, 상태 전이)
+```
+
+## 2. L1 — 단위 테스트
+
+- 파싱/정규화 함수: 기존 동작 고정 (golden 입출력)
+- KIS payload builder: TR ID·가격 문자열 포맷(국내 정수) 검증 — 이슈 #412 테스트 계획 채택
+- 주문 상태기계: 허용 전이 전체, 비허용 전이 거부
+- 분할매도 수량 계산: #288 케이스 (미체결 잔량 존재 시 over-sell 금지)
+- idempotency: 동일 key 재삽입 시 unique 제약 위반 확인
+
+## 3. L2 — 회귀/시나리오 테스트 (CI 상주)
+
+사고에서 나온 케이스를 테스트로 고정한다:
+
+1. **MU 중복 SELL (2026-07-01)**: 두 실행 경로가 같은 포지션을 초 단위 간격으로
+   매도 시도 → 두 번째는 chokepoint에서 abort, SELL publish 정확히 1회.
+   (동시 프로세스 시뮬레이션: 별도 커넥션 2개, WAL 모드)
+2. **#288 over-sell**: 피라미딩 3행, 첫 2행 지정가 미체결 상태에서 마지막 행 매도
+   → 스냅샷 잔량 기준 수량, broker 재조회 금지.
+3. **빈 portfolio 응답**: get_portfolio 1회 빈 리스트 → 보유 없음 확정 금지, 재확인.
+4. **주문 실패 보상**: broker 예외/타임아웃 주입 → 매수 원장 보상, 매도 원장 복원,
+   OrderFailed 알림 발생, UNKNOWN 경로는 체결조회 대조.
+5. **shadow/live 격리**: shadow 포지션이 live 매도 판단 쿼리에 절대 잡히지 않음.
+
+모의 broker(fake adapter)로 구현. 실제 KIS 호출 없음.
+
+## 4. L3 — Shadow 병행 기록 대조 (Phase 4 전용)
+
+- 신구 원장 동시 기록, 판단은 구원장 기준.
+- 매 거래일 마감 후 대조 스크립트: (ticker, account, qty, 상태) 완전 일치 여부.
+- 5 거래일 연속 무불일치가 읽기 전환 조건. 불일치 1건이라도 나오면 카운터 리셋.
+
+## 5. L4 — 운영 서버 배포 검증 (Phase별 게이트)
+
+### 절차 (매 Phase 공통)
+
+1. 서버에서 해당 브랜치 checkout, **demo 계좌 모드 확인**
+   (`kis_devlp.yaml` svr=vps 계열 + 환경 flag. real 전환 조건: config flag +
+   runtime env flag 동시 충족 — 이슈 #412 채택)
+2. 실제 장 시간에 정규 cron 스케줄로 최소 N 거래일 운영
+   (Phase 1: 1일, Phase 2: 3일, Phase 4: 5일+3일, Phase 6: 5일)
+3. 매일 확인 항목:
+   - `order_intents` ↔ `broker_orders` ↔ KIS demo 계좌 잔고 3자 대조
+   - 에러 로그 grep: `Actual purchase failed`, `Actual sell failed`, UNKNOWN 상태 잔존
+   - Telegram 알림 정상 수신 (특히 OrderFailed — Phase 3부터)
+   - GCP/Redis 시그널 수신측 중복 없음 (decision_id 기준)
+4. 이상 발견 시: 해당 Phase revert 배포 → 원인 분석 문서화 → 수정 후 재검증
+
+### 검증용 인위 시나리오 (demo 계좌에서 안전)
+
+- 정상 매수 → 익일 매도 full cycle
+- 장외 시간 매수 트리거 → 예약주문 경로 + 익일 체결 확인
+- 강제 실패: 잘못된 종목코드 주문 → FAILED 처리·알림·원장 보상 확인
+- 수동 개입: KIS 앱에서 demo 계좌에 수동 주문 → reconciliation 탐지 (Phase 5)
+
+### live 전환 게이트 (마지막)
+
+- 전 Phase 완료 + demo 무사고 기간 충족
+- Rocky 수동 승인 (config flag는 사람이 직접 변경, 자동화 금지)
+- 첫 live 주는 최소 슬롯(1종목)으로 카나리 운영
+
+## 6. 판단 로직 무변경 확인 (전 Phase 공통)
+
+이 리팩토링은 **실행 계층**의 재설계다. LLM 판단(프롬프트, 점수, 시나리오)은
+변경 대상이 아니다. Phase마다 판단 결과(decision, buy_score)의 분포가
+리팩토링 전과 유의미하게 달라지지 않았는지 로그 대조로 확인한다.
+달라졌다면 실행 계층 리팩토링이 판단 입력을 오염시킨 것 — 즉시 중단 신호.

--- a/tasks/issue-412/06-pr433-harvest-impact.md
+++ b/tasks/issue-412/06-pr433-harvest-impact.md
@@ -1,0 +1,42 @@
+# 06 — PR #433 하베스트가 #412에 주는 영향 (2026-07-15)
+
+> 외부 기여 PR #433(@tkgo11, 91파일/+12,876·-1,724, fork main→main, "원하는 만큼만 반영하세요")
+> 를 다각도 리뷰 후 **안전한 격리 조각만 4개 PR로 분리 반영**하고, 주문 생명주기 아이디어는
+> 여기(#412)로 흡수하기로 함. 이 노트는 그 결정과 #412 문서에 필요한 후속 갱신을 기록한다.
+
+## 반영한 것 (열린 PR — main 미머지, Rocky 리뷰 대기)
+- **#442** `fix(auth)` — OAuth 토큰 원자적 저장(mkstemp 0600+fsync+os.replace). #412 무관.
+- **#443** `fix(messaging)` — redis/pubsub/health `asyncio.to_thread` 오프로드. 원본 hunk의
+  `__init__` asyncio.Lock 크로스루프 취약점을 **지연 생성(getattr)으로 하드닝**. #412 무관.
+- **#444** `fix(trading)` — `_resolve_sell_quantity`가 잘못된/0/음수 명시 수량에 **전량(holding)
+  fallback → 0 반환 + 호출부 7곳(US 3·KR 4) 가드**. `None→전량`은 보존. ★ **#412 Phase 1 대상 파일**
+  (`prism-us/trading/us_stock_trading.py`, `trading/domestic_stock_trading.py`)을 건드림.
+- **#445** `fix(btc)` — `jeoningu_price_fetcher.get_current_price` mock→None + 호출부 가드
+  (평가 스킵 / 매도·매수 defer / 대시보드 buy_price fallback). 포지션 스위치 반쪽매도 BLOCKER 수정.
+
+## DROP 한 것 → #412로 흡수 (fork 직접 병합 안 함)
+- `us_pending_order_batch.py` claim/lease 상태기계 + 운영 DB 라이브 `ALTER TABLE` DDL → Phase 3(OrderIntent 영속화)에서 우리가 라이브 대조 테스트와 함께.
+- `has_open_inflight` inflight-TTL(OPEN+SHADOW→OPEN+TTL) → **기존 브랜치 `feature/loop-a-inflight-ttl`와 중복/충돌**. 그 브랜치에서 처리.
+- dedup 변경 → `feat/portfolio-dedup`와 중복.
+- 신규 `prism-us/trading/order_submission.py` 모듈 → **#412 Phase 2(ExecutionService chokepoint) 결정을 외부인이 선점**. 우리 설계로 대체.
+- `us_stock_trading.py`의 `OrderOutcomeUnknown`/`unknown_outcome`/`retry_safe` → 리뷰 결과 `asyncio.wait_for` 타임아웃에 삼켜져 **라이브 US 경로에서 무력**하고 소비자 0개. Phase 2/4에서 제대로 설계.
+- 프론트엔드 lockfile/ .tsx / CI / youtube 테스트 통삭제 등 노이즈 전량.
+
+## #412 문서에 필요한 후속 갱신 (★ A~D 머지 후 실행)
+1. **01-current-state.md** — 실주문/매도 수량 처리 현행 서술 갱신:
+   - `_resolve_sell_quantity`의 "잘못된 수량 → 전량청산" 위험이 #444로 **제거됨**(이제 거부+WARNING).
+     현행 상태 스냅샷을 #444 반영 후로 재베이스라인.
+   - BTC(jeoningu) 시세는 더 이상 mock fabricate 안 함(#445) — 시뮬 성과 서술 갱신.
+2. **04-migration-plan.md — Phase 1(순수함수 추출)**:
+   - 분할매도계산 순수함수화 시, #444가 이미 넣은 `_resolve_sell_quantity` + 7개 호출부 `<=0` 가드를
+     **prism_core로 그대로 이관**(재구현 금지, 회귀 방지). 가드의 실패-dict 계약(US 'ticker' / KR 'stock_code')도 보존.
+   - 시간대판정/파싱 추출은 영향 없음.
+3. **Phase 6(포크 흡수)** — #433 자체가 KR/US 포크 드리프트의 실피해(오늘 #438 텔레그램 버그와 동류)를
+   외부에서 또 드러냄. inert US OrderOutcomeUnknown이 그 증거. Phase 6 우선순위 근거로 추가.
+
+## 진입점 재확인 (변화 없음)
+실주문 진입점 9곳(#412 02§) 불변. #444는 그중 매도 계산 경로에 방어 가드만 추가(구조 불변)이라
+Phase 1 리베이스는 trivial. `order_submission.py`를 DROP했으므로 Phase 2 chokepoint 설계 공간은 그대로 비어 있음.
+
+## 다음
+A~D 머지되면 위 1·2 갱신 → Phase 1 착수(문서앵커 최신화 완료 상태).

--- a/tasks/issue-412/07-phase2-execution-plan.md
+++ b/tasks/issue-412/07-phase2-execution-plan.md
@@ -1,0 +1,61 @@
+# Phase 2 — ExecutionService 실행 계획
+
+> 기준: `main` `c4c2539d` (PR #447/#455 포함)  
+> 브랜치: `feature/issue-412-phase2-execution-service`  
+> 목표: 주문 동작을 바꾸지 않고 실주문 진입점을 단일 서비스 뒤로 이동한다.
+
+## 1. 잠글 기존 동작
+
+구현 전에 다음 회귀를 테스트로 고정한다.
+
+1. KR/US 중복 SELL 가드: 별도 SQLite 연결 두 개가 같은 포지션을 닫으려 할 때
+   첫 번째만 성공하고 두 번째는 주문·원장·publish 없이 중단한다.
+2. #288 피라미딩 분할매도: 미체결 주문 때문에 broker 수량이 줄지 않아도 한 pass의
+   주문 수량 합이 최초 snapshot을 넘지 않는다.
+3. 일시적인 빈 portfolio: 한 번의 빈 응답만으로 보유 없음 또는 전량청산으로 확정하지 않는다.
+4. 래퍼 계약: 기존 context에 전달되는 account/ticker/price/quantity 인자와 반환값이
+   리팩터 전후 동일하다.
+
+## 2. 최소 구조
+
+- `prism_core/execution_service.py`에 과도기 `ExecutionService`를 둔다.
+- 서비스는 기존 `AsyncTradingContext`/`AsyncUSTradingContext`와 US 예약주문 trader를
+  **그대로 위임**한다. 새 retry, lock, DB, idempotency 로직을 추가하지 않는다.
+- 일반 주문은 `execute_buy`/`execute_sell`, 루프 정정·취소는
+  `amend_or_cancel`, 예약주문은 기존 동기 호출 의미를 보존하는 전용 위임 메서드를 사용한다.
+- 보유수량/fresh-position 조회는 현재 주문 직전 안전검사를 보존하기 위한 과도기
+  pass-through로만 제공하고 Phase 5/6에서 BrokerAdapter/MarketDataPort로 분리한다.
+
+## 3. 이관 순서
+
+1. KR batch 3곳
+   - `stock_tracking_agent.py` 매도/매수
+   - `stock_tracking_enhanced_agent.py` 매수
+2. LLM-free 루프 3곳
+   - `tools/hardstop_seller.py`
+   - `tools/trend_exit_seller.py`
+   - `tools/fill_chaser.py`
+3. US 3곳
+   - `prism-us/us_stock_tracking_agent.py` 매도/매수
+   - `prism-us/us_pending_order_batch.py` 지연 예약주문 제출
+
+각 묶음은 기존 focused test를 통과시킨 뒤 다음 묶음으로 넘어간다.
+
+## 4. 명시적 비목표
+
+- `order_intents`/`broker_orders` 테이블과 idempotency: Phase 3
+- 포지션 상태기계 및 기존 delete 제거: Phase 4
+- owner lock 통합, BrokerAdapter, reconciliation: Phase 5
+- 이벤트버스와 KR/US 패키지 통합: Phase 6
+- 매매 판단, 주문 종류, 가격, 수량, 알림 발행 시점 변경
+
+## 5. 완료 증거
+
+- 신규 회귀/래퍼 테스트와 기존 거래 안전 테스트 통과
+- production 코드에서 직접 주문 컨텍스트·예약주문 호출은 ExecutionService 내부와
+  조회 전용 제외 목록에만 존재
+- import/compile 검사와 최소 진입점 smoke test 통과
+- 서버 demo에서 주문 경로가 실제 실행된 거래일 3일 동안 리팩터 전과 동일한 결과 확인
+
+live 배포와 3일 demo 게이트는 별도 운영 승인 및 장 시간 검증이 필요하므로, 코드 PR의
+완료와 운영 Phase 2 완료를 구분해 기록한다.

--- a/tasks/issue-412/07-phase2-execution-plan.md
+++ b/tasks/issue-412/07-phase2-execution-plan.md
@@ -26,6 +26,21 @@
 - 보유수량/fresh-position 조회는 현재 주문 직전 안전검사를 보존하기 위한 과도기
   pass-through로만 제공하고 Phase 5/6에서 BrokerAdapter/MarketDataPort로 분리한다.
 
+### 리뷰 중 발견된 안전 수정
+
+두 SQLite 연결을 동시에 출발시킨 실제 `sell_stock` 회귀에서 기존 guard가 모두 같은
+holding 행을 읽고 둘 다 성공하는 TOCTOU가 재현됐다. 서비스에는 DB 정책을 추가하지 않고,
+KR/US `sell_stock`의 기존 guard-read → history INSERT → holding DELETE 구간만
+`BEGIN IMMEDIATE` 트랜잭션으로 원자화한다. 이는 새 owner-lock 설계가 아니라 기존 guard의
+의도(중복 SELL 차단)를 실제 프로세스 경합에서도 성립시키는 결함 수정이다. Phase 5의
+hardstop/trend/fill owner-lock 통합은 계속 비목표로 남긴다.
+
+피라미딩 포지션에서는 ticker/account 집계만 확인하면 이미 매도된 동일 `row_id`의 두 번째
+작업이 남은 다른 행을 잘못 닫을 수 있으므로, `row_id`가 전달된 경로는 writer lock 안에서
+`id + ticker + account_key`가 모두 일치하는 행을 정확히 claim한다. CI는 실제 KR/US
+`sell_stock` 메서드를 경량 AST로 실행하여 KR/US × DELETE/WAL × 단일행/피라미딩의
+8개 두-연결 경쟁 조합을 필수 gate로 고정한다.
+
 ## 3. 이관 순서
 
 1. KR batch 3곳

--- a/tasks/issue-412/README.md
+++ b/tasks/issue-412/README.md
@@ -1,0 +1,48 @@
+# Issue #412 — 주문 실행 아키텍처 리팩토링 마스터 플랜
+
+> 이슈: [#412 매수/매도 Agent 분리와 KIS 실제 주문 실행 구조 이식 설계](https://github.com/dragon1086/prism-insight/issues/412)
+> 브랜치: `feature/issue-412-execution-architecture`
+> 상태: 계획 단계 (2026-07-06 시작)
+
+## 목적
+
+이슈 #412의 방향(계층 분리, OrderIntent 기반 실행, Broker Adapter)은 수용하되,
+greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 전환**으로 실행한다.
+
+최종 목표 2가지:
+
+1. **정합성**: 로컬 원장 선커밋 → 실주문 fire-and-forget 구조를 제거하고,
+   원장과 증권사 계좌가 어긋나지 않는 실행 계층을 만든다.
+2. **이식성**: `StockTrackingAgent` god class를 시장 불가지론적 코어 + 포트/어댑터로
+   해체한다. 이식성의 합격 기준은 **prism-us 포크(약 2,900줄)가 "프로파일 + 어댑터 조합"으로
+   대체되는 것**이다. 두 시장을 하나의 코어가 감당하면 제3 프로젝트 이식은 자동으로 따라온다.
+
+## 문서 맵
+
+| 문서 | 내용 |
+|------|------|
+| [01-current-state.md](01-current-state.md) | 현재 아키텍처 분석 — 실제 주문 경로, 결함, 이미 존재하는 안전장치 (file:line 증거) |
+| [02-issue-412-review.md](02-issue-412-review.md) | 이슈 #412 설계 검토 — 채택 / 보완 / 대체 / 추가 |
+| [03-target-design.md](03-target-design.md) | 목표 아키텍처 — 코어 엔진, 포트 인터페이스, 이벤트, 상태기계, DB 모델 |
+| [04-migration-plan.md](04-migration-plan.md) | Phase 0~6 단계별 실행 계획과 각 단계 완료 조건 |
+| [05-verification-plan.md](05-verification-plan.md) | 검증 전략 — 단위/golden/shadow 병행 기록/demo 계좌/서버 배포 절차/롤백 |
+
+## 진행 체크리스트
+
+- [x] Phase 0: 계획/설계/검증 문서 작성 (이 디렉토리)
+- [ ] Phase 0: 이슈 #412 코멘트로 방향 합의
+- [ ] Phase 1: 순수 함수 추출 + 회귀 테스트
+- [ ] Phase 2: ExecutionService chokepoint 도입 (동작 불변)
+- [ ] Phase 3: OrderIntent 영속화 + 쓰기 순서 교정
+- [ ] Phase 4: 포지션 상태기계 전환 (delete → 상태 전이)
+- [ ] Phase 5: BrokerAdapter 추출 (체결 조회 포함) + reconciliation (alert-only)
+- [ ] Phase 6: 이벤트 버스 / 코어-어댑터 패키지 분리 / prism-us 흡수
+
+## 작업 원칙
+
+- 각 Phase는 독립적으로 배포 가능하고, 실패 시 해당 Phase만 롤백한다.
+- Phase마다 **서버(운영 환경) demo 계좌 배포 검증**을 통과해야 다음 Phase로 넘어간다.
+  (검증 절차는 05-verification-plan.md 참고)
+- 코드 변경 전에 반드시 해당 Phase 문서를 갱신하고, 완료 조건을 먼저 정의한다.
+- 기존 사고에서 나온 회귀 케이스(2026-07-01 MU 중복 SELL, #288 over-sell,
+  빈 portfolio 응답)는 자동화 테스트로 고정한다.

--- a/tasks/issue-412/README.md
+++ b/tasks/issue-412/README.md
@@ -2,8 +2,8 @@
 
 > 이슈: [#412 매수/매도 Agent 분리와 KIS 실제 주문 실행 구조 이식 설계](https://github.com/dragon1086/prism-insight/issues/412)
 > 브랜치: `feature/issue-412-execution-architecture`
-> 상태: 계획 단계 (2026-07-06 시작, **2026-07-13 main #432 기준 전면 재검토** —
-> 브랜치 리베이스 + 전 문서의 앵커/전제 갱신. 변경 요약은 01 문서 §6)
+> 상태: Phase 2 착수 (2026-07-06 시작, 2026-07-13 main #432 기준 전면 재검토,
+> **2026-07-18 Phase 1-a/1-b main 배포 완료 후 Phase 2 실행 브랜치 시작**)
 
 ## 목적
 
@@ -34,8 +34,9 @@ greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 
 - [x] Phase 0: 계획/설계/검증 문서 작성 (이 디렉토리)
 - [x] Phase 0: 이슈 #412 코멘트로 방향 합의 (2026-07-06 게시)
 - [x] Phase 0.5: main #432 기준 재검토 — 앵커/전제 갱신, 주문 경로 9곳 재인벤토리 (2026-07-13)
-- [ ] Phase 1: 순수 함수 추출 + 회귀 테스트
-- [ ] Phase 2: ExecutionService chokepoint 도입 (동작 불변, 9곳 커버 + 기존 가드 CI 고정)
+- [x] Phase 1-a: 파싱/정규화 순수 함수 추출 (PR #447, main `36e6e5ec`)
+- [x] Phase 1-b: KST 주문시간대 순수 함수 추출 (PR #455, main `c4c2539d`)
+- [ ] Phase 2: ExecutionService chokepoint 도입 (동작 불변, 9곳 커버 + 기존 가드 CI 고정) — 진행 중
 - [ ] Phase 3: OrderIntent 영속화 + 쓰기 순서 교정
 - [ ] Phase 4: 포지션 상태기계 전환 (delete → 상태 전이)
 - [ ] Phase 5: BrokerAdapter 추출 (체결/미체결/정정 포함) + lock 일반화 + reconciliation (alert-only)
@@ -49,3 +50,5 @@ greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 
 - 코드 변경 전에 반드시 해당 Phase 문서를 갱신하고, 완료 조건을 먼저 정의한다.
 - 기존 사고에서 나온 회귀 케이스(2026-07-01 MU 중복 SELL, #288 over-sell,
   빈 portfolio 응답)는 자동화 테스트로 고정한다.
+
+Phase 2의 구체적인 작업 순서와 비목표는 [07-phase2-execution-plan.md](07-phase2-execution-plan.md)를 따른다.

--- a/tasks/issue-412/README.md
+++ b/tasks/issue-412/README.md
@@ -2,7 +2,8 @@
 
 > 이슈: [#412 매수/매도 Agent 분리와 KIS 실제 주문 실행 구조 이식 설계](https://github.com/dragon1086/prism-insight/issues/412)
 > 브랜치: `feature/issue-412-execution-architecture`
-> 상태: 계획 단계 (2026-07-06 시작)
+> 상태: 계획 단계 (2026-07-06 시작, **2026-07-13 main #432 기준 전면 재검토** —
+> 브랜치 리베이스 + 전 문서의 앵커/전제 갱신. 변경 요약은 01 문서 §6)
 
 ## 목적
 
@@ -14,8 +15,9 @@ greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 
 1. **정합성**: 로컬 원장 선커밋 → 실주문 fire-and-forget 구조를 제거하고,
    원장과 증권사 계좌가 어긋나지 않는 실행 계층을 만든다.
 2. **이식성**: `StockTrackingAgent` god class를 시장 불가지론적 코어 + 포트/어댑터로
-   해체한다. 이식성의 합격 기준은 **prism-us 포크(약 2,900줄)가 "프로파일 + 어댑터 조합"으로
-   대체되는 것**이다. 두 시장을 하나의 코어가 감당하면 제3 프로젝트 이식은 자동으로 따라온다.
+   해체한다. 이식성의 합격 기준은 **prism-us 포크(07-13 기준 3,600줄, 성장 중)가
+   "프로파일 + 어댑터 조합"으로 대체되는 것**이다. 두 시장을 하나의 코어가 감당하면
+   제3 프로젝트 이식은 자동으로 따라온다.
 
 ## 문서 맵
 
@@ -30,12 +32,13 @@ greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 
 ## 진행 체크리스트
 
 - [x] Phase 0: 계획/설계/검증 문서 작성 (이 디렉토리)
-- [ ] Phase 0: 이슈 #412 코멘트로 방향 합의
+- [x] Phase 0: 이슈 #412 코멘트로 방향 합의 (2026-07-06 게시)
+- [x] Phase 0.5: main #432 기준 재검토 — 앵커/전제 갱신, 주문 경로 9곳 재인벤토리 (2026-07-13)
 - [ ] Phase 1: 순수 함수 추출 + 회귀 테스트
-- [ ] Phase 2: ExecutionService chokepoint 도입 (동작 불변)
+- [ ] Phase 2: ExecutionService chokepoint 도입 (동작 불변, 9곳 커버 + 기존 가드 CI 고정)
 - [ ] Phase 3: OrderIntent 영속화 + 쓰기 순서 교정
 - [ ] Phase 4: 포지션 상태기계 전환 (delete → 상태 전이)
-- [ ] Phase 5: BrokerAdapter 추출 (체결 조회 포함) + reconciliation (alert-only)
+- [ ] Phase 5: BrokerAdapter 추출 (체결/미체결/정정 포함) + lock 일반화 + reconciliation (alert-only)
 - [ ] Phase 6: 이벤트 버스 / 코어-어댑터 패키지 분리 / prism-us 흡수
 
 ## 작업 원칙

--- a/tests/test_execution_service.py
+++ b/tests/test_execution_service.py
@@ -1,5 +1,7 @@
 import asyncio
 import ast
+import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -130,6 +132,34 @@ def test_unknown_amend_or_cancel_action_is_rejected():
             await ExecutionService(FakeTrader()).amend_or_cancel("replace", "AAPL")
 
     asyncio.run(exercise())
+
+
+def test_direct_order_methods_cannot_bypass_service_boundary():
+    from prism_core.execution_service import ExecutionService
+
+    execution = ExecutionService(FakeTrader())
+    for method_name in ExecutionService._DIRECT_ORDER_METHODS:
+        with pytest.raises(AttributeError, match="direct order method"):
+            getattr(execution, method_name)
+
+
+def test_us_factory_recovers_when_root_trading_package_is_cached(monkeypatch):
+    import trading  # noqa: F401 - cache the root package intentionally
+    from prism_core.execution_service import ExecutionService
+
+    class FakeUSContext:
+        def __init__(self, account_name=None):
+            self.account_name = account_name
+
+    fake_module = types.ModuleType("us_stock_trading")
+    fake_module.AsyncUSTradingContext = FakeUSContext
+    monkeypatch.delitem(sys.modules, "trading.us_stock_trading", raising=False)
+    monkeypatch.setitem(sys.modules, "us_stock_trading", fake_module)
+
+    execution = ExecutionService.us(account_name="us-primary")
+
+    assert isinstance(execution._resource, FakeUSContext)
+    assert execution._resource.account_name == "us-primary"
 
 
 def test_transient_empty_portfolio_is_rechecked_before_sell(monkeypatch):

--- a/tests/test_execution_service.py
+++ b/tests/test_execution_service.py
@@ -1,0 +1,220 @@
+import asyncio
+import ast
+from pathlib import Path
+
+import pytest
+
+
+class FakeTrader:
+    def __init__(self):
+        self.calls = []
+
+    async def async_buy_stock(self, *args, **kwargs):
+        self.calls.append(("buy", args, kwargs))
+        return {"success": True, "kind": "buy"}
+
+    async def async_sell_stock(self, *args, **kwargs):
+        self.calls.append(("sell", args, kwargs))
+        return {"success": True, "kind": "sell"}
+
+    def amend_order(self, *args, **kwargs):
+        self.calls.append(("amend", args, kwargs))
+        return {"success": True, "kind": "amend"}
+
+    def cancel_order(self, *args, **kwargs):
+        self.calls.append(("cancel", args, kwargs))
+        return {"success": True, "kind": "cancel"}
+
+    def buy_reserved_order(self, *args, **kwargs):
+        self.calls.append(("reserved_buy", args, kwargs))
+        return {"success": True, "kind": "reserved_buy"}
+
+    def sell_reserved_order(self, *args, **kwargs):
+        self.calls.append(("reserved_sell", args, kwargs))
+        return {"success": True, "kind": "reserved_sell"}
+
+    def get_holding_quantity(self, ticker):
+        self.calls.append(("holding", (ticker,), {}))
+        return 17
+
+
+class FakeContext:
+    def __init__(self, trader):
+        self.trader = trader
+        self.entered = False
+        self.exited = False
+
+    async def __aenter__(self):
+        self.entered = True
+        return self.trader
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.exited = True
+
+
+def test_async_context_and_order_arguments_are_preserved():
+    from prism_core.execution_service import ExecutionService
+
+    trader = FakeTrader()
+    context = FakeContext(trader)
+
+    async def exercise():
+        async with ExecutionService(context) as execution:
+            buy = await execution.execute_buy(stock_code="005930", limit_price=81000)
+            sell = await execution.execute_sell("005930", quantity=3)
+            assert execution.get_holding_quantity("005930") == 17
+        return buy, sell
+
+    buy, sell = asyncio.run(exercise())
+
+    assert context.entered is True
+    assert context.exited is True
+    assert buy == {"success": True, "kind": "buy"}
+    assert sell == {"success": True, "kind": "sell"}
+    assert trader.calls == [
+        ("buy", (), {"stock_code": "005930", "limit_price": 81000}),
+        ("sell", ("005930",), {"quantity": 3}),
+        ("holding", ("005930",), {}),
+    ]
+
+
+def test_amend_cancel_and_reserved_orders_delegate_without_rewriting_arguments():
+    from prism_core.execution_service import ExecutionService
+
+    trader = FakeTrader()
+    execution = ExecutionService(trader)
+
+    async def exercise():
+        amended = await execution.amend_or_cancel(
+            "amend", "AAPL", "123", 201.5, 2, "NASD", dry_run=True
+        )
+        cancelled = await execution.amend_or_cancel(
+            "cancel", "AAPL", "123", 2, "NASD", dry_run=True
+        )
+        return amended, cancelled
+
+    amended, cancelled = asyncio.run(exercise())
+    dry_run_cancelled = execution.amend_or_cancel_sync(
+        "cancel", "MSFT", "456", 1, "NASD", dry_run=True
+    )
+    reserved_buy = execution.execute_reserved_buy(
+        ticker="AAPL", limit_price=200.0, buy_amount=1000.0, exchange="NASD"
+    )
+    reserved_sell = execution.execute_reserved_sell(
+        ticker="AAPL", limit_price=199.0, exchange="NASD"
+    )
+
+    assert amended["kind"] == "amend"
+    assert cancelled["kind"] == "cancel"
+    assert dry_run_cancelled["kind"] == "cancel"
+    assert reserved_buy["kind"] == "reserved_buy"
+    assert reserved_sell["kind"] == "reserved_sell"
+    assert trader.calls == [
+        ("amend", ("AAPL", "123", 201.5, 2, "NASD"), {"dry_run": True}),
+        ("cancel", ("AAPL", "123", 2, "NASD"), {"dry_run": True}),
+        ("cancel", ("MSFT", "456", 1, "NASD"), {"dry_run": True}),
+        (
+            "reserved_buy",
+            (),
+            {"ticker": "AAPL", "limit_price": 200.0, "buy_amount": 1000.0, "exchange": "NASD"},
+        ),
+        ("reserved_sell", (), {"ticker": "AAPL", "limit_price": 199.0, "exchange": "NASD"}),
+    ]
+
+
+def test_unknown_amend_or_cancel_action_is_rejected():
+    from prism_core.execution_service import ExecutionService
+
+    async def exercise():
+        with pytest.raises(ValueError, match="unsupported order action"):
+            await ExecutionService(FakeTrader()).amend_or_cancel("replace", "AAPL")
+
+    asyncio.run(exercise())
+
+
+def test_transient_empty_portfolio_is_rechecked_before_sell(monkeypatch):
+    from trading import domestic_stock_trading as domestic
+
+    trader = domestic.DomesticStockTrading.__new__(domestic.DomesticStockTrading)
+    trader._stock_locks = {}
+    trader._semaphore = asyncio.Semaphore(1)
+    trader._global_lock = asyncio.Lock()
+
+    holding = {
+        "stock_code": "005930",
+        "quantity": 7,
+        "avg_price": 70000,
+        "profit_amount": 7000,
+        "profit_rate": 1.0,
+    }
+    portfolio_reads = [[holding], [], [holding]]
+    submitted = []
+
+    def get_portfolio():
+        return portfolio_reads.pop(0)
+
+    def smart_sell_all(stock_code, limit_price, quantity):
+        submitted.append((stock_code, limit_price, quantity))
+        return {
+            "success": True,
+            "quantity": quantity,
+            "order_no": "ORDER-1",
+            "message": "ok",
+        }
+
+    async def no_sleep(_delay):
+        return None
+
+    trader.get_portfolio = get_portfolio
+    trader.get_current_price = lambda _stock_code: {"current_price": 71000}
+    trader.smart_sell_all = smart_sell_all
+    monkeypatch.setattr(domestic.asyncio, "sleep", no_sleep)
+
+    result = asyncio.run(trader._execute_sell_stock("005930", limit_price=70500))
+
+    assert result["success"] is True
+    assert result["quantity"] == 7
+    assert portfolio_reads == []
+    assert submitted == [("005930", 70500, 7)]
+
+
+def test_all_real_order_entrypoints_route_through_execution_service():
+    repo_root = Path(__file__).resolve().parents[1]
+    entrypoint_files = [
+        "stock_tracking_agent.py",
+        "stock_tracking_enhanced_agent.py",
+        "tools/hardstop_seller.py",
+        "tools/trend_exit_seller.py",
+        "tools/fill_chaser.py",
+        "prism-us/us_stock_tracking_agent.py",
+        "prism-us/us_pending_order_batch.py",
+    ]
+    direct_order_methods = {
+        "async_buy_stock",
+        "async_sell_stock",
+        "buy_reserved_order",
+        "sell_reserved_order",
+        "amend_order",
+        "cancel_order",
+    }
+    direct_contexts = {"AsyncTradingContext", "AsyncUSTradingContext"}
+    violations = []
+
+    for relative_path in entrypoint_files:
+        path = repo_root / relative_path
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative_path)
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in direct_order_methods
+            ):
+                violations.append(f"{relative_path}:{node.lineno} calls {node.func.attr}")
+            elif isinstance(node, ast.ImportFrom):
+                for imported in node.names:
+                    if imported.name in direct_contexts:
+                        violations.append(
+                            f"{relative_path}:{node.lineno} imports {imported.name}"
+                        )
+
+    assert violations == [], "direct order entrypoints remain:\n" + "\n".join(violations)

--- a/tests/test_fill_chaser.py
+++ b/tests/test_fill_chaser.py
@@ -129,7 +129,13 @@ def _fast_defaults(monkeypatch):
 
 
 def _patch_ctx(monkeypatch, trader):
-    monkeypatch.setattr(lc, "_open_context", lambda market, account_name=None: FakeCtx(trader))
+    from prism_core.execution_service import ExecutionService
+
+    monkeypatch.setattr(
+        lc,
+        "_open_context",
+        lambda market, account_name=None: ExecutionService(FakeCtx(trader)),
+    )
 
 
 def _logs(db, action=None):
@@ -338,10 +344,14 @@ def test_inquiry_failure_degrades_to_noop(tmp_db, monkeypatch):
 # ── SHADOW verification helpers (dry-run payload + fill plausibility) ────────────
 def test_dry_run_payload_has_required_kr_fields(tmp_db, monkeypatch):
     """dry_run=True returns the exact KR amend body without any network/order."""
+    from prism_core.execution_service import ExecutionService
+
     trader = FakeTrader([], {})
     order = {"ticker": "005930", "side": "SELL", "order_no": "O1",
              "ord_unpr": 70000, "unfilled_qty": 10, "krx_fwdg_ord_orgno": "GNO1"}
-    payload = lc._build_dry_run_payload(trader, "KR", order, "AMEND", 69500)
+    payload = lc._build_dry_run_payload(
+        ExecutionService(trader), "KR", order, "AMEND", 69500
+    )
     assert payload["tr_id"] and "order-rvsecncl" in payload["api_url"]
     p = payload["params"]
     for k in ("CANO", "ACNT_PRDT_CD", "KRX_FWDG_ORD_ORGNO", "ORGN_ODNO",

--- a/tests/test_hardstop_seller.py
+++ b/tests/test_hardstop_seller.py
@@ -100,7 +100,13 @@ def _row(id_, ticker, buy_price, stop_loss=0.0):
 
 
 def _patch(monkeypatch, trader, agent_holder=None, make_agent_counter=None):
-    monkeypatch.setattr(la, "_open_context", lambda market, account_name=None: FakeCtx(trader))
+    from prism_core.execution_service import ExecutionService
+
+    monkeypatch.setattr(
+        la,
+        "_open_context",
+        lambda market, account_name=None: ExecutionService(FakeCtx(trader)),
+    )
 
     async def _fake_make_agent(market):
         if make_agent_counter is not None:

--- a/tests/test_layer2_stale_snapshot_guard.py
+++ b/tests/test_layer2_stale_snapshot_guard.py
@@ -21,6 +21,7 @@ Run:
     python3 tests/test_layer2_stale_snapshot_guard.py
 """
 
+import ast
 import importlib.util
 import os
 import re
@@ -71,6 +72,18 @@ def _insert_holding(cur, account_key, ticker, buy_price):
             VALUES (?, 'acct', ?, ?, ?, '2026-07-01 09:00:00')""",
         (account_key, ticker, f"{ticker} Inc", buy_price),
     )
+
+
+def _async_method_source(src, class_name, method_name):
+    """Return one async method's source without fixed-width text slicing."""
+    tree = ast.parse(src)
+    lines = src.splitlines(keepends=True)
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for child in node.body:
+                if isinstance(child, ast.AsyncFunctionDef) and child.name == method_name:
+                    return "".join(lines[child.lineno - 1:child.end_lineno])
+    return ""
 
 
 def _guard_would_skip(cur, ticker, account_key):
@@ -186,26 +199,32 @@ def test_guard_present_in_source():
 # ── Test 5: sell_stock chokepoint guard wired into BOTH agents ────────────────
 def test_sell_stock_chokepoint_guard():
     print("\n[Test 5] sell_stock chokepoint guard (KR + US) — covers loops too")
-    for label, path, marker, insert_tbl in (
-        ("KR", _KR_AGENT_PATH, "[SELL-GUARD][KR]", "INSERT INTO trading_history"),
-        ("US", _AGENT_PATH, "[SELL-GUARD][US]", "INSERT INTO us_trading_history"),
+    for label, path, class_name, marker, insert_tbl, holdings_tbl in (
+        ("KR", _KR_AGENT_PATH, "StockTrackingAgent", "[SELL-GUARD][KR]",
+         "INSERT INTO trading_history", "stock_holdings"),
+        ("US", _AGENT_PATH, "USStockTrackingAgent", "[SELL-GUARD][US]",
+         "INSERT INTO us_trading_history", "us_stock_holdings"),
     ):
         with open(path, "r", encoding="utf-8") as fh:
             src = fh.read()
-        sell_idx = src.find("async def sell_stock(")
-        check(sell_idx > 0, f"{label}: sell_stock defined")
-        guard_idx = src.find(marker)
-        insert_idx = src.find(insert_tbl, sell_idx)
-        check(guard_idx > sell_idx, f"{label}: guard marker inside sell_stock")
+        sell_src = _async_method_source(src, class_name, "sell_stock")
+        check(bool(sell_src), f"{label}: sell_stock defined")
+        guard_idx = sell_src.find(marker)
+        insert_idx = sell_src.find(insert_tbl)
+        check(guard_idx > 0, f"{label}: guard marker inside sell_stock")
         # The guard MUST run BEFORE the trading_history INSERT, else a phantom
         # sale row is written for an already-closed position.
         check(0 < guard_idx < insert_idx,
               f"{label}: guard precedes trading_history INSERT (no phantom P&L row)")
-        # And it must abort via `return False` so callers (orchestrator + loops)
-        # skip the real order + signal publish.
-        seg = src[guard_idx - 400:insert_idx]
-        check("return False" in seg, f"{label}: guard aborts via return False")
-        check('row_count", 0) == 0' in seg, f"{label}: guard predicate row_count == 0")
+        claim_idx = sell_src.find('self.conn.execute("BEGIN IMMEDIATE")')
+        claim = sell_src[claim_idx:insert_idx]
+        check(0 <= claim_idx < guard_idx, f"{label}: writer lock precedes guard read")
+        check("if not position_exists:" in claim and "return False" in claim,
+              f"{label}: missing position aborts via return False")
+        check(f"SELECT 1 FROM {holdings_tbl}" in claim and "WHERE id = ?" in claim,
+              f"{label}: row_id path claims the exact pyramid row")
+        check('row_count", 0) > 0' in claim,
+              f"{label}: legacy no-id path remains ticker/account scoped")
 
 
 def _run():

--- a/tests/test_sell_claim_concurrency.py
+++ b/tests/test_sell_claim_concurrency.py
@@ -1,0 +1,201 @@
+"""Dependency-light concurrency gate for the real KR/US sell_stock methods.
+
+The full agent modules pull in LLM and broker dependencies that the lightweight
+CI job intentionally does not install.  These tests compile the actual method
+ASTs from both agent sources, then exercise them with two SQLite connections.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import copy
+import logging
+import sqlite3
+import threading
+import traceback
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).parent.parent
+
+
+def _position_lookup(table):
+    def lookup(cursor, ticker, account_key=None):
+        cursor.execute(
+            f"SELECT buy_price FROM {table} WHERE ticker = ? AND account_key = ?",
+            (ticker, account_key),
+        )
+        prices = [float(row[0]) for row in cursor.fetchall()]
+        return {
+            "row_count": len(prices),
+            "avg_buy_price": sum(prices) / len(prices) if prices else 0.0,
+        }
+
+    return lookup
+
+
+@lru_cache
+def _load_real_sell_method(market):
+    if market == "KR":
+        path = PROJECT_ROOT / "stock_tracking_agent.py"
+        class_name = "StockTrackingAgent"
+        lookup_name = "get_existing_position_for_ticker"
+        lookup = _position_lookup("stock_holdings")
+    else:
+        path = PROJECT_ROOT / "prism-us" / "us_stock_tracking_agent.py"
+        class_name = "USStockTrackingAgent"
+        lookup_name = "get_us_existing_position_for_ticker"
+        lookup = _position_lookup("us_stock_holdings")
+
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    method = None
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            method = next(
+                child
+                for child in node.body
+                if isinstance(child, ast.AsyncFunctionDef) and child.name == "sell_stock"
+            )
+            break
+    assert method is not None
+
+    method = copy.deepcopy(method)
+    method.decorator_list = []
+    module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {
+        "Any": Any,
+        "Dict": Dict,
+        "Optional": Optional,
+        "datetime": datetime,
+        "logger": logging.getLogger(f"sell-claim-{market.lower()}"),
+        "traceback": traceback,
+        lookup_name: lookup,
+    }
+    exec(compile(module, str(path), "exec"), namespace)
+    return namespace["sell_stock"]
+
+
+def _create_schema(conn, market):
+    prefix = "us_" if market == "US" else ""
+    conn.execute(
+        f"""CREATE TABLE {prefix}stock_holdings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            account_key TEXT NOT NULL, account_name TEXT,
+            ticker TEXT NOT NULL, company_name TEXT NOT NULL,
+            buy_price REAL NOT NULL, buy_date TEXT NOT NULL,
+            current_price REAL, scenario TEXT, trigger_type TEXT,
+            trigger_mode TEXT, sector TEXT
+        )"""
+    )
+    conn.execute(
+        f"""CREATE TABLE {prefix}trading_history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            account_key TEXT NOT NULL, account_name TEXT,
+            ticker TEXT NOT NULL, company_name TEXT NOT NULL,
+            buy_price REAL NOT NULL, buy_date TEXT NOT NULL,
+            sell_price REAL NOT NULL, sell_date TEXT NOT NULL,
+            profit_rate REAL NOT NULL, holding_days INTEGER NOT NULL,
+            scenario TEXT, trigger_type TEXT, trigger_mode TEXT,
+            sector TEXT, exit_kind TEXT
+        )"""
+    )
+
+
+@pytest.mark.parametrize("market", ["KR", "US"])
+@pytest.mark.parametrize("journal_mode", ["DELETE", "WAL"])
+@pytest.mark.parametrize("pyramiding", [False, True], ids=["single", "pyramiding"])
+def test_real_sell_stock_claim_is_atomic(tmp_path, market, journal_mode, pyramiding):
+    db_path = tmp_path / f"{market.lower()}-{journal_mode.lower()}-claim.sqlite"
+    setup = sqlite3.connect(db_path)
+    actual_mode = setup.execute(f"PRAGMA journal_mode={journal_mode}").fetchone()[0]
+    assert actual_mode.upper() == journal_mode
+    _create_schema(setup, market)
+
+    holdings = "us_stock_holdings" if market == "US" else "stock_holdings"
+    history = "us_trading_history" if market == "US" else "trading_history"
+    ticker = "AAPL" if market == "US" else "005930"
+    company = "Apple" if market == "US" else "Samsung"
+    target_price = 180.0 if market == "US" else 70000.0
+    remaining_price = 175.0 if market == "US" else 68000.0
+    target_row_id = setup.execute(
+        f"""INSERT INTO {holdings}
+            (account_key, account_name, ticker, company_name, buy_price, buy_date)
+            VALUES (?, ?, ?, ?, ?, '2026-07-01 09:00:00')""",
+        ("ACC1", "primary", ticker, company, target_price),
+    ).lastrowid
+    if pyramiding:
+        setup.execute(
+            f"""INSERT INTO {holdings}
+                (account_key, account_name, ticker, company_name, buy_price, buy_date)
+                VALUES (?, ?, ?, ?, ?, '2026-06-15 09:00:00')""",
+            ("ACC1", "primary", ticker, company, remaining_price),
+        )
+    setup.commit()
+    setup.close()
+
+    sell_stock = _load_real_sell_method(market)
+    barrier = threading.Barrier(2)
+
+    stock = {
+        "id": target_row_id,
+        "ticker": ticker,
+        "company_name": company,
+        "buy_price": target_price,
+        "buy_date": "2026-07-01 09:00:00",
+        "current_price": target_price + 5,
+        "account_key": "ACC1",
+        "account_name": "primary",
+        "sector": "Technology",
+    }
+
+    def run_competitor():
+        conn = sqlite3.connect(db_path, timeout=1, check_same_thread=False)
+        conn.execute("PRAGMA busy_timeout=1000")
+        agent = type("SellClaimAgent", (), {})()
+        agent.conn = conn
+        agent.cursor = conn.cursor()
+        agent.message_queue = []
+        agent._msg_types = []
+        agent._account_scope = lambda: ("ACC1", "primary")
+        agent._get_trigger_win_rate = lambda _trigger: ""
+        agent.enable_journal = False
+        agent.journal_manager = None
+
+        async def create_journal(**_kwargs):
+            return True
+
+        agent._create_journal_entry = create_journal
+
+        async def exercise():
+            barrier.wait(timeout=5)
+            sold = await sell_stock(agent, dict(stock), "concurrency regression")
+            return sold, len(agent.message_queue)
+
+        try:
+            return asyncio.run(exercise())
+        finally:
+            conn.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(lambda _index: run_competitor(), range(2)))
+
+    verify = sqlite3.connect(db_path)
+    history_count = verify.execute(f"SELECT COUNT(*) FROM {history}").fetchone()[0]
+    remaining_prices = verify.execute(
+        f"SELECT buy_price FROM {holdings} ORDER BY id"
+    ).fetchall()
+    verify.close()
+
+    assert sorted(sold for sold, _messages in results) == [False, True]
+    assert sum(messages for _sold, messages in results) == 1
+    assert history_count == 1
+    assert remaining_prices == ([(remaining_price,)] if pyramiding else [])

--- a/tests/test_stock_tracking_agent_process_reports.py
+++ b/tests/test_stock_tracking_agent_process_reports.py
@@ -1,7 +1,10 @@
+import asyncio
 import logging
 import sqlite3
 import sys
+import threading
 import types
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -11,6 +14,7 @@ sys.path.insert(0, str(PROJECT_ROOT))
 
 import trading.domestic_stock_trading as domestic_trading
 from stock_tracking_agent import StockTrackingAgent
+from tracking.db_schema import TABLE_STOCK_HOLDINGS, TABLE_TRADING_HISTORY
 
 
 class _FakeAsyncTradingContext:
@@ -34,11 +38,107 @@ class _FakeAsyncTradingContext:
             "failed_accounts": ["kr-secondary"],
         }
 
-    async def async_sell_stock(self, stock_code, limit_price=None):
+    async def async_sell_stock(self, stock_code, limit_price=None, quantity=None):
         return {
             "success": True,
             "message": f"sold for {self.account_name}",
         }
+
+
+@pytest.mark.parametrize("pyramiding", [False, True], ids=["single", "pyramiding"])
+def test_concurrent_sell_guard_allows_one_kr_order_and_publish(tmp_path, pyramiding):
+    from prism_core.execution_service import ExecutionService
+
+    db_path = tmp_path / "kr-concurrent-sell.sqlite"
+    setup = sqlite3.connect(db_path)
+    setup.execute("PRAGMA journal_mode=WAL")
+    setup.execute(TABLE_STOCK_HOLDINGS)
+    setup.execute(TABLE_TRADING_HISTORY)
+    target_row_id = setup.execute(
+        """INSERT INTO stock_holdings
+           (account_key, account_name, ticker, company_name, buy_price, buy_date)
+           VALUES ('ACC1', 'primary', '005930', 'Samsung', 70000,
+                   '2026-07-01 09:00:00')"""
+    ).lastrowid
+    if pyramiding:
+        setup.execute(
+            """INSERT INTO stock_holdings
+               (account_key, account_name, ticker, company_name, buy_price, buy_date)
+               VALUES ('ACC1', 'primary', '005930', 'Samsung', 68000,
+                       '2026-06-15 09:00:00')"""
+        )
+    setup.commit()
+    setup.close()
+
+    barrier = threading.Barrier(2)
+
+    effects = {"broker": 0, "publish": 0, "journal": 0}
+    effects_lock = threading.Lock()
+
+    class Broker:
+        async def async_sell_stock(self, *args, **kwargs):
+            with effects_lock:
+                effects["broker"] += 1
+            return {"success": True}
+
+    stock = {
+        "ticker": "005930",
+        "company_name": "Samsung",
+        "buy_price": 70000,
+        "buy_date": "2026-07-01 09:00:00",
+        "current_price": 71000,
+        "account_key": "ACC1",
+        "account_name": "primary",
+        "id": target_row_id,
+    }
+
+    def run_competitor():
+        conn = sqlite3.connect(db_path, timeout=1, check_same_thread=False)
+        conn.execute("PRAGMA busy_timeout=1000")
+        agent = StockTrackingAgent.__new__(StockTrackingAgent)
+        agent.conn = conn
+        agent.cursor = conn.cursor()
+        agent.message_queue = []
+        agent._msg_types = []
+        agent._account_scope = lambda: ("ACC1", "primary")
+        agent._get_trigger_win_rate = lambda _trigger: ""
+
+        async def create_journal(**_kwargs):
+            with effects_lock:
+                effects["journal"] += 1
+            return True
+
+        agent._create_journal_entry = create_journal
+
+        async def exercise():
+            barrier.wait(timeout=5)
+            sold = await agent.sell_stock(dict(stock), "concurrency regression")
+            if sold:
+                await ExecutionService(Broker()).execute_sell("005930", quantity=1)
+                with effects_lock:
+                    effects["publish"] += 1
+            return sold, len(agent.message_queue)
+
+        try:
+            return asyncio.run(exercise())
+        finally:
+            conn.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(lambda _index: run_competitor(), range(2)))
+
+    verify = sqlite3.connect(db_path)
+    history_count = verify.execute("SELECT COUNT(*) FROM trading_history").fetchone()[0]
+    remaining_prices = verify.execute(
+        "SELECT buy_price FROM stock_holdings ORDER BY id"
+    ).fetchall()
+    verify.close()
+
+    assert sorted(sold for sold, _messages in results) == [False, True]
+    assert sum(messages for _sold, messages in results) == 1
+    assert history_count == 1
+    assert remaining_prices == ([(68000.0,)] if pyramiding else [])
+    assert effects == {"broker": 1, "publish": 1, "journal": 1}
 
 
 def _install_signal_modules(monkeypatch, redis_calls, gcp_calls):
@@ -226,6 +326,7 @@ async def test_update_holdings_masks_sold_account_payload(monkeypatch):
     agent.cursor.execute(
         """
         CREATE TABLE stock_holdings (
+            id INTEGER PRIMARY KEY,
             ticker TEXT,
             company_name TEXT,
             buy_price REAL,
@@ -278,7 +379,7 @@ async def test_update_holdings_masks_sold_account_payload(monkeypatch):
     async def fake_analyze_sell_decision(stock):
         return True, "Take profit"
 
-    async def fake_sell_stock(stock, reason):
+    async def fake_sell_stock(stock, reason, exit_kind=None):
         return True
 
     agent._get_current_stock_price = fake_get_current_stock_price

--- a/tests/test_trend_exit_seller.py
+++ b/tests/test_trend_exit_seller.py
@@ -108,7 +108,13 @@ def _row(id_, ticker, buy_price, stop_loss=0.0, target_price=0.0, highest_price=
 
 def _patch(monkeypatch, trader, agent_holder=None, make_agent_counter=None,
            ma50=0.0, regime="moderate_bull"):
-    monkeypatch.setattr(lb, "_open_context", lambda market, account_name=None: FakeCtx(trader))
+    from prism_core.execution_service import ExecutionService
+
+    monkeypatch.setattr(
+        lb,
+        "_open_context",
+        lambda market, account_name=None: ExecutionService(FakeCtx(trader)),
+    )
     # Network-free: fixed ma_50 + regime.
     monkeypatch.setattr(lb, "_fetch_ma50", lambda market, ticker: ma50)
     monkeypatch.setattr(lb, "_compute_live_regime", lambda market: regime)

--- a/tools/fill_chaser.py
+++ b/tools/fill_chaser.py
@@ -296,11 +296,11 @@ def record_seen(conn: sqlite3.Connection, ticker: str, market: str, side: str,
 
 # ── Trader context (KR / US) — read-only price + inquiry in SHADOW ─────────────
 def _open_context(market: str, account_name: Optional[str] = None):
+    from prism_core.execution_service import ExecutionService
+
     if market == "KR":
-        from trading.domestic_stock_trading import AsyncTradingContext
-        return AsyncTradingContext(account_name=account_name)
-    from us_stock_trading import AsyncUSTradingContext
-    return AsyncUSTradingContext(account_name=account_name)
+        return ExecutionService.domestic(account_name=account_name)
+    return ExecutionService.us(account_name=account_name)
 
 
 # ── Order-state normalisation across KR / US inquiry wrappers ──────────────────
@@ -441,21 +441,25 @@ def _build_dry_run_payload(trader, market: str, order: Dict[str, Any],
     try:
         if market == "KR":
             if action == "AMEND":
-                return trader.amend_order(
+                return trader.amend_or_cancel_sync(
+                    "amend",
                     ticker, order_no, int(new_price),
                     order.get("krx_fwdg_ord_orgno", ""), dry_run=True,
                 ) or {}
-            return trader.cancel_order(
+            return trader.amend_or_cancel_sync(
+                "cancel",
                 ticker, order_no, order.get("krx_fwdg_ord_orgno", ""),
                 dry_run=True,
             ) or {}
         else:  # US
             if action == "AMEND":
-                return trader.amend_order(
+                return trader.amend_or_cancel_sync(
+                    "amend",
                     ticker, order_no, float(new_price), unfilled_qty,
                     order.get("exchange"), dry_run=True,
                 ) or {}
-            return trader.cancel_order(
+            return trader.amend_or_cancel_sync(
+                "cancel",
                 ticker, order_no, unfilled_qty, order.get("exchange"),
                 dry_run=True,
             ) or {}
@@ -621,13 +625,13 @@ async def _do_amend(conn, trader, market, order, run_id, summary, mode,
                    market, side, ticker, order_no, old_price, new_price)
     try:
         if market == "KR":
-            result = await asyncio.to_thread(
-                trader.amend_order, ticker, order_no, int(new_price),
+            result = await trader.amend_or_cancel(
+                "amend", ticker, order_no, int(new_price),
                 order.get("krx_fwdg_ord_orgno", ""),
             )
         else:
-            result = await asyncio.to_thread(
-                trader.amend_order, ticker, order_no, float(new_price),
+            result = await trader.amend_or_cancel(
+                "amend", ticker, order_no, float(new_price),
                 unfilled_qty, order.get("exchange"),
             )
         ok = bool(result and result.get("success"))
@@ -667,13 +671,13 @@ async def _do_cancel(conn, trader, market, order, run_id, summary, mode,
                    market, side, ticker, order_no, reason)
     try:
         if market == "KR":
-            result = await asyncio.to_thread(
-                trader.cancel_order, ticker, order_no,
+            result = await trader.amend_or_cancel(
+                "cancel", ticker, order_no,
                 order.get("krx_fwdg_ord_orgno", ""),
             )
         else:
-            result = await asyncio.to_thread(
-                trader.cancel_order, ticker, order_no, unfilled_qty,
+            result = await trader.amend_or_cancel(
+                "cancel", ticker, order_no, unfilled_qty,
                 order.get("exchange"),
             )
         ok = bool(result and result.get("success"))

--- a/tools/fill_chaser.py
+++ b/tools/fill_chaser.py
@@ -837,7 +837,9 @@ def run_selftest(market: str) -> Dict[str, Any]:
     """Exercise compute-chase -> dry-run payload -> fill-plausibility -> SHADOW log
     on synthetic orders, with NO DB owner-lock, NO API calls and NO orders. Always
     SHADOW (never sends). Returns a concise summary dict."""
-    trader = _SelftestTrader(market)
+    from prism_core.execution_service import ExecutionService
+
+    trader = ExecutionService(_SelftestTrader(market))
     summary: Dict[str, Any] = {"market": market, "amend": 0, "cancel": 0,
                                "likely": 0, "unlikely": 0}
     # Chase one full step toward the market for the selftest so the synthetic
@@ -865,6 +867,7 @@ def _run_selftest_body(market: str, trader, summary: Dict[str, Any]) -> Dict[str
         new_price = _round_price(market, _compute_chase_price(side, order_price, market_price))
         verdict = _fill_verdict(side, new_price, market_price)
         payload = _build_dry_run_payload(trader, market, order, "AMEND", new_price)
+        _validate_selftest_payload(payload, market, "AMEND")
         summary["amend"] += 1
         summary["likely" if verdict == "FILL_LIKELY" else "unlikely"] += 1
         logger.info(
@@ -880,6 +883,7 @@ def _run_selftest_body(market: str, trader, summary: Dict[str, Any]) -> Dict[str
         # Also exercise the cancel payload path (e.g. a buy that would be abandoned).
         if side == "BUY":
             cxl = _build_dry_run_payload(trader, market, order, "CANCEL", 0.0)
+            _validate_selftest_payload(cxl, market, "CANCEL")
             summary["cancel"] += 1
             logger.info(
                 "[FILL_CHASER][SHADOW] selftest decision=WOULD_CANCEL market=%s ticker=%s "
@@ -891,6 +895,16 @@ def _run_selftest_body(market: str, trader, summary: Dict[str, Any]) -> Dict[str
             )
     logger.info("[FILL_CHASER][SHADOW] selftest %s summary: %s", market, summary)
     return summary
+
+
+def _validate_selftest_payload(payload: Dict[str, Any], market: str, action: str) -> None:
+    """Fail closed when the deployment smoke test cannot build an order payload."""
+    required = ("tr_id", "api_url", "params")
+    missing = [key for key in required if not payload.get(key)]
+    if missing:
+        raise RuntimeError(
+            f"{market} {action} selftest payload missing required fields: {missing}"
+        )
 
 
 def _run_both_isolated(selftest: bool = False) -> int:

--- a/tools/hardstop_seller.py
+++ b/tools/hardstop_seller.py
@@ -8,7 +8,7 @@ position the SAME way the batch does — so the simulator, the real KIS account
 and the Telegram channel all stay consistent:
 
     1. agent.sell_stock(stock_data, reason)   # simulator close + journal + queue msg
-    2. trading.async_sell_stock(ticker)       # real KIS market order
+    2. ExecutionService.execute_sell(ticker)  # real KIS market order
     3. agent.send_telegram_message(chat_id)   # flush the queued sell message
 
 This is exactly the batch's sequence (stock_tracking_agent.py ~1380-1452),
@@ -256,11 +256,11 @@ def record_inflight(conn: sqlite3.Connection, ticker: str, market: str, run_id: 
 
 # ── Trader context + agent factories (KR / US) ────────────────────────────────
 def _open_context(market: str, account_name: Optional[str] = None):
+    from prism_core.execution_service import ExecutionService
+
     if market == "KR":
-        from trading.domestic_stock_trading import AsyncTradingContext
-        return AsyncTradingContext(account_name=account_name)
-    from us_stock_trading import AsyncUSTradingContext
-    return AsyncUSTradingContext(account_name=account_name)
+        return ExecutionService.domestic(account_name=account_name)
+    return ExecutionService.us(account_name=account_name)
 
 
 async def _make_agent(market: str):
@@ -414,7 +414,7 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
                 if sold_qty <= 0:
                     logger.info("[%s] %s already flat at KIS (qty=0); sim closed", market, ticker)
                 else:
-                    result = await seller.async_sell_stock(ticker, quantity=sold_qty)
+                    result = await seller.execute_sell(ticker, quantity=sold_qty)
                     ok = bool(result and result.get("success"))
                     order_no = (result or {}).get("order_no")
                     logger.warning("[LIVE][%s] %s KIS sell success=%s order_no=%s msg=%s",

--- a/tools/trend_exit_seller.py
+++ b/tools/trend_exit_seller.py
@@ -31,7 +31,7 @@ On an actual ACT it closes the position the SAME way the batch and Hardstop do, 
 the simulator, the real KIS account and the Telegram channel all stay consistent:
 
     1. agent.sell_stock(stock_data, reason)   # simulator close + journal + queue msg
-    2. trading.async_sell_stock(ticker)       # real KIS market order
+    2. ExecutionService.execute_sell(ticker)  # real KIS market order
     3. agent.send_telegram_message(chat_id)   # flush the queued sell message
 
 SAFETY (read before enabling):
@@ -422,11 +422,11 @@ def _compute_live_regime(market: str) -> Optional[str]:
 
 # ── Trader context + agent factories (KR / US) ────────────────────────────────
 def _open_context(market: str, account_name: Optional[str] = None):
+    from prism_core.execution_service import ExecutionService
+
     if market == "KR":
-        from trading.domestic_stock_trading import AsyncTradingContext
-        return AsyncTradingContext(account_name=account_name)
-    from us_stock_trading import AsyncUSTradingContext
-    return AsyncUSTradingContext(account_name=account_name)
+        return ExecutionService.domestic(account_name=account_name)
+    return ExecutionService.us(account_name=account_name)
 
 
 async def _make_agent(market: str):
@@ -635,7 +635,7 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
                 if sold_qty <= 0:
                     logger.info("[%s] %s already flat at KIS (qty=0); sim closed", market, ticker)
                 else:
-                    result = await seller.async_sell_stock(ticker, quantity=sold_qty)
+                    result = await seller.execute_sell(ticker, quantity=sold_qty)
                     ok = bool(result and result.get("success"))
                     order_no = (result or {}).get("order_no")
                     logger.warning("[LIVE][%s] %s KIS sell success=%s order_no=%s msg=%s",


### PR DESCRIPTION
## 요약
- #412 Phase 2: KR/US 실주문 9개 진입점을 과도기 ExecutionService 뒤로 이관
- 기존 broker 인자/반환/수량 계산 순서 보존
- 실제 두 SQLite 연결에서 중복 SELL TOCTOU와 피라미딩 동일-row 경쟁을 재현하고 원자적 exact-row claim으로 수정
- US cached trading import, direct-order 우회, fill-chaser selftest fail-closed 보강

## 검증
- focused 142 passed (main에도 존재하는 fixture debt와 같은 이름 4개 의도적 제외)
- CI concurrency gate: KR/US × DELETE/WAL × single/pyramiding 8 passed
- db-server Python 3.11.11 / app-server su - prism Python 3.11.6 stdin compile 통과
- 독립 코드·아키텍처 리뷰 P0/P1 없음, GO

Closes #412 일부(Phase 2 코드 이관).