### PR TITLE
feat(trading): shadow legacy positions (#412 Phase 4-a)

### DIFF
--- a/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
+++ b/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
@@ -326,6 +326,226 @@ async def test_us_buy_dual_writes_open_position():
     )
 
 
+@pytest.mark.asyncio
+async def test_us_mirror_failures_keep_buy_and_sell_legacy_commits(monkeypatch):
+    """US shadow failures must stay observable and never block legacy writes."""
+    from prism_core.positions import PositionStore
+
+    agent = USStockTrackingAgent.__new__(USStockTrackingAgent)
+    agent.conn = sqlite3.connect(":memory:")
+    agent.conn.row_factory = sqlite3.Row
+    agent.cursor = agent.conn.cursor()
+    agent.cursor.execute(
+        """CREATE TABLE us_stock_holdings (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               account_key TEXT NOT NULL, account_name TEXT, ticker TEXT NOT NULL,
+               company_name TEXT NOT NULL, buy_price REAL NOT NULL,
+               buy_date TEXT NOT NULL, current_price REAL, last_updated TEXT,
+               scenario TEXT, target_price REAL, stop_loss REAL,
+               trigger_type TEXT, trigger_mode TEXT, sector TEXT
+           )"""
+    )
+    agent.cursor.execute(
+        """CREATE TABLE us_trading_history (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               account_key TEXT NOT NULL, account_name TEXT, ticker TEXT NOT NULL,
+               company_name TEXT NOT NULL, buy_price REAL NOT NULL,
+               buy_date TEXT NOT NULL, sell_price REAL NOT NULL,
+               sell_date TEXT NOT NULL, profit_rate REAL NOT NULL,
+               holding_days INTEGER NOT NULL, scenario TEXT, trigger_type TEXT,
+               trigger_mode TEXT, sector TEXT, exit_kind TEXT
+           )"""
+    )
+    PositionStore(agent.cursor).ensure_schema()
+    agent.conn.commit()
+    agent.position_ledger_shadow_enabled = True
+    agent.max_slots = 10
+    agent.message_queue = []
+    agent._msg_types = []
+    agent.enable_journal = False
+    agent.journal_manager = None
+    agent._account_scope = lambda: ("ACC1", "us-primary")
+    agent._get_trigger_win_rate = lambda _trigger: ""
+
+    async def no_holding(_ticker):
+        return False
+
+    async def no_slots():
+        return 0
+
+    agent._is_ticker_in_holdings = no_holding
+    agent._get_current_slots_count = no_slots
+
+    original_open = PositionStore.open_legacy_position
+
+    def fail_open(*_args, **_kwargs):
+        raise RuntimeError("open mirror injected failure api_key=top-secret")
+
+    monkeypatch.setattr(PositionStore, "open_legacy_position", fail_open)
+    assert await agent.buy_stock("AAPL", "Apple", 190.0, {"sector": "Technology"})
+    holding = dict(agent.conn.execute("SELECT * FROM us_stock_holdings").fetchone())
+    assert agent.conn.execute("SELECT COUNT(*) FROM us_stock_holdings").fetchone()[0] == 1
+    assert agent.conn.execute("SELECT COUNT(*) FROM positions").fetchone()[0] == 0
+    open_comparison = PositionStore(agent.conn).compare_legacy_positions("US")
+    assert not open_comparison["matches"]
+    assert len(open_comparison["missing_positions"]) == 1
+    assert [row["operation"] for row in open_comparison["unresolved_mirror_errors"]] == [
+        "open"
+    ]
+
+    monkeypatch.setattr(PositionStore, "open_legacy_position", original_open)
+    assert PositionStore(agent.conn).backfill_legacy_positions("US")["inserted"] == 1
+    agent.conn.commit()
+
+    def fail_close(*_args, **_kwargs):
+        raise RuntimeError("close mirror injected failure bearer private-token")
+
+    monkeypatch.setattr(PositionStore, "close_legacy_position", fail_close)
+    holding["current_price"] = 195.0
+    assert await agent.sell_stock(holding, "fail-open regression")
+
+    assert agent.conn.execute("SELECT COUNT(*) FROM us_stock_holdings").fetchone()[0] == 0
+    assert agent.conn.execute("SELECT COUNT(*) FROM us_trading_history").fetchone()[0] == 1
+    assert agent.conn.execute("SELECT status FROM positions").fetchone()[0] == "OPEN"
+    comparison = PositionStore(agent.conn).compare_legacy_positions("US")
+    assert not comparison["matches"]
+    assert len(comparison["extra_open_positions"]) == 1
+    assert [row["operation"] for row in comparison["unresolved_mirror_errors"]] == [
+        "open",
+        "close",
+    ]
+    assert "top-secret" not in str(comparison)
+    assert "private-token" not in str(comparison)
+
+
+@pytest.mark.asyncio
+async def test_us_full_exit_closes_all_siblings_before_one_order_and_publish(
+    monkeypatch, tmp_path
+):
+    """A queued full exit closes every legacy/shadow row but emits one order."""
+    from prism_core.positions import PositionStore
+
+    events = []
+    trading_module = types.ModuleType("trading.us_stock_trading")
+
+    class FullExitTradingContext:
+        def __init__(self, account_name=None, **_kwargs):
+            self.account_name = account_name
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def is_market_open(self):
+            return False
+
+        def is_reserved_order_available(self):
+            return False
+
+        async def async_sell_stock(self, ticker, limit_price=None, quantity=None):
+            events.append("broker")
+            assert ticker == "AAPL"
+            assert quantity is None
+            return {"success": True, "message": "queued full exit"}
+
+    trading_module.AsyncUSTradingContext = FullExitTradingContext
+    monkeypatch.setitem(sys.modules, "trading.us_stock_trading", trading_module)
+
+    redis_module = types.ModuleType("messaging.redis_signal_publisher")
+    gcp_module = types.ModuleType("messaging.gcp_pubsub_signal_publisher")
+
+    async def publish_sell_signal(**_kwargs):
+        events.append("redis")
+
+    async def gcp_publish_sell_signal(**_kwargs):
+        events.append("gcp")
+
+    redis_module.publish_sell_signal = publish_sell_signal
+    gcp_module.publish_sell_signal = gcp_publish_sell_signal
+    monkeypatch.setitem(sys.modules, "messaging.redis_signal_publisher", redis_module)
+    monkeypatch.setitem(sys.modules, "messaging.gcp_pubsub_signal_publisher", gcp_module)
+
+    agent = USStockTrackingAgent.__new__(USStockTrackingAgent)
+    agent.db_path = str(tmp_path / "order-intents.sqlite")
+    agent.conn = sqlite3.connect(":memory:")
+    agent.conn.row_factory = sqlite3.Row
+    agent.cursor = agent.conn.cursor()
+    agent.cursor.execute(
+        """CREATE TABLE us_stock_holdings (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               account_key TEXT NOT NULL, account_name TEXT, ticker TEXT NOT NULL,
+               company_name TEXT NOT NULL, buy_price REAL NOT NULL,
+               buy_date TEXT NOT NULL, current_price REAL, last_updated TEXT,
+               scenario TEXT, target_price REAL, stop_loss REAL,
+               trigger_type TEXT, trigger_mode TEXT, sector TEXT
+           )"""
+    )
+    agent.cursor.execute(
+        """CREATE TABLE us_trading_history (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               account_key TEXT NOT NULL, account_name TEXT, ticker TEXT NOT NULL,
+               company_name TEXT NOT NULL, buy_price REAL NOT NULL,
+               buy_date TEXT NOT NULL, sell_price REAL NOT NULL,
+               sell_date TEXT NOT NULL, profit_rate REAL NOT NULL,
+               holding_days INTEGER NOT NULL, scenario TEXT, trigger_type TEXT,
+               trigger_mode TEXT, sector TEXT, exit_kind TEXT
+           )"""
+    )
+    for price, opened_at in (
+        (180.0, "2026-07-01 09:00:00"),
+        (175.0, "2026-07-02 09:00:00"),
+    ):
+        agent.cursor.execute(
+            """INSERT INTO us_stock_holdings
+               (account_key, account_name, ticker, company_name, buy_price, buy_date,
+                current_price, scenario, trigger_type, trigger_mode, sector)
+               VALUES ('ACC1', 'us-primary', 'AAPL', 'Apple', ?, ?, ?, '{}',
+                       'AI Analysis', 'morning', 'Technology')""",
+            (price, opened_at, price),
+        )
+    store = PositionStore(agent.cursor)
+    store.ensure_schema()
+    assert store.backfill_legacy_positions("US")["inserted"] == 2
+    agent.conn.commit()
+
+    agent.position_ledger_shadow_enabled = True
+    agent.message_queue = []
+    agent._msg_types = []
+    agent.enable_journal = False
+    agent.journal_manager = None
+    agent._account_scope = lambda: ("ACC1", "us-primary")
+    agent._get_trigger_win_rate = lambda _trigger: ""
+    agent._get_live_regime_safe = lambda: {}
+
+    async def current_price(_ticker):
+        return 190.0
+
+    async def should_sell(_stock):
+        return True, "queued full-exit regression"
+
+    async def delete_decision(_ticker):
+        return True
+
+    agent._get_current_stock_price = current_price
+    agent._analyze_sell_decision = should_sell
+    agent._delete_holding_decision = delete_decision
+
+    sold = await USStockTrackingAgent.update_holdings(agent)
+
+    assert len(sold) == 2
+    assert events == ["broker", "redis", "gcp"]
+    assert agent.conn.execute("SELECT COUNT(*) FROM us_stock_holdings").fetchone()[0] == 0
+    assert agent.conn.execute("SELECT COUNT(*) FROM us_trading_history").fetchone()[0] == 2
+    statuses = agent.conn.execute(
+        "SELECT status FROM positions ORDER BY legacy_holding_id"
+    ).fetchall()
+    assert [row[0] for row in statuses] == ["CLOSED", "CLOSED"]
+    comparison = PositionStore(agent.conn).compare_legacy_positions("US")
+    assert comparison["matches"]
+
+
 def _install_signal_modules(monkeypatch, redis_calls, gcp_calls):
     redis_module = types.ModuleType("messaging.redis_signal_publisher")
     gcp_module = types.ModuleType("messaging.gcp_pubsub_signal_publisher")

--- a/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
+++ b/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
@@ -150,6 +150,7 @@ class _FakeAsyncUSTradingContext:
 @pytest.mark.parametrize("pyramiding", [False, True], ids=["single", "pyramiding"])
 def test_concurrent_sell_guard_allows_one_us_order_and_publish(tmp_path, pyramiding):
     from prism_core.execution_service import ExecutionService
+    from prism_core.positions import PositionStore
 
     db_path = tmp_path / "us-concurrent-sell.sqlite"
     setup = sqlite3.connect(db_path)
@@ -187,6 +188,11 @@ def test_concurrent_sell_guard_allows_one_us_order_and_publish(tmp_path, pyramid
                VALUES ('ACC1', 'us-primary', 'AAPL', 'Apple', 175,
                        '2026-06-15 09:00:00')"""
         )
+    position_store = PositionStore(setup)
+    position_store.ensure_schema()
+    assert position_store.backfill_legacy_positions("US")["inserted"] == (
+        2 if pyramiding else 1
+    )
     setup.commit()
     setup.close()
 
@@ -248,13 +254,76 @@ def test_concurrent_sell_guard_allows_one_us_order_and_publish(tmp_path, pyramid
     remaining_prices = verify.execute(
         "SELECT buy_price FROM us_stock_holdings ORDER BY id"
     ).fetchall()
+    position_states = verify.execute(
+        "SELECT legacy_holding_id, status FROM positions ORDER BY legacy_holding_id"
+    ).fetchall()
     verify.close()
 
     assert sorted(sold for sold, _messages in results) == [False, True]
     assert sum(messages for _sold, messages in results) == 1
     assert history_count == 1
     assert remaining_prices == ([(175.0,)] if pyramiding else [])
+    assert position_states == (
+        [(str(target_row_id), "CLOSED"), (str(target_row_id + 1), "OPEN")]
+        if pyramiding
+        else [(str(target_row_id), "CLOSED")]
+    )
     assert effects == {"broker": 1, "publish": 1}
+
+
+@pytest.mark.asyncio
+async def test_us_buy_dual_writes_open_position():
+    from prism_core.positions import PositionStore
+
+    agent = USStockTrackingAgent.__new__(USStockTrackingAgent)
+    agent.conn = sqlite3.connect(":memory:")
+    agent.cursor = agent.conn.cursor()
+    agent.cursor.execute(
+        """CREATE TABLE us_stock_holdings (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               account_key TEXT NOT NULL, account_name TEXT, ticker TEXT NOT NULL,
+               company_name TEXT NOT NULL, buy_price REAL NOT NULL,
+               buy_date TEXT NOT NULL, current_price REAL, last_updated TEXT,
+               scenario TEXT, target_price REAL, stop_loss REAL,
+               trigger_type TEXT, trigger_mode TEXT, sector TEXT
+           )"""
+    )
+    PositionStore(agent.cursor).ensure_schema()
+    agent.conn.commit()
+    agent.position_ledger_shadow_enabled = True
+    agent.max_slots = 10
+    agent.message_queue = []
+    agent._msg_types = []
+    agent._account_scope = lambda: ("ACC1", "us-primary")
+    agent._get_trigger_win_rate = lambda _trigger: ""
+
+    async def no_holding(_ticker):
+        return False
+
+    async def no_slots():
+        return 0
+
+    agent._is_ticker_in_holdings = no_holding
+    agent._get_current_slots_count = no_slots
+
+    assert await agent.buy_stock(
+        "AAPL", "Apple", 190.0, {"sector": "Technology"}
+    )
+    legacy = agent.conn.execute(
+        "SELECT id, account_key, ticker, buy_price, buy_date FROM us_stock_holdings"
+    ).fetchone()
+    mirror = agent.conn.execute(
+        "SELECT legacy_holding_id, account_id, symbol, entry_price, opened_at, status "
+        "FROM positions"
+    ).fetchone()
+    assert mirror == (
+        str(legacy[0]),
+        legacy[1],
+        legacy[2],
+        legacy[3],
+        legacy[4],
+        "OPEN",
+    )
 
 
 def _install_signal_modules(monkeypatch, redis_calls, gcp_calls):

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -657,8 +657,11 @@ class USStockTrackingAgent:
                     operation="initialize",
                     error=error,
                 )
-            except Exception:
-                pass
+            except Exception as audit_error:
+                logger.critical(
+                    "[POSITION-SHADOW][US] initialization audit failed (%s)",
+                    type(audit_error).__name__,
+                )
             self.conn.commit()
             return
         self.conn.execute("RELEASE position_shadow_init")

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -39,6 +39,7 @@ PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 from prism_core.execution_service import ExecutionService  # noqa: E402
 from prism_core.order_intents import OrderIntent  # noqa: E402
+from prism_core.positions import PositionStore, mirror_write_fail_open  # noqa: E402
 
 _openai_debug_spec = _ilu.spec_from_file_location("cores.openai_debug", PROJECT_ROOT / "cores" / "openai_debug.py")
 if _openai_debug_spec and _openai_debug_spec.loader:
@@ -526,6 +527,9 @@ class USStockTrackingAgent:
             self.enable_journal = env_value in ("true", "1", "yes")
         self.account_configs: list[dict[str, Any]] = []
         self.active_account: dict[str, Any] | None = None
+        self.position_ledger_shadow_enabled = os.environ.get(
+            "POSITION_LEDGER_SHADOW_ENABLED", "true"
+        ).strip().lower() not in {"0", "false", "no", "off"}
 
         # Journal and compression managers (initialized in initialize())
         self.journal_manager = None
@@ -569,6 +573,7 @@ class USStockTrackingAgent:
 
         # Create US database tables
         await self._create_tables()
+        self._initialize_position_ledger()
 
         # Initialize journal manager
         self.journal_manager = USJournalManager(
@@ -603,6 +608,127 @@ class USStockTrackingAgent:
         migrate_us_performance_tracker_columns(self.cursor, self.conn)
         # Migrate watchlist history columns for 7/14/30-day performance tracking
         migrate_us_watchlist_history_columns(self.cursor, self.conn)
+
+    def _position_ledger_enabled(self) -> bool:
+        return getattr(
+            self,
+            "position_ledger_shadow_enabled",
+            os.environ.get("POSITION_LEDGER_SHADOW_ENABLED", "true")
+            .strip()
+            .lower()
+            not in {"0", "false", "no", "off"},
+        )
+
+    def _initialize_position_ledger(self) -> None:
+        """Create/backfill the additive US shadow ledger without blocking startup."""
+        if not self._position_ledger_enabled():
+            logger.warning("[POSITION-SHADOW][US] disabled by kill switch")
+            return
+
+        self.conn.commit()
+        store = PositionStore(self.cursor)
+        try:
+            store.ensure_schema()
+            self.conn.commit()
+        except Exception as error:
+            self.conn.rollback()
+            logger.critical(
+                "[POSITION-SHADOW][US] schema initialization failed (%s)",
+                type(error).__name__,
+            )
+            return
+
+        self.conn.execute("BEGIN")
+        self.conn.execute("SAVEPOINT position_shadow_init")
+        try:
+            result = store.backfill_legacy_positions("US")
+        except Exception as error:
+            self.conn.execute("ROLLBACK TO position_shadow_init")
+            self.conn.execute("RELEASE position_shadow_init")
+            logger.critical(
+                "[POSITION-SHADOW][US] initialization failed (%s)",
+                type(error).__name__,
+            )
+            try:
+                store.record_mirror_error(
+                    market="US",
+                    legacy_holding_id=None,
+                    account_id=None,
+                    operation="initialize",
+                    error=error,
+                )
+            except Exception:
+                pass
+            self.conn.commit()
+            return
+        self.conn.execute("RELEASE position_shadow_init")
+        self.conn.commit()
+        logger.info(
+            "[POSITION-SHADOW][US] initialized inserted=%s existing=%s skipped=%s",
+            result["inserted"],
+            result["existing"],
+            result["skipped"],
+        )
+
+    def _mirror_position_open(
+        self,
+        *,
+        legacy_holding_id: int,
+        account_key: str,
+        account_name: str,
+        ticker: str,
+        entry_price: float,
+        opened_at: str,
+    ) -> bool:
+        if not self._position_ledger_enabled():
+            return True
+        return mirror_write_fail_open(
+            self.cursor,
+            logger=logger,
+            market="US",
+            legacy_holding_id=legacy_holding_id,
+            account_id=account_key,
+            operation="open",
+            write=lambda store: store.open_legacy_position(
+                market="US",
+                legacy_holding_id=legacy_holding_id,
+                account_id=account_key,
+                account_name=account_name,
+                symbol=ticker,
+                entry_price=entry_price,
+                opened_at=opened_at,
+            ),
+        )
+
+    def _mirror_position_closed(
+        self,
+        *,
+        legacy_holding_id: int,
+        account_key: str,
+        exit_price: float,
+        realized_pnl_pct: float,
+        exit_kind: str | None,
+        closed_at: str,
+    ) -> bool:
+        if not self._position_ledger_enabled():
+            return True
+        return mirror_write_fail_open(
+            self.cursor,
+            logger=logger,
+            market="US",
+            legacy_holding_id=legacy_holding_id,
+            account_id=account_key,
+            operation="close",
+            write=lambda store: store.close_legacy_position(
+                market="US",
+                legacy_holding_id=legacy_holding_id,
+                account_id=account_key,
+                exit_price=exit_price,
+                realized_pnl_pct=realized_pnl_pct,
+                exit_kind=exit_kind,
+                closed_at=closed_at,
+            ),
+        )
 
     def _get_trading_accounts(self) -> List[Dict[str, Any]]:
         default_mode = str(ka.getEnv().get("default_mode", "demo")).strip().lower()
@@ -1196,6 +1322,15 @@ class USStockTrackingAgent:
                     trigger_mode,
                     scenario.get('sector', 'Unknown')
                 )
+            )
+            legacy_holding_id = self.cursor.lastrowid
+            self._mirror_position_open(
+                legacy_holding_id=legacy_holding_id,
+                account_key=account_key,
+                account_name=account_name,
+                ticker=ticker,
+                entry_price=current_price,
+                opened_at=now,
             )
             self.conn.commit()
 
@@ -2248,15 +2383,20 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
             row_id = stock_data.get('id')
             if row_id is not None:
                 self.cursor.execute(
-                    "SELECT 1 FROM us_stock_holdings "
+                    "SELECT id FROM us_stock_holdings "
                     "WHERE id = ? AND ticker = ? AND account_key = ? LIMIT 1",
                     (row_id, ticker, account_key),
                 )
-                position_exists = self.cursor.fetchone() is not None
+                matched = self.cursor.fetchone()
+                legacy_holding_ids = [matched[0]] if matched is not None else []
             else:
-                position_exists = get_us_existing_position_for_ticker(
-                    self.cursor, ticker, account_key=account_key
-                ).get("row_count", 0) > 0
+                self.cursor.execute(
+                    "SELECT id FROM us_stock_holdings "
+                    "WHERE ticker = ? AND account_key = ? ORDER BY id",
+                    (ticker, account_key),
+                )
+                legacy_holding_ids = [row[0] for row in self.cursor.fetchall()]
+            position_exists = bool(legacy_holding_ids)
             if not position_exists:
                 logger.warning(
                     f"[SELL-GUARD][US] {ticker} ({company_name}) already closed by "
@@ -2322,6 +2462,16 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     )
                 except Exception as e:
                     logger.debug(f"{ticker} Cleanup adjustment log skipped: {e}")
+
+            for legacy_holding_id in legacy_holding_ids:
+                self._mirror_position_closed(
+                    legacy_holding_id=legacy_holding_id,
+                    account_key=account_key,
+                    exit_price=current_price,
+                    realized_pnl_pct=profit_rate,
+                    exit_kind=_exit_kind,
+                    closed_at=now,
+                )
             self.conn.commit()
 
             # Build sell message (same format as KR template)

--- a/prism_core/positions.py
+++ b/prism_core/positions.py
@@ -309,23 +309,36 @@ class PositionStore:
         )
 
     def _legacy_rows(self, market: str) -> list[dict[str, Any]]:
-        table = _LEGACY_TABLES[market]
-        columns = {
-            row[1] for row in self._execute(f"PRAGMA table_info({table})").fetchall()
-        }
-        if not columns:
+        if market == "KR":
+            table = "stock_holdings"
+            table_info = self._execute("PRAGMA table_info(stock_holdings)").fetchall()
+            cursor = self._execute("SELECT * FROM stock_holdings") if table_info else None
+        else:
+            table = "us_stock_holdings"
+            table_info = self._execute("PRAGMA table_info(us_stock_holdings)").fetchall()
+            cursor = self._execute("SELECT * FROM us_stock_holdings") if table_info else None
+        if cursor is None:
             raise RuntimeError(f"legacy table does not exist: {table}")
-        selected = []
-        for name, alias in (
+
+        column_indexes = {
+            description[0]: index
+            for index, description in enumerate(cursor.description or ())
+        }
+        aliases = (
             ("id", "legacy_holding_id"),
             ("account_key", "account_id"),
             ("account_name", "account_name"),
             ("ticker", "symbol"),
             ("buy_price", "entry_price"),
             ("buy_date", "opened_at"),
-        ):
-            selected.append(f"{name} AS {alias}" if name in columns else f"NULL AS {alias}")
-        return self._fetchall(f"SELECT {', '.join(selected)} FROM {table}")
+        )
+        return [
+            {
+                alias: row[column_indexes[name]] if name in column_indexes else None
+                for name, alias in aliases
+            }
+            for row in cursor.fetchall()
+        ]
 
     @staticmethod
     def _valid_legacy_row(row: dict[str, Any]) -> bool:
@@ -558,13 +571,12 @@ def mirror_write_fail_open(
     """
 
     store = PositionStore(connection_or_cursor)
-    savepoint = "position_shadow_write"
-    connection_or_cursor.execute(f"SAVEPOINT {savepoint}")
+    connection_or_cursor.execute("SAVEPOINT position_shadow_write")
     try:
         write(store)
     except Exception as error:
-        connection_or_cursor.execute(f"ROLLBACK TO {savepoint}")
-        connection_or_cursor.execute(f"RELEASE {savepoint}")
+        connection_or_cursor.execute("ROLLBACK TO position_shadow_write")
+        connection_or_cursor.execute("RELEASE position_shadow_write")
         logger.critical(
             "[POSITION-SHADOW][%s] %s failed for legacy_id=%s (%s)",
             _market(market),
@@ -588,5 +600,5 @@ def mirror_write_fail_open(
                 type(audit_error).__name__,
             )
         return False
-    connection_or_cursor.execute(f"RELEASE {savepoint}")
+    connection_or_cursor.execute("RELEASE position_shadow_write")
     return True

--- a/prism_core/positions.py
+++ b/prism_core/positions.py
@@ -1,0 +1,592 @@
+"""Additive shadow position ledger for issue #412 Phase 4-a.
+
+Every operation uses a caller-supplied SQLite connection or cursor.  This module
+never commits: the legacy write and its shadow write therefore remain under the
+caller's transaction boundary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+
+_POSITION_STATUSES = (
+    "PENDING_ENTRY",
+    "OPEN",
+    "ENTRY_FAILED",
+    "PENDING_EXIT",
+    "CLOSED",
+    "EXIT_UNKNOWN",
+)
+
+_ALLOWED_TRANSITIONS = {
+    "PENDING_ENTRY": frozenset({"OPEN", "ENTRY_FAILED"}),
+    "OPEN": frozenset({"PENDING_EXIT", "CLOSED"}),
+    "ENTRY_FAILED": frozenset(),
+    "PENDING_EXIT": frozenset({"OPEN", "CLOSED", "EXIT_UNKNOWN"}),
+    "CLOSED": frozenset(),
+    "EXIT_UNKNOWN": frozenset({"OPEN", "CLOSED"}),
+}
+
+_POSITIONS_SCHEMA = f"""
+CREATE TABLE IF NOT EXISTS positions (
+    id TEXT PRIMARY KEY,
+    market TEXT NOT NULL CHECK (market IN ('KR', 'US')),
+    legacy_holding_id TEXT NOT NULL,
+    account_id TEXT NOT NULL,
+    account_name TEXT,
+    symbol TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN {repr(_POSITION_STATUSES)}),
+    execution_mode TEXT NOT NULL,
+    opened_at TEXT,
+    closed_at TEXT,
+    entry_intent_id TEXT,
+    exit_intent_id TEXT,
+    entry_price REAL,
+    exit_price REAL,
+    realized_pnl_pct REAL,
+    exit_kind TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE (market, legacy_holding_id)
+)
+"""
+
+_MIRROR_ERRORS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS position_mirror_errors (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    market TEXT NOT NULL CHECK (market IN ('KR', 'US')),
+    legacy_holding_id TEXT,
+    account_ref TEXT,
+    operation TEXT NOT NULL,
+    error_type TEXT NOT NULL,
+    error_message TEXT NOT NULL,
+    resolved INTEGER NOT NULL DEFAULT 0 CHECK (resolved IN (0, 1)),
+    created_at TEXT NOT NULL,
+    resolved_at TEXT
+)
+"""
+
+_LEGACY_TABLES = {"KR": "stock_holdings", "US": "us_stock_holdings"}
+
+
+class InvalidPositionTransition(ValueError):
+    """Raised when a position lifecycle transition is not allowed."""
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _market(value: str) -> str:
+    market = str(value).upper()
+    if market not in _LEGACY_TABLES:
+        raise ValueError(f"unsupported market: {market}")
+    return market
+
+
+def account_fingerprint(account_id: Any) -> str:
+    """Return a stable, non-reversible account reference for safe output."""
+
+    value = str(account_id or "")
+    if not value:
+        raise ValueError("account_id is required")
+    return "sha256:" + hashlib.sha256(value.encode()).hexdigest()[:16]
+
+
+def legacy_position_id(market: str, legacy_holding_id: Any) -> str:
+    """Return the deterministic id for one legacy holding row."""
+
+    normalized_market = _market(market)
+    if legacy_holding_id is None or str(legacy_holding_id) == "":
+        raise ValueError("legacy_holding_id is required")
+    return f"legacy:{normalized_market}:{legacy_holding_id}"
+
+
+def _entry_fingerprint(entry_price: Any, opened_at: Any) -> str:
+    value = f"{entry_price}|{opened_at}"
+    return "sha256:" + hashlib.sha256(value.encode()).hexdigest()[:16]
+
+
+def _redact_error_text(value: str) -> str:
+    value = re.sub(r"(?i)bearer\s+[^\s,;]+", "Bearer [REDACTED]", value)
+    return re.sub(
+        r"(?i)(api[_-]?key|app[_-]?key|app[_-]?secret|token|password)"
+        r"(\s*[:=]\s*)[^\s,;]+",
+        r"\1\2[REDACTED]",
+        value,
+    )
+
+
+class PositionStore:
+    """Transaction-neutral operations for the shadow position ledger.
+
+    ``connection_or_cursor`` is owned by the caller.  None of these methods call
+    ``commit`` or ``rollback``, including schema creation and backfill.
+    """
+
+    def __init__(
+        self, connection_or_cursor: sqlite3.Connection | sqlite3.Cursor
+    ) -> None:
+        if not isinstance(connection_or_cursor, (sqlite3.Connection, sqlite3.Cursor)):
+            raise TypeError("PositionStore requires a sqlite3 Connection or Cursor")
+        self._db = connection_or_cursor
+
+    def _execute(self, sql: str, parameters: tuple[Any, ...] = ()) -> sqlite3.Cursor:
+        return self._db.execute(sql, parameters)
+
+    def _fetchall(
+        self, sql: str, parameters: tuple[Any, ...] = ()
+    ) -> list[dict[str, Any]]:
+        cursor = self._execute(sql, parameters)
+        columns = [item[0] for item in cursor.description or ()]
+        return [dict(zip(columns, row)) for row in cursor.fetchall()]
+
+    def ensure_schema(self) -> None:
+        """Create additive ledger tables without committing the transaction."""
+
+        self._execute(_POSITIONS_SCHEMA)
+        self._execute(_MIRROR_ERRORS_SCHEMA)
+        self._execute(
+            "CREATE INDEX IF NOT EXISTS idx_positions_state "
+            "ON positions(market, execution_mode, status)"
+        )
+        self._execute(
+            "CREATE INDEX IF NOT EXISTS idx_position_mirror_errors_open "
+            "ON position_mirror_errors(market, resolved, created_at)"
+        )
+
+    def open_legacy_position(
+        self,
+        *,
+        market: str,
+        legacy_holding_id: Any,
+        account_id: Any,
+        account_name: str | None,
+        symbol: Any,
+        entry_price: Any = None,
+        opened_at: str | None = None,
+    ) -> bool:
+        """Insert one OPEN legacy mirror, returning false when it already exists."""
+
+        market = _market(market)
+        position_id = legacy_position_id(market, legacy_holding_id)
+        account_id = str(account_id or "")
+        if not account_id:
+            raise ValueError("account_id is required")
+        symbol = str(symbol or "").upper()
+        if not symbol:
+            raise ValueError("symbol is required")
+        now = _utc_now()
+        changed = self._execute(
+            """
+            INSERT INTO positions (
+                id, market, legacy_holding_id, account_id, account_name, symbol,
+                status, execution_mode, opened_at, entry_price, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, 'OPEN', 'legacy', ?, ?, ?, ?)
+            ON CONFLICT(market, legacy_holding_id) DO NOTHING
+            """,
+            (
+                position_id,
+                market,
+                str(legacy_holding_id),
+                account_id,
+                account_name,
+                symbol,
+                opened_at,
+                entry_price,
+                now,
+                now,
+            ),
+        ).rowcount
+        return changed == 1
+
+    def transition(
+        self,
+        *,
+        market: str,
+        legacy_holding_id: Any,
+        account_id: Any,
+        to_status: str,
+        entry_intent_id: str | None = None,
+        exit_intent_id: str | None = None,
+        exit_price: Any = None,
+        realized_pnl_pct: Any = None,
+        exit_kind: str | None = None,
+        closed_at: str | None = None,
+    ) -> bool:
+        """Apply one validated transition matched by market, legacy id, and account."""
+
+        market = _market(market)
+        to_status = str(to_status).upper()
+        if to_status not in _POSITION_STATUSES:
+            raise InvalidPositionTransition(f"unknown position status: {to_status}")
+        legacy_holding_id = str(legacy_holding_id)
+        account_id = str(account_id or "")
+        if not account_id:
+            raise ValueError("account_id is required")
+        position_id = legacy_position_id(market, legacy_holding_id)
+        row = self._execute(
+            "SELECT status FROM positions WHERE id=? AND market=? "
+            "AND legacy_holding_id=? AND account_id=?",
+            (position_id, market, legacy_holding_id, account_id),
+        ).fetchone()
+        if row is None:
+            raise LookupError(
+                f"position not found for {market}/{legacy_holding_id}/account"
+            )
+        current_status = str(row[0])
+        if to_status not in _ALLOWED_TRANSITIONS[current_status]:
+            raise InvalidPositionTransition(
+                f"transition {current_status} -> {to_status} is not allowed"
+            )
+
+        now = _utc_now()
+        if to_status == "CLOSED" and closed_at is None:
+            closed_at = now
+        changed = self._execute(
+            """
+            UPDATE positions
+            SET status=?, entry_intent_id=COALESCE(?, entry_intent_id),
+                exit_intent_id=COALESCE(?, exit_intent_id),
+                exit_price=COALESCE(?, exit_price),
+                realized_pnl_pct=COALESCE(?, realized_pnl_pct),
+                exit_kind=COALESCE(?, exit_kind),
+                closed_at=CASE WHEN ?='CLOSED' THEN ? ELSE closed_at END,
+                updated_at=?
+            WHERE id=? AND market=? AND legacy_holding_id=? AND account_id=?
+              AND status=?
+            """,
+            (
+                to_status,
+                entry_intent_id,
+                exit_intent_id,
+                exit_price,
+                realized_pnl_pct,
+                exit_kind,
+                to_status,
+                closed_at,
+                now,
+                position_id,
+                market,
+                legacy_holding_id,
+                account_id,
+                current_status,
+            ),
+        ).rowcount
+        if changed != 1:
+            raise RuntimeError(f"position {position_id} changed concurrently")
+        return True
+
+    def close_legacy_position(
+        self,
+        *,
+        market: str,
+        legacy_holding_id: Any,
+        account_id: Any,
+        exit_intent_id: str | None = None,
+        exit_price: Any = None,
+        realized_pnl_pct: Any = None,
+        exit_kind: str | None = None,
+        closed_at: str | None = None,
+    ) -> bool:
+        """Close exactly one legacy mirror without committing."""
+
+        return self.transition(
+            market=market,
+            legacy_holding_id=legacy_holding_id,
+            account_id=account_id,
+            to_status="CLOSED",
+            exit_intent_id=exit_intent_id,
+            exit_price=exit_price,
+            realized_pnl_pct=realized_pnl_pct,
+            exit_kind=exit_kind,
+            closed_at=closed_at,
+        )
+
+    def _legacy_rows(self, market: str) -> list[dict[str, Any]]:
+        table = _LEGACY_TABLES[market]
+        columns = {
+            row[1] for row in self._execute(f"PRAGMA table_info({table})").fetchall()
+        }
+        if not columns:
+            raise RuntimeError(f"legacy table does not exist: {table}")
+        selected = []
+        for name, alias in (
+            ("id", "legacy_holding_id"),
+            ("account_key", "account_id"),
+            ("account_name", "account_name"),
+            ("ticker", "symbol"),
+            ("buy_price", "entry_price"),
+            ("buy_date", "opened_at"),
+        ):
+            selected.append(f"{name} AS {alias}" if name in columns else f"NULL AS {alias}")
+        return self._fetchall(f"SELECT {', '.join(selected)} FROM {table}")
+
+    @staticmethod
+    def _valid_legacy_row(row: dict[str, Any]) -> bool:
+        return (
+            row["legacy_holding_id"] is not None
+            and bool(str(row["account_id"] or ""))
+            and bool(str(row["symbol"] or ""))
+        )
+
+    def backfill_legacy_positions(self, market: str) -> dict[str, Any]:
+        """Idempotently mirror current legacy holdings; never commit or overwrite."""
+
+        market = _market(market)
+        inserted = existing = skipped = 0
+        for row in self._legacy_rows(market):
+            if not self._valid_legacy_row(row):
+                skipped += 1
+                continue
+            created = self.open_legacy_position(
+                market=market,
+                legacy_holding_id=row["legacy_holding_id"],
+                account_id=row["account_id"],
+                account_name=row["account_name"],
+                symbol=row["symbol"],
+                entry_price=row["entry_price"],
+                opened_at=row["opened_at"],
+            )
+            if created:
+                inserted += 1
+            else:
+                existing += 1
+        return {
+            "market": market,
+            "inserted": inserted,
+            "existing": existing,
+            "skipped": skipped,
+        }
+
+    def record_mirror_error(
+        self,
+        *,
+        market: str,
+        legacy_holding_id: Any,
+        account_id: Any,
+        operation: str,
+        error: BaseException,
+    ) -> int:
+        """Persist a sanitized mirror failure without committing."""
+
+        market = _market(market)
+        raw_account = str(account_id or "")
+        account_ref = account_fingerprint(raw_account) if raw_account else None
+        message = _redact_error_text(str(error))
+        if raw_account:
+            message = message.replace(raw_account, "[REDACTED]")
+        cursor = self._execute(
+            """
+            INSERT INTO position_mirror_errors (
+                market, legacy_holding_id, account_ref, operation,
+                error_type, error_message, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                market,
+                None if legacy_holding_id is None else str(legacy_holding_id),
+                account_ref,
+                str(operation),
+                type(error).__name__,
+                message,
+                _utc_now(),
+            ),
+        )
+        return int(cursor.lastrowid)
+
+    def resolve_mirror_error(self, error_id: int) -> bool:
+        """Mark one audit error resolved without committing."""
+
+        changed = self._execute(
+            "UPDATE position_mirror_errors SET resolved=1, resolved_at=? "
+            "WHERE id=? AND resolved=0",
+            (_utc_now(), error_id),
+        ).rowcount
+        return changed == 1
+
+    @staticmethod
+    def _identity(
+        legacy_holding_id: Any, account_ref: str, symbol: Any
+    ) -> dict[str, str]:
+        return {
+            "legacy_holding_id": str(legacy_holding_id),
+            "account_ref": account_ref,
+            "symbol": str(symbol).upper(),
+        }
+
+    def compare_legacy_positions(self, market: str) -> dict[str, Any]:
+        """Read-only comparison of legacy holdings and OPEN legacy positions."""
+
+        market = _market(market)
+        legacy: dict[tuple[str, str, str], dict[str, str]] = {}
+        legacy_entry_fingerprints: dict[tuple[str, str, str], str] = {}
+        invalid_legacy_rows: list[dict[str, str | None]] = []
+        for row in self._legacy_rows(market):
+            if not self._valid_legacy_row(row):
+                invalid_legacy_rows.append(
+                    {
+                        "legacy_holding_id": (
+                            None
+                            if row["legacy_holding_id"] is None
+                            else str(row["legacy_holding_id"])
+                        )
+                    }
+                )
+                continue
+            identity = self._identity(
+                row["legacy_holding_id"],
+                account_fingerprint(row["account_id"]),
+                row["symbol"],
+            )
+            key = tuple(identity.values())
+            legacy[key] = identity
+            legacy_entry_fingerprints[key] = _entry_fingerprint(
+                row["entry_price"], row["opened_at"]
+            )
+
+        position_rows = self._fetchall(
+            "SELECT legacy_holding_id, account_id, symbol, status, "
+            "entry_price, opened_at "
+            "FROM positions WHERE market=? AND execution_mode='legacy'",
+            (market,),
+        )
+        positions: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+        position_entry_fingerprints: dict[tuple[str, str, str], list[str]] = {}
+        for row in position_rows:
+            identity = self._identity(
+                row["legacy_holding_id"],
+                account_fingerprint(row["account_id"]),
+                row["symbol"],
+            )
+            key = tuple(identity.values())
+            positions.setdefault(key, []).append({**identity, "status": row["status"]})
+            position_entry_fingerprints.setdefault(key, []).append(
+                _entry_fingerprint(row["entry_price"], row["opened_at"])
+            )
+
+        missing_positions = [
+            identity for key, identity in legacy.items() if key not in positions
+        ]
+        extra_open_positions = [
+            row
+            for key, rows in positions.items()
+            if key not in legacy
+            for row in rows
+            if row["status"] == "OPEN"
+        ]
+        non_open_positions = [
+            row
+            for key, rows in positions.items()
+            if key in legacy
+            for row in rows
+            if row["status"] != "OPEN"
+        ]
+        duplicate_positions = [
+            {"identity": dict(zip(("legacy_holding_id", "account_ref", "symbol"), key)),
+             "count": len(rows)}
+            for key, rows in positions.items()
+            if len(rows) > 1
+        ]
+        entry_mismatches = [
+            {
+                **legacy[key],
+                "legacy_entry_fingerprint": legacy_entry_fingerprints[key],
+                "position_entry_fingerprints": position_entry_fingerprints[key],
+            }
+            for key, rows in positions.items()
+            if key in legacy
+            and any(row["status"] == "OPEN" for row in rows)
+            and legacy_entry_fingerprints[key]
+            not in position_entry_fingerprints[key]
+        ]
+        unresolved_mirror_errors = self._fetchall(
+            "SELECT id, legacy_holding_id, account_ref, operation, error_type, "
+            "error_message, created_at FROM position_mirror_errors "
+            "WHERE market=? AND resolved=0 ORDER BY id",
+            (market,),
+        )
+        mismatches = (
+            missing_positions,
+            extra_open_positions,
+            non_open_positions,
+            duplicate_positions,
+            entry_mismatches,
+            invalid_legacy_rows,
+            unresolved_mirror_errors,
+        )
+        return {
+            "market": market,
+            "matches": not any(mismatches),
+            "counts": {
+                "legacy": len(legacy),
+                "positions": len(position_rows),
+                "open_positions": sum(
+                    row["status"] == "OPEN" for row in position_rows
+                ),
+            },
+            "missing_positions": missing_positions,
+            "extra_open_positions": extra_open_positions,
+            "non_open_positions": non_open_positions,
+            "duplicate_positions": duplicate_positions,
+            "entry_mismatches": entry_mismatches,
+            "invalid_legacy_rows": invalid_legacy_rows,
+            "unresolved_mirror_errors": unresolved_mirror_errors,
+        }
+
+
+def mirror_write_fail_open(
+    connection_or_cursor: sqlite3.Connection | sqlite3.Cursor,
+    *,
+    logger: Any,
+    market: str,
+    legacy_holding_id: Any,
+    account_id: Any,
+    operation: str,
+    write: Callable[[PositionStore], Any],
+) -> bool:
+    """Run one mirror write behind a savepoint and audit any failure.
+
+    The caller owns the outer transaction. A failed shadow write is rolled back
+    to the savepoint, then a sanitized unresolved audit row is inserted in that
+    same transaction so the legacy path can continue and commit normally.
+    """
+
+    store = PositionStore(connection_or_cursor)
+    savepoint = "position_shadow_write"
+    connection_or_cursor.execute(f"SAVEPOINT {savepoint}")
+    try:
+        write(store)
+    except Exception as error:
+        connection_or_cursor.execute(f"ROLLBACK TO {savepoint}")
+        connection_or_cursor.execute(f"RELEASE {savepoint}")
+        logger.critical(
+            "[POSITION-SHADOW][%s] %s failed for legacy_id=%s (%s)",
+            _market(market),
+            operation,
+            legacy_holding_id,
+            type(error).__name__,
+        )
+        try:
+            store.record_mirror_error(
+                market=market,
+                legacy_holding_id=legacy_holding_id,
+                account_id=account_id,
+                operation=operation,
+                error=error,
+            )
+        except Exception as audit_error:
+            logger.critical(
+                "[POSITION-SHADOW][%s] audit write failed for legacy_id=%s (%s)",
+                _market(market),
+                legacy_holding_id,
+                type(audit_error).__name__,
+            )
+        return False
+    connection_or_cursor.execute(f"RELEASE {savepoint}")
+    return True

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -50,6 +50,7 @@ from cores.agents.trading_agents import create_trading_scenario_agent
 from cores.utils import parse_llm_json
 from prism_core.execution_service import ExecutionService
 from prism_core.order_intents import OrderIntent
+from prism_core.positions import PositionStore, mirror_write_fail_open
 
 # O'Neil 룰베이스 매도 (2026-06-04 US quota 사고 동일 룰 결함 KR에도 적용).
 # 방어적 import: 실패 시 _ONEIL_FALLBACK_AVAILABLE=False 로 기존 레거시 룰 유지.
@@ -127,6 +128,9 @@ class StockTrackingAgent:
         self.cursor = None
         self.account_configs: list[dict[str, Any]] = []
         self.active_account: dict[str, Any] | None = None
+        self.position_ledger_shadow_enabled = os.environ.get(
+            "POSITION_LEDGER_SHADOW_ENABLED", "true"
+        ).strip().lower() not in {"0", "false", "no", "off"}
 
         # Set trading journal feature flag
         # Priority: parameter > environment variable > default (False)
@@ -175,6 +179,7 @@ class StockTrackingAgent:
 
         # Create database tables
         await self._create_tables()
+        self._initialize_position_ledger()
 
         # Initialize helper managers (delegates to tracking/ package)
         self.journal_manager = JournalManager(
@@ -200,6 +205,127 @@ class StockTrackingAgent:
         add_trigger_columns_if_missing(self.cursor, self.conn)  # v1.16.5 migration
         add_sector_column_if_missing(self.cursor, self.conn)  # v1.17 migration for AI agent sector queries
         create_indexes(self.cursor, self.conn)
+
+    def _position_ledger_enabled(self) -> bool:
+        return getattr(
+            self,
+            "position_ledger_shadow_enabled",
+            os.environ.get("POSITION_LEDGER_SHADOW_ENABLED", "true")
+            .strip()
+            .lower()
+            not in {"0", "false", "no", "off"},
+        )
+
+    def _initialize_position_ledger(self) -> None:
+        """Create/backfill the additive KR shadow ledger without blocking startup."""
+        if not self._position_ledger_enabled():
+            logger.warning("[POSITION-SHADOW][KR] disabled by kill switch")
+            return
+
+        self.conn.commit()
+        store = PositionStore(self.cursor)
+        try:
+            store.ensure_schema()
+            self.conn.commit()
+        except Exception as error:
+            self.conn.rollback()
+            logger.critical(
+                "[POSITION-SHADOW][KR] schema initialization failed (%s)",
+                type(error).__name__,
+            )
+            return
+
+        self.conn.execute("BEGIN")
+        self.conn.execute("SAVEPOINT position_shadow_init")
+        try:
+            result = store.backfill_legacy_positions("KR")
+        except Exception as error:
+            self.conn.execute("ROLLBACK TO position_shadow_init")
+            self.conn.execute("RELEASE position_shadow_init")
+            logger.critical(
+                "[POSITION-SHADOW][KR] initialization failed (%s)",
+                type(error).__name__,
+            )
+            try:
+                store.record_mirror_error(
+                    market="KR",
+                    legacy_holding_id=None,
+                    account_id=None,
+                    operation="initialize",
+                    error=error,
+                )
+            except Exception:
+                pass
+            self.conn.commit()
+            return
+        self.conn.execute("RELEASE position_shadow_init")
+        self.conn.commit()
+        logger.info(
+            "[POSITION-SHADOW][KR] initialized inserted=%s existing=%s skipped=%s",
+            result["inserted"],
+            result["existing"],
+            result["skipped"],
+        )
+
+    def _mirror_position_open(
+        self,
+        *,
+        legacy_holding_id: int,
+        account_key: str,
+        account_name: str,
+        ticker: str,
+        entry_price: float,
+        opened_at: str,
+    ) -> bool:
+        if not self._position_ledger_enabled():
+            return True
+        return mirror_write_fail_open(
+            self.cursor,
+            logger=logger,
+            market="KR",
+            legacy_holding_id=legacy_holding_id,
+            account_id=account_key,
+            operation="open",
+            write=lambda store: store.open_legacy_position(
+                market="KR",
+                legacy_holding_id=legacy_holding_id,
+                account_id=account_key,
+                account_name=account_name,
+                symbol=ticker,
+                entry_price=entry_price,
+                opened_at=opened_at,
+            ),
+        )
+
+    def _mirror_position_closed(
+        self,
+        *,
+        legacy_holding_id: int,
+        account_key: str,
+        exit_price: float,
+        realized_pnl_pct: float,
+        exit_kind: str | None,
+        closed_at: str,
+    ) -> bool:
+        if not self._position_ledger_enabled():
+            return True
+        return mirror_write_fail_open(
+            self.cursor,
+            logger=logger,
+            market="KR",
+            legacy_holding_id=legacy_holding_id,
+            account_id=account_key,
+            operation="close",
+            write=lambda store: store.close_legacy_position(
+                market="KR",
+                legacy_holding_id=legacy_holding_id,
+                account_id=account_key,
+                exit_price=exit_price,
+                realized_pnl_pct=realized_pnl_pct,
+                exit_kind=exit_kind,
+                closed_at=closed_at,
+            ),
+        )
 
     def _get_trading_accounts(self) -> List[Dict[str, Any]]:
         default_mode = str(ka.getEnv().get("default_mode", "demo")).strip().lower()
@@ -1039,6 +1165,15 @@ class StockTrackingAgent:
                     scenario.get('sector', '알 수 없음'),
                 )
             )
+            legacy_holding_id = self.cursor.lastrowid
+            self._mirror_position_open(
+                legacy_holding_id=legacy_holding_id,
+                account_key=account_key,
+                account_name=account_name,
+                ticker=ticker,
+                entry_price=current_price,
+                opened_at=now,
+            )
             self.conn.commit()
 
             # Add purchase message — pyramiding adds (#288) get a distinct header
@@ -1373,15 +1508,20 @@ class StockTrackingAgent:
             row_id = stock_data.get('id')
             if row_id is not None:
                 self.cursor.execute(
-                    "SELECT 1 FROM stock_holdings "
+                    "SELECT id FROM stock_holdings "
                     "WHERE id = ? AND ticker = ? AND account_key = ? LIMIT 1",
                     (row_id, ticker, account_key),
                 )
-                position_exists = self.cursor.fetchone() is not None
+                matched = self.cursor.fetchone()
+                legacy_holding_ids = [matched[0]] if matched is not None else []
             else:
-                position_exists = get_existing_position_for_ticker(
-                    self.cursor, ticker, account_key=account_key
-                ).get("row_count", 0) > 0
+                self.cursor.execute(
+                    "SELECT id FROM stock_holdings "
+                    "WHERE ticker = ? AND account_key = ? ORDER BY id",
+                    (ticker, account_key),
+                )
+                legacy_holding_ids = [row[0] for row in self.cursor.fetchall()]
+            position_exists = bool(legacy_holding_ids)
             if not position_exists:
                 logger.warning(
                     f"[SELL-GUARD][KR] {ticker}({company_name}) already closed by "
@@ -1450,6 +1590,16 @@ class StockTrackingAgent:
                 self.cursor.execute(
                     "DELETE FROM stock_holdings WHERE ticker = ? AND account_key = ?",
                     (ticker, account_key)
+                )
+
+            for legacy_holding_id in legacy_holding_ids:
+                self._mirror_position_closed(
+                    legacy_holding_id=legacy_holding_id,
+                    account_key=account_key,
+                    exit_price=current_price,
+                    realized_pnl_pct=profit_rate,
+                    exit_kind=_exit_kind,
+                    closed_at=now,
                 )
 
             # Save changes

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -254,8 +254,11 @@ class StockTrackingAgent:
                     operation="initialize",
                     error=error,
                 )
-            except Exception:
-                pass
+            except Exception as audit_error:
+                logger.critical(
+                    "[POSITION-SHADOW][KR] initialization audit failed (%s)",
+                    type(audit_error).__name__,
+                )
             self.conn.commit()
             return
         self.conn.execute("RELEASE position_shadow_init")

--- a/tasks/issue-412/09-phase4a-execution-plan.md
+++ b/tasks/issue-412/09-phase4a-execution-plan.md
@@ -1,0 +1,117 @@
+# Issue #412 Phase 4-a 실행 계획 — Position shadow ledger
+
+> 기준: main `8ff33b17` (Phase 3 OrderIntent 배포 완료)
+> 목표: 기존 `stock_holdings`/`us_stock_holdings` 판단 원장을 바꾸지 않고,
+> 신규 `positions` 원장을 병행 기록·대조할 수 있는 안전한 첫 단계
+
+## 1. 왜 Phase 4를 나누는가
+
+현재 batch와 loop는 legacy simulator 원장을 broker보다 먼저 변경한다.
+
+- 매수: legacy holding INSERT/COMMIT 후 OrderIntent 생성과 broker 호출
+- 매도: history INSERT + legacy holding DELETE/COMMIT 후 OrderIntent 생성과 broker 호출
+- hardstop/trend도 같은 `sell_stock()`을 호출한 뒤 broker 주문을 낸다.
+
+이 상태에서 곧바로 `PENDING_ENTRY -> OPEN -> PENDING_EXIT -> CLOSED`를 운영
+source of truth로 바꾸면 batch, loop, pyramiding, US full-exit, publish 시점을 한 번에
+변경하게 된다. Phase 4-a는 먼저 legacy와 신규 원장이 항상 같은 포지션 집합을
+표현하는지 shadow로 증명한다. Phase 4-b에서만 intent 생성 순서를 앞으로 옮기고
+PENDING 상태와 읽기 전환을 다룬다.
+
+## 2. Phase 4-a 범위
+
+### 2.1 신규 `positions` 테이블과 `PositionStore`
+
+- 한 테이블에서 KR/US를 `market`으로 구분한다.
+- 한 legacy holding row를 한 position row로 취급한다. pyramiding은 같은 symbol의
+  서로 다른 `legacy_holding_id`를 가진 독립 position 여러 개다.
+- 안정 키는 `UNIQUE(market, legacy_holding_id)`이고 position id는
+  `legacy:{market}:{legacy_holding_id}` 형태의 결정적 값이다.
+- close/transition은 key만 보지 않고 `account_id` 일치까지 검증한다.
+- 필수 필드:
+  - identity: `id`, `market`, `legacy_holding_id`, `account_id`, `account_name`, `symbol`
+  - lifecycle: `status`, `execution_mode`, `opened_at`, `closed_at`
+  - linkage: `entry_intent_id`, `exit_intent_id` (4-a에서는 nullable)
+  - immutable snapshot: `entry_price`, `exit_price`, `realized_pnl_pct`, `exit_kind`
+  - audit: `created_at`, `updated_at`
+- 허용 상태는 전체 목표 상태를 미리 고정한다:
+  `PENDING_ENTRY`, `OPEN`, `ENTRY_FAILED`, `PENDING_EXIT`, `CLOSED`, `EXIT_UNKNOWN`.
+- 4-a production mirror는 legacy 동작을 그대로 반영하므로 `OPEN`/`CLOSED`만 쓴다.
+  `execution_mode='legacy'`로 기록해 shadow/demo/live 의미를 거짓으로 추정하지 않는다.
+
+### 2.2 idempotent backfill
+
+- KR/US agent DB 초기화 시 해당 legacy holdings를 `OPEN`으로 `INSERT OR IGNORE`한다.
+- 기존 position을 덮어쓰거나 삭제하지 않는다.
+- 현재 legacy schema에 row id/account key가 없는 비정상 행은 건너뛰고 mismatch로 노출한다.
+- 운영 실사 기준 현재 KR 3행/US 6행 모두 id/account key가 있고 pyramiding 행은 0이다.
+
+### 2.3 legacy와 같은 transaction의 dual-write
+
+- buy: legacy INSERT의 `lastrowid`로 position `OPEN`을 삽입한 뒤 기존 COMMIT.
+- sell: 기존 `BEGIN IMMEDIATE` transaction 안에서 history INSERT, legacy DELETE,
+  position `CLOSED` 전이를 함께 수행한 뒤 기존 COMMIT.
+- US full-exit은 `sell_stock()`이 sibling row별로 호출되므로 각 legacy id를 각각 닫는다.
+- 성공 경로는 같은 transaction이다. mirror 쓰기는 `SAVEPOINT`로 감싸고, 내부 오류 시
+  mirror 부분만 rollback한 뒤 legacy 동작과 broker 호출을 막지 않는 fail-open shadow 정책을
+  사용한다. 실패는 구조화 ERROR 로그와 additive `position_mirror_errors`에 raw account 없이
+  durable 기록한다. 대조기는 unresolved error를 즉시 불일치로 판정한다.
+- 판단 쿼리, 주문 수량, broker 호출, Telegram/Redis/GCP publish 순서는 변경하지 않는다.
+
+### 2.4 read-only 대조기
+
+- `tools/compare_position_ledger.py --db-path ...`는 market/account/symbol/legacy id/entry fingerprint 기준으로
+  legacy의 현재 holding 집합과 `positions(status='OPEN', execution_mode='legacy')`를 비교한다.
+- 일치 시 exit 0, 불일치/중복/잘못된 CLOSED 상태 시 non-zero와 구조화 JSON을 출력한다.
+- 구조화 출력에는 raw `account_id`를 노출하지 않고 hash 또는 마스킹된 식별자만 포함한다.
+- 자동 수정은 금지한다. 운영 cron 등록은 코드 리뷰·배포 gate 통과 후 별도 수행한다.
+
+## 3. 명시적 비목표
+
+- 판단 루프의 `positions` 읽기 전환
+- production에서 PENDING 상태 사용 또는 legacy 쓰기 순서 변경
+- broker 접수와 체결(FILLED)의 동일시
+- 주문 실패 시 legacy 원장 자동 보상
+- BrokerAdapter, amend/cancel, execution 조회, reconciliation 자동화
+- hardstop/trend owner lock 통합
+- 기존 holdings/history 삭제 또는 schema 변경
+
+위 항목은 최소 5번의 실제 주문 경로 실행일 동안 shadow ledger 무불일치가 확인된 뒤
+Phase 4-b 또는 Phase 5에서 수행한다.
+
+## 4. 테스트 우선 순서
+
+1. schema가 additive이며 기존 테이블/row를 보존한다.
+2. 허용 전이는 성공하고 비허용 전이는 거부된다.
+3. KR/US backfill은 OPEN을 만들고 재실행해도 중복되지 않는다.
+4. 같은 symbol의 pyramiding row 여러 개가 독립 position으로 보존된다.
+5. KR/US buy dual-write가 legacy row와 OPEN position을 같은 commit에 남긴다.
+6. KR/US sell dual-write가 정확한 legacy id 하나만 CLOSED로 만들며 남은 pyramid row는 OPEN이다.
+7. US full-exit sibling 전부가 각각 CLOSED가 된다.
+8. 기존 2-connection 동시 SELL 테스트에서 history/legacy delete/position close/publish가 모두 1회다.
+9. mirror 실패 주입 시 기존 legacy 결과와 broker 호출 순서가 바뀌지 않고 대조기가 mismatch를 반환한다.
+10. mirror 실패는 savepoint rollback 후 raw account 없는 durable error를 남기며 관찰 연속일 카운터를 리셋한다.
+11. 대조기 일치/누락/extra/중복/unresolved-error 케이스와 exit code를 검증한다.
+
+## 5. 배포·관찰 gate
+
+1. 로컬 focused tests + 기존 KR/US process/concurrency/loop 회귀 전체 통과.
+2. DB 서버 detached worktree에서 실제 Python 3.11 compile/import, 운영 DB 복제 없는
+   read-only schema 사전점검, 임시 DB backfill/compare 통과.
+3. main 병합 후 주문 프로세스 0인 안전창에 additive schema 적용.
+4. 최초 backfill 직후 legacy OPEN 집합과 positions OPEN 집합이 완전 일치해야 한다.
+   비교 단위는 legacy에 없는 broker quantity가 아니라
+   `(market, account, legacy_id, ticker, active row_count, entry fingerprint)`다.
+5. 매일 batch + hardstop/trend 실행 후 대조 결과 저장. batch-rest로 주문 경로가 실행되지 않은
+   날은 관찰 일수에 포함하지 않는다.
+6. mismatch 또는 unresolved mirror error가 한 건이라도 생기면 연속 무불일치 카운터를 0으로 리셋한다.
+7. 최소 5 실행일 무불일치 전에는 Phase 4-b 읽기 전환을 시작하지 않는다.
+8. 롤백: `POSITION_LEDGER_SHADOW_ENABLED=false`; 신규 테이블은 보존해 사후 분석에 사용한다.
+
+## 6. 완료 조건
+
+- 신규 원장은 운영 판단/주문 결과에 영향을 주지 않는다.
+- 기존 holdings/history row와 schema가 변하지 않는다.
+- KR/US 단일·pyramiding·US full-exit·동시 SELL에서 shadow position 집합이 일치한다.
+- 대조기가 불일치를 자동 수정하지 않고 non-zero로 탐지한다.
+- 5 실행일 관찰 계획과 Phase 4-b 진입 gate가 handoff에 기록된다.

--- a/tasks/issue-412/README.md
+++ b/tasks/issue-412/README.md
@@ -2,8 +2,8 @@
 
 > 이슈: [#412 매수/매도 Agent 분리와 KIS 실제 주문 실행 구조 이식 설계](https://github.com/dragon1086/prism-insight/issues/412)
 > 브랜치: `feature/issue-412-execution-architecture`
-> 상태: Phase 2 착수 (2026-07-06 시작, 2026-07-13 main #432 기준 전면 재검토,
-> **2026-07-18 Phase 1-a/1-b main 배포 완료 후 Phase 2 실행 브랜치 시작**)
+> 상태: Phase 4-a 착수 (2026-07-06 시작, 2026-07-13 main #432 기준 전면 재검토,
+> **2026-07-19 Phase 3 main 배포 완료 후 position shadow ledger 시작**)
 
 ## 목적
 
@@ -36,9 +36,10 @@ greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 
 - [x] Phase 0.5: main #432 기준 재검토 — 앵커/전제 갱신, 주문 경로 9곳 재인벤토리 (2026-07-13)
 - [x] Phase 1-a: 파싱/정규화 순수 함수 추출 (PR #447, main `36e6e5ec`)
 - [x] Phase 1-b: KST 주문시간대 순수 함수 추출 (PR #455, main `c4c2539d`)
-- [ ] Phase 2: ExecutionService chokepoint 도입 (동작 불변, 9곳 커버 + 기존 가드 CI 고정) — 진행 중
-- [ ] Phase 3: OrderIntent 영속화 + 쓰기 순서 교정
-- [ ] Phase 4: 포지션 상태기계 전환 (delete → 상태 전이)
+- [x] Phase 2: ExecutionService chokepoint 도입 (PR #456, main `1aca6029`)
+- [x] Phase 3: OrderIntent 영속화 (PR #459, main `8ff33b17`)
+- [ ] Phase 4-a: position OPEN/CLOSED shadow 병행 기록 + 대조 — 진행 중
+- [ ] Phase 4-b: PENDING 전이 + 5 실행일 무불일치 후 읽기 전환
 - [ ] Phase 5: BrokerAdapter 추출 (체결/미체결/정정 포함) + lock 일반화 + reconciliation (alert-only)
 - [ ] Phase 6: 이벤트 버스 / 코어-어댑터 패키지 분리 / prism-us 흡수
 
@@ -52,3 +53,4 @@ greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 
   빈 portfolio 응답)는 자동화 테스트로 고정한다.
 
 Phase 2의 구체적인 작업 순서와 비목표는 [07-phase2-execution-plan.md](07-phase2-execution-plan.md)를 따른다.
+Phase 4-a의 안전한 shadow 범위와 관찰 gate는 [09-phase4a-execution-plan.md](09-phase4a-execution-plan.md)를 따른다.

--- a/tests/test_layer2_stale_snapshot_guard.py
+++ b/tests/test_layer2_stale_snapshot_guard.py
@@ -221,10 +221,15 @@ def test_sell_stock_chokepoint_guard():
         check(0 <= claim_idx < guard_idx, f"{label}: writer lock precedes guard read")
         check("if not position_exists:" in claim and "return False" in claim,
               f"{label}: missing position aborts via return False")
-        check(f"SELECT 1 FROM {holdings_tbl}" in claim and "WHERE id = ?" in claim,
-              f"{label}: row_id path claims the exact pyramid row")
-        check('row_count", 0) > 0' in claim,
-              f"{label}: legacy no-id path remains ticker/account scoped")
+        check(
+            f"SELECT id FROM {holdings_tbl}" in claim
+            and "WHERE id = ? AND ticker = ? AND account_key = ?" in claim,
+            f"{label}: row_id path claims the exact pyramid row",
+        )
+        check(
+            "WHERE ticker = ? AND account_key = ? ORDER BY id" in claim,
+            f"{label}: legacy no-id path remains ticker/account scoped",
+        )
 
 
 def _run():

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -1,0 +1,460 @@
+import json
+import sqlite3
+
+import pytest
+
+from prism_core.positions import (
+    InvalidPositionTransition,
+    PositionStore,
+    account_fingerprint,
+    legacy_position_id,
+    mirror_write_fail_open,
+)
+from tools.compare_position_ledger import main as compare_main
+
+
+def _legacy_schema(conn: sqlite3.Connection) -> None:
+    for table in ("stock_holdings", "us_stock_holdings"):
+        conn.execute(
+            f"""
+            CREATE TABLE {table} (
+                id INTEGER PRIMARY KEY,
+                account_key TEXT,
+                account_name TEXT,
+                ticker TEXT,
+                buy_price REAL,
+                buy_date TEXT
+            )
+            """
+        )
+
+
+def _insert_legacy(
+    conn: sqlite3.Connection,
+    table: str,
+    row_id: int,
+    account_id: str | None,
+    symbol: str,
+    price: float = 100.0,
+) -> None:
+    conn.execute(
+        f"INSERT INTO {table} VALUES (?, ?, ?, ?, ?, ?)",
+        (row_id, account_id, "primary", symbol, price, "2026-07-18T09:00:00"),
+    )
+
+
+def test_schema_is_additive_and_caller_controls_transaction() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE stock_holdings (id INTEGER PRIMARY KEY, ticker TEXT)")
+    conn.execute("INSERT INTO stock_holdings VALUES (1, '005930')")
+    conn.commit()
+    before = conn.execute("PRAGMA table_info(stock_holdings)").fetchall()
+
+    conn.execute("BEGIN")
+    PositionStore(conn).ensure_schema()
+    conn.rollback()
+
+    assert conn.execute("PRAGMA table_info(stock_holdings)").fetchall() == before
+    assert conn.execute("SELECT * FROM stock_holdings").fetchall() == [(1, "005930")]
+    assert (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='positions'"
+        ).fetchone()
+        is None
+    )
+
+    PositionStore(conn).ensure_schema()
+    tables = {
+        row[0]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    assert {"positions", "position_mirror_errors"} <= tables
+
+
+def test_transition_graph_and_database_check_are_enforced() -> None:
+    conn = sqlite3.connect(":memory:")
+    store = PositionStore(conn)
+    store.ensure_schema()
+    assert store.open_legacy_position(
+        market="KR",
+        legacy_holding_id=7,
+        account_id="vps:kr-primary:01",
+        account_name="primary",
+        symbol="005930",
+        entry_price=71000,
+        opened_at="2026-07-18T09:00:00",
+    )
+
+    assert store.transition(
+        market="KR",
+        legacy_holding_id=7,
+        account_id="vps:kr-primary:01",
+        to_status="CLOSED",
+        exit_price=73000,
+        realized_pnl_pct=2.81,
+        exit_kind="target",
+    )
+    row = conn.execute(
+        "SELECT status, exit_price, exit_kind, closed_at FROM positions"
+    ).fetchone()
+    assert row[:3] == ("CLOSED", 73000.0, "target")
+    assert row[3]
+
+    with pytest.raises(InvalidPositionTransition):
+        store.transition(
+            market="KR",
+            legacy_holding_id=7,
+            account_id="vps:kr-primary:01",
+            to_status="OPEN",
+        )
+    with pytest.raises(LookupError):
+        store.transition(
+            market="KR",
+            legacy_holding_id=7,
+            account_id="wrong-account",
+            to_status="OPEN",
+        )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """
+            INSERT INTO positions (
+                id, market, legacy_holding_id, account_id, symbol, status,
+                execution_mode, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "bad",
+                "KR",
+                "99",
+                account_fingerprint("account"),
+                "005930",
+                "BROKEN",
+                "legacy",
+                "2026-07-18",
+                "2026-07-18",
+            ),
+        )
+
+
+def test_kr_and_us_backfill_is_idempotent_and_skips_invalid_rows() -> None:
+    conn = sqlite3.connect(":memory:")
+    _legacy_schema(conn)
+    _insert_legacy(conn, "stock_holdings", 1, "kr-secret-account", "005930")
+    _insert_legacy(conn, "stock_holdings", 2, None, "000660")
+    _insert_legacy(conn, "us_stock_holdings", 11, "us-secret-account", "AAPL", 190)
+    store = PositionStore(conn)
+    store.ensure_schema()
+
+    kr = store.backfill_legacy_positions("KR")
+    us = store.backfill_legacy_positions("US")
+    again = store.backfill_legacy_positions("KR")
+
+    assert kr == {"market": "KR", "inserted": 1, "existing": 0, "skipped": 1}
+    assert us == {"market": "US", "inserted": 1, "existing": 0, "skipped": 0}
+    assert again == {"market": "KR", "inserted": 0, "existing": 1, "skipped": 1}
+    assert conn.execute("SELECT COUNT(*) FROM positions").fetchone()[0] == 2
+    rows = conn.execute(
+        "SELECT id, market, account_id, symbol, status, execution_mode "
+        "FROM positions ORDER BY market"
+    ).fetchall()
+    assert rows == [
+        (
+            legacy_position_id("KR", 1),
+            "KR",
+            "kr-secret-account",
+            "005930",
+            "OPEN",
+            "legacy",
+        ),
+        (
+            legacy_position_id("US", 11),
+            "US",
+            "us-secret-account",
+            "AAPL",
+            "OPEN",
+            "legacy",
+        ),
+    ]
+    assert store.compare_legacy_positions("US")["matches"]
+
+    mismatch = store.compare_legacy_positions("KR")
+    payload = json.dumps(mismatch, sort_keys=True)
+    assert not mismatch["matches"]
+    assert mismatch["invalid_legacy_rows"] == [{"legacy_holding_id": "2"}]
+    assert "kr-secret-account" not in payload
+    assert "us-secret-account" not in payload
+
+
+def test_cursor_backfill_does_not_commit_callers_transaction() -> None:
+    conn = sqlite3.connect(":memory:")
+    _legacy_schema(conn)
+    store = PositionStore(conn.cursor())
+    store.ensure_schema()
+    conn.commit()
+
+    conn.execute("BEGIN")
+    _insert_legacy(conn, "stock_holdings", 1, "acct", "005930")
+    assert store.backfill_legacy_positions("KR")["inserted"] == 1
+    conn.rollback()
+
+    assert conn.execute("SELECT COUNT(*) FROM stock_holdings").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM positions").fetchone()[0] == 0
+
+
+def test_pyramiding_rows_remain_independent() -> None:
+    conn = sqlite3.connect(":memory:")
+    _legacy_schema(conn)
+    _insert_legacy(conn, "stock_holdings", 1, "acct", "005930", 70000)
+    _insert_legacy(conn, "stock_holdings", 2, "acct", "005930", 72000)
+    store = PositionStore(conn)
+    store.ensure_schema()
+    assert store.backfill_legacy_positions("KR")["inserted"] == 2
+
+    assert store.close_legacy_position(
+        market="KR",
+        legacy_holding_id=1,
+        account_id="acct",
+        exit_price=74000,
+        realized_pnl_pct=5.71,
+        exit_kind="target",
+    )
+    rows = conn.execute(
+        "SELECT legacy_holding_id, status FROM positions ORDER BY legacy_holding_id"
+    ).fetchall()
+    assert rows == [("1", "CLOSED"), ("2", "OPEN")]
+
+
+def test_us_full_exit_can_close_multiple_rows_with_one_intent() -> None:
+    conn = sqlite3.connect(":memory:")
+    _legacy_schema(conn)
+    for row_id, price in ((1, 180.0), (2, 175.0), (3, 170.0)):
+        _insert_legacy(conn, "us_stock_holdings", row_id, "acct", "AAPL", price)
+    store = PositionStore(conn)
+    store.ensure_schema()
+    assert store.backfill_legacy_positions("US")["inserted"] == 3
+
+    for row_id in (1, 2, 3):
+        assert store.close_legacy_position(
+            market="US",
+            legacy_holding_id=row_id,
+            account_id="acct",
+            exit_intent_id="intent-full-exit",
+            exit_price=190.0,
+            exit_kind="stop",
+        )
+
+    rows = conn.execute(
+        "SELECT status, exit_intent_id FROM positions ORDER BY legacy_holding_id"
+    ).fetchall()
+    assert rows == [("CLOSED", "intent-full-exit")] * 3
+
+
+def test_compare_is_read_only_and_reports_structured_mismatches_and_audit_errors() -> None:
+    conn = sqlite3.connect(":memory:")
+    _legacy_schema(conn)
+    _insert_legacy(conn, "stock_holdings", 1, "secret-account", "005930")
+    _insert_legacy(conn, "stock_holdings", 2, "secret-account", "000660")
+    store = PositionStore(conn)
+    store.ensure_schema()
+    store.open_legacy_position(
+        market="KR",
+        legacy_holding_id=1,
+        account_id="secret-account",
+        account_name="primary",
+        symbol="005930",
+        entry_price=100,
+        opened_at="2026-07-18",
+    )
+    store.open_legacy_position(
+        market="KR",
+        legacy_holding_id=3,
+        account_id="secret-account",
+        account_name="primary",
+        symbol="035420",
+        entry_price=100,
+        opened_at="2026-07-18",
+    )
+    store.open_legacy_position(
+        market="KR",
+        legacy_holding_id=2,
+        account_id="secret-account",
+        account_name="primary",
+        symbol="000660",
+        entry_price=100,
+        opened_at="2026-07-18",
+    )
+    store.close_legacy_position(
+        market="KR", legacy_holding_id=2, account_id="secret-account"
+    )
+    error_id = store.record_mirror_error(
+        market="KR",
+        legacy_holding_id=1,
+        account_id="secret-account",
+        operation="close",
+        error=RuntimeError("failed account=secret-account"),
+    )
+    before = conn.total_changes
+
+    result = store.compare_legacy_positions("KR")
+
+    assert conn.total_changes == before
+    assert not result["matches"]
+    assert result["missing_positions"] == []
+    assert result["extra_open_positions"][0]["legacy_holding_id"] == "3"
+    assert result["non_open_positions"][0] == {
+        "legacy_holding_id": "2",
+        "account_ref": account_fingerprint("secret-account"),
+        "symbol": "000660",
+        "status": "CLOSED",
+    }
+    assert result["unresolved_mirror_errors"][0]["id"] == error_id
+    assert "secret-account" not in json.dumps(result, sort_keys=True)
+    stored_error = conn.execute(
+        "SELECT account_ref, error_message FROM position_mirror_errors WHERE id=?",
+        (error_id,),
+    ).fetchone()
+    assert stored_error == (
+        account_fingerprint("secret-account"),
+        "failed account=[REDACTED]",
+    )
+
+    assert store.resolve_mirror_error(error_id)
+    assert not store.resolve_mirror_error(error_id)
+
+
+def test_compare_detects_entry_fingerprint_drift_without_exposing_account() -> None:
+    conn = sqlite3.connect(":memory:")
+    _legacy_schema(conn)
+    _insert_legacy(conn, "stock_holdings", 1, "secret-account", "005930", 70000)
+    store = PositionStore(conn)
+    store.ensure_schema()
+    assert store.backfill_legacy_positions("KR")["inserted"] == 1
+    conn.execute(
+        "UPDATE positions SET entry_price=71000 WHERE market='KR' "
+        "AND legacy_holding_id='1'"
+    )
+
+    result = store.compare_legacy_positions("KR")
+
+    assert not result["matches"]
+    assert len(result["entry_mismatches"]) == 1
+    payload = json.dumps(result, sort_keys=True)
+    assert "secret-account" not in payload
+
+
+def test_mirror_error_redacts_credentials() -> None:
+    conn = sqlite3.connect(":memory:")
+    store = PositionStore(conn)
+    store.ensure_schema()
+    store.record_mirror_error(
+        market="US",
+        legacy_holding_id=1,
+        account_id="secret-account",
+        operation="open",
+        error=RuntimeError(
+            "Bearer bearer-secret api_key=key-secret token:token-secret "
+            "password=pass-secret account=secret-account"
+        ),
+    )
+
+    message = conn.execute(
+        "SELECT error_message FROM position_mirror_errors"
+    ).fetchone()[0]
+    assert "bearer-secret" not in message
+    assert "key-secret" not in message
+    assert "token-secret" not in message
+    assert "pass-secret" not in message
+    assert "secret-account" not in message
+
+
+def test_mirror_savepoint_rolls_back_partial_write_and_keeps_audit() -> None:
+    conn = sqlite3.connect(":memory:")
+    _legacy_schema(conn)
+    store = PositionStore(conn)
+    store.ensure_schema()
+    _insert_legacy(conn, "stock_holdings", 1, "secret-account", "005930")
+
+    class Logger:
+        def critical(self, *_args, **_kwargs):
+            pass
+
+    def broken_write(position_store: PositionStore) -> None:
+        position_store.open_legacy_position(
+            market="KR",
+            legacy_holding_id=1,
+            account_id="secret-account",
+            account_name="primary",
+            symbol="005930",
+            entry_price=70000,
+            opened_at="2026-07-18",
+        )
+        raise RuntimeError("token=top-secret account=secret-account")
+
+    assert not mirror_write_fail_open(
+        conn.cursor(),
+        logger=Logger(),
+        market="KR",
+        legacy_holding_id=1,
+        account_id="secret-account",
+        operation="open",
+        write=broken_write,
+    )
+    conn.commit()
+
+    assert conn.execute("SELECT COUNT(*) FROM stock_holdings").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM positions").fetchone()[0] == 0
+    error = conn.execute(
+        "SELECT account_ref, error_message, resolved FROM position_mirror_errors"
+    ).fetchone()
+    assert error[0] == account_fingerprint("secret-account")
+    assert "secret-account" not in error[1]
+    assert "top-secret" not in error[1]
+    assert error[2] == 0
+
+
+def test_compare_cli_is_read_only_and_never_prints_raw_account(
+    tmp_path, capsys
+) -> None:
+    db_path = tmp_path / "ledger.sqlite"
+    conn = sqlite3.connect(db_path)
+    _legacy_schema(conn)
+    _insert_legacy(conn, "stock_holdings", 1, "secret-account", "005930")
+    _insert_legacy(conn, "us_stock_holdings", 2, "us-secret-account", "AAPL")
+    store = PositionStore(conn)
+    store.ensure_schema()
+    store.backfill_legacy_positions("KR")
+    store.backfill_legacy_positions("US")
+    conn.commit()
+    before = conn.total_changes
+    conn.close()
+
+    assert compare_main(["--db-path", str(db_path)]) == 0
+    output = capsys.readouterr().out
+    assert '"status": "ok"' in output
+    assert "secret-account" not in output
+    assert "us-secret-account" not in output
+
+    verify = sqlite3.connect(db_path)
+    assert verify.total_changes == 0
+    verify.close()
+    assert before > 0
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "DELETE FROM positions WHERE market='KR' AND legacy_holding_id='1'"
+    )
+    conn.commit()
+    conn.close()
+
+    assert compare_main(["--db-path", str(db_path), "--market", "kr"]) == 1
+    assert '"status": "mismatch"' in capsys.readouterr().out
+
+
+def test_compare_cli_returns_setup_error_without_leaking_details(tmp_path, capsys) -> None:
+    missing = tmp_path / "missing.sqlite"
+
+    assert compare_main(["--db-path", str(missing)]) == 2
+    output = capsys.readouterr().out
+    assert '"status": "error"' in output
+    assert str(missing) not in output

--- a/tests/test_sell_claim_concurrency.py
+++ b/tests/test_sell_claim_concurrency.py
@@ -167,6 +167,10 @@ def test_real_sell_stock_claim_is_atomic(tmp_path, market, journal_mode, pyramid
         agent._msg_types = []
         agent._account_scope = lambda: ("ACC1", "primary")
         agent._get_trigger_win_rate = lambda _trigger: ""
+        # This dependency-light fixture compiles only sell_stock's AST. The real
+        # agents provide this helper; shadow-ledger behavior is covered by the
+        # full caller tests in the KR/US process-report suites.
+        agent._mirror_position_closed = lambda **_kwargs: True
         agent.enable_journal = False
         agent.journal_manager = None
 

--- a/tests/test_stock_tracking_agent_process_reports.py
+++ b/tests/test_stock_tracking_agent_process_reports.py
@@ -201,6 +201,83 @@ async def test_kr_buy_dual_writes_open_position():
     )
 
 
+@pytest.mark.asyncio
+async def test_kr_mirror_failures_keep_buy_and_sell_legacy_commits(monkeypatch):
+    """Shadow failures must be observable without blocking the legacy ledger."""
+    from prism_core.positions import PositionStore
+
+    agent = StockTrackingAgent.__new__(StockTrackingAgent)
+    agent.conn = sqlite3.connect(":memory:")
+    agent.conn.row_factory = sqlite3.Row
+    agent.cursor = agent.conn.cursor()
+    agent.cursor.execute(TABLE_STOCK_HOLDINGS)
+    agent.cursor.execute(TABLE_TRADING_HISTORY)
+    PositionStore(agent.cursor).ensure_schema()
+    agent.conn.commit()
+    agent.position_ledger_shadow_enabled = True
+    agent.max_slots = 10
+    agent.message_queue = []
+    agent._msg_types = []
+    agent._account_scope = lambda: ("ACC1", "primary")
+    agent._get_trigger_win_rate = lambda _trigger: ""
+
+    async def no_holding(_ticker):
+        return False
+
+    async def no_slots():
+        return 0
+
+    async def no_journal(**_kwargs):
+        return True
+
+    agent._is_ticker_in_holdings = no_holding
+    agent._get_current_slots_count = no_slots
+    agent._create_journal_entry = no_journal
+
+    original_open = PositionStore.open_legacy_position
+
+    def fail_open(*_args, **_kwargs):
+        raise RuntimeError("open mirror injected failure token=top-secret")
+
+    monkeypatch.setattr(PositionStore, "open_legacy_position", fail_open)
+    assert await agent.buy_stock(
+        "005930", "Samsung", 70000, {"sector": "Technology"}
+    )
+    holding = dict(agent.conn.execute("SELECT * FROM stock_holdings").fetchone())
+    assert agent.conn.execute("SELECT COUNT(*) FROM stock_holdings").fetchone()[0] == 1
+    assert agent.conn.execute("SELECT COUNT(*) FROM positions").fetchone()[0] == 0
+    open_comparison = PositionStore(agent.conn).compare_legacy_positions("KR")
+    assert not open_comparison["matches"]
+    assert len(open_comparison["missing_positions"]) == 1
+    assert [row["operation"] for row in open_comparison["unresolved_mirror_errors"]] == [
+        "open"
+    ]
+
+    monkeypatch.setattr(PositionStore, "open_legacy_position", original_open)
+    assert PositionStore(agent.conn).backfill_legacy_positions("KR")["inserted"] == 1
+    agent.conn.commit()
+
+    def fail_close(*_args, **_kwargs):
+        raise RuntimeError("close mirror injected failure password=hunter2")
+
+    monkeypatch.setattr(PositionStore, "close_legacy_position", fail_close)
+    holding["current_price"] = 71000
+    assert await agent.sell_stock(holding, "fail-open regression")
+
+    assert agent.conn.execute("SELECT COUNT(*) FROM stock_holdings").fetchone()[0] == 0
+    assert agent.conn.execute("SELECT COUNT(*) FROM trading_history").fetchone()[0] == 1
+    assert agent.conn.execute("SELECT status FROM positions").fetchone()[0] == "OPEN"
+    comparison = PositionStore(agent.conn).compare_legacy_positions("KR")
+    assert not comparison["matches"]
+    assert len(comparison["extra_open_positions"]) == 1
+    assert [row["operation"] for row in comparison["unresolved_mirror_errors"]] == [
+        "open",
+        "close",
+    ]
+    assert "top-secret" not in str(comparison)
+    assert "hunter2" not in str(comparison)
+
+
 def test_kr_position_kill_switch_skips_shadow_write():
     agent = StockTrackingAgent.__new__(StockTrackingAgent)
     agent.conn = sqlite3.connect(":memory:")

--- a/tests/test_stock_tracking_agent_process_reports.py
+++ b/tests/test_stock_tracking_agent_process_reports.py
@@ -48,6 +48,7 @@ class _FakeAsyncTradingContext:
 @pytest.mark.parametrize("pyramiding", [False, True], ids=["single", "pyramiding"])
 def test_concurrent_sell_guard_allows_one_kr_order_and_publish(tmp_path, pyramiding):
     from prism_core.execution_service import ExecutionService
+    from prism_core.positions import PositionStore
 
     db_path = tmp_path / "kr-concurrent-sell.sqlite"
     setup = sqlite3.connect(db_path)
@@ -67,6 +68,11 @@ def test_concurrent_sell_guard_allows_one_kr_order_and_publish(tmp_path, pyramid
                VALUES ('ACC1', 'primary', '005930', 'Samsung', 68000,
                        '2026-06-15 09:00:00')"""
         )
+    position_store = PositionStore(setup)
+    position_store.ensure_schema()
+    assert position_store.backfill_legacy_positions("KR")["inserted"] == (
+        2 if pyramiding else 1
+    )
     setup.commit()
     setup.close()
 
@@ -132,13 +138,89 @@ def test_concurrent_sell_guard_allows_one_kr_order_and_publish(tmp_path, pyramid
     remaining_prices = verify.execute(
         "SELECT buy_price FROM stock_holdings ORDER BY id"
     ).fetchall()
+    position_states = verify.execute(
+        "SELECT legacy_holding_id, status FROM positions ORDER BY legacy_holding_id"
+    ).fetchall()
     verify.close()
 
     assert sorted(sold for sold, _messages in results) == [False, True]
     assert sum(messages for _sold, messages in results) == 1
     assert history_count == 1
     assert remaining_prices == ([(68000.0,)] if pyramiding else [])
+    assert position_states == (
+        [(str(target_row_id), "CLOSED"), (str(target_row_id + 1), "OPEN")]
+        if pyramiding
+        else [(str(target_row_id), "CLOSED")]
+    )
     assert effects == {"broker": 1, "publish": 1, "journal": 1}
+
+
+@pytest.mark.asyncio
+async def test_kr_buy_dual_writes_open_position():
+    from prism_core.positions import PositionStore
+
+    agent = StockTrackingAgent.__new__(StockTrackingAgent)
+    agent.conn = sqlite3.connect(":memory:")
+    agent.cursor = agent.conn.cursor()
+    agent.cursor.execute(TABLE_STOCK_HOLDINGS)
+    PositionStore(agent.cursor).ensure_schema()
+    agent.conn.commit()
+    agent.position_ledger_shadow_enabled = True
+    agent.max_slots = 10
+    agent.message_queue = []
+    agent._msg_types = []
+    agent._account_scope = lambda: ("ACC1", "primary")
+    agent._get_trigger_win_rate = lambda _trigger: ""
+
+    async def no_holding(_ticker):
+        return False
+
+    async def no_slots():
+        return 0
+
+    agent._is_ticker_in_holdings = no_holding
+    agent._get_current_slots_count = no_slots
+
+    assert await agent.buy_stock(
+        "005930", "Samsung", 70000, {"sector": "Technology"}
+    )
+    legacy = agent.conn.execute(
+        "SELECT id, account_key, ticker, buy_price, buy_date FROM stock_holdings"
+    ).fetchone()
+    mirror = agent.conn.execute(
+        "SELECT legacy_holding_id, account_id, symbol, entry_price, opened_at, status "
+        "FROM positions"
+    ).fetchone()
+    assert mirror == (
+        str(legacy[0]),
+        legacy[1],
+        legacy[2],
+        legacy[3],
+        legacy[4],
+        "OPEN",
+    )
+
+
+def test_kr_position_kill_switch_skips_shadow_write():
+    agent = StockTrackingAgent.__new__(StockTrackingAgent)
+    agent.conn = sqlite3.connect(":memory:")
+    agent.cursor = agent.conn.cursor()
+    agent.position_ledger_shadow_enabled = False
+
+    assert agent._mirror_position_open(
+        legacy_holding_id=1,
+        account_key="ACC1",
+        account_name="primary",
+        ticker="005930",
+        entry_price=70000,
+        opened_at="2026-07-18",
+    )
+    assert (
+        agent.conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='positions'"
+        ).fetchone()
+        is None
+    )
 
 
 def _install_signal_modules(monkeypatch, redis_calls, gcp_calls):

--- a/tools/compare_position_ledger.py
+++ b/tools/compare_position_ledger.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Read-only legacy holdings versus Phase 4-a positions comparison."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+from typing import Sequence
+
+from prism_core.positions import PositionStore
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db-path", default="stock_tracking_db.sqlite")
+    parser.add_argument(
+        "--market",
+        choices=("kr", "us", "both"),
+        default="both",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    markets = ("KR", "US") if args.market == "both" else (args.market.upper(),)
+    try:
+        uri = Path(args.db_path).resolve().as_uri() + "?mode=ro"
+        connection = sqlite3.connect(uri, uri=True)
+        try:
+            store = PositionStore(connection)
+            results = [store.compare_legacy_positions(market) for market in markets]
+        finally:
+            connection.close()
+    except Exception as error:
+        print(
+            json.dumps(
+                {"status": "error", "error_type": type(error).__name__},
+                sort_keys=True,
+            )
+        )
+        return 2
+
+    matches = all(result["matches"] for result in results)
+    print(
+        json.dumps(
+            {"status": "ok" if matches else "mismatch", "results": results},
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+    return 0 if matches else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 요약
- legacy holdings를 읽기 기준으로 유지한 채 additive `positions` shadow ledger 추가
- KR/US OPEN/CLOSED dual-write, idempotent backfill, read-only comparator CLI 추가
- savepoint fail-open + durable audit + kill switch로 기존 거래 흐름 보호
- 다계정/피라미딩/US full-exit 및 실제 caller mirror 장애 회귀 테스트 추가

## 안전성
- Phase 4-a는 관찰 전용이며 legacy read path와 실제 주문 의미를 변경하지 않음
- `POSITION_LEDGER_SHADOW_ENABLED=false` 즉시 비활성화 가능
- mirror 실패 시 legacy transaction은 계속되고 unresolved audit/comparator mismatch로 노출

## 검증
- DB 서버 분리 worktree 핵심 관련군: 55 passed
- Position tests: 12 passed
- 신규 core/CLI 및 변경 테스트 Ruff green, compile/diff-check green
- hardstop/trend 확장군의 기존 실패 2건은 origin/main에서도 동일 재현되어 본 PR 회귀 아님
- 독립 최종 리뷰: APPROVE (CRITICAL/HIGH/MEDIUM 0)

Part of #412. Phase 4-b의 PENDING 상태/read switch와 Phase 5 broker fill reconciliation은 후속 PR로 분리합니다.