### PR TITLE
refactor(report): remove mcp-agent runtime from KR pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
             "openai>=2.9,<3" \
             "openai-agents==0.7.0" \
             mcp \
+            tenacity \
             pytest \
             pytest-asyncio
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
           # shadow one another.
           python -m pytest tests/test_execution_service.py -q \
             -k "not transient_empty_portfolio"
+          python -m pytest --noconftest \
+            tests/test_report_agent_contract.py \
+            tests/test_report_generation_backend.py -q
           python -m pytest \
             tests/test_issue_288_pyramiding.py \
             tests/test_layer2_stale_snapshot_guard.py -q

--- a/cores/agents/company_info_agents.py
+++ b/cores/agents/company_info_agents.py
@@ -1,4 +1,4 @@
-from mcp_agent.agents.agent import Agent
+from cores.agents.report_agent import ReportAgent as Agent
 
 
 def create_company_status_agent(company_name, company_code, reference_date, urls, language: str = "ko"):

--- a/cores/agents/market_index_agents.py
+++ b/cores/agents/market_index_agents.py
@@ -1,4 +1,4 @@
-from mcp_agent.agents.agent import Agent
+from cores.agents.report_agent import ReportAgent as Agent
 
 
 def create_market_index_analysis_agent(reference_date, max_years_ago, max_years, language: str = "ko", prefetched_kospi: str = None, prefetched_kosdaq: str = None):

--- a/cores/agents/news_strategy_agents.py
+++ b/cores/agents/news_strategy_agents.py
@@ -1,4 +1,4 @@
-from mcp_agent.agents.agent import Agent
+from cores.agents.report_agent import ReportAgent as Agent
 
 
 def create_news_analysis_agent(company_name, company_code, reference_date, language: str = "ko"):

--- a/cores/agents/report_agent.py
+++ b/cores/agents/report_agent.py
@@ -1,0 +1,23 @@
+"""SDK-neutral report agent definition."""
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class ReportAgent:
+    """Describe one report agent without constructing an SDK-specific object."""
+
+    name: str
+    instruction: str
+    server_names: tuple[str, ...] = ()
+
+    def __init__(
+        self,
+        name: str,
+        instruction: str,
+        server_names: Iterable[str] | None = None,
+    ) -> None:
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "instruction", instruction)
+        object.__setattr__(self, "server_names", tuple(server_names or ()))

--- a/cores/agents/stock_price_agents.py
+++ b/cores/agents/stock_price_agents.py
@@ -1,4 +1,4 @@
-from mcp_agent.agents.agent import Agent
+from cores.agents.report_agent import ReportAgent as Agent
 
 def create_price_volume_analysis_agent(company_name, company_code, reference_date, max_years_ago, max_years, language: str = "ko", prefetched_data: str = None):
     """Create stock price and trading volume analysis agent

--- a/cores/analysis.py
+++ b/cores/analysis.py
@@ -3,15 +3,25 @@ import asyncio
 from datetime import datetime
 from dotenv import load_dotenv
 
-from mcp_agent.app import MCPApp
-
 # Standard logger for the buy-quality SHADOW hook. The function-local `logger`
-# (parallel_app.logger) is an mcp_agent context-bound logger that RAISES when
-# called outside an active logging context — which silently killed the
-# [BUY_QUALITY][SHADOW] verdict logs (swallowed by the hook's except). This
-# plain logger writes to stdout (captured by the cron logs) and never raises.
 import logging as _logging
 _BQ_LOG = _logging.getLogger("prism.buy_quality")
+
+
+class _ReportRunContext:
+    """Keep the existing async scope while using a standard process logger."""
+
+    def __init__(self, name: str):
+        self.logger = _logging.getLogger(name)
+
+    def run(self):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
 
 from cores.agents import get_agent_directory
 from cores.report_generation import generate_report, generate_summary, generate_investment_strategy, get_disclaimer, generate_market_report
@@ -45,7 +55,7 @@ async def analyze_stock(company_code: str = "000660", company_name: str = "SK하
         str: Generated final report markdown text
     """
     # 1. Initial setup and preprocessing
-    app = MCPApp(name="stock_analysis")
+    app = _ReportRunContext(name="stock_analysis")
 
     # Use today's date if reference_date is not provided
     if reference_date is None:
@@ -85,16 +95,15 @@ async def analyze_stock(company_code: str = "000660", company_name: str = "SK하
 
         if parallel_enabled:
             # Parallel execution mode
-            # Create independent MCPApp context for each section to prevent MCP server conflicts
+            # Keep independent section loggers; the backend owns MCP server lifecycles.
             logger.info(f"Running analysis in PARALLEL mode for {company_name}...")
 
             async def process_section(section):
-                """Process a single section with its own MCPApp context"""
+                """Process a single section with its own logger context."""
                 if section not in agents:
                     return section, None
 
-                # Create independent MCPApp instance for each section
-                section_app = MCPApp(name=f"stock_analysis_{section}")
+                section_app = _ReportRunContext(name=f"stock_analysis_{section}")
 
                 async with section_app.run() as section_context:
                     section_logger = section_context.logger
@@ -117,7 +126,7 @@ async def analyze_stock(company_code: str = "000660", company_name: str = "SK하
                         section_logger.error(f"Final failure processing {section}: {e}")
                         return section, f"Analysis failed: {section}"
 
-            # Execute all sections in parallel (each with its own MCPApp context)
+            # Execute all sections in parallel (each with its own logger context).
             results = await asyncio.gather(*[process_section(section) for section in base_sections])
             for section, report in results:
                 if report is not None:

--- a/cores/llm/agent_bridge.py
+++ b/cores/llm/agent_bridge.py
@@ -73,6 +73,10 @@ def ensure_openai_agents_configured() -> None:
 
     base_url = os.environ.get("OPENAI_BASE_URL")
     api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        from cores.llm.config_loader import resolve_openai_api_key
+
+        api_key = resolve_openai_api_key()
 
     if base_url:
         # Proxy branch — delegate entirely to the existing helper which already

--- a/cores/llm/backends/openai_agents_backend.py
+++ b/cores/llm/backends/openai_agents_backend.py
@@ -93,6 +93,9 @@ def build_model_settings(params: LLMParams) -> "ModelSettings":
     if params.temperature is not None:
         kwargs["temperature"] = params.temperature
 
+    if params.parallel_tool_calls is not None:
+        kwargs["parallel_tool_calls"] = params.parallel_tool_calls
+
     if params.reasoning_effort and params.reasoning_effort != "none":
         kwargs["reasoning"] = Reasoning(effort=params.reasoning_effort)
 

--- a/cores/llm/config_loader.py
+++ b/cores/llm/config_loader.py
@@ -33,6 +33,7 @@ _PROJECT_ROOT = _HERE.parent.parent
 
 _NATIVE_CONFIG = _HERE / "mcp_servers.yaml"
 _LEGACY_CONFIG = _PROJECT_ROOT / "mcp_agent.config.yaml"
+_LEGACY_SECRETS = _PROJECT_ROOT / "mcp_agent.secrets.yaml"
 
 _ENV_VAR_RE = re.compile(r"\$\{([^}:]+)(?::-([^}]*))?\}")
 
@@ -100,6 +101,48 @@ def resolve_secret(
             f"Add {name}=<value> to your .env file or environment."
         )
     return value or None
+
+
+def resolve_openai_api_key(
+    secret_path: "str | Path | None" = None,
+) -> Optional[str]:
+    """Resolve the OpenAI key from env, with a transitional legacy fallback."""
+    env_key = os.environ.get("OPENAI_API_KEY")
+    if env_key:
+        return env_key
+
+    resolved = Path(secret_path) if secret_path is not None else _LEGACY_SECRETS
+    if not resolved.exists():
+        return None
+
+    raw = yaml.safe_load(resolved.read_text()) or {}
+    key = (raw.get("openai") or {}).get("api_key")
+    if key:
+        logger.warning(
+            "DEPRECATION: loading OPENAI_API_KEY from the legacy secrets YAML. "
+            "Move it to the process environment before removing the compatibility fallback."
+        )
+        return str(key)
+    return None
+
+
+def load_report_mcp_registry(config_path: "str | Path | None" = None):
+    """Load report MCP servers while preserving the current production config."""
+    if config_path is not None:
+        return load_mcp_registry(config_path)
+
+    report_override = os.environ.get("REPORT_MCP_CONFIG")
+    if report_override:
+        return load_mcp_registry(report_override)
+
+    if _LEGACY_CONFIG.exists():
+        logger.warning(
+            "DEPRECATION: report MCP servers still use the legacy config because "
+            "production credentials have not yet moved to environment variables."
+        )
+        return load_mcp_registry(_LEGACY_CONFIG)
+
+    return load_mcp_registry()
 
 
 def load_mcp_registry(config_path: "str | Path | None" = None):

--- a/cores/llm/ports.py
+++ b/cores/llm/ports.py
@@ -23,6 +23,7 @@ class LLMParams:
     max_tokens: int = 8000
     reasoning_effort: Optional[str] = None
     temperature: Optional[float] = None
+    parallel_tool_calls: Optional[bool] = None
     max_iterations: int = 10
     stop_sequences: tuple = ()
 

--- a/cores/llm/tests/test_config.py
+++ b/cores/llm/tests/test_config.py
@@ -5,7 +5,6 @@ All tests are network-free and filesystem-contained (tmp_path fixtures).
 from __future__ import annotations
 
 import re
-from pathlib import Path
 
 import pytest
 import yaml
@@ -14,6 +13,8 @@ from cores.llm.config_loader import (
     _interpolate_obj,
     interpolate_env,
     load_mcp_registry,
+    load_report_mcp_registry,
+    resolve_openai_api_key,
     resolve_secret,
 )
 
@@ -99,6 +100,26 @@ class TestResolveSecret:
         assert resolve_secret("REQUIRED_KEY", required=True) == "present"
 
 
+class TestResolveOpenaiApiKey:
+    def test_env_takes_precedence(self, tmp_path, monkeypatch):
+        legacy = tmp_path / "legacy-secrets.yaml"
+        legacy.write_text("openai:\n  api_key: legacy-key\n")
+        monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+
+        assert resolve_openai_api_key(legacy) == "env-key"
+
+    def test_legacy_yaml_is_transitional_fallback(self, tmp_path, monkeypatch):
+        legacy = tmp_path / "legacy-secrets.yaml"
+        legacy.write_text("openai:\n  api_key: legacy-key\n")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        assert resolve_openai_api_key(legacy) == "legacy-key"
+
+    def test_missing_sources_return_none(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        assert resolve_openai_api_key(tmp_path / "missing.yaml") is None
+
+
 # ---------------------------------------------------------------------------
 # load_mcp_registry
 # ---------------------------------------------------------------------------
@@ -177,6 +198,14 @@ class TestLoadMcpRegistry:
         finally:
             config_mod._NATIVE_CONFIG = orig_native
         assert "myserver" in registry.names()
+
+    def test_report_registry_explicit_config_preserves_current_servers(self, tmp_path):
+        cfg = tmp_path / "report-mcp.yaml"
+        cfg.write_text(_LEGACY_YAML)
+
+        registry = load_report_mcp_registry(cfg)
+
+        assert "legacyserver" in registry.names()
 
 
 # ---------------------------------------------------------------------------

--- a/cores/llm/tests/test_openai_agents_backend.py
+++ b/cores/llm/tests/test_openai_agents_backend.py
@@ -7,7 +7,6 @@ All SDK interactions are replaced with fakes/monkeypatches so no real API
 calls are made.  Each async test is decorated with @pytest.mark.asyncio.
 """
 
-import contextlib
 from typing import Any
 
 import pytest
@@ -128,6 +127,12 @@ def test_build_model_settings_temperature_set():
     params = LLMParams(temperature=0.7)
     ms = build_model_settings(params)
     assert ms.temperature == 0.7
+
+
+def test_build_model_settings_parallel_tool_calls_set():
+    params = LLMParams(parallel_tool_calls=True)
+    ms = build_model_settings(params)
+    assert ms.parallel_tool_calls is True
 
 
 # ---------------------------------------------------------------------------

--- a/cores/report_generation.py
+++ b/cores/report_generation.py
@@ -1,7 +1,9 @@
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
-from mcp_agent.agents.agent import Agent
-from mcp_agent.workflows.llm.augmented_llm import RequestParams
-from cores.llm.openai_responses_llm import OpenAIResponsesLLM as OpenAIAugmentedLLM
+from cores.agents.report_agent import ReportAgent
+from cores.llm.agent_bridge import ensure_openai_agents_configured
+from cores.llm.backends.openai_agents_backend import OpenAIAgentsBackend
+from cores.llm.config_loader import load_report_mcp_registry
+from cores.llm.ports import AgentSpec, LLMParams
 
 import os
 from cores.openai_error_logging import log_openai_error
@@ -11,6 +13,41 @@ from cores.openai_error_logging import log_openai_error
 # path above: gpt-5.6 rejects function tools + reasoning_effort on chat.completions.
 REPORT_MODEL = os.environ.get("REPORT_MODEL", "gpt-5.6-terra")
 REPORT_EFFORT = os.environ.get("REPORT_EFFORT", "medium")
+
+_report_backend = None
+
+
+def _get_report_backend():
+    """Lazily configure the SDK and native MCP registry for report calls."""
+    global _report_backend
+    if _report_backend is None:
+        ensure_openai_agents_configured()
+        _report_backend = OpenAIAgentsBackend(load_report_mcp_registry())
+    return _report_backend
+
+
+async def _generate_agent_text(
+    agent,
+    message: str,
+    *,
+    max_tokens: int,
+    max_iterations: int,
+) -> str:
+    """Run one SDK-neutral report definition through the shared LLM port."""
+    spec = AgentSpec(
+        name=agent.name,
+        instructions=agent.instruction,
+        model=REPORT_MODEL,
+        mcp_servers=tuple(agent.server_names),
+        params=LLMParams(
+            max_tokens=max_tokens,
+            reasoning_effort=REPORT_EFFORT,
+            parallel_tool_calls=True,
+            max_iterations=max_iterations,
+        ),
+    )
+    result = await _get_report_backend().run(spec, message)
+    return result.text
 
 
 # Language name mapping for report generation
@@ -44,8 +81,6 @@ async def generate_report(agent, section, company_name, company_code, reference_
         language: Report language code (default: "ko")
     """
     language_name = LANGUAGE_NAMES.get(language, language.upper())
-
-    llm = await agent.attach_llm(OpenAIAugmentedLLM)
 
     # Create language-specific message
     if language == "ko":
@@ -110,15 +145,11 @@ async def generate_report(agent, section, company_name, company_code, reference_
 """
 
     try:
-        report = await llm.generate_str(
-            message=message,
-            request_params=RequestParams(
-                model=REPORT_MODEL,
-                reasoning_effort=REPORT_EFFORT,
-                maxTokens=32000,
-                parallel_tool_calls=True,
-                use_history=True
-            )
+        report = await _generate_agent_text(
+            agent,
+            message,
+            max_tokens=32000,
+            max_iterations=10,
         )
     except Exception as e:
         log_openai_error(logger, e, f"report generation for {section}")
@@ -138,8 +169,6 @@ async def generate_market_report(agent, section, reference_date, logger, languag
         language: Report language code (default: "ko")
     """
     language_name = LANGUAGE_NAMES.get(language, language.upper())
-
-    llm = await agent.attach_llm(OpenAIAugmentedLLM)
 
     # Create language-specific message
     if language == "ko":
@@ -204,16 +233,11 @@ async def generate_market_report(agent, section, reference_date, logger, languag
 """
 
     try:
-        report = await llm.generate_str(
-            message=message,
-            request_params=RequestParams(
-                model=REPORT_MODEL,
-                reasoning_effort=REPORT_EFFORT,
-                maxTokens=32000,
-                max_iterations=3,
-                parallel_tool_calls=True,
-                use_history=True
-            )
+        report = await _generate_agent_text(
+            agent,
+            message,
+            max_tokens=32000,
+            max_iterations=3,
         )
     except Exception as e:
         log_openai_error(logger, e, f"market report generation for {section}")
@@ -235,10 +259,6 @@ async def generate_summary(section_reports, company_name, company_code, referenc
         language: Report language code (default: "ko")
     """
     try:
-        from mcp_agent.agents.agent import Agent
-        from mcp_agent.workflows.llm.augmented_llm import RequestParams
-        from cores.llm.openai_responses_llm import OpenAIResponsesLLM as OpenAIAugmentedLLM
-
         language_name = LANGUAGE_NAMES.get(language, language.upper())
 
         # Generate comprehensive report including all sections
@@ -312,22 +332,16 @@ Comprehensive Analysis Report:
 {all_reports}
 """
 
-        summary_agent = Agent(
+        summary_agent = ReportAgent(
             name="summary_agent",
             instruction=instruction
         )
 
-        llm = await summary_agent.attach_llm(OpenAIAugmentedLLM)
-        executive_summary = await llm.generate_str(
-            message=message,
-            request_params=RequestParams(
-                model=REPORT_MODEL,
-                reasoning_effort=REPORT_EFFORT,
-                maxTokens=16000,
-                max_iterations=2,
-                parallel_tool_calls=True,
-                use_history=True
-            )
+        executive_summary = await _generate_agent_text(
+            summary_agent,
+            message,
+            max_tokens=16000,
+            max_iterations=2,
         )
         return executive_summary
     except Exception as e:
@@ -352,9 +366,6 @@ async def generate_investment_strategy(section_reports, combined_reports, compan
         logger: Logger
         language: Report language code (default: "ko")
     """
-    from mcp_agent.workflows.llm.augmented_llm import RequestParams
-    from cores.llm.openai_responses_llm import OpenAIResponsesLLM as OpenAIAugmentedLLM
-
     language_name = LANGUAGE_NAMES.get(language, language.upper())
 
     try:
@@ -549,22 +560,16 @@ Please present a consistent and executable investment strategy that investors ca
 ## ⚠️ CHARACTER LIMIT: Keep the report under 3000 characters. Be concise and focus on key insights!
 """
 
-        investment_strategy_agent = Agent(
+        investment_strategy_agent = ReportAgent(
             name="investment_strategy_agent",
             instruction=instruction
         )
 
-        llm = await investment_strategy_agent.attach_llm(OpenAIAugmentedLLM)
-        investment_strategy = await llm.generate_str(
-            message=message,
-            request_params=RequestParams(
-                model=REPORT_MODEL,
-                reasoning_effort=REPORT_EFFORT,
-                maxTokens=32000,
-                max_iterations=3,
-                parallel_tool_calls=True,
-                use_history=True
-            )
+        investment_strategy = await _generate_agent_text(
+            investment_strategy_agent,
+            message,
+            max_tokens=32000,
+            max_iterations=3,
         )
         logger.info(f"Completed investment_strategy - {len(investment_strategy)} characters")
         return investment_strategy

--- a/tests/test_report_agent_contract.py
+++ b/tests/test_report_agent_contract.py
@@ -1,0 +1,84 @@
+"""Characterization tests for the KR detailed-report agent definitions."""
+
+from cores.agents.company_info_agents import (
+    create_company_overview_agent,
+    create_company_status_agent,
+)
+from cores.agents.market_index_agents import create_market_index_analysis_agent
+from cores.agents.news_strategy_agents import create_news_analysis_agent
+from cores.agents.stock_price_agents import (
+    create_investor_trading_analysis_agent,
+    create_price_volume_analysis_agent,
+)
+
+
+def _assert_agent(agent, name, servers):
+    assert agent.name == name
+    assert isinstance(agent.instruction, str)
+    assert len(agent.instruction) > 100
+    assert tuple(agent.server_names) == tuple(servers)
+
+
+def test_price_agents_preserve_names_and_tool_servers():
+    price = create_price_volume_analysis_agent(
+        "SK하이닉스", "000660", "20260718", "20250718", 1
+    )
+    investor = create_investor_trading_analysis_agent(
+        "SK하이닉스", "000660", "20260718", "20250718", 1
+    )
+
+    _assert_agent(price, "price_volume_analysis_agent", ["kospi_kosdaq"])
+    _assert_agent(investor, "investor_trading_analysis_agent", ["kospi_kosdaq"])
+
+
+def test_prefetched_price_agents_remove_tool_servers():
+    price = create_price_volume_analysis_agent(
+        "SK하이닉스",
+        "000660",
+        "20260718",
+        "20250718",
+        1,
+        prefetched_data="prefetched OHLCV",
+    )
+    investor = create_investor_trading_analysis_agent(
+        "SK하이닉스",
+        "000660",
+        "20260718",
+        "20250718",
+        1,
+        prefetched_data="prefetched investor flow",
+    )
+
+    _assert_agent(price, "price_volume_analysis_agent", [])
+    _assert_agent(investor, "investor_trading_analysis_agent", [])
+
+
+def test_company_and_news_agents_preserve_tool_servers():
+    urls = {"기업현황": "https://example.test/status", "기업개요": "https://example.test/overview"}
+    status = create_company_status_agent(
+        "SK하이닉스", "000660", "20260718", urls
+    )
+    overview = create_company_overview_agent(
+        "SK하이닉스", "000660", "20260718", urls
+    )
+    news = create_news_analysis_agent("SK하이닉스", "000660", "20260718")
+
+    _assert_agent(status, "company_status_agent", ["firecrawl"])
+    _assert_agent(overview, "company_overview_agent", ["firecrawl"])
+    _assert_agent(news, "news_analysis_agent", ["perplexity", "firecrawl"])
+
+
+def test_market_agent_preserves_dynamic_tool_servers():
+    live = create_market_index_analysis_agent(
+        "20260718", "20250718", 1
+    )
+    prefetched = create_market_index_analysis_agent(
+        "20260718",
+        "20250718",
+        1,
+        prefetched_kospi="kospi data",
+        prefetched_kosdaq="kosdaq data",
+    )
+
+    _assert_agent(live, "market_index_analysis_agent", ["kospi_kosdaq", "perplexity"])
+    _assert_agent(prefetched, "market_index_analysis_agent", ["perplexity"])

--- a/tests/test_report_generation_backend.py
+++ b/tests/test_report_generation_backend.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from cores.agents.report_agent import ReportAgent
+from cores.llm.ports import LLMResult
+import cores.report_generation as report_generation
+
+
+class _RecordingBackend:
+    def __init__(self, text="generated report"):
+        self.text = text
+        self.calls = []
+
+    async def run(self, spec, user_input):
+        self.calls.append((spec, user_input))
+        return LLMResult(text=self.text)
+
+
+@pytest.mark.asyncio
+async def test_generate_agent_text_maps_report_contract(monkeypatch):
+    backend = _RecordingBackend()
+    monkeypatch.setattr(report_generation, "_report_backend", backend)
+    agent = ReportAgent(
+        name="news_analysis_agent",
+        instruction="Analyze verified news only.",
+        server_names=["perplexity", "firecrawl"],
+    )
+
+    result = await report_generation._generate_agent_text(
+        agent,
+        "user prompt",
+        max_tokens=32000,
+        max_iterations=3,
+    )
+
+    assert result == "generated report"
+    spec, user_input = backend.calls[0]
+    assert spec.name == agent.name
+    assert spec.instructions == agent.instruction
+    assert spec.model == report_generation.REPORT_MODEL
+    assert spec.mcp_servers == ("perplexity", "firecrawl")
+    assert spec.params.max_tokens == 32000
+    assert spec.params.reasoning_effort == report_generation.REPORT_EFFORT
+    assert spec.params.parallel_tool_calls is True
+    assert spec.params.max_iterations == 3
+    assert user_input == "user prompt"
+
+
+@pytest.mark.asyncio
+async def test_four_report_paths_preserve_limits_and_prompts(monkeypatch):
+    backend = _RecordingBackend()
+    monkeypatch.setattr(report_generation, "_report_backend", backend)
+    logger = Mock()
+    section_agent = ReportAgent("section_agent", "section instructions")
+
+    assert await report_generation.generate_report(
+        section_agent, "company_status", "SK하이닉스", "000660", "20260718", logger
+    ) == "generated report"
+    assert await report_generation.generate_market_report(
+        section_agent, "market_index_analysis", "20260718", logger
+    ) == "generated report"
+    assert await report_generation.generate_summary(
+        {"company_status": "status report"},
+        "SK하이닉스",
+        "000660",
+        "20260718",
+        logger,
+    ) == "generated report"
+    assert await report_generation.generate_investment_strategy(
+        {"company_status": "status report"},
+        "combined report",
+        "SK하이닉스",
+        "000660",
+        "20260718",
+        logger,
+    ) == "generated report"
+
+    assert [call[0].name for call in backend.calls] == [
+        "section_agent",
+        "section_agent",
+        "summary_agent",
+        "investment_strategy_agent",
+    ]
+    assert [call[0].params.max_tokens for call in backend.calls] == [
+        32000,
+        32000,
+        16000,
+        32000,
+    ]
+    assert [call[0].params.max_iterations for call in backend.calls] == [10, 3, 2, 3]
+    assert "SK하이닉스(000660)" in backend.calls[0][1]
+    assert "시장과 거시환경" in backend.calls[1][1]
+    assert "status report" in backend.calls[2][1]
+    assert "combined report" in backend.calls[3][1]
+
+
+def test_kr_report_pipeline_has_no_mcp_agent_runtime_imports():
+    project_root = Path(__file__).parent.parent
+    paths = [
+        "cores/analysis.py",
+        "cores/report_generation.py",
+        "cores/agents/report_agent.py",
+        "cores/agents/stock_price_agents.py",
+        "cores/agents/company_info_agents.py",
+        "cores/agents/news_strategy_agents.py",
+        "cores/agents/market_index_agents.py",
+    ]
+
+    for relative_path in paths:
+        source = (project_root / relative_path).read_text(encoding="utf-8")
+        assert "mcp_agent" not in source, relative_path
+        assert "MCPApp" not in source, relative_path


### PR DESCRIPTION
## 요약
- KR 상세 보고서 section agent를 SDK-neutral ReportAgent descriptor로 전환
- cores/report_generation.py를 기존 OpenAIAgentsBackend 포트로 이관
- cores/analysis.py의 global/section MCPApp 중첩 제거
- 기존 gpt-5.6-terra/medium, max tokens, iterations, parallel tool calls 보존
- 운영 credential이 아직 legacy YAML에 있어 env 우선 + deprecation fallback으로 동작 보존

## 검증
- report + cores/llm: 117 passed, 1 skipped
- mcp-agent 미설치 system Python import 및 7개 report tests 통과
- db/app Python 3.11 candidate compile 및 legacy key/MCP 8-server resolution 통과
- db-server 실제 gpt-5.6-terra Responses + time MCP tool loop PASS

## 배포 전 조건
- app-server는 openai 1.109.1이고 openai-agents 미설치. 현재 bot에는 영향 없음.
- merge/deploy 전에 app bot을 정지한 상태에서 requirements의 openai 2.43/openai-agents 0.7.0으로 동기화하고 import/live report smoke 후 기존 nohup 명령으로 재기동해야 함.
- Telegram evaluate/follow-up의 report_generator.py global MCPApp은 이번 PR 비범위(후속 단계).