### PR TITLE
refactor(telegram): remove global mcp-agent runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,9 @@ jobs:
             -k "not transient_empty_portfolio"
           python -m pytest --noconftest \
             tests/test_report_agent_contract.py \
-            tests/test_report_generation_backend.py -q
+            tests/test_report_generation_backend.py \
+            tests/test_report_generator_contract.py \
+            tests/test_telegram_report_backend.py -q
           python -m pytest \
             tests/test_issue_288_pyramiding.py \
             tests/test_layer2_stale_snapshot_guard.py -q

--- a/cores/archive/insight_agent.py
+++ b/cores/archive/insight_agent.py
@@ -295,13 +295,9 @@ class InsightAgent:
         ctx = await self._build_retrieval_context(question)
         context_str = self._format_context(ctx)
 
-        # 3. Agent + LLM (mcp-agent global app reused)
+        # 3. Agent + LLM (archive-only legacy mcp-agent path)
         response_text = ""
         try:
-            # global app 초기화 보장 (firecrawl 패턴과 동일)
-            from report_generator import get_or_create_global_mcp_app, reset_global_mcp_app
-            _ = await get_or_create_global_mcp_app()
-
             today_kst = datetime.now(_KST).strftime("%Y-%m-%d")
             dated_prompt = (
                 f"# 오늘 날짜: {today_kst} (KST)\n"
@@ -334,10 +330,6 @@ class InsightAgent:
                 logger.error(
                     f"InsightAgent LLM call failed: {agent_err}", exc_info=True
                 )
-                try:
-                    await reset_global_mcp_app()
-                except Exception:
-                    pass
                 # Fallback: retrieval 원문 반환
                 fallback = (
                     "[인사이트 엔진 오류] 관련 컨텍스트만 전달합니다.\n\n"

--- a/report_generator.py
+++ b/report_generator.py
@@ -2,7 +2,6 @@
 Report generation and conversion module
 """
 import asyncio
-import atexit
 import json
 import logging
 import os
@@ -13,84 +12,55 @@ from pathlib import Path
 from typing import Optional
 
 import markdown
-from mcp_agent.agents.agent import Agent
-from mcp_agent.app import MCPApp
-from mcp_agent.workflows.llm.augmented_llm import RequestParams
-from mcp_agent.workflows.llm.augmented_llm_anthropic import AnthropicAugmentedLLM
+from cores.agents.report_agent import ReportAgent as Agent
+from cores.llm.agent_bridge import ensure_openai_agents_configured
+from cores.llm.backends.openai_agents_backend import OpenAIAgentsBackend
+from cores.llm.config_loader import load_report_mcp_registry
+from cores.llm.ports import AgentSpec, LLMParams
 
 # Logger setup
 logger = logging.getLogger(__name__)
 
-# ============================================================================
-# Global MCPApp management (prevent process accumulation)
-# ============================================================================
-_global_mcp_app: Optional[MCPApp] = None
-_app_lock = asyncio.Lock()
-_app_initialized = False
+TELEGRAM_ANALYSIS_MODEL = os.environ.get(
+    "TELEGRAM_ANALYSIS_MODEL", "gpt-5.6-terra"
+)
+TELEGRAM_ANALYSIS_EFFORT = os.environ.get(
+    "TELEGRAM_ANALYSIS_EFFORT", "medium"
+)
+
+_telegram_backend = None
 
 
-async def get_or_create_global_mcp_app() -> MCPApp:
-    """
-    Get or create global MCPApp instance
-
-    Using this approach:
-    - Server process starts only once
-    - No new process creation per request
-    - Prevents resource leaks
-
-    Returns:
-        MCPApp: Global MCPApp instance
-    """
-    global _global_mcp_app, _app_initialized
-
-    async with _app_lock:
-        if _global_mcp_app is None or not _app_initialized:
-            logger.info("Starting global MCPApp initialization")
-            _global_mcp_app = MCPApp(name="telegram_ai_bot_global")
-            await _global_mcp_app.initialize()
-            _app_initialized = True
-            logger.info(f"Global MCPApp initialization complete (Session ID: {_global_mcp_app.session_id})")
-        return _global_mcp_app
+def _get_telegram_backend():
+    """Lazily configure the shared SDK backend for Telegram analysis calls."""
+    global _telegram_backend
+    if _telegram_backend is None:
+        ensure_openai_agents_configured()
+        _telegram_backend = OpenAIAgentsBackend(load_report_mcp_registry())
+    return _telegram_backend
 
 
-async def cleanup_global_mcp_app():
-    """Cleanup global MCPApp"""
-    global _global_mcp_app, _app_initialized
-
-    async with _app_lock:
-        if _global_mcp_app is not None and _app_initialized:
-            logger.info("Starting global MCPApp cleanup")
-            try:
-                await _global_mcp_app.cleanup()
-                logger.info("Global MCPApp cleanup complete")
-            except Exception as e:
-                logger.error(f"Error during global MCPApp cleanup: {e}")
-            finally:
-                _global_mcp_app = None
-                _app_initialized = False
-
-
-async def reset_global_mcp_app():
-    """Restart global MCPApp (on error)"""
-    logger.warning("Attempting to restart global MCPApp")
-    await cleanup_global_mcp_app()
-    return await get_or_create_global_mcp_app()
-
-
-def _cleanup_on_exit():
-    """Cleanup on program exit"""
-    global _global_mcp_app
-    try:
-        if _global_mcp_app is not None:
-            logger.info("Cleaning up global MCPApp on program exit")
-            asyncio.run(cleanup_global_mcp_app())
-    except Exception as e:
-        logger.error(f"Error during exit cleanup: {e}")
-
-
-# Auto cleanup on program exit
-atexit.register(_cleanup_on_exit)
-# ============================================================================
+async def _generate_telegram_text(
+    *,
+    agent: Agent,
+    message: str,
+    max_tokens: int,
+) -> str:
+    """Run one Telegram analysis request without an mcp-agent runtime."""
+    spec = AgentSpec(
+        name=agent.name,
+        instructions=agent.instruction,
+        model=TELEGRAM_ANALYSIS_MODEL,
+        mcp_servers=tuple(agent.server_names),
+        params=LLMParams(
+            max_tokens=max_tokens,
+            reasoning_effort=TELEGRAM_ANALYSIS_EFFORT,
+            parallel_tool_calls=True,
+            max_iterations=10,
+        ),
+    )
+    result = await _get_telegram_backend().run(spec, message)
+    return result.text
 
 # Constant definitions
 REPORTS_DIR = Path("reports")
@@ -672,8 +642,6 @@ async def generate_follow_up_response(ticker, ticker_name, conversation_context,
     """
     추가 질문에 대한 AI 응답 생성 (Agent 방식 사용)
     
-    ⚠️ 전역 MCPApp 사용으로 프로세스 누적 방지
-    
     Args:
         ticker (str): 종목 코드
         ticker_name (str): 종목명
@@ -685,10 +653,6 @@ async def generate_follow_up_response(ticker, ticker_name, conversation_context,
         str: AI 응답
     """
     try:
-        # 전역 MCPApp 사용 (매번 새로 생성하지 않음!)
-        app = await get_or_create_global_mcp_app()
-        app_logger = app.logger
-
         # 현재 날짜 정보 가져오기
         current_date = datetime.now().strftime('%Y%m%d')
 
@@ -730,22 +694,17 @@ async def generate_follow_up_response(ticker, ticker_name, conversation_context,
             server_names=["perplexity", "kospi_kosdaq"]
         )
 
-        # LLM 연결
-        llm = await agent.attach_llm(AnthropicAugmentedLLM)
-
         # 응답 생성
-        response = await llm.generate_str(
+        response = await _generate_telegram_text(
+            agent=agent,
             message="""사용자의 추가 질문에 대해 답변해주세요.
                     
                     이전 대화를 참고하되, 사용자의 새 질문에 집중하여 답변하세요.
                     필요한 경우 최신 데이터를 조회하여 정확한 정보를 제공하세요.
                     """,
-            request_params=RequestParams(
-                model="claude-sonnet-5",
-                maxTokens=4000
-            )
+            max_tokens=4000,
         )
-        app_logger.info(f"추가 질문 응답 생성 결과: {str(response)[:100]}...")
+        logger.info(f"추가 질문 응답 생성 결과: {str(response)[:100]}...")
 
         return clean_model_response(response)
 
@@ -754,21 +713,12 @@ async def generate_follow_up_response(ticker, ticker_name, conversation_context,
         import traceback
         logger.error(traceback.format_exc())
         
-        # 오류 발생 시 전역 app 재시작 시도
-        try:
-            logger.warning("오류 발생으로 인한 전역 MCPApp 재시작 시도")
-            await reset_global_mcp_app()
-        except Exception as reset_error:
-            logger.error(f"MCPApp 재시작 실패: {reset_error}")
-        
         return "죄송합니다. 응답 생성 중 오류가 발생했습니다. 다시 시도해주세요."
 
 
 async def generate_evaluation_response(ticker, ticker_name, avg_price, period, tone, background, report_path=None, memory_context: str = ""):
     """
     종목 평가 AI 응답 생성
-
-    ⚠️ 전역 MCPApp 사용으로 프로세스 누적 방지
 
     Args:
         ticker (str): 종목 코드
@@ -784,10 +734,6 @@ async def generate_evaluation_response(ticker, ticker_name, avg_price, period, t
         str: AI 응답
     """
     try:
-        # 전역 MCPApp 사용 (매번 새로 생성하지 않음!)
-        app = await get_or_create_global_mcp_app()
-        app_logger = app.logger
-
         # 현재 날짜 정보 가져오기
         current_date = datetime.now().strftime('%Y%m%d')
 
@@ -921,9 +867,6 @@ async def generate_evaluation_response(ticker, ticker_name, avg_price, period, t
             server_names=["perplexity", "kospi_kosdaq", "time"]
         )
 
-        # LLM 연결
-        llm = await agent.attach_llm(AnthropicAugmentedLLM)
-
         # 보고서 내용 확인
         report_content = ""
         if report_path and os.path.exists(report_path):
@@ -931,18 +874,16 @@ async def generate_evaluation_response(ticker, ticker_name, avg_price, period, t
                 report_content = f.read()
 
         # 응답 생성
-        response = await llm.generate_str(
+        response = await _generate_telegram_text(
+            agent=agent,
             message=f"""보고서를 바탕으로 종목 평가 응답을 생성해 주세요.
 
                     ## 참고 자료
                     {report_content if report_content else "관련 보고서가 없습니다. 시장 데이터 조회와 perplexity 검색을 통해 최신 정보를 수집하여 평가해주세요."}
                     """,
-            request_params=RequestParams(
-                model="claude-sonnet-5",
-                maxTokens=8000
-            )
+            max_tokens=8000,
         )
-        app_logger.info(f"응답 생성 결과: {str(response)}")
+        logger.info(f"응답 생성 결과: {str(response)}")
 
         return clean_model_response(response)
 
@@ -950,13 +891,6 @@ async def generate_evaluation_response(ticker, ticker_name, avg_price, period, t
         logger.error(f"응답 생성 중 오류: {str(e)}")
         import traceback
         logger.error(traceback.format_exc())
-        
-        # 오류 발생 시 전역 app 재시작 시도
-        try:
-            logger.warning("오류 발생으로 인한 전역 MCPApp 재시작 시도")
-            await reset_global_mcp_app()
-        except Exception as reset_error:
-            logger.error(f"MCPApp 재시작 실패: {reset_error}")
         
         return "죄송합니다. 평가 중 오류가 발생했습니다. 다시 시도해주세요."
 
@@ -968,8 +902,6 @@ async def generate_evaluation_response(ticker, ticker_name, avg_price, period, t
 async def generate_us_evaluation_response(ticker, ticker_name, avg_price, period, tone, background, memory_context: str = ""):
     """
     US 주식 평가 AI 응답 생성
-
-    ⚠️ 전역 MCPApp 사용으로 프로세스 누적 방지
 
     Args:
         ticker (str): 티커 심볼 (예: AAPL, MSFT)
@@ -984,10 +916,6 @@ async def generate_us_evaluation_response(ticker, ticker_name, avg_price, period
         str: AI 응답
     """
     try:
-        # 전역 MCPApp 사용 (매번 새로 생성하지 않음!)
-        app = await get_or_create_global_mcp_app()
-        app_logger = app.logger
-
         # 현재 날짜 정보 가져오기
         current_date = datetime.now().strftime('%Y%m%d')
 
@@ -1124,22 +1052,17 @@ async def generate_us_evaluation_response(ticker, ticker_name, avg_price, period
             server_names=["perplexity", "yahoo_finance", "time"]
         )
 
-        # LLM 연결
-        llm = await agent.attach_llm(AnthropicAugmentedLLM)
-
         # 응답 생성
-        response = await llm.generate_str(
+        response = await _generate_telegram_text(
+            agent=agent,
             message=f"""미국 주식 {ticker_name}({ticker})에 대한 종목 평가 응답을 생성해 주세요.
 
                     먼저 yahoo_finance 도구를 사용하여 최신 주가 데이터, 기관 투자자 정보, 애널리스트 추천을 조회하고,
                     perplexity로 최신 뉴스와 시장 동향을 검색한 후 종합적인 평가를 제공해주세요.
                     """,
-            request_params=RequestParams(
-                model="claude-sonnet-5",
-                maxTokens=8000
-            )
+            max_tokens=8000,
         )
-        app_logger.info(f"US 응답 생성 결과: {str(response)}")
+        logger.info(f"US 응답 생성 결과: {str(response)}")
 
         return clean_model_response(response)
 
@@ -1148,21 +1071,12 @@ async def generate_us_evaluation_response(ticker, ticker_name, avg_price, period
         import traceback
         logger.error(traceback.format_exc())
 
-        # 오류 발생 시 전역 app 재시작 시도
-        try:
-            logger.warning("오류 발생으로 인한 전역 MCPApp 재시작 시도")
-            await reset_global_mcp_app()
-        except Exception as reset_error:
-            logger.error(f"MCPApp 재시작 실패: {reset_error}")
-
         return "죄송합니다. 미국 주식 평가 중 오류가 발생했습니다. 다시 시도해주세요."
 
 
 async def generate_us_follow_up_response(ticker, ticker_name, conversation_context, user_question, tone):
     """
     US 주식 추가 질문에 대한 AI 응답 생성 (Agent 방식 사용)
-
-    ⚠️ 전역 MCPApp 사용으로 프로세스 누적 방지
 
     Args:
         ticker (str): 티커 심볼 (예: AAPL)
@@ -1175,10 +1089,6 @@ async def generate_us_follow_up_response(ticker, ticker_name, conversation_conte
         str: AI 응답
     """
     try:
-        # 전역 MCPApp 사용 (매번 새로 생성하지 않음!)
-        app = await get_or_create_global_mcp_app()
-        app_logger = app.logger
-
         # 현재 날짜 정보 가져오기
         current_date = datetime.now().strftime('%Y%m%d')
 
@@ -1221,22 +1131,17 @@ async def generate_us_follow_up_response(ticker, ticker_name, conversation_conte
             server_names=["perplexity", "yahoo_finance"]
         )
 
-        # Connect to LLM
-        llm = await agent.attach_llm(AnthropicAugmentedLLM)
-
         # Generate response
-        response = await llm.generate_str(
+        response = await _generate_telegram_text(
+            agent=agent,
             message="""사용자의 추가 질문에 대해 답변해주세요.
 
                     이전 대화를 참고하되, 사용자의 새 질문에 집중하여 답변하세요.
                     필요한 경우 yahoo_finance를 통해 최신 데이터를 조회하여 정확한 정보를 제공하세요.
                     """,
-            request_params=RequestParams(
-                model="claude-sonnet-5",
-                maxTokens=4000
-            )
+            max_tokens=4000,
         )
-        app_logger.info(f"US follow-up response generated: {str(response)[:100]}...")
+        logger.info(f"US follow-up response generated: {str(response)[:100]}...")
 
         return clean_model_response(response)
 
@@ -1244,13 +1149,6 @@ async def generate_us_follow_up_response(ticker, ticker_name, conversation_conte
         logger.error(f"Error generating US follow-up response: {str(e)}")
         import traceback
         logger.error(traceback.format_exc())
-
-        # Try restarting global app on error
-        try:
-            logger.warning("Attempting to restart global MCPApp due to error")
-            await reset_global_mcp_app()
-        except Exception as reset_error:
-            logger.error(f"MCPApp 재시작 실패: {reset_error}")
 
         return "죄송합니다. 미국 주식 응답 생성 중 오류가 발생했습니다. 다시 시도해주세요."
 
@@ -1278,10 +1176,6 @@ async def generate_journal_conversation_response(
         str: AI 응답
     """
     try:
-        # Use global MCPApp
-        app = await get_or_create_global_mcp_app()
-        app_logger = app.logger
-
         # Current date
         current_date = datetime.now().strftime('%Y년 %m월 %d일')
 
@@ -1341,20 +1235,15 @@ async def generate_journal_conversation_response(
             server_names=["perplexity", "kospi_kosdaq"]
         )
 
-        # Connect to LLM
-        llm = await agent.attach_llm(AnthropicAugmentedLLM)
-
         # Generate response
-        response = await llm.generate_str(
+        response = await _generate_telegram_text(
+            agent=agent,
             message=f"""사용자 메시지: {user_message}
 
 위 메시지에 자연스럽게 응답해주세요. 사용자의 과거 기록(저널, 평가 등)을 참고하여 개인화된 답변을 제공하세요.""",
-            request_params=RequestParams(
-                model="claude-sonnet-5",
-                maxTokens=4000
-            )
+            max_tokens=4000,
         )
-        app_logger.info(f"Journal conversation response generated: user_id={user_id}, response_len={len(response)}")
+        logger.info(f"Journal conversation response generated: user_id={user_id}, response_len={len(response)}")
 
         return clean_model_response(response)
 
@@ -1363,31 +1252,24 @@ async def generate_journal_conversation_response(
         import traceback
         logger.error(traceback.format_exc())
 
-        # Try restarting global app on error
-        try:
-            await reset_global_mcp_app()
-        except Exception:
-            pass
-
         return "죄송해요, 응답 생성 중 문제가 생겼어요. 다시 말씀해주시겠어요? 💭"
 
 
 # =============================================================================
-# Firecrawl Search + Claude analysis
+# Firecrawl Search + shared LLM analysis
 # =============================================================================
 
 async def generate_firecrawl_search_response(search_query: str, analysis_prompt: str, limit: int = 5) -> Optional[str]:
     """
-    Cost-efficient Firecrawl /search (2 credits) + Claude Sonnet analysis.
-    Uses the same global MCPApp pattern as other generate_* functions.
+    Cost-efficient Firecrawl /search (2 credits) plus shared LLM analysis.
 
     Args:
         search_query: Web search query for Firecrawl
-        analysis_prompt: Prompt for Claude to analyze the search results
+        analysis_prompt: Prompt used to analyze the search results
         limit: Number of search results (default 5)
 
     Returns:
-        str: Claude-generated analysis, or None on error
+        str: Generated analysis, or None on error
     """
     try:
         from firecrawl_client import firecrawl_search
@@ -1401,7 +1283,7 @@ async def generate_firecrawl_search_response(search_query: str, analysis_prompt:
         items = result.web if result and result.web else []
 
         if not items:
-            logger.warning(f"No search results for: {search_query[:50]}, falling back to Claude-only analysis")
+            logger.warning(f"No search results for: {search_query[:50]}, falling back to model-only analysis")
             context = "(최신 웹 검색 결과를 찾지 못했습니다. 알려진 시장 지식을 바탕으로 분석합니다.)\n\n"
         else:
             # Step 2: Build context — prefer full markdown, fall back to description snippet
@@ -1417,9 +1299,7 @@ async def generate_firecrawl_search_response(search_query: str, analysis_prompt:
 
             logger.info(f"Search context built: {len(items)} results, {len(context)} chars")
 
-        # Step 3: Use global MCPApp + Claude Sonnet for analysis
-        app = await get_or_create_global_mcp_app()
-
+        # Step 3: analyze the gathered content with the shared LLM backend.
         current_date = datetime.now().strftime("%Y년 %m월 %d일")
         agent = Agent(
             name="firecrawl_search_analyst",
@@ -1434,16 +1314,12 @@ async def generate_firecrawl_search_response(search_query: str, analysis_prompt:
             server_names=[]
         )
 
-        llm = await agent.attach_llm(AnthropicAugmentedLLM)
-
-        response = await llm.generate_str(
+        response = await _generate_telegram_text(
+            agent=agent,
             message=f"다음은 웹 검색 결과입니다:\n\n{context}\n\n---\n\n{analysis_prompt}",
-            request_params=RequestParams(
-                model="claude-sonnet-5",
-                maxTokens=4000
-            )
+            max_tokens=4000,
         )
-        app.logger.info(f"Firecrawl search+Claude response: {len(response)} chars")
+        logger.info(f"Firecrawl search analysis response: {len(response)} chars")
 
         return clean_model_response(response)
 
@@ -1451,11 +1327,6 @@ async def generate_firecrawl_search_response(search_query: str, analysis_prompt:
         logger.error(f"generate_firecrawl_search_response failed: {e}")
         import traceback
         logger.error(traceback.format_exc())
-
-        try:
-            await reset_global_mcp_app()
-        except Exception:
-            pass
 
         return None
 
@@ -1489,7 +1360,7 @@ async def generate_firecrawl_followup_response(
 ) -> Optional[str]:
     """
     Follow-up conversation for Firecrawl-based commands (signal, us_signal, theme, us_theme, ask).
-    First response comes from Firecrawl; subsequent replies use Anthropic Sonnet 4.6
+    First response comes from Firecrawl; subsequent replies use the shared LLM backend
     with command-specific MCP servers so the conversation stays grounded in live data.
 
     Args:
@@ -1499,10 +1370,9 @@ async def generate_firecrawl_followup_response(
         user_question: The user's new follow-up question
 
     Returns:
-        str: Claude-generated response, or None on error
+        str: Generated response, or None on error
     """
     try:
-        app = await get_or_create_global_mcp_app()
         server_names = _FIRECRAWL_CMD_SERVERS.get(command, ["perplexity"])
         persona = _FIRECRAWL_CMD_PERSONA.get(command, "투자 분석 전문가")
         current_date = datetime.now().strftime("%Y년 %m월 %d일")
@@ -1542,23 +1412,16 @@ async def generate_firecrawl_followup_response(
             server_names=server_names,
         )
 
-        llm = await agent.attach_llm(AnthropicAugmentedLLM)
-        response = await llm.generate_str(
+        response = await _generate_telegram_text(
+            agent=agent,
             message=user_question,
-            request_params=RequestParams(
-                model="claude-sonnet-5",
-                maxTokens=4000,
-            ),
+            max_tokens=4000,
         )
-        app.logger.info(f"firecrawl_followup ({command}): {len(response)} chars")
+        logger.info(f"firecrawl_followup ({command}): {len(response)} chars")
         return clean_model_response(response)
 
     except Exception as e:
         logger.error(f"generate_firecrawl_followup_response failed ({command}): {e}")
         import traceback
         logger.error(traceback.format_exc())
-        try:
-            await reset_global_mcp_app()
-        except Exception:
-            pass
         return None

--- a/tasks/plans/remove-telegram-mcpapp.md
+++ b/tasks/plans/remove-telegram-mcpapp.md
@@ -1,0 +1,38 @@
+# Telegram report_generator MCPApp 제거 계획
+
+## 목표
+
+`telegram_ai_bot.py`의 평가·후속질문·저널·Firecrawl 응답 경로에서
+`mcp-agent`의 전역 `MCPApp`, `Agent`, `AnthropicAugmentedLLM`, `RequestParams` 런타임을 제거한다.
+이미 운영 검증된 `cores.llm` 포트와 `OpenAIAgentsBackend`를 재사용한다.
+
+## 보존할 동작
+
+- 7개 공개 async 함수의 인자와 반환형
+- 함수별 프롬프트, MCP 서버 목록, 최대 토큰
+- `clean_model_response()` 후처리
+- 예외 발생 시 기존 사용자용 오류 문자열
+- Telegram 봇의 command 등록, polling, background worker 수명주기
+- `report_generator.py`의 동기식 KR/US 보고서 생성 경로
+
+## 변경 순서
+
+1. source/behavior contract 테스트로 현재 7개 함수와 서버·토큰 설정을 고정한다.
+2. `report_generator.py`에 SDK-neutral 실행 helper를 추가한다.
+3. 7개 함수의 전역 MCPApp/Agent/LLM 결합을 helper 호출로 치환한다.
+4. `telegram_ai_bot.py`의 시작·종료 MCPApp 수명주기 코드를 삭제한다.
+5. 대상 런타임 파일에 `mcp_agent`/`MCPApp` 잔재가 없는지 테스트한다.
+6. 단위 테스트, import-without-mcp-agent, compile, Ruff, diff check를 실행한다.
+7. 격리 app-server 환경에서 Telegram import와 실제 Terra+MCP smoke를 통과한 뒤 PR을 연다.
+
+## 모델 및 롤백
+
+- 기본: `TELEGRAM_ANALYSIS_MODEL=gpt-5.6-terra`
+- 기본 effort: `TELEGRAM_ANALYSIS_EFFORT=medium`
+- 운영 조정은 두 환경변수로 수행하며 코드 롤백 없이 모델을 바꿀 수 있게 한다.
+
+## 제외 범위
+
+- `cores/llm/backends/mcp_agent_backend.py` 및 archive 전용 코드의 최종 삭제
+- legacy YAML credential의 환경변수 이전
+- 프롬프트 문구 개선이나 응답 형식 개편

--- a/telegram_ai_bot.py
+++ b/telegram_ai_bot.py
@@ -33,7 +33,6 @@ from analysis_manager import (
 # Internal module imports
 from report_generator import (
     generate_evaluation_response, get_cached_report, generate_follow_up_response,
-    get_or_create_global_mcp_app, cleanup_global_mcp_app,
     generate_us_evaluation_response, generate_us_follow_up_response,
     get_cached_us_report, generate_journal_conversation_response,
     generate_firecrawl_search_response, generate_firecrawl_followup_response
@@ -2862,7 +2861,7 @@ class TelegramAIBot:
 
     # Firecrawl Spark(/AGENT) jobs can hang server-side in IN_PROGRESS or FAIL
     # without returning, which would otherwise block the executor thread until the
-    # 300s ConversationHandler timeout. Cap the wait and fall back to search+Claude.
+    # 300s ConversationHandler timeout. Cap the wait and fall back to search+LLM.
     _FIRECRAWL_AGENT_TIMEOUT = 120  # seconds
 
     async def _run_firecrawl_command(self, update: Update, prompt: str, disclaimer: str,
@@ -2878,9 +2877,9 @@ class TelegramAIBot:
             model: Spark agent model — "spark-1-mini" (default) or "spark-1-pro".
             max_credits: Per-call credit ceiling passed to the agent.
             fallback_search_query: When set together with fallback_analysis_prompt,
-                a Firecrawl Spark timeout/failure/empty result triggers a search+Claude
+                a Firecrawl Spark timeout/failure/empty result triggers a search+LLM
                 fallback (generate_firecrawl_search_response) instead of erroring out.
-            fallback_analysis_prompt: Analysis instruction passed to the Claude fallback.
+            fallback_analysis_prompt: Analysis instruction passed to the LLM fallback.
             timeout: Seconds to wait for the Spark agent before giving up (defaults to
                 _FIRECRAWL_AGENT_TIMEOUT). Heavy spark-1-pro jobs need a larger budget so
                 legitimate deep-research runs are not cut off prematurely.
@@ -2907,9 +2906,9 @@ class TelegramAIBot:
                 )
                 result = None
 
-            # Fallback: Spark hung/failed/returned empty — retry via search+Claude (Anthropic).
+            # Fallback: Spark hung/failed/returned empty — retry via search+LLM.
             if not result and fallback_search_query and fallback_analysis_prompt:
-                logger.info("Falling back to search+Claude after Firecrawl agent miss")
+                logger.info("Falling back to search+LLM after Firecrawl agent miss")
                 try:
                     await waiting_msg.edit_text("🔍 리서치 중... (보조 엔진 전환)")
                 except Exception:
@@ -2919,7 +2918,7 @@ class TelegramAIBot:
                         fallback_search_query, fallback_analysis_prompt
                     )
                 except Exception as fe:
-                    logger.error(f"Search+Claude fallback failed: {fe}", exc_info=True)
+                    logger.error(f"Search+LLM fallback failed: {fe}", exc_info=True)
                     result = None
 
             # Delete waiting message
@@ -2968,8 +2967,7 @@ class TelegramAIBot:
 
     async def _run_search_and_claude(self, update: Update, search_query: str, analysis_prompt: str, disclaimer: str):
         """
-        Cost-efficient helper using Firecrawl /search (2 credits) + Claude Sonnet 5.
-        Uses the same global MCPApp + AnthropicAugmentedLLM pattern as /evaluate.
+        Cost-efficient helper using Firecrawl /search (2 credits) plus shared LLM analysis.
 
         Returns:
             tuple: (success: bool, response_text: str | None, sent_msg_id: int | None)
@@ -3009,7 +3007,7 @@ class TelegramAIBot:
                 return False, None, None
 
         except Exception as e:
-            logger.error(f"Search+Claude command error: {e}", exc_info=True)
+            logger.error(f"Search+LLM command error: {e}", exc_info=True)
             try:
                 await waiting_msg.delete()
             except Exception:
@@ -3644,9 +3642,8 @@ class TelegramAIBot:
     # ==========================================================================
 
     async def _handle_firecrawl_reply(self, update: Update, fc_ctx: FirecrawlConversationContext):
-        """Handle a reply to a Firecrawl bot message — continue via Anthropic Sonnet 5."""
+        """Handle a reply to a Firecrawl bot message via the shared LLM backend."""
         user_question = update.message.text.strip()
-        chat_id = update.effective_chat.id
 
         waiting_msg = await update.message.reply_text("💭 분석 중입니다... 잠시만 기다려주세요.")
 
@@ -3722,15 +3719,6 @@ class TelegramAIBot:
 
     async def run(self):
         """Run bot"""
-        # Initialize global MCP App
-        try:
-            logger.info("Initializing global MCPApp...")
-            await get_or_create_global_mcp_app()
-            logger.info("Global MCPApp initialization complete")
-        except Exception as e:
-            logger.error(f"Global MCPApp initialization failed: {e}")
-            # Start bot even if initialization fails (can retry later)
-        
         # Run bot
         await self.application.initialize()
         # Sync slash-command menu with BotFather (1x on startup)
@@ -3755,14 +3743,6 @@ class TelegramAIBot:
         finally:
             # Clean up resources on exit
             logger.info("Bot shutdown started - cleaning up resources...")
-            
-            # Clean up global MCP App
-            try:
-                logger.info("Cleaning up global MCPApp...")
-                await cleanup_global_mcp_app()
-                logger.info("Global MCPApp cleanup complete")
-            except Exception as e:
-                logger.error(f"Global MCPApp cleanup failed: {e}")
             
             # Stop bot
             await self.application.stop()

--- a/tests/test_report_generator_contract.py
+++ b/tests/test_report_generator_contract.py
@@ -1,0 +1,102 @@
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "report_generator.py"
+
+EXPECTED = {
+    "generate_follow_up_response": {
+        "args": ["ticker", "ticker_name", "conversation_context", "user_question", "tone"],
+        "servers": ("perplexity", "kospi_kosdaq"),
+        "max_tokens": 4000,
+    },
+    "generate_evaluation_response": {
+        "args": ["ticker", "ticker_name", "avg_price", "period", "tone", "background", "report_path", "memory_context"],
+        "servers": ("perplexity", "kospi_kosdaq", "time"),
+        "max_tokens": 8000,
+    },
+    "generate_us_evaluation_response": {
+        "args": ["ticker", "ticker_name", "avg_price", "period", "tone", "background", "memory_context"],
+        "servers": ("perplexity", "yahoo_finance", "time"),
+        "max_tokens": 8000,
+    },
+    "generate_us_follow_up_response": {
+        "args": ["ticker", "ticker_name", "conversation_context", "user_question", "tone"],
+        "servers": ("perplexity", "yahoo_finance"),
+        "max_tokens": 4000,
+    },
+    "generate_journal_conversation_response": {
+        "args": ["user_id", "user_message", "memory_context", "ticker", "ticker_name", "conversation_history"],
+        "servers": ("perplexity", "kospi_kosdaq"),
+        "max_tokens": 4000,
+    },
+    "generate_firecrawl_search_response": {
+        "args": ["search_query", "analysis_prompt", "limit"],
+        "servers": (),
+        "max_tokens": 4000,
+    },
+    "generate_firecrawl_followup_response": {
+        "args": ["command", "query", "conversation_context", "user_question"],
+        "servers": None,
+        "max_tokens": 4000,
+    },
+}
+
+
+def _keyword_node(call: ast.Call, *names: str):
+    for keyword in call.keywords:
+        if keyword.arg in names:
+            return keyword.value
+    raise AssertionError(f"missing keyword {names}")
+
+
+def _literal_keyword(call: ast.Call, *names: str):
+    return ast.literal_eval(_keyword_node(call, *names))
+
+
+def _contract(function: ast.AsyncFunctionDef):
+    agent_call = None
+    generation_call = None
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Name) and node.func.id == "Agent":
+            agent_call = node
+        if isinstance(node.func, ast.Name) and node.func.id == "_generate_telegram_text":
+            generation_call = node
+
+    assert agent_call is not None
+    if agent_call is not None:
+        server_node = _keyword_node(agent_call, "server_names")
+        servers = None if isinstance(server_node, ast.Name) else tuple(ast.literal_eval(server_node))
+    if generation_call is not None:
+        max_tokens = _literal_keyword(generation_call, "max_tokens")
+    else:
+        request_call = next(
+            node
+            for node in ast.walk(function)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "RequestParams"
+        )
+        max_tokens = _literal_keyword(request_call, "maxTokens")
+
+    return servers, max_tokens
+
+
+def test_public_async_contracts_are_preserved():
+    tree = ast.parse(SOURCE.read_text())
+    functions = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, ast.AsyncFunctionDef) and node.name in EXPECTED
+    }
+    assert functions.keys() == EXPECTED.keys()
+
+    for name, expected in EXPECTED.items():
+        function = functions[name]
+        assert [arg.arg for arg in function.args.args] == expected["args"]
+        servers, max_tokens = _contract(function)
+        assert servers == expected["servers"]
+        assert max_tokens == expected["max_tokens"]

--- a/tests/test_telegram_report_backend.py
+++ b/tests/test_telegram_report_backend.py
@@ -1,0 +1,59 @@
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+sys.modules.setdefault("markdown", types.SimpleNamespace(markdown=lambda text: text))
+
+import report_generator
+from cores.agents.report_agent import ReportAgent
+from cores.llm.ports import LLMResult
+
+
+class RecordingBackend:
+    def __init__(self):
+        self.calls = []
+
+    async def run(self, spec, user_input):
+        self.calls.append((spec, user_input))
+        return LLMResult(text="backend-result")
+
+
+def test_generate_telegram_text_preserves_runtime_contract(monkeypatch):
+    backend = RecordingBackend()
+    monkeypatch.setattr(report_generator, "_telegram_backend", backend)
+    monkeypatch.setattr(report_generator, "TELEGRAM_ANALYSIS_MODEL", "test-model")
+    monkeypatch.setattr(report_generator, "TELEGRAM_ANALYSIS_EFFORT", "high")
+    agent = ReportAgent(
+        name="contract-agent",
+        instruction="contract instructions",
+        server_names=("perplexity", "time"),
+    )
+
+    result = asyncio.run(
+        report_generator._generate_telegram_text(
+            agent=agent,
+            message="contract message",
+            max_tokens=4321,
+        )
+    )
+
+    assert result == "backend-result"
+    spec, user_input = backend.calls[0]
+    assert spec.name == "contract-agent"
+    assert spec.instructions == "contract instructions"
+    assert spec.model == "test-model"
+    assert spec.mcp_servers == ("perplexity", "time")
+    assert spec.params.max_tokens == 4321
+    assert spec.params.reasoning_effort == "high"
+    assert spec.params.parallel_tool_calls is True
+    assert spec.params.max_iterations == 10
+    assert user_input == "contract message"
+
+
+def test_telegram_runtime_sources_are_mcp_agent_free():
+    root = Path(__file__).resolve().parents[1]
+    for relative in ("report_generator.py", "telegram_ai_bot.py"):
+        source = (root / relative).read_text()
+        assert "mcp_agent" not in source
+        assert "MCPApp" not in source


### PR DESCRIPTION
## Summary
- route 7 Telegram evaluation/follow-up/journal/Firecrawl analysis functions through OpenAIAgentsBackend
- remove the global MCPApp startup/shutdown lifecycle from telegram_ai_bot.py
- preserve prompts, MCP server sets, token budgets, public signatures, response cleanup, and error messages
- default to gpt-5.6-terra with TELEGRAM_ANALYSIS_MODEL / TELEGRAM_ANALYSIS_EFFORT overrides

## Safety evidence
- 7-function AST comparison: instructions/messages/server sets/token budgets unchanged
- 65 focused tests passed with openai-agents SDK
- compile, Ruff F, diff check passed
- app-server isolated worktree imported telegram_ai_bot with mcp_agent imports forcibly blocked
- live app-server gpt-5.6-terra + time MCP smoke passed without loading mcp_agent

## Deployment
Do not auto-deploy with merge. Restart the app-server Telegram bot using the recorded su - prism / exact nohup procedure and validate one PID, command registration, Telegram HTTP 200s, and fatal log zero.