### PR TITLE
fix(trading): make position comparator directly executable

### DIFF
--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -1,5 +1,8 @@
 import json
 import sqlite3
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 
@@ -439,6 +442,24 @@ def test_compare_cli_is_read_only_and_never_prints_raw_account(
     assert verify.total_changes == 0
     verify.close()
     assert before > 0
+
+    command = [
+        sys.executable,
+        str(Path(__file__).parents[1] / "tools" / "compare_position_ledger.py"),
+        "--db-path",
+        str(db_path),
+    ]
+    direct = subprocess.run(
+        command,
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert direct.returncode == 0, direct.stderr
+    assert '"status": "ok"' in direct.stdout
+    assert "secret-account" not in direct.stdout
+    assert "us-secret-account" not in direct.stdout
 
     conn = sqlite3.connect(db_path)
     conn.execute(

--- a/tools/compare_position_ledger.py
+++ b/tools/compare_position_ledger.py
@@ -6,8 +6,13 @@ from __future__ import annotations
 import argparse
 import json
 import sqlite3
+import sys
 from pathlib import Path
 from typing import Sequence
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 from prism_core.positions import PositionStore
 


### PR DESCRIPTION
## 문제
운영 표준인 `python tools/compare_position_ledger.py ...` 직접 실행 시 script directory만 `sys.path`에 잡혀 `prism_core` import가 실패했습니다.

## 수정
- CLI가 자신의 경로에서 project root를 결정해 import path를 명시
- 임의의 다른 cwd에서 subprocess 직접 실행하는 회귀 테스트 추가

## 검증
- `tests/test_positions.py`: 12 passed
- compile/diff-check green

Follow-up to #460 / #412 Phase 4-a.