### PR TITLE
refactor(trading): link persisted intents to positions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,9 @@ jobs:
           # shadow one another.
           python -m pytest tests/test_execution_service.py -q \
             -k "not transient_empty_portfolio"
-          python -m pytest --noconftest tests/test_order_intents.py -q
+          python -m pytest --noconftest \
+            tests/test_order_intents.py \
+            tests/test_positions.py -q
           python -m pytest --noconftest \
             tests/test_report_agent_contract.py \
             tests/test_report_generation_backend.py \

--- a/prism-us/tests/test_trend_exit_seller_us.py
+++ b/prism-us/tests/test_trend_exit_seller_us.py
@@ -58,11 +58,15 @@ class FakeAgent:
         self.calls = calls
         self.conn = None
 
-    async def sell_stock(self, stock_data, sell_reason):
+    async def sell_stock(self, stock_data, sell_reason, **kwargs):
         self.calls.append(f"sim:{stock_data.get('ticker')}")
         return True
 
-    async def send_telegram_message(self, chat_id, language="en"):
+    def _link_position_exit_intent(self, **kwargs):
+        self.calls.append(f"link:{kwargs.get('legacy_holding_id')}")
+        return True
+
+    async def send_telegram_message(self, chat_id, language="en", **kwargs):
         self.calls.append("tg")
         return True
 
@@ -101,7 +105,16 @@ def _row(id_, ticker, buy_price, stop_loss=0.0, target_price=0.0, highest_price=
 
 def _patch(monkeypatch, trader, agent_holder=None, make_agent_counter=None,
            ma50=0.0, regime="moderate_bull"):
-    monkeypatch.setattr(lb, "_open_context", lambda market, account_name=None: FakeCtx(trader))
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore
+
+    monkeypatch.setattr(
+        lb,
+        "_open_context",
+        lambda market, account_name=None: ExecutionService(
+            FakeCtx(trader), intent_store=IntentStore(lb.DB_PATH)
+        ),
+    )
     monkeypatch.setattr(lb, "_fetch_ma50", lambda market, ticker: ma50)
     monkeypatch.setattr(lb, "_compute_live_regime", lambda market: regime)
 
@@ -250,7 +263,7 @@ def test_us_live_sim_kis_telegram_order(tmp_db, monkeypatch):
     # per-sell flush + run-end flush each invoke send_telegram_message; the run-end
     # portfolio summary is de-duplicated (portfolio_broadcast) so only ONE actual
     # portfolio message goes out in prod (see tests/test_portfolio_broadcast.py).
-    assert calls == ["sim:AAPL", "kis:AAPL:5", "tg", "tg"]
+    assert calls == ["sim:AAPL", "kis:AAPL:5", "link:1", "tg", "tg"]
     assert _inflight(tmp_db, "FILLED") == 1
 
 

--- a/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
+++ b/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
@@ -118,6 +118,8 @@ def _load_us_agent_module():
 us_agent_module = _load_us_agent_module()
 USStockTrackingAgent = us_agent_module.USStockTrackingAgent
 
+from prism_core.positions import LegacyPositionWriteResult
+
 
 class _FakeAsyncUSTradingContext:
     def __init__(self, account_name=None, **kwargs):
@@ -468,8 +470,8 @@ async def test_us_full_exit_closes_all_siblings_before_one_order_and_publish(
     monkeypatch.setitem(sys.modules, "messaging.gcp_pubsub_signal_publisher", gcp_module)
 
     agent = USStockTrackingAgent.__new__(USStockTrackingAgent)
-    agent.db_path = str(tmp_path / "order-intents.sqlite")
-    agent.conn = sqlite3.connect(":memory:")
+    agent.db_path = str(tmp_path / "full-exit.sqlite")
+    agent.conn = sqlite3.connect(agent.db_path)
     agent.conn.row_factory = sqlite3.Row
     agent.cursor = agent.conn.cursor()
     agent.cursor.execute(
@@ -538,10 +540,16 @@ async def test_us_full_exit_closes_all_siblings_before_one_order_and_publish(
     assert events == ["broker", "redis", "gcp"]
     assert agent.conn.execute("SELECT COUNT(*) FROM us_stock_holdings").fetchone()[0] == 0
     assert agent.conn.execute("SELECT COUNT(*) FROM us_trading_history").fetchone()[0] == 2
-    statuses = agent.conn.execute(
-        "SELECT status FROM positions ORDER BY legacy_holding_id"
+    positions = agent.conn.execute(
+        "SELECT status, exit_intent_id FROM positions ORDER BY legacy_holding_id"
     ).fetchall()
-    assert [row[0] for row in statuses] == ["CLOSED", "CLOSED"]
+    assert [row[0] for row in positions] == ["CLOSED", "CLOSED"]
+    assert positions[0][1]
+    assert positions[0][1] == positions[1][1]
+    assert agent.conn.execute(
+        "SELECT source_position_id FROM order_intents WHERE id=?",
+        (positions[0][1],),
+    ).fetchone()[0] == "legacy:US:1,legacy:US:2"
     comparison = PositionStore(agent.conn).compare_legacy_positions("US")
     assert comparison["matches"]
 
@@ -596,6 +604,7 @@ async def test_process_reports_analyzes_once_and_dedupes_signals(monkeypatch, ca
     slot_checks = []
     sector_checks = []
     buy_calls = []
+    link_calls = []
     redis_calls = []
     gcp_calls = []
     watchlist_calls = []
@@ -634,6 +643,10 @@ async def test_process_reports_analyzes_once_and_dedupes_signals(monkeypatch, ca
         ticker, company_name, current_price, scenario, rank_change_msg, is_add=False
     ):
         buy_calls.append((agent.active_account["name"], ticker))
+        return LegacyPositionWriteResult(True, len(buy_calls))
+
+    def fake_link_position_entry_intent(**kwargs):
+        link_calls.append(kwargs)
         return True
 
     async def fake_save_watchlist_item(**kwargs):
@@ -645,7 +658,8 @@ async def test_process_reports_analyzes_once_and_dedupes_signals(monkeypatch, ca
     agent._is_ticker_in_holdings = fake_is_ticker_in_holdings
     agent._get_current_slots_count = fake_get_current_slots_count
     agent._check_sector_diversity = fake_check_sector_diversity
-    agent.buy_stock = fake_buy_stock
+    agent._buy_stock_with_position = fake_buy_stock
+    agent._link_position_entry_intent = fake_link_position_entry_intent
     agent._save_watchlist_item = fake_save_watchlist_item
 
     _install_signal_modules(monkeypatch, redis_calls, gcp_calls)
@@ -662,6 +676,15 @@ async def test_process_reports_analyzes_once_and_dedupes_signals(monkeypatch, ca
     assert slot_checks == ["us-primary", "us-secondary"]
     assert sector_checks == [("us-primary", "Technology"), ("us-secondary", "Technology")]
     assert buy_calls == [("us-primary", "AAPL"), ("us-secondary", "AAPL")]
+    assert [call["legacy_holding_id"] for call in link_calls] == [1, 2]
+    assert all(call["intent_id"] for call in link_calls)
+    intent_sources = sqlite3.connect(agent.db_path).execute(
+        "SELECT account_id, source_position_id FROM order_intents ORDER BY account_id"
+    ).fetchall()
+    assert intent_sources == [
+        ("vps:us-primary:01", "legacy:US:1"),
+        ("vps:us-secondary:01", "legacy:US:2"),
+    ]
     assert len(redis_calls) == 1
     assert len(gcp_calls) == 1
     assert watchlist_calls == []
@@ -721,7 +744,7 @@ async def test_process_reports_saves_watchlist_once_when_not_traded(monkeypatch)
     agent._is_ticker_in_holdings = fake_is_ticker_in_holdings
     agent._get_current_slots_count = fake_get_current_slots_count
     agent._check_sector_diversity = fake_check_sector_diversity
-    agent.buy_stock = fake_buy_stock
+    agent._buy_stock_with_position = fake_buy_stock
     agent._save_watchlist_item = fake_save_watchlist_item
 
     buy_count, sell_count = await USStockTrackingAgent.process_reports(agent, ["report-a.pdf"])

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -37,9 +37,18 @@ from typing import List, Dict, Any, Tuple, Optional
 # Add parent directory to path for imports
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
-from prism_core.execution_service import ExecutionService  # noqa: E402
+from prism_core.execution_service import (  # noqa: E402
+    ExecutionService,
+    OrderOutcomeUnknown,
+)
 from prism_core.order_intents import OrderIntent  # noqa: E402
-from prism_core.positions import PositionStore, mirror_write_fail_open  # noqa: E402
+from prism_core.positions import (  # noqa: E402
+    LegacyPositionWriteResult,
+    PositionStore,
+    bounded_link_write_fail_open,
+    legacy_position_id,
+    mirror_write_fail_open,
+)
 
 _openai_debug_spec = _ilu.spec_from_file_location("cores.openai_debug", PROJECT_ROOT / "cores" / "openai_debug.py")
 if _openai_debug_spec and _openai_debug_spec.loader:
@@ -733,6 +742,78 @@ class USStockTrackingAgent:
             ),
         )
 
+    def _link_position_entry_intent(
+        self, *, legacy_holding_id: int, account_key: str, intent_id: str
+    ) -> bool:
+        if not self._position_ledger_enabled():
+            return True
+        try:
+            self.conn.commit()
+            linked = bounded_link_write_fail_open(
+                self.cursor,
+                logger=logger,
+                market="US",
+                legacy_holding_id=legacy_holding_id,
+                account_id=account_key,
+                operation="link_entry_intent",
+                write=lambda store: store.link_entry_intent(
+                    market="US",
+                    legacy_holding_id=legacy_holding_id,
+                    account_id=account_key,
+                    intent_id=intent_id,
+                ),
+            )
+            self.conn.commit()
+            return linked
+        except Exception as error:
+            if self.conn.in_transaction:
+                self.conn.rollback()
+            logger.critical(
+                "[POSITION-LINK][US] entry linkage failed for legacy_id=%s (%s)",
+                legacy_holding_id,
+                type(error).__name__,
+            )
+            return False
+
+    def _link_position_exit_intent(
+        self,
+        *,
+        legacy_holding_id: int,
+        account_key: str,
+        intent_id: str,
+        expected_position_ids: list[str] | None = None,
+    ) -> bool:
+        if not self._position_ledger_enabled():
+            return True
+        try:
+            self.conn.commit()
+            linked = bounded_link_write_fail_open(
+                self.cursor,
+                logger=logger,
+                market="US",
+                legacy_holding_id=legacy_holding_id,
+                account_id=account_key,
+                operation="link_exit_intent",
+                write=lambda store: store.link_exit_intent(
+                    market="US",
+                    legacy_holding_id=legacy_holding_id,
+                    account_id=account_key,
+                    intent_id=intent_id,
+                    expected_position_ids=expected_position_ids,
+                ),
+            )
+            self.conn.commit()
+            return linked
+        except Exception as error:
+            if self.conn.in_transaction:
+                self.conn.rollback()
+            logger.critical(
+                "[POSITION-LINK][US] exit linkage failed for legacy_id=%s (%s)",
+                legacy_holding_id,
+                type(error).__name__,
+            )
+            return False
+
     def _get_trading_accounts(self) -> List[Dict[str, Any]]:
         default_mode = str(ka.getEnv().get("default_mode", "demo")).strip().lower()
         svr = "vps" if default_mode == "demo" else "prod"
@@ -1265,6 +1346,20 @@ class USStockTrackingAgent:
 
     async def buy_stock(self, ticker: str, company_name: str, current_price: float,
                         scenario: Dict[str, Any], rank_change_msg: str = "", is_add: bool = False) -> bool:
+        """Preserve the public bool contract while exposing an internal typed result."""
+
+        result = await self._buy_stock_with_position(
+            ticker,
+            company_name,
+            current_price,
+            scenario,
+            rank_change_msg,
+            is_add=is_add,
+        )
+        return result.success
+
+    async def _buy_stock_with_position(self, ticker: str, company_name: str, current_price: float,
+                        scenario: Dict[str, Any], rank_change_msg: str = "", is_add: bool = False) -> LegacyPositionWriteResult:
         """
         Process stock purchase.
 
@@ -1278,19 +1373,19 @@ class USStockTrackingAgent:
                     insert an independent additional row instead of a first entry.
 
         Returns:
-            bool: Purchase success status
+            Internal success result with the inserted legacy holding id.
         """
         try:
             # Check if already holding (skipped for a pyramiding add)
             if not is_add and await self._is_ticker_in_holdings(ticker):
                 logger.warning(f"{ticker} ({company_name}) already in holdings")
-                return False
+                return LegacyPositionWriteResult(False, None)
 
             # Check available slots
             current_slots = await self._get_current_slots_count()
             if current_slots >= self.max_slots:
                 logger.warning(f"Holdings already at maximum ({self.max_slots})")
-                return False
+                return LegacyPositionWriteResult(False, None)
 
             # Current time
             now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -1472,12 +1567,12 @@ class USStockTrackingAgent:
             self.message_queue.append(message)
             logger.info(f"{ticker} ({company_name}) purchase complete")
 
-            return True
+            return LegacyPositionWriteResult(True, int(legacy_holding_id))
 
         except Exception as e:
             logger.error(f"{ticker} Error during purchase: {str(e)}")
             logger.error(traceback.format_exc())
-            return False
+            return LegacyPositionWriteResult(False, None)
 
     async def _save_watchlist_item(
         self,
@@ -2676,6 +2771,14 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
 
                         # Only execute trading if we have a valid price
                         if current_price > 0:
+                            closed_rows = (
+                                sibling_rows if plan == "full_exit" else [stock]
+                            )
+                            closed_legacy_ids = [row["id"] for row in closed_rows]
+                            expected_position_ids = sorted(
+                                legacy_position_id("US", row_id)
+                                for row_id in closed_legacy_ids
+                            )
                             try:
                                 async with ExecutionService.us(
                                     account_name=stock.get("account_name"),
@@ -2709,10 +2812,8 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                                     # the ticker was already added to fully_exited_tickers above.
                                     # Pass limit_price for reserved orders (required for US market)
                                     # If limit_price is 0, trading module will use MOO (Market On Open)
-                                    source_position_id = (
-                                        ",".join(sorted(str(row["id"]) for row in sibling_rows))
-                                        if plan == "full_exit"
-                                        else stock.get("id")
+                                    source_position_id = ",".join(
+                                        expected_position_ids
                                     )
                                     order_intent = OrderIntent.create(
                                         market="US",
@@ -2733,10 +2834,29 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                                         intent=order_intent,
                                     )
 
+                                persisted_intent_id = trade_result.get("intent_id")
+                                if persisted_intent_id:
+                                    self._link_position_exit_intent(
+                                        legacy_holding_id=closed_legacy_ids[0],
+                                        account_key=stock.get("account_key"),
+                                        intent_id=persisted_intent_id,
+                                        expected_position_ids=expected_position_ids,
+                                    )
+
                                 if trade_result['success']:
                                     logger.info(f"Actual sell successful: {trade_result['message']}")
                                 else:
                                     logger.error(f"Actual sell failed: {trade_result['message']}")
+                            except OrderOutcomeUnknown as trade_err:
+                                self._link_position_exit_intent(
+                                    legacy_holding_id=closed_legacy_ids[0],
+                                    account_key=stock.get("account_key"),
+                                    intent_id=trade_err.intent_id,
+                                    expected_position_ids=expected_position_ids,
+                                )
+                                logger.warning(
+                                    f"Trading outcome unknown: {trade_err}"
+                                )
                             except Exception as trade_err:
                                 logger.warning(f"Trading execution skipped: {trade_err}")
                         else:
@@ -3138,7 +3258,15 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
 
                     if normalized_decision == "entry" and adjusted_score >= min_score and sector_diverse and not _cd_block:
                         # is_add => pyramiding additional independent row (#288)
-                        buy_success = await self.buy_stock(ticker, company_name, current_price, scenario, rank_change_msg, is_add=is_add)
+                        buy_result = await self._buy_stock_with_position(
+                            ticker,
+                            company_name,
+                            current_price,
+                            scenario,
+                            rank_change_msg,
+                            is_add=is_add,
+                        )
+                        buy_success = buy_result.success
 
                         if buy_success:
                             trade_result = {'success': False, 'message': 'Trading not executed'}
@@ -3146,6 +3274,9 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                             if current_price > 0:
                                 try:
                                     account_key, _ = self._account_scope()
+                                    opened_position_id = legacy_position_id(
+                                        "US", buy_result.legacy_holding_id
+                                    )
                                     order_intent = OrderIntent.create(
                                         market="US",
                                         account_id=account_key,
@@ -3154,6 +3285,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                                         order_style="smart",
                                         source="us_batch",
                                         source_decision_id=source_decision_id,
+                                        source_position_id=opened_position_id,
                                         limit_price=current_price,
                                         reason="AI analysis entry",
                                     )
@@ -3167,10 +3299,27 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                                             intent=order_intent,
                                         )
 
+                                    persisted_intent_id = trade_result.get("intent_id")
+                                    if persisted_intent_id:
+                                        self._link_position_entry_intent(
+                                            legacy_holding_id=buy_result.legacy_holding_id,
+                                            account_key=account_key,
+                                            intent_id=persisted_intent_id,
+                                        )
+
                                     if trade_result['success']:
                                         logger.info(f"Actual purchase successful: {trade_result['message']}")
                                     else:
                                         logger.error(f"Actual purchase failed: {trade_result['message']}")
+                                except OrderOutcomeUnknown as trade_err:
+                                    self._link_position_entry_intent(
+                                        legacy_holding_id=buy_result.legacy_holding_id,
+                                        account_key=account_key,
+                                        intent_id=trade_err.intent_id,
+                                    )
+                                    logger.warning(
+                                        f"Trading outcome unknown: {trade_err}"
+                                    )
                                 except Exception as trade_err:
                                     logger.warning(f"Trading execution skipped: {trade_err}")
                             else:

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -750,7 +750,7 @@ class USStockTrackingAgent:
         try:
             self.conn.commit()
             linked = bounded_link_write_fail_open(
-                self.cursor,
+                self.db_path,
                 logger=logger,
                 market="US",
                 legacy_holding_id=legacy_holding_id,
@@ -788,7 +788,7 @@ class USStockTrackingAgent:
         try:
             self.conn.commit()
             linked = bounded_link_write_fail_open(
-                self.cursor,
+                self.db_path,
                 logger=logger,
                 market="US",
                 legacy_holding_id=legacy_holding_id,

--- a/prism_core/order_intents.py
+++ b/prism_core/order_intents.py
@@ -166,9 +166,12 @@ class OrderIntent:
             raise ValueError(
                 "OrderIntent requires source_decision_id or source_position_id"
             )
-        identity = (
-            f"position:{position_id}" if position_id else f"decision:{decision_id}"
-        )
+        if side == "BUY" and decision_id:
+            identity = f"decision:{decision_id}"
+        elif position_id:
+            identity = f"position:{position_id}"
+        else:
+            identity = f"decision:{decision_id}"
         key_source = "|".join(
             ("v1", market, account_id, symbol, side, identity)
         )

--- a/prism_core/positions.py
+++ b/prism_core/positions.py
@@ -13,6 +13,7 @@ import sqlite3
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Callable
 
 
@@ -362,13 +363,31 @@ class PositionStore:
             raise ValueError("intent_id is required")
 
         if link_kind == "entry":
-            intent_column = "entry_intent_id"
             expected_side = "BUY"
             required_status = "OPEN"
+            position_query = (
+                "SELECT id, legacy_holding_id, account_id, symbol, status, "
+                "entry_intent_id AS current_intent_id FROM positions "
+                "WHERE market=? AND account_id=?"
+            )
+            update_query = (
+                "UPDATE positions SET entry_intent_id=?, updated_at=? "
+                "WHERE market=? AND account_id=? AND id=? AND status=? "
+                "AND entry_intent_id IS NULL"
+            )
         elif link_kind == "exit":
-            intent_column = "exit_intent_id"
             expected_side = "SELL"
             required_status = "CLOSED"
+            position_query = (
+                "SELECT id, legacy_holding_id, account_id, symbol, status, "
+                "exit_intent_id AS current_intent_id FROM positions "
+                "WHERE market=? AND account_id=?"
+            )
+            update_query = (
+                "UPDATE positions SET exit_intent_id=?, updated_at=? "
+                "WHERE market=? AND account_id=? AND id=? AND status=? "
+                "AND exit_intent_id IS NULL"
+            )
         else:
             raise ValueError(f"unsupported intent link kind: {link_kind}")
 
@@ -421,14 +440,12 @@ class PositionStore:
                 f"{link_kind} intent source_position_id does not match position"
             )
 
-        placeholders = ",".join("?" for _ in expected_sources)
         source_ids = tuple(sorted(expected_sources))
-        positions = self._fetchall(
-            f"SELECT id, legacy_holding_id, account_id, symbol, status, "
-            f"{intent_column} AS current_intent_id FROM positions "
-            f"WHERE market=? AND account_id=? AND id IN ({placeholders})",
-            (market, account_id, *source_ids),
-        )
+        positions = [
+            row
+            for row in self._fetchall(position_query, (market, account_id))
+            if str(row["id"]) in expected_sources
+        ]
         if {str(row["id"]) for row in positions} != expected_sources:
             raise LookupError(f"{link_kind} source positions not found")
         if any(
@@ -471,19 +488,21 @@ class PositionStore:
         unlinked_count = sum(
             row["current_intent_id"] is None for row in positions
         )
-        changed = self._execute(
-            f"UPDATE positions SET {intent_column}=?, updated_at=? "
-            f"WHERE market=? AND account_id=? AND id IN ({placeholders}) "
-            f"AND status=? AND {intent_column} IS NULL",
-            (
-                intent_id,
-                _utc_now(),
-                market,
-                account_id,
-                *source_ids,
-                required_status,
-            ),
-        ).rowcount
+        now = _utc_now()
+        changed = sum(
+            self._execute(
+                update_query,
+                (
+                    intent_id,
+                    now,
+                    market,
+                    account_id,
+                    source_id,
+                    required_status,
+                ),
+            ).rowcount
+            for source_id in source_ids
+        )
         if changed != unlinked_count:
             raise RuntimeError("source positions changed concurrently")
         return True
@@ -891,7 +910,7 @@ def mirror_write_fail_open(
 
 
 def bounded_link_write_fail_open(
-    connection_or_cursor: sqlite3.Connection | sqlite3.Cursor,
+    db_path: str | Path,
     *,
     logger: Any,
     market: str,
@@ -905,22 +924,18 @@ def bounded_link_write_fail_open(
     Validation failures still use the durable mirror-error table. SQLITE_BUSY /
     SQLITE_LOCKED cannot write to that same database, so those failures emit a
     CRITICAL runtime log and are detected later by the intent-link comparator.
-    The caller must enter with no unrelated pending writes; an outermost savepoint
-    release may commit this isolated linkage, while the caller retains connection
-    lifecycle and any final no-op commit/rollback handling.
+    A dedicated short-lived connection isolates the 50ms busy timeout from the
+    agent's long-lived legacy connection. The outermost savepoint release commits
+    this linkage/audit transaction before the connection is closed.
     """
 
-    connection = (
-        connection_or_cursor
-        if isinstance(connection_or_cursor, sqlite3.Connection)
-        else connection_or_cursor.connection
+    connection = sqlite3.connect(
+        str(db_path), timeout=_POSITION_LINK_BUSY_TIMEOUT_MS / 1000
     )
-    previous_timeout = int(connection.execute("PRAGMA busy_timeout").fetchone()[0])
-    connection.execute(f"PRAGMA busy_timeout={_POSITION_LINK_BUSY_TIMEOUT_MS}")
     try:
         try:
             return mirror_write_fail_open(
-                connection_or_cursor,
+                connection,
                 logger=logger,
                 market=market,
                 legacy_holding_id=legacy_holding_id,
@@ -942,4 +957,4 @@ def bounded_link_write_fail_open(
             )
             return False
     finally:
-        connection.execute(f"PRAGMA busy_timeout={previous_timeout}")
+        connection.close()

--- a/prism_core/positions.py
+++ b/prism_core/positions.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import hashlib
 import re
 import sqlite3
+from collections.abc import Iterable
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable
 
@@ -72,10 +74,20 @@ CREATE TABLE IF NOT EXISTS position_mirror_errors (
 """
 
 _LEGACY_TABLES = {"KR": "stock_holdings", "US": "us_stock_holdings"}
+_POSITION_LINK_BUSY_TIMEOUT_MS = 50
+_SQLITE_LOCK_PRIMARY_CODES = frozenset({5, 6})  # SQLITE_BUSY, SQLITE_LOCKED
 
 
 class InvalidPositionTransition(ValueError):
     """Raised when a position lifecycle transition is not allowed."""
+
+
+@dataclass(frozen=True)
+class LegacyPositionWriteResult:
+    """Internal result boundary preserving the public simulator bool contract."""
+
+    success: bool
+    legacy_holding_id: int | None
 
 
 def _utc_now() -> str:
@@ -119,6 +131,26 @@ def _redact_error_text(value: str) -> str:
         r"(\s*[:=]\s*)[^\s,;]+",
         r"\1\2[REDACTED]",
         value,
+    )
+
+
+def _is_sqlite_lock_error(error: BaseException) -> bool:
+    if not isinstance(error, sqlite3.OperationalError):
+        return False
+    error_code = getattr(error, "sqlite_errorcode", None)
+    if (
+        isinstance(error_code, int)
+        and error_code & 0xFF in _SQLITE_LOCK_PRIMARY_CODES
+    ):
+        return True
+    message = str(error).strip().lower()
+    return any(
+        lock_text in message
+        for lock_text in (
+            "database is locked",
+            "database table is locked",
+            "database schema is locked",
+        )
     )
 
 
@@ -308,6 +340,192 @@ class PositionStore:
             closed_at=closed_at,
         )
 
+    def _link_intent(
+        self,
+        *,
+        market: str,
+        legacy_holding_id: Any,
+        account_id: Any,
+        intent_id: Any,
+        link_kind: str,
+        expected_position_ids: Iterable[str] | None = None,
+    ) -> bool:
+        """Validate and persist one intent link without owning the transaction."""
+
+        market = _market(market)
+        legacy_holding_id = str(legacy_holding_id)
+        account_id = str(account_id or "")
+        if not account_id:
+            raise ValueError("account_id is required")
+        intent_id = str(intent_id or "")
+        if not intent_id:
+            raise ValueError("intent_id is required")
+
+        if link_kind == "entry":
+            intent_column = "entry_intent_id"
+            expected_side = "BUY"
+            required_status = "OPEN"
+        elif link_kind == "exit":
+            intent_column = "exit_intent_id"
+            expected_side = "SELL"
+            required_status = "CLOSED"
+        else:
+            raise ValueError(f"unsupported intent link kind: {link_kind}")
+
+        position_id = legacy_position_id(market, legacy_holding_id)
+        if expected_position_ids is None:
+            expected_sources = {position_id}
+        else:
+            source_items = tuple(str(item) for item in expected_position_ids)
+            expected_sources = set(source_items)
+            if len(expected_sources) != len(source_items):
+                raise ValueError("expected_position_ids must not contain duplicates")
+            if any(
+                not item.startswith(f"legacy:{market}:") for item in expected_sources
+            ):
+                raise ValueError(
+                    "expected_position_ids must contain canonical position ids"
+                )
+            if market != "US" and expected_sources != {position_id}:
+                raise ValueError("multiple source positions are only supported for US")
+        if position_id not in expected_sources:
+            raise ValueError("source_position_id does not include target position")
+
+        intent = self._execute(
+            "SELECT market, account_id, symbol, side, source_position_id "
+            "FROM order_intents WHERE id=?",
+            (intent_id,),
+        ).fetchone()
+        if intent is None:
+            raise LookupError(f"intent not found: {intent_id}")
+
+        intent_identity = (
+            str(intent[0]).upper(),
+            str(intent[1]),
+            str(intent[2]).upper(),
+            str(intent[3]).upper(),
+        )
+        source_position_id = intent[4]
+        source_items = (
+            ()
+            if source_position_id is None
+            else tuple(item.strip() for item in str(source_position_id).split(","))
+        )
+        if (
+            not source_items
+            or any(not item for item in source_items)
+            or len(set(source_items)) != len(source_items)
+            or set(source_items) != expected_sources
+        ):
+            raise ValueError(
+                f"{link_kind} intent source_position_id does not match position"
+            )
+
+        placeholders = ",".join("?" for _ in expected_sources)
+        source_ids = tuple(sorted(expected_sources))
+        positions = self._fetchall(
+            f"SELECT id, legacy_holding_id, account_id, symbol, status, "
+            f"{intent_column} AS current_intent_id FROM positions "
+            f"WHERE market=? AND account_id=? AND id IN ({placeholders})",
+            (market, account_id, *source_ids),
+        )
+        if {str(row["id"]) for row in positions} != expected_sources:
+            raise LookupError(f"{link_kind} source positions not found")
+        if any(
+            str(row["id"])
+            != legacy_position_id(market, row["legacy_holding_id"])
+            for row in positions
+        ):
+            raise ValueError(f"{link_kind} source position identity is invalid")
+        if any(
+            intent_identity
+            != (
+                market,
+                str(row["account_id"]),
+                str(row["symbol"]).upper(),
+                expected_side,
+            )
+            for row in positions
+        ):
+            raise ValueError(f"{link_kind} intent does not match position")
+
+        current_intent_ids = {row["current_intent_id"] for row in positions}
+        if current_intent_ids == {intent_id}:
+            return True
+        if any(
+            current_intent_id not in {None, intent_id}
+            for current_intent_id in current_intent_ids
+        ):
+            raise ValueError(f"{link_kind} intent already linked")
+        invalid_statuses = {
+            str(row["status"])
+            for row in positions
+            if str(row["status"]) != required_status
+        }
+        if invalid_statuses:
+            raise InvalidPositionTransition(
+                f"{link_kind} intent linkage requires {required_status} position, "
+                f"found {','.join(sorted(invalid_statuses))}"
+            )
+
+        unlinked_count = sum(
+            row["current_intent_id"] is None for row in positions
+        )
+        changed = self._execute(
+            f"UPDATE positions SET {intent_column}=?, updated_at=? "
+            f"WHERE market=? AND account_id=? AND id IN ({placeholders}) "
+            f"AND status=? AND {intent_column} IS NULL",
+            (
+                intent_id,
+                _utc_now(),
+                market,
+                account_id,
+                *source_ids,
+                required_status,
+            ),
+        ).rowcount
+        if changed != unlinked_count:
+            raise RuntimeError("source positions changed concurrently")
+        return True
+
+    def link_entry_intent(
+        self,
+        *,
+        market: str,
+        legacy_holding_id: Any,
+        account_id: Any,
+        intent_id: Any,
+    ) -> bool:
+        """Link one persisted BUY intent to an OPEN legacy position."""
+
+        return self._link_intent(
+            market=market,
+            legacy_holding_id=legacy_holding_id,
+            account_id=account_id,
+            intent_id=intent_id,
+            link_kind="entry",
+        )
+
+    def link_exit_intent(
+        self,
+        *,
+        market: str,
+        legacy_holding_id: Any,
+        account_id: Any,
+        intent_id: Any,
+        expected_position_ids: Iterable[str] | None = None,
+    ) -> bool:
+        """Link one persisted SELL intent to a CLOSED legacy position."""
+
+        return self._link_intent(
+            market=market,
+            legacy_holding_id=legacy_holding_id,
+            account_id=account_id,
+            intent_id=intent_id,
+            link_kind="exit",
+            expected_position_ids=expected_position_ids,
+        )
+
     def _legacy_rows(self, market: str) -> list[dict[str, Any]]:
         if market == "KR":
             table = "stock_holdings"
@@ -464,11 +682,12 @@ class PositionStore:
             )
 
         position_rows = self._fetchall(
-            "SELECT legacy_holding_id, account_id, symbol, status, "
-            "entry_price, opened_at "
+            "SELECT id, legacy_holding_id, account_id, symbol, status, "
+            "entry_intent_id, exit_intent_id, entry_price, opened_at "
             "FROM positions WHERE market=? AND execution_mode='legacy'",
             (market,),
         )
+        positions_by_id = {str(row["id"]): row for row in position_rows}
         positions: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
         position_entry_fingerprints: dict[tuple[str, str, str], list[str]] = {}
         for row in position_rows:
@@ -524,6 +743,62 @@ class PositionStore:
             "WHERE market=? AND resolved=0 ORDER BY id",
             (market,),
         )
+        intent_link_mismatches: list[dict[str, Any]] = []
+        has_intent_table = self._execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' "
+            "AND name='order_intents'"
+        ).fetchone()
+        if has_intent_table:
+            intent_rows = self._fetchall(
+                "SELECT id, account_id, symbol, side, source_position_id "
+                "FROM order_intents WHERE market=? AND source_position_id IS NOT NULL",
+                (market,),
+            )
+            canonical_prefix = f"legacy:{market}:"
+            for intent in intent_rows:
+                source_ids = tuple(
+                    item.strip()
+                    for item in str(intent["source_position_id"]).split(",")
+                )
+                if (
+                    not source_ids
+                    or any(not item.startswith(canonical_prefix) for item in source_ids)
+                    or len(set(source_ids)) != len(source_ids)
+                ):
+                    continue
+                side = str(intent["side"]).upper()
+                if side not in {"BUY", "SELL"}:
+                    continue
+                intent_column = (
+                    "entry_intent_id" if side == "BUY" else "exit_intent_id"
+                )
+                for source_id in source_ids:
+                    position = positions_by_id.get(source_id)
+                    reasons = []
+                    if position is None:
+                        reasons.append("missing_position")
+                    else:
+                        if str(position["account_id"]) != str(intent["account_id"]):
+                            reasons.append("account_mismatch")
+                        if str(position["symbol"]).upper() != str(
+                            intent["symbol"]
+                        ).upper():
+                            reasons.append("symbol_mismatch")
+                        if position[intent_column] != intent["id"]:
+                            reasons.append("missing_or_wrong_link")
+                    if reasons:
+                        intent_link_mismatches.append(
+                            {
+                                "intent_id": str(intent["id"]),
+                                "position_id": source_id,
+                                "account_ref": account_fingerprint(
+                                    intent["account_id"]
+                                ),
+                                "symbol": str(intent["symbol"]).upper(),
+                                "side": side,
+                                "reasons": reasons,
+                            }
+                        )
         mismatches = (
             missing_positions,
             extra_open_positions,
@@ -532,6 +807,7 @@ class PositionStore:
             entry_mismatches,
             invalid_legacy_rows,
             unresolved_mirror_errors,
+            intent_link_mismatches,
         )
         return {
             "market": market,
@@ -550,6 +826,7 @@ class PositionStore:
             "entry_mismatches": entry_mismatches,
             "invalid_legacy_rows": invalid_legacy_rows,
             "unresolved_mirror_errors": unresolved_mirror_errors,
+            "intent_link_mismatches": intent_link_mismatches,
         }
 
 
@@ -584,6 +861,15 @@ def mirror_write_fail_open(
             legacy_holding_id,
             type(error).__name__,
         )
+        if _is_sqlite_lock_error(error):
+            logger.critical(
+                "[POSITION-SHADOW][%s] %s audit deferred to comparator "
+                "because sqlite is locked for legacy_id=%s",
+                _market(market),
+                operation,
+                legacy_holding_id,
+            )
+            return False
         try:
             store.record_mirror_error(
                 market=market,
@@ -602,3 +888,58 @@ def mirror_write_fail_open(
         return False
     connection_or_cursor.execute("RELEASE position_shadow_write")
     return True
+
+
+def bounded_link_write_fail_open(
+    connection_or_cursor: sqlite3.Connection | sqlite3.Cursor,
+    *,
+    logger: Any,
+    market: str,
+    legacy_holding_id: Any,
+    account_id: Any,
+    operation: str,
+    write: Callable[[PositionStore], Any],
+) -> bool:
+    """Run post-broker linkage with a bounded SQLite lock wait.
+
+    Validation failures still use the durable mirror-error table. SQLITE_BUSY /
+    SQLITE_LOCKED cannot write to that same database, so those failures emit a
+    CRITICAL runtime log and are detected later by the intent-link comparator.
+    The caller must enter with no unrelated pending writes; an outermost savepoint
+    release may commit this isolated linkage, while the caller retains connection
+    lifecycle and any final no-op commit/rollback handling.
+    """
+
+    connection = (
+        connection_or_cursor
+        if isinstance(connection_or_cursor, sqlite3.Connection)
+        else connection_or_cursor.connection
+    )
+    previous_timeout = int(connection.execute("PRAGMA busy_timeout").fetchone()[0])
+    connection.execute(f"PRAGMA busy_timeout={_POSITION_LINK_BUSY_TIMEOUT_MS}")
+    try:
+        try:
+            return mirror_write_fail_open(
+                connection_or_cursor,
+                logger=logger,
+                market=market,
+                legacy_holding_id=legacy_holding_id,
+                account_id=account_id,
+                operation=operation,
+                write=write,
+            )
+        except Exception as error:
+            if connection.in_transaction:
+                connection.rollback()
+            if not _is_sqlite_lock_error(error):
+                raise
+            logger.critical(
+                "[POSITION-LINK][%s] %s commit skipped because sqlite is "
+                "locked for legacy_id=%s; comparator will detect the gap",
+                _market(market),
+                operation,
+                legacy_holding_id,
+            )
+            return False
+    finally:
+        connection.execute(f"PRAGMA busy_timeout={previous_timeout}")

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -48,9 +48,15 @@ from cores.llm.openai_responses_llm import OpenAIResponsesLLM as OpenAIAugmented
 from cores.openai_error_logging import log_openai_error
 from cores.agents.trading_agents import create_trading_scenario_agent
 from cores.utils import parse_llm_json
-from prism_core.execution_service import ExecutionService
+from prism_core.execution_service import ExecutionService, OrderOutcomeUnknown
 from prism_core.order_intents import OrderIntent
-from prism_core.positions import PositionStore, mirror_write_fail_open
+from prism_core.positions import (
+    LegacyPositionWriteResult,
+    PositionStore,
+    bounded_link_write_fail_open,
+    legacy_position_id,
+    mirror_write_fail_open,
+)
 
 # O'Neil 룰베이스 매도 (2026-06-04 US quota 사고 동일 룰 결함 KR에도 적용).
 # 방어적 import: 실패 시 _ONEIL_FALLBACK_AVAILABLE=False 로 기존 레거시 룰 유지.
@@ -329,6 +335,78 @@ class StockTrackingAgent:
                 closed_at=closed_at,
             ),
         )
+
+    def _link_position_entry_intent(
+        self, *, legacy_holding_id: int, account_key: str, intent_id: str
+    ) -> bool:
+        if not self._position_ledger_enabled():
+            return True
+        try:
+            self.conn.commit()
+            linked = bounded_link_write_fail_open(
+                self.cursor,
+                logger=logger,
+                market="KR",
+                legacy_holding_id=legacy_holding_id,
+                account_id=account_key,
+                operation="link_entry_intent",
+                write=lambda store: store.link_entry_intent(
+                    market="KR",
+                    legacy_holding_id=legacy_holding_id,
+                    account_id=account_key,
+                    intent_id=intent_id,
+                ),
+            )
+            self.conn.commit()
+            return linked
+        except Exception as error:
+            if self.conn.in_transaction:
+                self.conn.rollback()
+            logger.critical(
+                "[POSITION-LINK][KR] entry linkage failed for legacy_id=%s (%s)",
+                legacy_holding_id,
+                type(error).__name__,
+            )
+            return False
+
+    def _link_position_exit_intent(
+        self,
+        *,
+        legacy_holding_id: int,
+        account_key: str,
+        intent_id: str,
+        expected_position_ids: list[str] | None = None,
+    ) -> bool:
+        if not self._position_ledger_enabled():
+            return True
+        try:
+            self.conn.commit()
+            linked = bounded_link_write_fail_open(
+                self.cursor,
+                logger=logger,
+                market="KR",
+                legacy_holding_id=legacy_holding_id,
+                account_id=account_key,
+                operation="link_exit_intent",
+                write=lambda store: store.link_exit_intent(
+                    market="KR",
+                    legacy_holding_id=legacy_holding_id,
+                    account_id=account_key,
+                    intent_id=intent_id,
+                    expected_position_ids=expected_position_ids,
+                ),
+            )
+            self.conn.commit()
+            return linked
+        except Exception as error:
+            if self.conn.in_transaction:
+                self.conn.rollback()
+            logger.critical(
+                "[POSITION-LINK][KR] exit linkage failed for legacy_id=%s (%s)",
+                legacy_holding_id,
+                type(error).__name__,
+            )
+            return False
 
     def _get_trading_accounts(self) -> List[Dict[str, Any]]:
         default_mode = str(ka.getEnv().get("default_mode", "demo")).strip().lower()
@@ -1096,6 +1174,19 @@ class StockTrackingAgent:
             return False
 
     async def buy_stock(self, ticker: str, company_name: str, current_price: float, scenario: Dict[str, Any], rank_change_msg: str = "", is_add: bool = False) -> bool:
+        """Preserve the public bool contract while exposing an internal typed result."""
+
+        result = await self._buy_stock_with_position(
+            ticker,
+            company_name,
+            current_price,
+            scenario,
+            rank_change_msg,
+            is_add=is_add,
+        )
+        return result.success
+
+    async def _buy_stock_with_position(self, ticker: str, company_name: str, current_price: float, scenario: Dict[str, Any], rank_change_msg: str = "", is_add: bool = False) -> LegacyPositionWriteResult:
         """
         Process stock purchase
 
@@ -1109,19 +1200,19 @@ class StockTrackingAgent:
                     insert an independent additional row instead of a first entry.
 
         Returns:
-            bool: Purchase success status
+            Internal success result with the inserted legacy holding id.
         """
         try:
             # Check if already holding (skipped for a pyramiding add)
             if not is_add and await self._is_ticker_in_holdings(ticker):
                 logger.warning(f"{ticker}({company_name}) already in holdings")
-                return False
+                return LegacyPositionWriteResult(False, None)
 
             # Check available slots
             current_slots = await self._get_current_slots_count()
             if current_slots >= self.max_slots:
                 logger.warning(f"Holdings already at maximum ({self.max_slots})")
-                return False
+                return LegacyPositionWriteResult(False, None)
 
             # Check market-based maximum portfolio size
             max_portfolio_size = scenario.get('max_portfolio_size', self.max_slots)
@@ -1133,7 +1224,7 @@ class StockTrackingAgent:
                     max_portfolio_size = self.max_slots
             if current_slots >= max_portfolio_size:
                 logger.warning(f"Reached market-based max portfolio size ({max_portfolio_size}). Current holdings: {current_slots}")
-                return False
+                return LegacyPositionWriteResult(False, None)
 
             # Current time
             now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -1310,12 +1401,12 @@ class StockTrackingAgent:
             self.message_queue.append(message)
             logger.info(f"{ticker}({company_name}) purchase complete")
 
-            return True
+            return LegacyPositionWriteResult(True, int(legacy_holding_id))
 
         except Exception as e:
             logger.error(f"{ticker} Error during purchase processing: {str(e)}")
             logger.error(traceback.format_exc())
-            return False
+            return LegacyPositionWriteResult(False, None)
 
     def _get_live_regime_safe(self) -> Optional[str]:
         """매도 판단용 '현재' KOSPI 레짐을 1회 계산(OpenAI 무관). 실패 시 None → stale 폴백."""
@@ -1886,6 +1977,10 @@ class StockTrackingAgent:
                                     f"remaining rows={remaining_rows})"
                                 )
                             # Execute async sell with limit price for reserved orders
+                            closed_legacy_id = stock.get("id")
+                            closed_position_id = legacy_position_id(
+                                "KR", closed_legacy_id
+                            )
                             order_intent = OrderIntent.create(
                                 market="KR",
                                 account_id=stock.get("account_key") or stock.get("account_name") or "default",
@@ -1893,17 +1988,33 @@ class StockTrackingAgent:
                                 side="sell",
                                 order_style="smart",
                                 source="kr_batch",
-                                source_position_id=stock.get("id"),
+                                source_position_id=closed_position_id,
                                 quantity=sell_quantity,
                                 limit_price=current_price,
                                 reason=sell_reason,
                             )
-                            trade_result = await trading.execute_sell(
-                                stock_code=ticker,
-                                limit_price=current_price,
-                                quantity=sell_quantity,
-                                intent=order_intent,
-                            )
+                            try:
+                                trade_result = await trading.execute_sell(
+                                    stock_code=ticker,
+                                    limit_price=current_price,
+                                    quantity=sell_quantity,
+                                    intent=order_intent,
+                                )
+                            except OrderOutcomeUnknown as error:
+                                self._link_position_exit_intent(
+                                    legacy_holding_id=closed_legacy_id,
+                                    account_key=stock.get("account_key"),
+                                    intent_id=error.intent_id,
+                                )
+                                raise
+
+                            persisted_intent_id = trade_result.get("intent_id")
+                            if persisted_intent_id:
+                                self._link_position_exit_intent(
+                                    legacy_holding_id=closed_legacy_id,
+                                    account_key=stock.get("account_key"),
+                                    intent_id=persisted_intent_id,
+                                )
 
                         if trade_result['success']:
                             logger.info(f"Actual sell successful: {trade_result['message']}")
@@ -2240,10 +2351,20 @@ class StockTrackingAgent:
                             _cd_block = _enforce
 
                     if analysis_result.get("decision") == "Enter" and not _cd_block and not _regime_floor_block:
-                        buy_success = await self.buy_stock(ticker, company_name, current_price, scenario, rank_change_msg)
+                        buy_result = await self._buy_stock_with_position(
+                            ticker,
+                            company_name,
+                            current_price,
+                            scenario,
+                            rank_change_msg,
+                        )
+                        buy_success = buy_result.success
 
                         if buy_success:
                             account_key, _ = self._account_scope()
+                            opened_position_id = legacy_position_id(
+                                "KR", buy_result.legacy_holding_id
+                            )
                             order_intent = OrderIntent.create(
                                 market="KR",
                                 account_id=account_key,
@@ -2252,17 +2373,34 @@ class StockTrackingAgent:
                                 order_style="smart",
                                 source="kr_batch",
                                 source_decision_id=source_decision_id,
+                                source_position_id=opened_position_id,
                                 limit_price=current_price,
                                 reason="AI analysis entry",
                             )
-                            async with ExecutionService.domestic(
-                                account_name=account["name"],
-                                db_path=self.db_path,
-                            ) as trading:
-                                trade_result = await trading.execute_buy(
-                                    stock_code=ticker,
-                                    limit_price=current_price,
-                                    intent=order_intent,
+                            try:
+                                async with ExecutionService.domestic(
+                                    account_name=account["name"],
+                                    db_path=self.db_path,
+                                ) as trading:
+                                    trade_result = await trading.execute_buy(
+                                        stock_code=ticker,
+                                        limit_price=current_price,
+                                        intent=order_intent,
+                                    )
+                            except OrderOutcomeUnknown as error:
+                                self._link_position_entry_intent(
+                                    legacy_holding_id=buy_result.legacy_holding_id,
+                                    account_key=account_key,
+                                    intent_id=error.intent_id,
+                                )
+                                raise
+
+                            persisted_intent_id = trade_result.get("intent_id")
+                            if persisted_intent_id:
+                                self._link_position_entry_intent(
+                                    legacy_holding_id=buy_result.legacy_holding_id,
+                                    account_key=account_key,
+                                    intent_id=persisted_intent_id,
                                 )
 
                             if trade_result['success']:

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -344,7 +344,7 @@ class StockTrackingAgent:
         try:
             self.conn.commit()
             linked = bounded_link_write_fail_open(
-                self.cursor,
+                self.db_path,
                 logger=logger,
                 market="KR",
                 legacy_holding_id=legacy_holding_id,
@@ -382,7 +382,7 @@ class StockTrackingAgent:
         try:
             self.conn.commit()
             linked = bounded_link_write_fail_open(
-                self.cursor,
+                self.db_path,
                 logger=logger,
                 market="KR",
                 legacy_holding_id=legacy_holding_id,

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -6,6 +6,7 @@ from scipy import stats
 from typing import List, Tuple, Dict, Any
 from datetime import datetime, timedelta
 from stock_tracking_agent import StockTrackingAgent
+from prism_core.positions import LegacyPositionWriteResult, legacy_position_id
 import asyncio
 import logging
 import json
@@ -18,7 +19,7 @@ from cores.llm.openai_responses_llm import OpenAIResponsesLLM as OpenAIAugmented
 # Import core agents
 from cores.agents.trading_agents import create_sell_decision_agent
 from cores.utils import parse_llm_json
-from prism_core.execution_service import ExecutionService
+from prism_core.execution_service import ExecutionService, OrderOutcomeUnknown
 from prism_core.order_intents import OrderIntent
 
 logging.basicConfig(
@@ -635,10 +636,21 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                 # Process buy if entry decision
                 if decision == "Enter" and buy_score >= min_score and sector_diverse and not _cd_block:
                     # Process buy (is_add => pyramiding additional independent row, #288)
-                    buy_success = await self.buy_stock(ticker, company_name, current_price, scenario, rank_change_msg, is_add=is_add)
+                    buy_result = await self._buy_stock_with_position(
+                        ticker,
+                        company_name,
+                        current_price,
+                        scenario,
+                        rank_change_msg,
+                        is_add=is_add,
+                    )
+                    buy_success = buy_result.success
 
                     if buy_success:
                         account_key, account_name = self._account_scope()
+                        opened_position_id = legacy_position_id(
+                            "KR", buy_result.legacy_holding_id
+                        )
                         order_intent = OrderIntent.create(
                             market="KR",
                             account_id=account_key,
@@ -647,19 +659,36 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                             order_style="smart",
                             source="kr_enhanced_batch",
                             source_decision_id=f"report:{os.path.basename(pdf_report_path)}",
+                            source_position_id=opened_position_id,
                             limit_price=current_price,
                             reason="AI analysis entry",
                         )
                         # Call actual account trading function (async)
-                        async with ExecutionService.domestic(
-                            account_name=account_name,
-                            db_path=self.db_path,
-                        ) as trading:
-                            # Execute async buy with limit price for reserved orders
-                            trade_result = await trading.execute_buy(
-                                stock_code=ticker,
-                                limit_price=current_price,
-                                intent=order_intent,
+                        try:
+                            async with ExecutionService.domestic(
+                                account_name=account_name,
+                                db_path=self.db_path,
+                            ) as trading:
+                                # Execute async buy with limit price for reserved orders
+                                trade_result = await trading.execute_buy(
+                                    stock_code=ticker,
+                                    limit_price=current_price,
+                                    intent=order_intent,
+                                )
+                        except OrderOutcomeUnknown as error:
+                            self._link_position_entry_intent(
+                                legacy_holding_id=buy_result.legacy_holding_id,
+                                account_key=account_key,
+                                intent_id=error.intent_id,
+                            )
+                            raise
+
+                        persisted_intent_id = trade_result.get("intent_id")
+                        if persisted_intent_id:
+                            self._link_position_entry_intent(
+                                legacy_holding_id=buy_result.legacy_holding_id,
+                                account_key=account_key,
+                                intent_id=persisted_intent_id,
                             )
 
                         if trade_result['success']:
@@ -725,7 +754,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
             logger.error(traceback.format_exc())
             return 0, 0
 
-    async def buy_stock(self, ticker: str, company_name: str, current_price: float, scenario: Dict[str, Any], rank_change_msg: str = "", is_add: bool = False) -> bool:
+    async def _buy_stock_with_position(self, ticker: str, company_name: str, current_price: float, scenario: Dict[str, Any], rank_change_msg: str = "", is_add: bool = False) -> LegacyPositionWriteResult:
         """
         Stock buy processing (override parent class method)
 
@@ -743,13 +772,19 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                 scenario['stop_loss'] = stop_loss
                 logger.info(f"{ticker} Dynamic stop-loss calculated: {stop_loss:,.0f} KRW")
 
-            # Call parent class's buy_stock method
-            return await super().buy_stock(ticker, company_name, current_price, scenario, rank_change_msg, is_add=is_add)
+            return await super()._buy_stock_with_position(
+                ticker,
+                company_name,
+                current_price,
+                scenario,
+                rank_change_msg,
+                is_add=is_add,
+            )
 
         except Exception as e:
             logger.error(f"{ticker} Error during purchase processing: {str(e)}")
             logger.error(traceback.format_exc())
-            return False
+            return LegacyPositionWriteResult(False, None)
 
     async def _save_watchlist_item(
         self,

--- a/tasks/issue-412/09-phase4a-execution-plan.md
+++ b/tasks/issue-412/09-phase4a-execution-plan.md
@@ -15,8 +15,9 @@
 이 상태에서 곧바로 `PENDING_ENTRY -> OPEN -> PENDING_EXIT -> CLOSED`를 운영
 source of truth로 바꾸면 batch, loop, pyramiding, US full-exit, publish 시점을 한 번에
 변경하게 된다. Phase 4-a는 먼저 legacy와 신규 원장이 항상 같은 포지션 집합을
-표현하는지 shadow로 증명한다. Phase 4-b에서만 intent 생성 순서를 앞으로 옮기고
-PENDING 상태와 읽기 전환을 다룬다.
+표현하는지 shadow로 증명한다. 동작 순서를 유지하는 Phase 4-b1 intent linkage는
+병행할 수 있지만, intent 생성 순서를 앞으로 옮기는 Phase 4-b2 PENDING 상태와
+읽기 전환은 아래 관찰 gate를 통과한 뒤에만 다룬다.
 
 ## 2. Phase 4-a 범위
 
@@ -77,7 +78,8 @@ PENDING 상태와 읽기 전환을 다룬다.
 - 기존 holdings/history 삭제 또는 schema 변경
 
 위 항목은 최소 5번의 실제 주문 경로 실행일 동안 shadow ledger 무불일치가 확인된 뒤
-Phase 4-b 또는 Phase 5에서 수행한다.
+Phase 4-b2, Phase 4 read switch 또는 Phase 5에서 수행한다. 기존 순서를 바꾸지 않고
+nullable intent id만 연결하는 Phase 4-b1은 이 gate의 적용 대상이 아니다.
 
 ## 4. 테스트 우선 순서
 
@@ -105,7 +107,7 @@ Phase 4-b 또는 Phase 5에서 수행한다.
 5. 매일 batch + hardstop/trend 실행 후 대조 결과 저장. batch-rest로 주문 경로가 실행되지 않은
    날은 관찰 일수에 포함하지 않는다.
 6. mismatch 또는 unresolved mirror error가 한 건이라도 생기면 연속 무불일치 카운터를 0으로 리셋한다.
-7. 최소 5 실행일 무불일치 전에는 Phase 4-b 읽기 전환을 시작하지 않는다.
+7. 최소 5 실행일 무불일치 전에는 Phase 4-b2 PENDING 전이와 Phase 4 read switch를 시작하지 않는다.
 8. 롤백: `POSITION_LEDGER_SHADOW_ENABLED=false`; 신규 테이블은 보존해 사후 분석에 사용한다.
 
 ## 6. 완료 조건
@@ -114,4 +116,4 @@ Phase 4-b 또는 Phase 5에서 수행한다.
 - 기존 holdings/history row와 schema가 변하지 않는다.
 - KR/US 단일·pyramiding·US full-exit·동시 SELL에서 shadow position 집합이 일치한다.
 - 대조기가 불일치를 자동 수정하지 않고 non-zero로 탐지한다.
-- 5 실행일 관찰 계획과 Phase 4-b 진입 gate가 handoff에 기록된다.
+- 5 실행일 관찰 계획과 Phase 4-b2/read switch 진입 gate가 handoff에 기록된다.

--- a/tasks/issue-412/10-phase4b1-intent-linkage-plan.md
+++ b/tasks/issue-412/10-phase4b1-intent-linkage-plan.md
@@ -1,0 +1,80 @@
+# Issue #412 Phase 4-b1 실행 계획 — Position ↔ persisted intent linkage
+
+> 기준: main `5ed6f38c` (Phase 4-a + direct comparator hotfix 배포 완료)
+> 목표: 기존 simulator/read/order/publish 순서를 바꾸지 않고, 실제로 영속화된
+> `order_intents.id`를 해당 legacy position에 연결한다.
+
+## 1. 왜 Phase 4-b를 다시 나누는가
+
+목표 상태기계의 `PENDING_ENTRY/PENDING_EXIT`을 의미 있게 쓰려면
+`intent CREATED -> position PENDING_* -> broker -> position 확정` 순서가 필요하다.
+현재 운영은 legacy holding INSERT/DELETE를 먼저 commit한 뒤 intent를 만들고 broker를
+호출한다. 이 순서 변경은 실패 보상과 UNKNOWN reconciliation까지 함께 요구하므로
+단순 리팩터링 범위를 넘는다.
+
+따라서 4-b1은 현재 순서를 그대로 보존하면서 Phase 3 intent 원장과 Phase 4-a position
+원장의 식별자만 연결한다. 4-b2에서만 write-ahead/PENDING 전이를 별도 검토한다.
+
+## 2. 포함 범위
+
+- `PositionStore`에 persisted intent 검증 + idempotent linkage API 추가.
+  - entry: legacy OPEN position의 `entry_intent_id`
+  - exit: legacy CLOSED position의 `exit_intent_id`
+  - intent가 `order_intents`에 실제 존재하고 market/account/symbol/side가 position과
+    일치할 때만 연결한다.
+  - `order_intents.source_position_id`도 대상 canonical position id
+    (`legacy:{MARKET}:{holding_id}`)와 일치해야 한다. US full-exit은 정렬된 sibling
+    canonical id 집합 전체가 정확히 일치해야 한다.
+  - 같은 intent 재연결은 성공, 다른 intent로 덮어쓰기는 거부한다.
+  - US full-exit은 전체 sibling의 존재/account/symbol/CLOSED/overwrite를 먼저 검증하고
+    하나의 SQL UPDATE로 동일 exit intent를 모두 연결한다.
+- buy simulator 성공 시 legacy holding id를 내부 caller가 안전하게 받을 수 있는
+  동작 보존형 결과 경계를 추가한다. 기존 public bool 사용자는 그대로 유지한다.
+- broker 실행 결과의 `intent_id`(중복 차단이면 기존 persisted id 포함)를 사용해 연결한다.
+- 신규 BUY intent에는 canonical `source_position_id`도 기록하되 idempotency identity는
+  기존 `source_decision_id`를 계속 우선한다. SELL은 position identity를 우선한다.
+- duplicate 결과는 기존 intent의 source position이 현재 대상과 정확히 같을 때만 연결한다.
+  다르거나 NULL이면 linkage를 비워두고 durable audit을 남긴다.
+- UNKNOWN 예외도 persisted intent id가 있으므로 연결하되 legacy 보상은 하지 않는다.
+- linkage SQLite lock busy timeout은 50ms로 제한해 기존 거래/publish를 지연시키지 않는다.
+- validation linkage 실패는 구조화 로그 + durable mirror audit으로 남긴다. SQLite lock은
+  같은 DB에 audit을 쓸 수 없으므로 CRITICAL 운영 로그를 남기고 comparator가 canonical
+  intent source와 NULL/wrong linkage를 후속 탐지한다.
+- `POSITION_LEDGER_SHADOW_ENABLED=false`이면 linkage도 no-op한다.
+
+## 3. 명시적 비목표
+
+- production `PENDING_ENTRY/PENDING_EXIT` 사용
+- legacy holding/history 쓰기 또는 판단 read 순서 변경
+- OrderIntent reserve 시점 변경
+- broker 호출, 수량 계산, Telegram/Redis/GCP publish 순서 변경
+- 주문 실패 시 simulator 보상
+- read source를 `positions`로 전환
+- 체결(FILLED) 추정, reconciliation, amend/cancel
+- 기존 position/intent schema 삭제·변경 또는 FK 강제 migration
+
+## 4. 테스트 우선 gate
+
+1. persisted intent만 연결되고 identity 불일치/미영속 intent는 거부된다.
+2. 같은 intent 재연결은 idempotent, 다른 intent overwrite는 거부된다.
+3. OPEN entry / CLOSED exit 상태 제약을 지킨다.
+4. US full-exit sibling 여러 행에 같은 exit intent가 연결된다.
+5. KR/US buy caller는 기존 bool 결과를 유지하면서 정확한 legacy id를 linkage에 전달한다.
+6. KR/US batch와 enhanced buy, batch/loop sell의 broker/publish 순서는 그대로다.
+7. BUY는 decision-first, SELL은 position-first idempotency를 유지한다.
+8. duplicate intent 결과는 source position이 정확히 같을 때만 persisted existing intent id를
+   연결하고, 다르면 거부/audit한다.
+9. validation linkage 오류 주입 시 legacy 결과·broker/publish가 유지되고 unresolved audit이 남는다.
+   SQLite lock은 1초 미만에 fail-open하고 comparator가 missing linkage를 탐지한다.
+10. 기존 Phase 4-a comparator/positions, Phase 3 intent, sell concurrency 전체 회귀 통과.
+
+## 5. 완료 조건과 롤백
+
+- 모든 새 linkage는 additive nullable 컬럼만 갱신한다.
+- legacy와 positions의 OPEN 집합 comparator는 계속 일치한다.
+- 운영 DB의 기존 9 position은 linkage null이어도 정상이며 과거 주문을 추정 backfill하지 않는다.
+- 신규 주문부터만 linkage를 채운다.
+- 롤백은 `POSITION_LEDGER_SHADOW_ENABLED=false`; 기존 linkage 값은 사후 분석을 위해 보존한다.
+- 4-b1 완료는 4-b2 PENDING write-ahead 또는 read switch 승인을 의미하지 않는다.
+- broker 성공 후 linkage commit 전에 프로세스가 종료되는 crash gap은 4-b1에서 자동 복구하지
+  않는다. comparator의 `intent_link_mismatches`가 탐지만 수행하고 reconciliation은 Phase 5 비목표다.

--- a/tasks/issue-412/README.md
+++ b/tasks/issue-412/README.md
@@ -2,8 +2,8 @@
 
 > 이슈: [#412 매수/매도 Agent 분리와 KIS 실제 주문 실행 구조 이식 설계](https://github.com/dragon1086/prism-insight/issues/412)
 > 브랜치: `feature/issue-412-execution-architecture`
-> 상태: Phase 4-a 착수 (2026-07-06 시작, 2026-07-13 main #432 기준 전면 재검토,
-> **2026-07-19 Phase 3 main 배포 완료 후 position shadow ledger 시작**)
+> 상태: Phase 4-b1 착수 (2026-07-06 시작, 2026-07-13 main #432 기준 전면 재검토,
+> **2026-07-19 Phase 4-a position shadow ledger 배포 완료 후 intent linkage 시작**)
 
 ## 목적
 
@@ -38,8 +38,10 @@ greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 
 - [x] Phase 1-b: KST 주문시간대 순수 함수 추출 (PR #455, main `c4c2539d`)
 - [x] Phase 2: ExecutionService chokepoint 도입 (PR #456, main `1aca6029`)
 - [x] Phase 3: OrderIntent 영속화 (PR #459, main `8ff33b17`)
-- [ ] Phase 4-a: position OPEN/CLOSED shadow 병행 기록 + 대조 — 진행 중
-- [ ] Phase 4-b: PENDING 전이 + 5 실행일 무불일치 후 읽기 전환
+- [x] Phase 4-a: position OPEN/CLOSED shadow 병행 기록 + 대조 (PR #460/#461, main `5ed6f38c`)
+- [ ] Phase 4-b1: persisted intent ↔ position linkage — 진행 중, legacy 순서/read 유지
+- [ ] Phase 4-b2: PENDING write-ahead + 실패 보상 (별도 위험 PR)
+- [ ] Phase 4 read switch: 충분한 운영 대조 후 별도 승인
 - [ ] Phase 5: BrokerAdapter 추출 (체결/미체결/정정 포함) + lock 일반화 + reconciliation (alert-only)
 - [ ] Phase 6: 이벤트 버스 / 코어-어댑터 패키지 분리 / prism-us 흡수
 
@@ -54,3 +56,4 @@ greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 
 
 Phase 2의 구체적인 작업 순서와 비목표는 [07-phase2-execution-plan.md](07-phase2-execution-plan.md)를 따른다.
 Phase 4-a의 안전한 shadow 범위와 관찰 gate는 [09-phase4a-execution-plan.md](09-phase4a-execution-plan.md)를 따른다.
+Phase 4-b1의 동작 보존형 intent linkage 범위는 [10-phase4b1-intent-linkage-plan.md](10-phase4b1-intent-linkage-plan.md)를 따른다.

--- a/tests/test_hardstop_seller.py
+++ b/tests/test_hardstop_seller.py
@@ -63,6 +63,10 @@ class FakeAgent:
         self.calls.append(f"sim:{stock_data.get('ticker')}")
         return True
 
+    def _link_position_exit_intent(self, **kwargs):
+        self.calls.append(f"link:{kwargs.get('legacy_holding_id')}")
+        return True
+
     async def send_telegram_message(self, chat_id, language="ko", **kwargs):
         self.calls.append("tg")
         return True
@@ -163,7 +167,13 @@ def test_live_order_is_sim_then_kis_then_telegram(tmp_db, monkeypatch):
     # per-sell flush + run-end flush each invoke send_telegram_message; the run-end
     # portfolio summary is de-duplicated (portfolio_broadcast) so only ONE actual
     # portfolio message goes out in prod (see tests/test_portfolio_broadcast.py).
-    assert calls == ["sim:005930", "kis:005930:10", "tg", "tg"]   # exact order
+    assert calls == [
+        "sim:005930",
+        "kis:005930:10",
+        "link:1",
+        "tg",
+        "tg",
+    ]  # exact order
     assert _inflight(tmp_db, "FILLED") == 1
 
 
@@ -239,7 +249,7 @@ def test_pyramided_ticker_is_skipped(tmp_db, monkeypatch):
     assert calls == []
 
 
-def test_inflight_guard_blocks_second_trigger(tmp_db, monkeypatch):
+def test_shadow_record_does_not_block_second_trigger(tmp_db, monkeypatch):
     monkeypatch.setattr(la, "HARDSTOP_LIVE", False)
     monkeypatch.setattr(la, "HARDSTOP_ENABLED", True)
     _seed(tmp_db, [_row(1, "005930", 100.0)])
@@ -250,8 +260,9 @@ def test_inflight_guard_blocks_second_trigger(tmp_db, monkeypatch):
     asyncio.run(la.run_market("KR", "run1"))
     summary2 = asyncio.run(la.run_market("KR", "run2"))
 
-    assert summary2["skipped"] == 1
-    assert _inflight(tmp_db) == 1
+    assert summary2["skipped"] == 0
+    assert summary2["shadow"] == 1
+    assert _inflight(tmp_db) == 2
 
 
 def test_owner_lock_is_exclusive(tmp_db):

--- a/tests/test_order_intents.py
+++ b/tests/test_order_intents.py
@@ -1,5 +1,6 @@
 import asyncio
 import ast
+import hashlib
 import sqlite3
 from pathlib import Path
 
@@ -434,6 +435,78 @@ def test_same_buy_decision_key_is_shared_across_sources():
     second = OrderIntent.create(source="retry_worker", **kwargs)
 
     assert first.idempotency_key == second.idempotency_key
+
+
+def test_buy_prefers_decision_identity_when_position_is_also_present():
+    from prism_core.order_intents import OrderIntent
+
+    kwargs = {
+        "market": "US",
+        "account_id": "acct-us",
+        "symbol": "AAPL",
+        "side": "buy",
+        "order_style": "smart",
+        "source": "us_batch",
+        "source_decision_id": "report:AAPL_20260719.pdf",
+    }
+    first = OrderIntent.create(source_position_id="position:101", **kwargs)
+    second = OrderIntent.create(source_position_id="position:102", **kwargs)
+
+    assert first.idempotency_key == second.idempotency_key
+    assert first.request_payload()["source_decision_id"] == kwargs[
+        "source_decision_id"
+    ]
+    assert first.request_payload()["source_position_id"] == "position:101"
+
+
+def test_sell_prefers_position_identity_when_decision_is_also_present():
+    from prism_core.order_intents import OrderIntent
+
+    kwargs = {
+        "market": "KR",
+        "account_id": "acct-1",
+        "symbol": "005930",
+        "side": "sell",
+        "order_style": "market",
+        "source": "kr_batch",
+        "source_decision_id": "decision:shared",
+    }
+    first = OrderIntent.create(source_position_id="position:101", **kwargs)
+    second = OrderIntent.create(source_position_id="position:102", **kwargs)
+
+    assert first.idempotency_key != second.idempotency_key
+    assert first.request_payload()["source_decision_id"] == "decision:shared"
+    assert first.request_payload()["source_position_id"] == "position:101"
+
+
+@pytest.mark.parametrize(
+    ("side", "identity_kwargs", "identity"),
+    (
+        ("buy", {"source_decision_id": "decision:only"}, "decision:decision:only"),
+        ("buy", {"source_position_id": "position:only"}, "position:position:only"),
+        ("sell", {"source_decision_id": "decision:only"}, "decision:decision:only"),
+        ("sell", {"source_position_id": "position:only"}, "position:position:only"),
+    ),
+)
+def test_single_source_identity_keeps_existing_idempotency(
+    side, identity_kwargs, identity
+):
+    from prism_core.order_intents import OrderIntent
+
+    kwargs = {
+        "market": "KR",
+        "account_id": "acct-1",
+        "symbol": "005930",
+        "side": side,
+        "order_style": "market",
+        **identity_kwargs,
+    }
+    first = OrderIntent.create(source="batch", **kwargs)
+    second = OrderIntent.create(source="retry", **kwargs)
+    key_source = f"v1|KR|acct-1|005930|{side.upper()}|{identity}"
+
+    assert first.idempotency_key == second.idempotency_key
+    assert first.idempotency_key == hashlib.sha256(key_source.encode()).hexdigest()
 
 
 def test_all_production_new_order_calls_supply_an_intent():

--- a/tests/test_parallel_trading_batch.py
+++ b/tests/test_parallel_trading_batch.py
@@ -33,6 +33,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 import stock_tracking_enhanced_agent as enh_mod
+from prism_core.positions import LegacyPositionWriteResult
 from stock_tracking_enhanced_agent import EnhancedStockTrackingAgent
 
 
@@ -207,17 +208,26 @@ async def test_gates_run_sequentially_after_parallel_phase(monkeypatch):
         # First Tech candidate is diverse; once one is bought, block the rest.
         return sector not in bought_sectors
 
-    async def fake_buy_stock(ticker, company_name, current_price, scenario,
-                             rank_change_msg="", is_add=False):
+    next_legacy_id = iter((101, 102))
+
+    async def fake_buy_stock_with_position(
+        ticker,
+        company_name,
+        current_price,
+        scenario,
+        rank_change_msg="",
+        is_add=False,
+    ):
         events.append(("buy", ticker))
         bought_sectors.add(scenario.get("sector", "Tech"))
-        return True
+        return LegacyPositionWriteResult(True, next(next_legacy_id))
 
     agent._analyze_report_core = core_stub
     agent._extract_ticker_info = fake_extract_ticker_info
     agent._is_ticker_in_holdings = fake_is_holding
     agent._check_sector_diversity = fake_sector_diversity
-    agent.buy_stock = fake_buy_stock
+    agent._buy_stock_with_position = fake_buy_stock_with_position
+    agent._link_position_entry_intent = MagicMock(return_value=True)
 
     buy_count, _ = await agent.process_reports([path_a, path_b])
 

--- a/tests/test_parallel_trading_batch.py
+++ b/tests/test_parallel_trading_batch.py
@@ -141,7 +141,7 @@ async def test_prepass_respects_semaphore_cap(monkeypatch):
 # 2. Order-sensitive gates stay in the sequential phase
 # ---------------------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_gates_run_sequentially_after_parallel_phase(monkeypatch):
+async def test_gates_run_sequentially_after_parallel_phase(monkeypatch, tmp_path):
     """
     Cores are computed in the parallel pre-pass; then the REAL analyze_report runs
     the holdings/sector gates sequentially in original order. A second same-sector
@@ -182,6 +182,7 @@ async def test_gates_run_sequentially_after_parallel_phase(monkeypatch):
     monkeypatch.setitem(sys.modules, "messaging.gcp_pubsub_signal_publisher", gcp_mod)
 
     agent = _make_agent()
+    agent.db_path = str(tmp_path / "parallel-order-intents.sqlite")
 
     path_a = "reports/005930_A_20260101_morning.pdf"
     path_b = "reports/000660_B_20260101_morning.pdf"

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -2,14 +2,19 @@ import json
 import sqlite3
 import subprocess
 import sys
+import time
+from dataclasses import FrozenInstanceError
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
 from prism_core.positions import (
     InvalidPositionTransition,
+    LegacyPositionWriteResult,
     PositionStore,
     account_fingerprint,
+    bounded_link_write_fail_open,
     legacy_position_id,
     mirror_write_fail_open,
 )
@@ -30,6 +35,37 @@ def _legacy_schema(conn: sqlite3.Connection) -> None:
             )
             """
         )
+
+
+def _order_intents_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE order_intents (
+            id TEXT PRIMARY KEY,
+            market TEXT NOT NULL,
+            account_id TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            side TEXT NOT NULL,
+            source_position_id TEXT
+        )
+        """
+    )
+
+
+def _insert_intent(
+    conn: sqlite3.Connection,
+    intent_id: str,
+    *,
+    market: str = "KR",
+    account_id: str = "acct",
+    symbol: str = "005930",
+    side: str = "BUY",
+    source_position_id: str | None = "legacy:KR:1",
+) -> None:
+    conn.execute(
+        "INSERT INTO order_intents VALUES (?, ?, ?, ?, ?, ?)",
+        (intent_id, market, account_id, symbol, side, source_position_id),
+    )
 
 
 def _insert_legacy(
@@ -72,6 +108,15 @@ def test_schema_is_additive_and_caller_controls_transaction() -> None:
         for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
     }
     assert {"positions", "position_mirror_errors"} <= tables
+
+
+def test_legacy_position_write_result_is_immutable_and_explicit() -> None:
+    result = LegacyPositionWriteResult(success=True, legacy_holding_id=17)
+
+    assert result.success is True
+    assert result.legacy_holding_id == 17
+    with pytest.raises(FrozenInstanceError):
+        setattr(result, "success", False)
 
 
 def test_transition_graph_and_database_check_are_enforced() -> None:
@@ -251,6 +296,363 @@ def test_us_full_exit_can_close_multiple_rows_with_one_intent() -> None:
         "SELECT status, exit_intent_id FROM positions ORDER BY legacy_holding_id"
     ).fetchall()
     assert rows == [("CLOSED", "intent-full-exit")] * 3
+
+
+def test_entry_link_requires_persisted_matching_buy_intent() -> None:
+    conn = sqlite3.connect(":memory:")
+    _order_intents_schema(conn)
+    store = PositionStore(conn)
+    store.ensure_schema()
+    assert store.open_legacy_position(
+        market="KR",
+        legacy_holding_id=1,
+        account_id="acct",
+        account_name="primary",
+        symbol="005930",
+    )
+
+    with pytest.raises(LookupError, match="intent not found"):
+        store.link_entry_intent(
+            market="KR",
+            legacy_holding_id=1,
+            account_id="acct",
+            intent_id="missing",
+        )
+
+    mismatches = (
+        ("wrong-market", "US", "acct", "005930", "BUY"),
+        ("wrong-account", "KR", "other", "005930", "BUY"),
+        ("wrong-symbol", "KR", "acct", "000660", "BUY"),
+        ("wrong-side", "KR", "acct", "005930", "SELL"),
+    )
+    for intent_id, market, account_id, symbol, side in mismatches:
+        _insert_intent(
+            conn,
+            intent_id,
+            market=market,
+            account_id=account_id,
+            symbol=symbol,
+            side=side,
+        )
+        with pytest.raises(ValueError, match="does not match position"):
+            store.link_entry_intent(
+                market="KR",
+                legacy_holding_id=1,
+                account_id="acct",
+                intent_id=intent_id,
+            )
+
+    _insert_intent(conn, "missing-source", source_position_id=None)
+    _insert_intent(conn, "wrong-source", source_position_id="legacy:KR:999")
+    for intent_id in ("missing-source", "wrong-source"):
+        with pytest.raises(ValueError, match="source_position_id"):
+            store.link_entry_intent(
+                market="KR",
+                legacy_holding_id=1,
+                account_id="acct",
+                intent_id=intent_id,
+            )
+
+    _insert_intent(conn, "entry-intent")
+    assert store.link_entry_intent(
+        market="KR",
+        legacy_holding_id=1,
+        account_id="acct",
+        intent_id="entry-intent",
+    )
+    assert conn.execute("SELECT entry_intent_id FROM positions").fetchone() == (
+        "entry-intent",
+    )
+
+
+def test_intent_link_is_idempotent_rejects_overwrite_and_does_not_commit() -> None:
+    conn = sqlite3.connect(":memory:")
+    _order_intents_schema(conn)
+    store = PositionStore(conn)
+    store.ensure_schema()
+    store.open_legacy_position(
+        market="KR",
+        legacy_holding_id=1,
+        account_id="acct",
+        account_name="primary",
+        symbol="005930",
+    )
+    _insert_intent(conn, "entry-one")
+    _insert_intent(conn, "entry-two")
+    conn.commit()
+
+    conn.execute("BEGIN")
+    assert store.link_entry_intent(
+        market="KR",
+        legacy_holding_id=1,
+        account_id="acct",
+        intent_id="entry-one",
+    )
+    assert store.link_entry_intent(
+        market="KR",
+        legacy_holding_id=1,
+        account_id="acct",
+        intent_id="entry-one",
+    )
+    store.close_legacy_position(
+        market="KR", legacy_holding_id=1, account_id="acct"
+    )
+    assert store.link_entry_intent(
+        market="KR",
+        legacy_holding_id=1,
+        account_id="acct",
+        intent_id="entry-one",
+    )
+    conn.execute(
+        "UPDATE positions SET status='OPEN', closed_at=NULL WHERE id='legacy:KR:1'"
+    )
+    conn.execute(
+        "UPDATE order_intents SET source_position_id='legacy:KR:999' "
+        "WHERE id='entry-one'"
+    )
+    with pytest.raises(ValueError, match="source_position_id"):
+        store.link_entry_intent(
+            market="KR",
+            legacy_holding_id=1,
+            account_id="acct",
+            intent_id="entry-one",
+        )
+    conn.execute(
+        "UPDATE order_intents SET source_position_id='legacy:KR:1' "
+        "WHERE id='entry-one'"
+    )
+    with pytest.raises(ValueError, match="already linked"):
+        store.link_entry_intent(
+            market="KR",
+            legacy_holding_id=1,
+            account_id="acct",
+            intent_id="entry-two",
+        )
+    conn.rollback()
+
+    assert conn.execute("SELECT entry_intent_id FROM positions").fetchone() == (None,)
+
+
+def test_entry_and_exit_intent_links_enforce_position_state() -> None:
+    conn = sqlite3.connect(":memory:")
+    _order_intents_schema(conn)
+    store = PositionStore(conn)
+    store.ensure_schema()
+    store.open_legacy_position(
+        market="KR",
+        legacy_holding_id=1,
+        account_id="acct",
+        account_name="primary",
+        symbol="005930",
+    )
+    _insert_intent(conn, "entry-intent")
+    _insert_intent(conn, "exit-intent", side="SELL")
+
+    with pytest.raises(InvalidPositionTransition, match="CLOSED"):
+        store.link_exit_intent(
+            market="KR",
+            legacy_holding_id=1,
+            account_id="acct",
+            intent_id="exit-intent",
+        )
+
+    store.close_legacy_position(
+        market="KR", legacy_holding_id=1, account_id="acct"
+    )
+    with pytest.raises(InvalidPositionTransition, match="OPEN"):
+        store.link_entry_intent(
+            market="KR",
+            legacy_holding_id=1,
+            account_id="acct",
+            intent_id="entry-intent",
+        )
+    assert store.link_exit_intent(
+        market="KR",
+        legacy_holding_id=1,
+        account_id="acct",
+        intent_id="exit-intent",
+    )
+
+
+def test_us_sibling_positions_can_share_one_persisted_exit_intent() -> None:
+    conn = sqlite3.connect(":memory:")
+    _order_intents_schema(conn)
+    store = PositionStore(conn)
+    store.ensure_schema()
+    _insert_intent(
+        conn,
+        "full-exit",
+        market="US",
+        account_id="acct",
+        symbol="AAPL",
+        side="SELL",
+        source_position_id=(
+            "legacy:US:1,legacy:US:2,legacy:US:3"
+        ),
+    )
+    expected_position_ids = {
+        legacy_position_id("US", legacy_holding_id)
+        for legacy_holding_id in (1, 2, 3)
+    }
+    for legacy_holding_id in (1, 2, 3):
+        store.open_legacy_position(
+            market="US",
+            legacy_holding_id=legacy_holding_id,
+            account_id="acct",
+            account_name="primary",
+            symbol="AAPL",
+        )
+    conn.execute("UPDATE positions SET symbol='MSFT' WHERE id='legacy:US:3'")
+    with pytest.raises(ValueError, match="does not match position"):
+        store.link_exit_intent(
+            market="US",
+            legacy_holding_id=1,
+            account_id="acct",
+            intent_id="full-exit",
+            expected_position_ids=expected_position_ids,
+        )
+    conn.execute("UPDATE positions SET symbol='AAPL' WHERE id='legacy:US:3'")
+
+    conn.execute("UPDATE positions SET account_id='other' WHERE id='legacy:US:3'")
+    with pytest.raises(LookupError, match="source positions not found"):
+        store.link_exit_intent(
+            market="US",
+            legacy_holding_id=1,
+            account_id="acct",
+            intent_id="full-exit",
+            expected_position_ids=expected_position_ids,
+        )
+    conn.execute("UPDATE positions SET account_id='acct' WHERE id='legacy:US:3'")
+
+    with pytest.raises(InvalidPositionTransition, match="CLOSED"):
+        store.link_exit_intent(
+            market="US",
+            legacy_holding_id=1,
+            account_id="acct",
+            intent_id="full-exit",
+            expected_position_ids=expected_position_ids,
+        )
+
+    for legacy_holding_id in (1, 2, 3):
+        store.close_legacy_position(
+            market="US",
+            legacy_holding_id=legacy_holding_id,
+            account_id="acct",
+        )
+
+    conn.execute(
+        "UPDATE order_intents SET source_position_id="
+        "'legacy:US:1,legacy:US:2,legacy:US:999' WHERE id='full-exit'"
+    )
+    with pytest.raises(LookupError, match="source positions not found"):
+        store.link_exit_intent(
+            market="US",
+            legacy_holding_id=1,
+            account_id="acct",
+            intent_id="full-exit",
+            expected_position_ids={
+                "legacy:US:1",
+                "legacy:US:2",
+                "legacy:US:999",
+            },
+        )
+    conn.execute(
+        "UPDATE order_intents SET source_position_id="
+        "'legacy:US:1,legacy:US:2,legacy:US:3' WHERE id='full-exit'"
+    )
+
+    assert store.link_exit_intent(
+        market="US",
+        legacy_holding_id=1,
+        account_id="acct",
+        intent_id="full-exit",
+        expected_position_ids=expected_position_ids,
+    )
+
+    assert conn.execute(
+        "SELECT COUNT(*) FROM positions WHERE exit_intent_id='full-exit'"
+    ).fetchone() == (3,)
+
+
+def test_bounded_link_lock_wait_is_short_and_comparator_detects_missing_link(
+    tmp_path,
+) -> None:
+    db_path = tmp_path / "locked.sqlite"
+    conn = sqlite3.connect(db_path)
+    _legacy_schema(conn)
+    _order_intents_schema(conn)
+    _insert_legacy(conn, "stock_holdings", 1, "acct", "005930")
+    store = PositionStore(conn)
+    store.ensure_schema()
+    store.backfill_legacy_positions("KR")
+    _insert_intent(conn, "entry-intent")
+    conn.commit()
+
+    blocker = sqlite3.connect(db_path)
+    blocker.execute("BEGIN")
+    blocker.execute("SELECT * FROM positions").fetchall()
+    logger = MagicMock()
+    original_timeout = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+
+    started = time.monotonic()
+    linked = bounded_link_write_fail_open(
+        conn,
+        logger=logger,
+        market="KR",
+        legacy_holding_id=1,
+        account_id="acct",
+        operation="link_entry_intent",
+        write=lambda position_store: position_store.link_entry_intent(
+            market="KR",
+            legacy_holding_id=1,
+            account_id="acct",
+            intent_id="entry-intent",
+        ),
+    )
+    elapsed = time.monotonic() - started
+
+    assert linked is False
+    assert elapsed < 1.0
+    assert conn.execute("PRAGMA busy_timeout").fetchone()[0] == original_timeout
+    assert logger.critical.call_count >= 1
+    assert conn.execute(
+        "SELECT COUNT(*) FROM position_mirror_errors"
+    ).fetchone() == (0,)
+
+    blocker.rollback()
+    comparison = PositionStore(conn).compare_legacy_positions("KR")
+    assert comparison["matches"] is False
+    assert comparison["intent_link_mismatches"] == [
+        {
+            "intent_id": "entry-intent",
+            "position_id": "legacy:KR:1",
+            "account_ref": account_fingerprint("acct"),
+            "symbol": "005930",
+            "side": "BUY",
+            "reasons": ["missing_or_wrong_link"],
+        }
+    ]
+
+
+def test_bounded_link_recognizes_python310_lock_error_without_error_code() -> None:
+    conn = sqlite3.connect(":memory:")
+    logger = MagicMock()
+
+    def raise_legacy_lock_error(_store) -> None:
+        error = sqlite3.OperationalError("database is locked")
+        assert getattr(error, "sqlite_errorcode", None) is None
+        raise error
+
+    assert bounded_link_write_fail_open(
+        conn,
+        logger=logger,
+        market="KR",
+        legacy_holding_id=1,
+        account_id="acct",
+        operation="link_entry_intent",
+        write=raise_legacy_lock_error,
+    ) is False
+    assert logger.critical.call_count >= 2
 
 
 def test_compare_is_read_only_and_reports_structured_mismatches_and_audit_errors() -> None:

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -592,11 +592,9 @@ def test_bounded_link_lock_wait_is_short_and_comparator_detects_missing_link(
     blocker.execute("BEGIN")
     blocker.execute("SELECT * FROM positions").fetchall()
     logger = MagicMock()
-    original_timeout = conn.execute("PRAGMA busy_timeout").fetchone()[0]
-
     started = time.monotonic()
     linked = bounded_link_write_fail_open(
-        conn,
+        db_path,
         logger=logger,
         market="KR",
         legacy_holding_id=1,
@@ -613,7 +611,6 @@ def test_bounded_link_lock_wait_is_short_and_comparator_detects_missing_link(
 
     assert linked is False
     assert elapsed < 1.0
-    assert conn.execute("PRAGMA busy_timeout").fetchone()[0] == original_timeout
     assert logger.critical.call_count >= 1
     assert conn.execute(
         "SELECT COUNT(*) FROM position_mirror_errors"
@@ -634,8 +631,10 @@ def test_bounded_link_lock_wait_is_short_and_comparator_detects_missing_link(
     ]
 
 
-def test_bounded_link_recognizes_python310_lock_error_without_error_code() -> None:
-    conn = sqlite3.connect(":memory:")
+def test_bounded_link_recognizes_python310_lock_error_without_error_code(
+    tmp_path,
+) -> None:
+    db_path = tmp_path / "legacy-lock.sqlite"
     logger = MagicMock()
 
     def raise_legacy_lock_error(_store) -> None:
@@ -644,7 +643,7 @@ def test_bounded_link_recognizes_python310_lock_error_without_error_code() -> No
         raise error
 
     assert bounded_link_write_fail_open(
-        conn,
+        db_path,
         logger=logger,
         market="KR",
         legacy_holding_id=1,

--- a/tests/test_stock_tracking_agent_process_reports.py
+++ b/tests/test_stock_tracking_agent_process_reports.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(PROJECT_ROOT))
 
 import trading.domestic_stock_trading as domestic_trading
 from stock_tracking_agent import StockTrackingAgent
+from prism_core.positions import LegacyPositionWriteResult
 from tracking.db_schema import TABLE_STOCK_HOLDINGS, TABLE_TRADING_HISTORY
 
 
@@ -341,6 +342,7 @@ async def test_process_reports_analyzes_once_and_dedupes_signals(monkeypatch, ca
     slot_checks = []
     sector_checks = []
     buy_calls = []
+    link_calls = []
     redis_calls = []
     gcp_calls = []
 
@@ -375,6 +377,10 @@ async def test_process_reports_analyzes_once_and_dedupes_signals(monkeypatch, ca
 
     async def fake_buy_stock(ticker, company_name, current_price, scenario, rank_change_msg):
         buy_calls.append((agent.active_account["name"], ticker))
+        return LegacyPositionWriteResult(True, len(buy_calls))
+
+    def fake_link_position_entry_intent(**kwargs):
+        link_calls.append(kwargs)
         return True
 
     agent._analyze_report_core = fake_core
@@ -382,7 +388,8 @@ async def test_process_reports_analyzes_once_and_dedupes_signals(monkeypatch, ca
     agent._is_ticker_in_holdings = fake_is_ticker_in_holdings
     agent._get_current_slots_count = fake_get_current_slots_count
     agent._check_sector_diversity = fake_check_sector_diversity
-    agent.buy_stock = fake_buy_stock
+    agent._buy_stock_with_position = fake_buy_stock
+    agent._link_position_entry_intent = fake_link_position_entry_intent
 
     monkeypatch.setattr(domestic_trading, "AsyncTradingContext", _FakeAsyncTradingContext)
     _install_signal_modules(monkeypatch, redis_calls, gcp_calls)
@@ -398,6 +405,15 @@ async def test_process_reports_analyzes_once_and_dedupes_signals(monkeypatch, ca
     assert slot_checks == ["kr-primary", "kr-secondary"]
     assert sector_checks == [("kr-primary", "Technology"), ("kr-secondary", "Technology")]
     assert buy_calls == [("kr-primary", "005930"), ("kr-secondary", "005930")]
+    assert [call["legacy_holding_id"] for call in link_calls] == [1, 2]
+    assert all(call["intent_id"] for call in link_calls)
+    intent_sources = sqlite3.connect(agent.db_path).execute(
+        "SELECT account_id, source_position_id FROM order_intents ORDER BY account_id"
+    ).fetchall()
+    assert intent_sources == [
+        ("vps:kr-primary:01", "legacy:KR:1"),
+        ("vps:kr-secondary:01", "legacy:KR:2"),
+    ]
     assert len(redis_calls) == 1
     assert len(gcp_calls) == 1
     assert "partial success" in caplog.text.lower()
@@ -466,7 +482,7 @@ async def test_process_reports_saves_watchlist_once_when_not_traded(monkeypatch)
     agent._is_ticker_in_holdings = fake_is_ticker_in_holdings
     agent._get_current_slots_count = fake_get_current_slots_count
     agent._check_sector_diversity = fake_check_sector_diversity
-    agent.buy_stock = fake_buy_stock
+    agent._buy_stock_with_position = fake_buy_stock
     agent._save_watchlist_item = fake_save_watchlist_item
 
     buy_count, sell_count = await StockTrackingAgent.process_reports(agent, ["report-a.pdf"])

--- a/tests/test_trend_exit_seller.py
+++ b/tests/test_trend_exit_seller.py
@@ -69,6 +69,10 @@ class FakeAgent:
         self.calls.append(f"sim:{stock_data.get('ticker')}")
         return True
 
+    def _link_position_exit_intent(self, **kwargs):
+        self.calls.append(f"link:{kwargs.get('legacy_holding_id')}")
+        return True
+
     async def send_telegram_message(self, chat_id, language="ko", **kwargs):
         self.calls.append("tg")
         return True
@@ -330,7 +334,13 @@ def test_live_order_is_sim_then_kis_then_telegram(tmp_db, monkeypatch):
     # per-sell flush + run-end flush each invoke send_telegram_message; the run-end
     # portfolio summary is de-duplicated (portfolio_broadcast) so only ONE actual
     # portfolio message goes out in prod (see tests/test_portfolio_broadcast.py).
-    assert calls == ["sim:005930", "kis:005930:10", "tg", "tg"]   # exact order
+    assert calls == [
+        "sim:005930",
+        "kis:005930:10",
+        "link:1",
+        "tg",
+        "tg",
+    ]  # exact order
     assert _inflight(tmp_db, "FILLED") == 1
 
 

--- a/tools/hardstop_seller.py
+++ b/tools/hardstop_seller.py
@@ -419,7 +419,9 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
                     logger.info("[%s] %s already flat at KIS (qty=0); sim closed", market, ticker)
                 else:
                     from prism_core.order_intents import OrderIntent
+                    from prism_core.positions import legacy_position_id
 
+                    closed_legacy_id = stock_data.get("id")
                     order_intent = OrderIntent.create(
                         market=market,
                         account_id=stock_data.get("account_key") or stock_data.get("account_name") or "default",
@@ -427,7 +429,9 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
                         side="sell",
                         order_style="market",
                         source="hardstop",
-                        source_position_id=stock_data.get("id"),
+                        source_position_id=legacy_position_id(
+                            market, closed_legacy_id
+                        ),
                         quantity=sold_qty,
                         reason=reason,
                     )
@@ -437,6 +441,13 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
                         intent=order_intent,
                     )
                     intent_status = (result or {}).get("intent_status")
+                    persisted_intent_id = (result or {}).get("intent_id")
+                    if persisted_intent_id:
+                        ag._link_position_exit_intent(
+                            legacy_holding_id=closed_legacy_id,
+                            account_key=stock_data.get("account_key"),
+                            intent_id=persisted_intent_id,
+                        )
                     if intent_status in {"UNKNOWN", "QUEUED"}:
                         outcome_unknown = intent_status == "UNKNOWN"
                     ok = bool(result and result.get("success"))
@@ -446,6 +457,11 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
         except OrderOutcomeUnknown as e:
             outcome_unknown = True
             order_no = (e.broker_result or {}).get("order_no")
+            ag._link_position_exit_intent(
+                legacy_holding_id=stock_data.get("id"),
+                account_key=stock_data.get("account_key"),
+                intent_id=e.intent_id,
+            )
             logger.critical(
                 "[%s] %s KIS sell outcome UNKNOWN after sim close: intent=%s",
                 market, ticker, e.intent_id,

--- a/tools/trend_exit_seller.py
+++ b/tools/trend_exit_seller.py
@@ -640,7 +640,9 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
                     logger.info("[%s] %s already flat at KIS (qty=0); sim closed", market, ticker)
                 else:
                     from prism_core.order_intents import OrderIntent
+                    from prism_core.positions import legacy_position_id
 
+                    closed_legacy_id = stock_data.get("id")
                     order_intent = OrderIntent.create(
                         market=market,
                         account_id=stock_data.get("account_key") or stock_data.get("account_name") or "default",
@@ -648,7 +650,9 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
                         side="sell",
                         order_style="market",
                         source="trend_exit",
-                        source_position_id=stock_data.get("id"),
+                        source_position_id=legacy_position_id(
+                            market, closed_legacy_id
+                        ),
                         quantity=sold_qty,
                         reason=reason,
                     )
@@ -658,6 +662,13 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
                         intent=order_intent,
                     )
                     intent_status = (result or {}).get("intent_status")
+                    persisted_intent_id = (result or {}).get("intent_id")
+                    if persisted_intent_id:
+                        ag._link_position_exit_intent(
+                            legacy_holding_id=closed_legacy_id,
+                            account_key=stock_data.get("account_key"),
+                            intent_id=persisted_intent_id,
+                        )
                     if intent_status in {"UNKNOWN", "QUEUED"}:
                         outcome_unknown = intent_status == "UNKNOWN"
                     ok = bool(result and result.get("success"))
@@ -667,6 +678,11 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
         except OrderOutcomeUnknown as e:
             outcome_unknown = True
             order_no = (e.broker_result or {}).get("order_no")
+            ag._link_position_exit_intent(
+                legacy_holding_id=stock_data.get("id"),
+                account_key=stock_data.get("account_key"),
+                intent_id=e.intent_id,
+            )
             logger.critical(
                 "[%s] %s KIS sell outcome UNKNOWN after sim close: intent=%s",
                 market, ticker, e.intent_id,


### PR DESCRIPTION
## Summary
- link persisted OrderIntent IDs to existing OPEN/CLOSED shadow positions without changing legacy read/write or simulator→broker→publish ordering
- preserve public buy_stock bool APIs while returning legacy holding IDs through a private typed boundary
- validate exact market/account/symbol/side/canonical position identity, with atomic US full-exit sibling linkage
- bound SQLite lock wait to 50ms and detect missed links through the read-only comparator
- keep Phase 4-b2 PENDING write-ahead and read switch explicitly deferred

## Safety
- linkage is nullable/additive and fail-open behind POSITION_LEDGER_SHADOW_ENABLED
- BUY idempotency remains decision-first; SELL remains position-first
- no broker payload, quantity, legacy holdings/history, or publish ordering change
- SQLite lock/commit lock fails open with CRITICAL log and comparator detection

## Verification
- independent final code review: APPROVE
- independent SQLite/architecture re-review: GO
- local: 41 core + 35 loop tests passed; ruff/compile/diff-check passed
- db-server Python 3.11.11: 41 core + 14 KR process/parallel + 25 KR loops + 10 US process + 10 US loop = 100 passed
- actual cron startup gates: KR/US orchestrator, hardstop, trend-exit, US pending all passed
- production DB read-only comparator: KR 3/3, US 6/6, all mismatches/audits/intent-link gaps 0
- app-server via su - prism: telegram bot/report/execution/intent/position import + compile passed; running bot untouched

Closes no issue; advances #412 Phase 4-b1 only.