### PR TITLE
refactor(trading): add Phase 4-b2 pending lifecycle foundation

### DIFF
--- a/prism_core/execution_service.py
+++ b/prism_core/execution_service.py
@@ -201,6 +201,19 @@ class ExecutionService:
             return self._intent_store.blocked_result(existing)
         await asyncio.to_thread(self._intent_store.mark_submitting, intent.id)
 
+        return await self._execute_submitting_order(
+            method, *args, intent=intent, **kwargs
+        )
+
+    async def _execute_submitting_order(
+        self,
+        method,
+        *args,
+        intent: OrderIntent,
+        **kwargs,
+    ):
+        """Call broker and persist the result for an already-SUBMITTING intent."""
+
         try:
             result = await method(*args, **kwargs)
         except asyncio.CancelledError as exc:
@@ -273,6 +286,62 @@ class ExecutionService:
             broker=broker,
         )
 
+    async def _execute_pre_reserved_order(
+        self,
+        method,
+        *args,
+        intent: OrderIntent,
+        reservation: Any,
+        side: str,
+        **kwargs,
+    ):
+        if self._intent_store is None:
+            raise RuntimeError(
+                "pre-reserved execution requires the originating IntentStore"
+            )
+        claim_task = asyncio.create_task(
+            asyncio.to_thread(
+                self._intent_store.claim_reservation,
+                reservation,
+                intent,
+                expected_side=side,
+            )
+        )
+        try:
+            await asyncio.shield(claim_task)
+        except asyncio.CancelledError:
+            claimed = False
+            try:
+                await asyncio.shield(claim_task)
+                claimed = True
+            except Exception as claim_error:
+                logger.critical(
+                    "[ORDER_INTENT] cancelled pre-reserved claim failed id=%s error=%s",
+                    intent.id,
+                    type(claim_error).__name__,
+                )
+            if claimed:
+                try:
+                    await asyncio.to_thread(
+                        self._intent_store.record_result,
+                        intent,
+                        status="UNKNOWN",
+                        accepted=False,
+                        response=None,
+                        error=asyncio.CancelledError(),
+                    )
+                except Exception as persistence_error:
+                    logger.critical(
+                        "[ORDER_INTENT] cancelled pre-reserved UNKNOWN persistence "
+                        "failed id=%s error=%s",
+                        intent.id,
+                        type(persistence_error).__name__,
+                    )
+            raise
+        return await self._execute_submitting_order(
+            method, *args, intent=intent, **kwargs
+        )
+
     def _execute_order_sync(
         self,
         method,
@@ -296,6 +365,18 @@ class ExecutionService:
             )
             return self._intent_store.blocked_result(existing)
         self._intent_store.mark_submitting(intent.id)
+
+        return self._execute_submitting_order_sync(
+            method, *args, intent=intent, **kwargs
+        )
+
+    def _execute_submitting_order_sync(
+        self,
+        method,
+        *args,
+        intent: OrderIntent,
+        **kwargs,
+    ):
         try:
             result = method(*args, **kwargs)
         except Exception as exc:
@@ -350,6 +431,26 @@ class ExecutionService:
             broker=broker,
         )
 
+    def _execute_pre_reserved_order_sync(
+        self,
+        method,
+        *args,
+        intent: OrderIntent,
+        reservation: Any,
+        side: str,
+        **kwargs,
+    ):
+        if self._intent_store is None:
+            raise RuntimeError(
+                "pre-reserved execution requires the originating IntentStore"
+            )
+        self._intent_store.claim_reservation(
+            reservation, intent, expected_side=side
+        )
+        return self._execute_submitting_order_sync(
+            method, *args, intent=intent, **kwargs
+        )
+
     async def execute_buy(
         self,
         *args,
@@ -373,6 +474,38 @@ class ExecutionService:
             self._active_trader.async_sell_stock,
             *args,
             intent=intent,
+            **kwargs,
+        )
+
+    async def execute_pre_reserved_buy(
+        self,
+        *args,
+        intent: OrderIntent,
+        reservation: Any,
+        **kwargs,
+    ):
+        return await self._execute_pre_reserved_order(
+            self._active_trader.async_buy_stock,
+            *args,
+            intent=intent,
+            reservation=reservation,
+            side="BUY",
+            **kwargs,
+        )
+
+    async def execute_pre_reserved_sell(
+        self,
+        *args,
+        intent: OrderIntent,
+        reservation: Any,
+        **kwargs,
+    ):
+        return await self._execute_pre_reserved_order(
+            self._active_trader.async_sell_stock,
+            *args,
+            intent=intent,
+            reservation=reservation,
+            side="SELL",
             **kwargs,
         )
 
@@ -416,6 +549,43 @@ class ExecutionService:
             intent=intent,
             **kwargs,
         )
+
+    def execute_pre_reserved_reserved_buy(
+        self,
+        *args,
+        intent: OrderIntent,
+        reservation: Any,
+        **kwargs,
+    ):
+        return self._execute_pre_reserved_order_sync(
+            self._active_trader.buy_reserved_order,
+            *args,
+            intent=intent,
+            reservation=reservation,
+            side="BUY",
+            **kwargs,
+        )
+
+    def execute_pre_reserved_reserved_sell(
+        self,
+        *args,
+        intent: OrderIntent,
+        reservation: Any,
+        **kwargs,
+    ):
+        return self._execute_pre_reserved_order_sync(
+            self._active_trader.sell_reserved_order,
+            *args,
+            intent=intent,
+            reservation=reservation,
+            side="SELL",
+            **kwargs,
+        )
+
+    # Explicit sync aliases keep call sites readable when the underlying KIS
+    # operation is a synchronous reserved-order endpoint.
+    execute_pre_reserved_buy_sync = execute_pre_reserved_reserved_buy
+    execute_pre_reserved_sell_sync = execute_pre_reserved_reserved_sell
 
 
 __all__ = ["ExecutionService", "OrderOutcomeUnknown"]

--- a/prism_core/order_intents.py
+++ b/prism_core/order_intents.py
@@ -212,11 +212,33 @@ class OrderIntent:
         }
 
 
+class _ReservationCapability(dict[str, Any]):
+    """Unforgeable-by-API proof that this store inserted one CREATED intent."""
+
+    def __init__(
+        self,
+        value: dict[str, Any],
+        *,
+        owner: object,
+        intent: OrderIntent,
+        connection: sqlite3.Connection,
+    ) -> None:
+        super().__init__(value)
+        self._owner = owner
+        self._intent = intent
+        self._intent_id = intent.id
+        self._idempotency_key = intent.idempotency_key
+        self._connection = connection
+        self._consumed = False
+
+
 class IntentStore:
     """SQLite intent store with cross-process idempotency reservation."""
 
     def __init__(self, db_path: str | Path, *, timeout: float = 30.0):
         self.db_path = str(db_path)
+        self._resolved_db_path = str(Path(db_path).expanduser().resolve())
+        self._capability_owner = object()
         self.timeout = timeout
         self.ensure_schema()
 
@@ -239,56 +261,137 @@ class IntentStore:
                 "ON broker_orders(intent_id, submitted_at)"
             )
 
-    def reserve(self, intent: OrderIntent) -> tuple[bool, dict[str, Any]]:
+    def _validate_connection(self, connection: sqlite3.Connection) -> None:
+        if not isinstance(connection, sqlite3.Connection):
+            raise TypeError("reserve_in_transaction requires sqlite3.Connection")
+        main_path = next(
+            (
+                str(row[2])
+                for row in connection.execute("PRAGMA database_list")
+                if str(row[1]) == "main"
+            ),
+            "",
+        )
+        if not main_path or str(Path(main_path).resolve()) != self._resolved_db_path:
+            raise ValueError("connection does not target this IntentStore database")
+
+    def _reserve_on(
+        self,
+        connection: sqlite3.Connection,
+        intent: OrderIntent,
+        *,
+        issue_capability: bool,
+    ) -> tuple[bool, dict[str, Any]]:
         now = _utc_now()
-        with self._connect() as conn:
-            conn.execute("BEGIN IMMEDIATE")
-            try:
-                conn.execute(
-                    """
-                    INSERT INTO order_intents (
-                        id, idempotency_key, market, account_id, symbol, side,
-                        order_style, quantity, cash_amount, limit_price, reason,
-                        source, source_decision_id, source_position_id,
-                        execution_mode, status, raw_request_json, created_at, updated_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                              'CREATED', ?, ?, ?)
-                    """,
-                    (
-                        intent.id,
-                        intent.idempotency_key,
-                        intent.market,
-                        intent.account_id,
-                        intent.symbol,
-                        intent.side,
-                        intent.order_style,
-                        intent.quantity,
-                        intent.cash_amount,
-                        intent.limit_price,
-                        intent.reason,
-                        intent.source,
-                        intent.source_decision_id,
-                        intent.source_position_id,
-                        intent.execution_mode,
-                        _json(intent.request_payload()),
-                        intent.created_at,
-                        now,
-                    ),
-                )
-            except sqlite3.IntegrityError:
-                row = conn.execute(
-                    "SELECT id, status, idempotency_key FROM order_intents "
-                    "WHERE idempotency_key = ?",
-                    (intent.idempotency_key,),
-                ).fetchone()
-                if row is None:
-                    raise
-                return False, dict(row)
-        return True, {
+        try:
+            connection.execute(
+                """
+                INSERT INTO order_intents (
+                    id, idempotency_key, market, account_id, symbol, side,
+                    order_style, quantity, cash_amount, limit_price, reason,
+                    source, source_decision_id, source_position_id,
+                    execution_mode, status, raw_request_json, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                          'CREATED', ?, ?, ?)
+                """,
+                (
+                    intent.id,
+                    intent.idempotency_key,
+                    intent.market,
+                    intent.account_id,
+                    intent.symbol,
+                    intent.side,
+                    intent.order_style,
+                    intent.quantity,
+                    intent.cash_amount,
+                    intent.limit_price,
+                    intent.reason,
+                    intent.source,
+                    intent.source_decision_id,
+                    intent.source_position_id,
+                    intent.execution_mode,
+                    _json(intent.request_payload()),
+                    intent.created_at,
+                    now,
+                ),
+            )
+        except sqlite3.IntegrityError:
+            row = connection.execute(
+                "SELECT id, status, idempotency_key FROM order_intents "
+                "WHERE idempotency_key = ?",
+                (intent.idempotency_key,),
+            ).fetchone()
+            if row is None:
+                raise
+            columns = ("id", "status", "idempotency_key")
+            return False, dict(zip(columns, row))
+        value = {
             "id": intent.id,
             "status": "CREATED",
             "idempotency_key": intent.idempotency_key,
         }
+        if issue_capability:
+            value = _ReservationCapability(
+                value,
+                owner=self._capability_owner,
+                intent=intent,
+                connection=connection,
+            )
+        return True, value
+
+    def reserve_in_transaction(
+        self,
+        connection: sqlite3.Connection,
+        intent: OrderIntent,
+    ) -> tuple[bool, dict[str, Any]]:
+        """Reserve without beginning, committing, or rolling back caller work."""
+
+        self._validate_connection(connection)
+        if not connection.in_transaction:
+            raise RuntimeError(
+                "reserve_in_transaction requires an active caller-owned transaction"
+            )
+        return self._reserve_on(connection, intent, issue_capability=True)
+
+    def reserve(self, intent: OrderIntent) -> tuple[bool, dict[str, Any]]:
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            return self._reserve_on(conn, intent, issue_capability=False)
+
+    def claim_reservation(
+        self,
+        reservation: Any,
+        intent: OrderIntent,
+        *,
+        expected_side: str,
+    ) -> None:
+        """Consume an opaque committed reservation before any broker call."""
+
+        if (
+            not isinstance(reservation, _ReservationCapability)
+            or reservation._owner is not self._capability_owner
+            or reservation._intent != intent
+            or reservation._intent_id != intent.id
+            or reservation._idempotency_key != intent.idempotency_key
+            or reservation._consumed
+        ):
+            raise TypeError("valid unused IntentStore reservation is required")
+        if intent.side != expected_side:
+            raise ValueError("reservation side does not match execution method")
+        try:
+            transaction_is_open = reservation._connection.in_transaction
+        except sqlite3.ProgrammingError:
+            # A caller may commit and close its short-lived transaction before
+            # handing the capability to the execution service.  mark_submitting()
+            # below is the authoritative committed-row check; a close-triggered
+            # rollback leaves no CREATED row and therefore still fails closed.
+            transaction_is_open = False
+        if transaction_is_open:
+            raise RuntimeError(
+                "reservation transaction must commit before broker execution"
+            )
+        self.mark_submitting(intent.id)
+        reservation._consumed = True
 
     def mark_submitting(self, intent_id: str) -> None:
         with self._connect() as conn:

--- a/prism_core/positions.py
+++ b/prism_core/positions.py
@@ -125,6 +125,16 @@ def _entry_fingerprint(entry_price: Any, opened_at: Any) -> str:
     return "sha256:" + hashlib.sha256(value.encode()).hexdigest()[:16]
 
 
+def _age_seconds(value: Any) -> int | None:
+    try:
+        timestamp = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+        return max(0, int((datetime.now(timezone.utc) - timestamp).total_seconds()))
+    except (TypeError, ValueError):
+        return None
+
+
 def _redact_error_text(value: str) -> str:
     value = re.sub(r"(?i)bearer\s+[^\s,;]+", "Bearer [REDACTED]", value)
     return re.sub(
@@ -171,6 +181,17 @@ class PositionStore:
 
     def _execute(self, sql: str, parameters: tuple[Any, ...] = ()) -> sqlite3.Cursor:
         return self._db.execute(sql, parameters)
+
+    def _require_active_transaction(self) -> None:
+        connection = (
+            self._db
+            if isinstance(self._db, sqlite3.Connection)
+            else self._db.connection
+        )
+        if not connection.in_transaction:
+            raise RuntimeError(
+                "position lifecycle requires an active caller-owned transaction"
+            )
 
     def _fetchall(
         self, sql: str, parameters: tuple[Any, ...] = ()
@@ -237,6 +258,440 @@ class PositionStore:
             ),
         ).rowcount
         return changed == 1
+
+    @staticmethod
+    def _source_position_ids(value: Any) -> tuple[str, ...]:
+        if value is None:
+            return ()
+        items = tuple(item.strip() for item in str(value).split(","))
+        if not items or any(not item for item in items) or len(set(items)) != len(items):
+            raise ValueError("intent source_position_id is invalid")
+        return items
+
+    def _validated_intent(
+        self,
+        *,
+        intent_id: Any,
+        market: str,
+        account_id: str,
+        symbol: str,
+        side: str,
+        position_ids: Iterable[str],
+    ) -> dict[str, Any]:
+        intent_id = str(intent_id or "")
+        if not intent_id:
+            raise ValueError("intent_id is required")
+        cursor = self._execute(
+            "SELECT id, market, account_id, symbol, side, source_position_id, status "
+            "FROM order_intents WHERE id=?",
+            (intent_id,),
+        )
+        columns = [item[0] for item in cursor.description or ()]
+        row = cursor.fetchone()
+        if row is None:
+            raise LookupError(f"intent not found: {intent_id}")
+        intent = dict(zip(columns, row))
+        expected_ids = tuple(position_ids)
+        if (
+            str(intent["market"]).upper() != market
+            or str(intent["account_id"]) != account_id
+            or str(intent["symbol"]).upper() != symbol
+            or str(intent["side"]).upper() != side
+            or set(self._source_position_ids(intent["source_position_id"]))
+            != set(expected_ids)
+        ):
+            raise ValueError("intent identity does not match source positions")
+        if str(intent["status"]).upper() not in {
+            "CREATED",
+            "SUBMITTING",
+            "SUBMITTED",
+            "QUEUED",
+            "FAILED",
+            "UNKNOWN",
+        }:
+            raise ValueError("intent status is not valid for position lifecycle")
+        return intent
+
+    def prepare_entry(
+        self,
+        *,
+        market: str,
+        legacy_holding_id: Any,
+        account_id: Any,
+        account_name: str | None,
+        symbol: Any,
+        intent_id: Any,
+        entry_price: Any = None,
+        opened_at: str | None = None,
+    ) -> bool:
+        """Create one PENDING_ENTRY linked to a persisted matching BUY intent."""
+
+        self._require_active_transaction()
+        market = _market(market)
+        position_id = legacy_position_id(market, legacy_holding_id)
+        account_id = str(account_id or "")
+        symbol = str(symbol or "").upper()
+        if not account_id or not symbol:
+            raise ValueError("account_id and symbol are required")
+        intent_id = str(intent_id or "")
+        intent = self._validated_intent(
+            intent_id=intent_id,
+            market=market,
+            account_id=account_id,
+            symbol=symbol,
+            side="BUY",
+            position_ids=(position_id,),
+        )
+        if str(intent["status"]).upper() != "CREATED":
+            raise InvalidPositionTransition("entry prepare requires CREATED intent")
+        row = self._execute(
+            "SELECT market, legacy_holding_id, account_id, symbol, status, "
+            "entry_intent_id FROM positions WHERE id=?",
+            (position_id,),
+        ).fetchone()
+        if row is not None:
+            identity = (market, str(legacy_holding_id), account_id, symbol)
+            if tuple(str(value).upper() if index in {0, 3} else str(value)
+                     for index, value in enumerate(row[:4])) != identity:
+                raise ValueError("entry position identity mismatch")
+            if row[5] != intent_id:
+                raise ValueError("entry intent overwrite is not allowed")
+            if str(row[4]) in {"PENDING_ENTRY", "OPEN", "ENTRY_FAILED"}:
+                return True
+            raise InvalidPositionTransition(
+                f"entry prepare requires PENDING_ENTRY, found {row[4]}"
+            )
+        now = _utc_now()
+        self._execute(
+            """
+            INSERT INTO positions (
+                id, market, legacy_holding_id, account_id, account_name, symbol,
+                status, execution_mode, opened_at, entry_intent_id, entry_price,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, 'PENDING_ENTRY', 'legacy', ?, ?, ?, ?, ?)
+            """,
+            (
+                position_id,
+                market,
+                str(legacy_holding_id),
+                account_id,
+                account_name,
+                symbol,
+                opened_at,
+                intent_id,
+                entry_price,
+                now,
+                now,
+            ),
+        )
+        return True
+
+    def _finish_entry(
+        self,
+        *,
+        market: str,
+        legacy_holding_id: Any,
+        account_id: Any,
+        symbol: Any,
+        intent_id: Any,
+        to_status: str,
+        required_intent_status: str,
+    ) -> bool:
+        self._require_active_transaction()
+        market = _market(market)
+        position_id = legacy_position_id(market, legacy_holding_id)
+        account_id = str(account_id or "")
+        symbol = str(symbol or "").upper()
+        intent_id = str(intent_id or "")
+        if not account_id or not symbol:
+            raise ValueError("account_id and symbol are required")
+        intent = self._validated_intent(
+            intent_id=intent_id,
+            market=market,
+            account_id=account_id,
+            symbol=symbol,
+            side="BUY",
+            position_ids=(position_id,),
+        )
+        if str(intent["status"]).upper() != required_intent_status:
+            raise InvalidPositionTransition(
+                f"entry {to_status} requires {required_intent_status} intent"
+            )
+        row = self._execute(
+            "SELECT status, entry_intent_id, symbol FROM positions "
+            "WHERE id=? AND market=? AND account_id=?",
+            (position_id, market, account_id),
+        ).fetchone()
+        if row is None:
+            raise LookupError(f"entry position not found: {position_id}")
+        if row[1] != intent_id:
+            raise ValueError("entry intent does not match position")
+        if str(row[2]).upper() != symbol:
+            raise ValueError("entry symbol does not match position")
+        if str(row[0]) == to_status:
+            return True
+        if str(row[0]) != "PENDING_ENTRY":
+            raise InvalidPositionTransition(
+                f"entry finalize requires PENDING_ENTRY, found {row[0]}"
+            )
+        changed = self._execute(
+            "UPDATE positions SET status=?, updated_at=? "
+            "WHERE id=? AND market=? AND account_id=? AND status='PENDING_ENTRY' "
+            "AND entry_intent_id=?",
+            (to_status, _utc_now(), position_id, market, account_id, intent_id),
+        ).rowcount
+        if changed != 1:
+            raise RuntimeError(f"position {position_id} changed concurrently")
+        return True
+
+    def complete_entry(self, **identity: Any) -> bool:
+        """Transition one claimed entry to OPEN without committing."""
+
+        return self._finish_entry(
+            to_status="OPEN", required_intent_status="SUBMITTED", **identity
+        )
+
+    def fail_entry(self, **identity: Any) -> bool:
+        """Transition one claimed entry to ENTRY_FAILED without committing."""
+
+        return self._finish_entry(
+            to_status="ENTRY_FAILED", required_intent_status="FAILED", **identity
+        )
+
+    def _validate_exit_positions(
+        self,
+        *,
+        market: str,
+        account_id: str,
+        symbol: str,
+        position_ids: tuple[str, ...],
+        intent_id: str,
+        allowed_statuses: frozenset[str],
+        allow_unlinked: bool,
+    ) -> list[dict[str, Any]]:
+        if not position_ids or len(set(position_ids)) != len(position_ids):
+            raise ValueError("position_ids must be non-empty and unique")
+        if any(not item.startswith(f"legacy:{market}:") for item in position_ids):
+            raise ValueError("position_ids must be canonical for market")
+        if market != "US" and len(position_ids) != 1:
+            raise ValueError("multiple exit positions are only supported for US")
+        intent = self._validated_intent(
+            intent_id=intent_id,
+            market=market,
+            account_id=account_id,
+            symbol=symbol,
+            side="SELL",
+            position_ids=position_ids,
+        )
+        if allow_unlinked and str(intent["status"]).upper() != "CREATED":
+            raise InvalidPositionTransition("exit prepare requires CREATED intent")
+        rows = [
+            row
+            for row in self._fetchall(
+                "SELECT id, legacy_holding_id, account_id, symbol, status, "
+                "exit_intent_id FROM positions WHERE market=? AND account_id=?",
+                (market, account_id),
+            )
+            if str(row["id"]) in position_ids
+        ]
+        if {str(row["id"]) for row in rows} != set(position_ids):
+            raise LookupError("exit source positions not found")
+        for row in rows:
+            if (
+                str(row["id"])
+                != legacy_position_id(market, row["legacy_holding_id"])
+                or str(row["account_id"]) != account_id
+                or str(row["symbol"]).upper() != symbol
+            ):
+                raise ValueError("exit position identity mismatch")
+            if str(row["status"]) not in allowed_statuses:
+                raise InvalidPositionTransition(
+                    f"exit lifecycle does not allow status {row['status']}"
+                )
+            linked = row["exit_intent_id"]
+            if linked != intent_id and not (allow_unlinked and linked is None):
+                raise ValueError("exit intent overwrite is not allowed")
+        return rows
+
+    def _update_exit_many(
+        self,
+        *,
+        market: str,
+        account_id: str,
+        position_ids: tuple[str, ...],
+        intent_id: str,
+        from_status: str,
+        to_status: str,
+        exit_price: Any = None,
+        realized_pnl_pct: Any = None,
+        exit_kind: str | None = None,
+        closed_at: str | None = None,
+    ) -> None:
+        self._require_active_transaction()
+        now = _utc_now()
+        if to_status == "CLOSED" and closed_at is None:
+            closed_at = now
+        self._execute("SAVEPOINT position_exit_many")
+        try:
+            changed = sum(
+                self._execute(
+                    """
+                    UPDATE positions SET status=?, exit_intent_id=?,
+                        exit_price=COALESCE(?, exit_price),
+                        realized_pnl_pct=COALESCE(?, realized_pnl_pct),
+                        exit_kind=COALESCE(?, exit_kind),
+                        closed_at=CASE WHEN ?='CLOSED' THEN ? ELSE closed_at END,
+                        updated_at=?
+                    WHERE id=? AND market=? AND account_id=? AND status=?
+                      AND (exit_intent_id IS NULL OR exit_intent_id=?)
+                    """,
+                    (
+                        to_status,
+                        intent_id,
+                        exit_price,
+                        realized_pnl_pct,
+                        exit_kind,
+                        to_status,
+                        closed_at,
+                        now,
+                        position_id,
+                        market,
+                        account_id,
+                        from_status,
+                        intent_id,
+                    ),
+                ).rowcount
+                for position_id in sorted(position_ids)
+            )
+            if changed != len(position_ids):
+                raise RuntimeError("exit source positions changed concurrently")
+        except Exception:
+            self._execute("ROLLBACK TO position_exit_many")
+            self._execute("RELEASE position_exit_many")
+            raise
+        self._execute("RELEASE position_exit_many")
+
+    def prepare_exit_many(
+        self,
+        *,
+        market: str,
+        account_id: Any,
+        symbol: Any,
+        position_ids: Iterable[str],
+        intent_id: Any,
+    ) -> bool:
+        """Atomically claim OPEN source positions for one persisted SELL intent."""
+
+        market = _market(market)
+        account_id = str(account_id or "")
+        symbol = str(symbol or "").upper()
+        intent_id = str(intent_id or "")
+        source_ids = tuple(str(item) for item in position_ids)
+        rows = self._validate_exit_positions(
+            market=market,
+            account_id=account_id,
+            symbol=symbol,
+            position_ids=source_ids,
+            intent_id=intent_id,
+            allowed_statuses=frozenset({"OPEN", "PENDING_EXIT"}),
+            allow_unlinked=True,
+        )
+        statuses = {str(row["status"]) for row in rows}
+        links = {row["exit_intent_id"] for row in rows}
+        if statuses == {"PENDING_EXIT"} and links == {intent_id}:
+            return True
+        if statuses != {"OPEN"} or links != {None}:
+            raise InvalidPositionTransition("exit positions are not claimable together")
+        self._update_exit_many(
+            market=market,
+            account_id=account_id,
+            position_ids=source_ids,
+            intent_id=intent_id,
+            from_status="OPEN",
+            to_status="PENDING_EXIT",
+        )
+        return True
+
+    def _finish_exit_many(
+        self,
+        *,
+        market: str,
+        account_id: Any,
+        symbol: Any,
+        position_ids: Iterable[str],
+        intent_id: Any,
+        to_status: str,
+        required_intent_status: str,
+        exit_price: Any = None,
+        realized_pnl_pct: Any = None,
+        exit_kind: str | None = None,
+        closed_at: str | None = None,
+    ) -> bool:
+        market = _market(market)
+        account_id = str(account_id or "")
+        symbol = str(symbol or "").upper()
+        intent_id = str(intent_id or "")
+        source_ids = tuple(str(item) for item in position_ids)
+        intent = self._validated_intent(
+            intent_id=intent_id,
+            market=market,
+            account_id=account_id,
+            symbol=symbol,
+            side="SELL",
+            position_ids=source_ids,
+        )
+        if str(intent["status"]).upper() != required_intent_status:
+            raise InvalidPositionTransition(
+                f"exit {to_status} requires {required_intent_status} intent"
+            )
+        rows = self._validate_exit_positions(
+            market=market,
+            account_id=account_id,
+            symbol=symbol,
+            position_ids=source_ids,
+            intent_id=intent_id,
+            allowed_statuses=frozenset({"PENDING_EXIT", to_status}),
+            allow_unlinked=False,
+        )
+        statuses = {str(row["status"]) for row in rows}
+        if statuses == {to_status}:
+            return True
+        if statuses != {"PENDING_EXIT"}:
+            raise InvalidPositionTransition("exit positions are not finalizable together")
+        self._update_exit_many(
+            market=market,
+            account_id=account_id,
+            position_ids=source_ids,
+            intent_id=intent_id,
+            from_status="PENDING_EXIT",
+            to_status=to_status,
+            exit_price=exit_price,
+            realized_pnl_pct=realized_pnl_pct,
+            exit_kind=exit_kind,
+            closed_at=closed_at,
+        )
+        return True
+
+    def complete_exit_many(self, **values: Any) -> bool:
+        """Atomically finalize claimed exits as CLOSED."""
+
+        return self._finish_exit_many(
+            to_status="CLOSED", required_intent_status="SUBMITTED", **values
+        )
+
+    def fail_exit_many(self, **values: Any) -> bool:
+        """Atomically return explicitly failed exits to OPEN."""
+
+        return self._finish_exit_many(
+            to_status="OPEN", required_intent_status="FAILED", **values
+        )
+
+    def mark_exit_unknown_many(self, **values: Any) -> bool:
+        """Atomically quarantine exits whose broker outcome is ambiguous."""
+
+        return self._finish_exit_many(
+            to_status="EXIT_UNKNOWN", required_intent_status="UNKNOWN", **values
+        )
 
     def transition(
         self,
@@ -670,10 +1125,17 @@ class PositionStore:
             "symbol": str(symbol).upper(),
         }
 
-    def compare_legacy_positions(self, market: str) -> dict[str, Any]:
+    def compare_legacy_positions(
+        self,
+        market: str,
+        *,
+        pending_stale_after_seconds: int = 300,
+    ) -> dict[str, Any]:
         """Read-only comparison of legacy holdings and OPEN legacy positions."""
 
         market = _market(market)
+        if pending_stale_after_seconds < 0:
+            raise ValueError("pending_stale_after_seconds must be non-negative")
         legacy: dict[tuple[str, str, str], dict[str, str]] = {}
         legacy_entry_fingerprints: dict[tuple[str, str, str], str] = {}
         invalid_legacy_rows: list[dict[str, str | None]] = []
@@ -702,7 +1164,7 @@ class PositionStore:
 
         position_rows = self._fetchall(
             "SELECT id, legacy_holding_id, account_id, symbol, status, "
-            "entry_intent_id, exit_intent_id, entry_price, opened_at "
+            "entry_intent_id, exit_intent_id, entry_price, opened_at, updated_at "
             "FROM positions WHERE market=? AND execution_mode='legacy'",
             (market,),
         )
@@ -736,7 +1198,7 @@ class PositionStore:
             for key, rows in positions.items()
             if key in legacy
             for row in rows
-            if row["status"] != "OPEN"
+            if row["status"] not in {"OPEN", "PENDING_ENTRY", "PENDING_EXIT"}
         ]
         duplicate_positions = [
             {"identity": dict(zip(("legacy_holding_id", "account_ref", "symbol"), key)),
@@ -756,6 +1218,36 @@ class PositionStore:
             and legacy_entry_fingerprints[key]
             not in position_entry_fingerprints[key]
         ]
+        pending_positions: list[dict[str, Any]] = []
+        stale_pending_positions: list[dict[str, Any]] = []
+        exit_unknown_positions: list[dict[str, Any]] = []
+        for row in position_rows:
+            status = str(row["status"])
+            if status not in {"PENDING_ENTRY", "PENDING_EXIT", "EXIT_UNKNOWN"}:
+                continue
+            age_seconds = _age_seconds(row["updated_at"])
+            item = {
+                "position_id": str(row["id"]),
+                "legacy_holding_id": str(row["legacy_holding_id"]),
+                "account_ref": account_fingerprint(row["account_id"]),
+                "symbol": str(row["symbol"]).upper(),
+                "status": status,
+                "intent_id": (
+                    row["entry_intent_id"]
+                    if status == "PENDING_ENTRY"
+                    else row["exit_intent_id"]
+                ),
+                "age_seconds": age_seconds,
+            }
+            if status == "EXIT_UNKNOWN":
+                exit_unknown_positions.append(item)
+            elif (
+                age_seconds is None
+                or age_seconds >= pending_stale_after_seconds
+            ):
+                stale_pending_positions.append(item)
+            else:
+                pending_positions.append(item)
         unresolved_mirror_errors = self._fetchall(
             "SELECT id, legacy_holding_id, account_ref, operation, error_type, "
             "error_message, created_at FROM position_mirror_errors "
@@ -827,6 +1319,9 @@ class PositionStore:
             invalid_legacy_rows,
             unresolved_mirror_errors,
             intent_link_mismatches,
+            pending_positions,
+            stale_pending_positions,
+            exit_unknown_positions,
         )
         return {
             "market": market,
@@ -837,6 +1332,9 @@ class PositionStore:
                 "open_positions": sum(
                     row["status"] == "OPEN" for row in position_rows
                 ),
+                "pending_positions": len(pending_positions),
+                "stale_pending_positions": len(stale_pending_positions),
+                "exit_unknown_positions": len(exit_unknown_positions),
             },
             "missing_positions": missing_positions,
             "extra_open_positions": extra_open_positions,
@@ -846,6 +1344,9 @@ class PositionStore:
             "invalid_legacy_rows": invalid_legacy_rows,
             "unresolved_mirror_errors": unresolved_mirror_errors,
             "intent_link_mismatches": intent_link_mismatches,
+            "pending_positions": pending_positions,
+            "stale_pending_positions": stale_pending_positions,
+            "exit_unknown_positions": exit_unknown_positions,
         }
 
 

--- a/tasks/issue-412/11-phase4b2-pending-exit-plan.md
+++ b/tasks/issue-412/11-phase4b2-pending-exit-plan.md
@@ -1,0 +1,157 @@
+# Issue #412 Phase 4-b2 실행 계획 — PENDING write-ahead와 실패 보상
+
+> 기준: main `9b3ecc58` (Phase 4-b1 배포 완료)
+> 원칙: legacy holdings/history는 계속 유일한 판단 read source이며, 주문 흐름 변경은
+> 시장·방향별로 분리해 각각 독립적으로 롤백할 수 있어야 한다.
+
+## 1. 전체를 한 PR로 구현하지 않는 이유
+
+현재 BUY는 legacy holding INSERT와 OPEN mirror를 먼저 커밋한 뒤 intent를 reserve하고
+broker를 호출한다. 신규 position id가 `legacy:{MARKET}:{holding_id}`이므로 holding INSERT
+전에는 canonical position id가 존재하지 않는다. BUY write-ahead는 provisional position
+identity 또는 simulator DB/message staging 분해가 필요하며 단순 상태 전이 추가가 아니다.
+
+현재 SELL도 legacy history INSERT + holding DELETE + CLOSED mirror를 먼저 커밋한 뒤 broker를
+호출한다. 이 순서를 그대로 둔 채 실패 시 holding을 재생성하면 전체 legacy row, history,
+US adjustment cleanup, message queue를 완전히 복원해야 하며 crash 중간 상태가 더 위험하다.
+
+따라서 4-b2를 다음처럼 분리한다.
+
+1. **4-b2a — transaction-aware 기반 API**: 실제 주문 호출부는 바꾸지 않고 intent 사전예약,
+   pre-reserved 실행, position prepare/finalize/fail API와 comparator만 추가한다.
+2. **4-b2b — KR 전체 전환**: KR batch BUY/SELL, enhanced BUY, KR hardstop/trend-exit을
+   시장 단위 feature flag로 동시에 전환한다.
+3. **4-b2c — US queue 연속성 + US 전체 전환**: `us_pending_orders`가 원 intent ID를
+   이어받도록 고친 뒤 US batch/loop/sibling 경로를 동시에 전환한다.
+
+## 2. Phase 4-b2a 범위 — 운영 동작 OFF
+
+### 추가할 core 경계
+
+- `IntentStore.reserve_in_transaction(connection, intent)`
+  - caller의 SQLite transaction 안에서 intent CREATED를 원자적으로 예약한다.
+  - 기존 `reserve()`와 동일한 idempotency 결과를 반환하고 commit/rollback을 소유하지 않는다.
+- `ExecutionService.execute_pre_reserved_*`
+  - opaque reservation 없이는 호출할 수 없다.
+  - intent를 다시 reserve하지 않고 CREATED -> SUBMITTING -> result 상태만 수행한다.
+  - broker 호출 동안 SQLite transaction은 절대 열려 있지 않아야 한다.
+- `PositionStore`
+  - `prepare_entry`, `complete_entry`, `fail_entry`
+  - `prepare_exit_many`, `complete_exit_many`, `fail_exit_many`
+  - `mark_exit_unknown_many`
+  - market/account/symbol/source ids/status/intent overwrite를 모두 검증하고 multi-row는 원자 처리한다.
+- comparator
+  - 짧은 PENDING과 stale PENDING, EXIT_UNKNOWN을 구분해 숨김없이 보고한다.
+
+4-b2a에서는 production agent/loop/pending-batch 호출 순서를 변경하지 않는다. 즉 배포해도
+기존 simulator -> intent/broker -> publish 동작은 그대로다.
+
+## 3. Phase 4-b2b KR 상태 순서
+
+### ENTRY
+
+```text
+legacy holding INSERT + intent CREATED + position PENDING_ENTRY (한 transaction)
+  -> commit -> broker
+     SUBMITTED -> position OPEN
+     QUEUED -> PENDING_ENTRY 유지, 기존 intent를 pending batch가 이어서 제출
+     explicit FAILED -> 해당 legacy row만 삭제 + ENTRY_FAILED
+     UNKNOWN/cancel -> PENDING_ENTRY 유지 + CRITICAL, 자동 재주문 금지
+```
+
+legacy AUTOINCREMENT ID는 transaction 안 INSERT로 얻고, 같은 transaction에서 intent와
+canonical `legacy:KR:{id}` PENDING position을 함께 커밋한다. 외부에는 세 상태가 원자적으로 보인다.
+
+### EXIT
+
+```text
+intent CREATED + position OPEN -> PENDING_EXIT (한 transaction)
+  -> commit -> broker
+     SUBMITTED -> legacy history/holding + position CLOSED (한 transaction)
+     QUEUED -> PENDING_EXIT 유지, 기존 intent를 pending batch가 이어서 제출
+     explicit FAILED -> position OPEN (legacy 불변, 기존 position-key intent link 보존)
+     UNKNOWN/cancel -> position EXIT_UNKNOWN (legacy 유지, 자동 재주문 금지)
+```
+
+### 공통 핵심 규칙
+
+- intent를 먼저 reserve한 프로세스만 position claim을 시도한다.
+- claim은 market/account/symbol/source_position_id/OPEN 상태/기존 intent overwrite를 전부
+  검증한 뒤 같은 SQLite transaction에서 수행한다.
+- US ticker 전체 청산은 sibling canonical id 전체를 먼저 검증한 뒤 모두 PENDING_EXIT으로
+  원자 전이한다. 부분 피라미딩 청산은 대상 row 하나만 claim한다.
+- claim 성공 전에는 broker를 절대 호출하지 않는다.
+- claim 이후에도 legacy holding은 유지하므로 명시적 broker 실패에는 legacy 복원이 없다.
+- broker SUBMITTED만 기존 `sell_stock()`을 호출해 history INSERT + holding DELETE를
+  수행한다. 그 transaction에서 PENDING_EXIT -> CLOSED를 확정한다.
+- UNKNOWN은 legacy holding을 유지하고 position을 EXIT_UNKNOWN으로 바꾼다. 같은 position의
+  후속 SELL intent는 차단하고 운영 알림/reconciliation 대상으로 남긴다.
+- 현행 SELL idempotency key는 position identity만 사용하므로 FAILED도 새 intent 자동 재제출이
+  차단된다. 4-b2a는 이 안전 우선 동작을 보존한다. 4-b2b 활성화 전에 명시적 거절의 운영 알림과
+  감사 가능한 retry/new-attempt 정책을 별도로 확정해야 하며, 그 전에는 KR gate를 켜지 않는다.
+- 기존 `buy_stock()`/`sell_stock()` public bool 계약은 유지한다.
+- subscriber publish와 Telegram flush는 legacy `sell_stock()` 성공 뒤에만 실행한다.
+- KIS 조회 결과 이미 qty=0이면 broker 호출 없이 기존 simulator close를 수행하되, intent와
+  position에는 명시적인 local-flat 결과가 남아야 한다.
+
+## 4. Phase 4-b2c US 선행조건
+
+- 현재 `us_pending_order_batch.py`는 queued intent를 이어가지 않고 새 intent를 만든다.
+- `us_pending_orders`에 원 intent ID와 source position IDs를 저장하고, batch가 기존 QUEUED
+  intent를 claim해 SUBMITTED/FAILED/UNKNOWN으로 계속 전이해야 한다.
+- US full-exit sibling의 prepare/finalize/fail/unknown은 모두 한 transaction에서 all-or-nothing.
+- 위 queue 연속성이 완료되기 전에는 US PENDING 상태를 운영 활성화하지 않는다.
+
+## 5. 롤아웃 및 롤백
+
+- 4-b2a는 호출부 미배선이라 별도 운영 flag 없이 동작 변화가 없다.
+- 4-b2b 신규 env gate: `POSITION_PENDING_KR_ENABLED=false`가 기본값.
+- 4-b2c 신규 env gate: `POSITION_PENDING_US_ENABLED=false`가 기본값.
+- false이면 simulator -> broker -> publish 기존 순서와 기존 linkage를 바이트 수준으로 유지한다.
+- true는 해당 시장의 batch + hardstop + trend-exit 경로가 함께 신규 lifecycle을 사용할 준비가
+  된 뒤에만 허용한다. 일부 경로만 활성화하면 legacy read가 PENDING position을 다시 선택할 수 있다.
+- 운영 활성화는 거래 프로세스가 없는 창에 수행하고 다음 1회 배치를 집중 관찰한다.
+- 문제 시 신규 주문을 중지한 뒤 PENDING/UNKNOWN이 없는 것을 확인하고 env를 false로 되돌린다.
+  남은 PENDING/UNKNOWN이 있는데 flag만 내리는 롤백은 금지한다.
+
+## 6. 테스트 우선 gate
+
+1. transaction-aware reserve는 caller rollback 시 intent도 사라지고 commit 시 CREATED가 보인다.
+2. 기존 reserve와 transaction reserve의 duplicate/idempotency 결과가 동일하다.
+3. opaque reservation 없이는 pre-reserved broker API를 호출할 수 없다.
+4. pre-reserved 실행은 재-reserve하지 않고 broker를 정확히 한 번 호출한다.
+5. persisted intent만 PENDING_ENTRY/PENDING_EXIT prepare가 가능하다.
+6. identity/account/symbol/source sibling 불일치와 overwrite는 broker 전에 차단된다.
+7. 같은 intent 재호출은 idempotent하고 다른 intent는 차단된다.
+8. 두 connection 동시 SELL에서 하나만 claim하고 broker도 정확히 한 번 호출된다.
+9. explicit FAILED는 PENDING_EXIT -> OPEN, legacy holding/history/message는 불변이다.
+10. timeout/exception/cancel/ledger-after-broker failure는 EXIT_UNKNOWN, legacy holding 유지,
+    재주문 차단이다.
+11. SUBMITTED 결과만 기존 legacy sell을 실행하고 CLOSED로 확정하며 QUEUED는 PENDING을 유지한다.
+12. US full-exit sibling 전체 prepare/finalize/fail이 원자적이며 부분 업데이트가 없다.
+13. QUEUED -> pending batch -> SUBMITTED가 동일 intent ID를 유지한다.
+14. SQLite lock/disk-full/write-ahead 실패 시 broker 호출은 0회다.
+15. KR/US batch, hardstop, trend-exit의 broker/publish/Telegram 횟수와 순서를 각각 고정한다.
+16. gate=false에서 기존 회귀 테스트 결과와 호출 순서가 그대로다.
+17. comparator는 PENDING/EXIT_UNKNOWN을 정상 OPEN 일치로 숨기지 않고 intent/status/age를
+    식별 가능한 mismatch로 보고한다.
+
+## 7. 명시적 비목표
+
+- positions를 판단 read source로 전환
+- FILLED/PARTIALLY_FILLED 추정
+- UNKNOWN 자동 복구 또는 자동 OPEN 전환
+- KIS 체결 조회/reconciliation (Phase 5)
+- legacy 테이블/schema 삭제
+- hardstop/trend owner-lock 통합 (Phase 5)
+- US pending-order queue 자체의 구조 이관
+
+## 8. 4-b2a 완료 조건
+
+- 신규 core 상태 API가 추가되지만 production caller diff는 0이다.
+- 기존 전체 회귀 + 신규 transaction/transition/concurrency failure-injection이 green이다.
+- 운영동등 DB copy에서 cron 명령 전부 startup/import 및 comparator 통과.
+- 독립 architecture/SQLite/concurrency/final 리뷰에서 blocker 0.
+- CI Python 3.10/3.11/3.12 + static analysis green.
+- 실제 운영 활성화는 별도 승인된 무거래 창에서 수행하며, 첫 배치 전후 positions/intent/
+  legacy/broker/publish 수를 대조한다.

--- a/tasks/issue-412/README.md
+++ b/tasks/issue-412/README.md
@@ -2,8 +2,9 @@
 
 > 이슈: [#412 매수/매도 Agent 분리와 KIS 실제 주문 실행 구조 이식 설계](https://github.com/dragon1086/prism-insight/issues/412)
 > 브랜치: `feature/issue-412-execution-architecture`
-> 상태: Phase 4-b1 착수 (2026-07-06 시작, 2026-07-13 main #432 기준 전면 재검토,
-> **2026-07-19 Phase 4-a position shadow ledger 배포 완료 후 intent linkage 시작**)
+> 상태: Phase 4-b1 배포 완료, Phase 4-b2a 기반 API 구현/검증 중
+> (2026-07-06 시작, 2026-07-13 main #432 기준 전면 재검토,
+> **2026-07-19 Phase 4-b1 PR #462, main `9b3ecc58` 배포 완료**)
 
 ## 목적
 
@@ -28,6 +29,7 @@ greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 
 | [03-target-design.md](03-target-design.md) | 목표 아키텍처 — 코어 엔진, 포트 인터페이스, 이벤트, 상태기계, DB 모델 |
 | [04-migration-plan.md](04-migration-plan.md) | Phase 0~6 단계별 실행 계획과 각 단계 완료 조건 |
 | [05-verification-plan.md](05-verification-plan.md) | 검증 전략 — 단위/golden/shadow 병행 기록/demo 계좌/서버 배포 절차/롤백 |
+| [11-phase4b2-pending-exit-plan.md](11-phase4b2-pending-exit-plan.md) | Phase 4-b2 분할 계획 — 4-b2a 기반 API, 4-b2b KR 전환, 4-b2c US queue 연속성/전환 |
 
 ## 진행 체크리스트
 
@@ -39,8 +41,10 @@ greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 
 - [x] Phase 2: ExecutionService chokepoint 도입 (PR #456, main `1aca6029`)
 - [x] Phase 3: OrderIntent 영속화 (PR #459, main `8ff33b17`)
 - [x] Phase 4-a: position OPEN/CLOSED shadow 병행 기록 + 대조 (PR #460/#461, main `5ed6f38c`)
-- [ ] Phase 4-b1: persisted intent ↔ position linkage — 진행 중, legacy 순서/read 유지
-- [ ] Phase 4-b2: PENDING write-ahead + 실패 보상 (별도 위험 PR)
+- [x] Phase 4-b1: persisted intent ↔ position linkage, legacy 순서/read 유지 (PR #462, main `9b3ecc58`)
+- [ ] Phase 4-b2a: transaction-aware reserve/PENDING lifecycle 기반 API — 운영 호출부 미배선
+- [ ] Phase 4-b2b: KR 전체 경로 PENDING write-ahead + 실패 보상 (시장 단위 gate)
+- [ ] Phase 4-b2c: US queued-intent 연속성 + US 전체 경로 전환 (시장 단위 gate)
 - [ ] Phase 4 read switch: 충분한 운영 대조 후 별도 승인
 - [ ] Phase 5: BrokerAdapter 추출 (체결/미체결/정정 포함) + lock 일반화 + reconciliation (alert-only)
 - [ ] Phase 6: 이벤트 버스 / 코어-어댑터 패키지 분리 / prism-us 흡수
@@ -57,3 +61,4 @@ greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 
 Phase 2의 구체적인 작업 순서와 비목표는 [07-phase2-execution-plan.md](07-phase2-execution-plan.md)를 따른다.
 Phase 4-a의 안전한 shadow 범위와 관찰 gate는 [09-phase4a-execution-plan.md](09-phase4a-execution-plan.md)를 따른다.
 Phase 4-b1의 동작 보존형 intent linkage 범위는 [10-phase4b1-intent-linkage-plan.md](10-phase4b1-intent-linkage-plan.md)를 따른다.
+Phase 4-b2의 안전한 분할, 상태 전이, 활성화 차단 조건은 [11-phase4b2-pending-exit-plan.md](11-phase4b2-pending-exit-plan.md)를 따른다.

--- a/tests/test_order_intents.py
+++ b/tests/test_order_intents.py
@@ -2,6 +2,7 @@ import asyncio
 import ast
 import hashlib
 import sqlite3
+import threading
 from pathlib import Path
 
 import pytest
@@ -115,6 +116,368 @@ def test_schema_is_additive_and_preserves_existing_tables(tmp_path):
     assert after == before
     assert row == (1, "005930")
     assert {"order_intents", "broker_orders"} <= tables
+
+
+def test_transaction_reservation_obeys_caller_commit_and_rollback(tmp_path):
+    from prism_core.order_intents import IntentStore
+
+    db_path = tmp_path / "orders.sqlite"
+    store = IntentStore(db_path)
+    rolled_back = _intent(source_position_id="rollback")
+    committed = _intent(source_position_id="commit")
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        created, reservation = store.reserve_in_transaction(conn, rolled_back)
+        assert created is True
+        assert reservation["status"] == "CREATED"
+        conn.rollback()
+
+        conn.execute("BEGIN IMMEDIATE")
+        created, reservation = store.reserve_in_transaction(conn, committed)
+        assert created is True
+        assert reservation["status"] == "CREATED"
+        conn.commit()
+
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute(
+            "SELECT id, status FROM order_intents ORDER BY id"
+        ).fetchall() == [(committed.id, "CREATED")]
+
+
+def test_transaction_reservation_rejects_autocommit_without_begin(tmp_path):
+    from prism_core.order_intents import IntentStore
+
+    db_path = tmp_path / "orders.sqlite"
+    store = IntentStore(db_path)
+    connection = sqlite3.connect(db_path, isolation_level=None)
+    intent = _intent(source_position_id="autocommit")
+
+    with pytest.raises(RuntimeError, match="active caller-owned transaction"):
+        store.reserve_in_transaction(connection, intent)
+
+    assert connection.execute(
+        "SELECT COUNT(*) FROM order_intents WHERE id=?", (intent.id,)
+    ).fetchone() == (0,)
+
+
+def test_transaction_reservation_matches_duplicate_result_of_reserve(tmp_path):
+    from prism_core.order_intents import IntentStore
+
+    db_path = tmp_path / "orders.sqlite"
+    store = IntentStore(db_path)
+    first = _intent(source_position_id="same")
+    duplicate = _intent(source_position_id="same")
+    assert store.reserve(first)[0] is True
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        created, existing = store.reserve_in_transaction(conn, duplicate)
+        conn.rollback()
+
+    assert created is False
+    assert existing == {
+        "id": first.id,
+        "status": "CREATED",
+        "idempotency_key": first.idempotency_key,
+    }
+
+
+def test_pre_reserved_execution_requires_store_capability_and_calls_broker_once(
+    tmp_path,
+):
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore
+
+    db_path = tmp_path / "orders.sqlite"
+    store = IntentStore(db_path)
+    intent = _intent(source_position_id="pre-reserved")
+    broker = FakeBroker()
+    service = ExecutionService(broker, intent_store=store)
+
+    with pytest.raises(TypeError):
+        asyncio.run(
+            service.execute_pre_reserved_buy(
+                "005930", intent=intent, reservation={"id": intent.id}
+            )
+        )
+    assert broker.calls == 0
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        created, reservation = store.reserve_in_transaction(conn, intent)
+        assert created is True
+        conn.commit()
+
+    result = asyncio.run(
+        service.execute_pre_reserved_buy(
+            "005930", intent=intent, reservation=reservation
+        )
+    )
+
+    assert result["intent_status"] == "SUBMITTED"
+    assert broker.calls == 1
+    with pytest.raises(TypeError, match="unused"):
+        ExecutionService(
+            broker, intent_store=store
+        ).execute_pre_reserved_reserved_buy(
+            "AAPL", intent=intent, reservation=reservation
+        )
+    assert broker.calls == 1
+    intents, orders = _rows(db_path)
+    assert intents[0][0] == "SUBMITTED"
+    assert len(orders) == 1
+
+
+def test_rolled_back_pre_reservation_blocks_broker(tmp_path):
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore
+
+    db_path = tmp_path / "orders.sqlite"
+    store = IntentStore(db_path)
+    intent = _intent(source_position_id="rolled-back-capability")
+    broker = FakeBroker()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        created, reservation = store.reserve_in_transaction(conn, intent)
+        assert created is True
+        conn.rollback()
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(
+            ExecutionService(
+                broker, intent_store=store
+            ).execute_pre_reserved_buy(
+                "005930", intent=intent, reservation=reservation
+            )
+        )
+    assert broker.calls == 0
+
+
+def test_pre_reserved_execution_rejects_active_transaction_and_foreign_db(
+    tmp_path,
+):
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore
+
+    db_path = tmp_path / "orders.sqlite"
+    foreign_path = tmp_path / "foreign.sqlite"
+    store = IntentStore(db_path, timeout=0.05)
+    intent = _intent(source_position_id="active-transaction")
+    broker = FakeBroker()
+    conn = sqlite3.connect(db_path)
+    conn.execute("BEGIN IMMEDIATE")
+    created, reservation = store.reserve_in_transaction(conn, intent)
+    assert created is True
+
+    with pytest.raises(RuntimeError, match="must commit"):
+        asyncio.run(
+            ExecutionService(
+                broker, intent_store=store
+            ).execute_pre_reserved_buy(
+                "005930", intent=intent, reservation=reservation
+            )
+        )
+    assert broker.calls == 0
+    conn.rollback()
+
+    sqlite3.connect(foreign_path).close()
+    with sqlite3.connect(foreign_path) as foreign:
+        with pytest.raises(ValueError, match="does not target"):
+            store.reserve_in_transaction(foreign, _intent(source_position_id="foreign"))
+
+
+def test_pre_reserved_sync_reserved_order_uses_capability_once(tmp_path):
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore, OrderIntent
+
+    db_path = tmp_path / "orders.sqlite"
+    store = IntentStore(db_path)
+    intent = OrderIntent.create(
+        market="US",
+        account_id="acct-us",
+        symbol="AAPL",
+        side="BUY",
+        order_style="reserved",
+        source="test",
+        source_decision_id="reserved-capability",
+    )
+    broker = FakeBroker()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        created, reservation = store.reserve_in_transaction(conn, intent)
+        assert created is True
+        conn.commit()
+
+    result = ExecutionService(
+        broker, intent_store=store
+    ).execute_pre_reserved_reserved_buy(
+        "AAPL", intent=intent, reservation=reservation
+    )
+
+    assert result["intent_status"] == "SUBMITTED"
+    assert broker.calls == 1
+
+
+def test_closed_reservation_connection_uses_committed_row_as_authority(tmp_path):
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore
+
+    db_path = tmp_path / "orders.sqlite"
+    store = IntentStore(db_path)
+    committed = _intent(source_position_id="closed-committed")
+    rolled_back = _intent(source_position_id="closed-rolled-back")
+
+    committed_connection = sqlite3.connect(db_path)
+    committed_connection.execute("BEGIN IMMEDIATE")
+    _, committed_reservation = store.reserve_in_transaction(
+        committed_connection, committed
+    )
+    committed_connection.commit()
+    committed_connection.close()
+
+    rolled_back_connection = sqlite3.connect(db_path)
+    rolled_back_connection.execute("BEGIN IMMEDIATE")
+    _, rolled_back_reservation = store.reserve_in_transaction(
+        rolled_back_connection, rolled_back
+    )
+    rolled_back_connection.rollback()
+    rolled_back_connection.close()
+
+    committed_broker = FakeBroker()
+    result = asyncio.run(
+        ExecutionService(
+            committed_broker, intent_store=store
+        ).execute_pre_reserved_buy(
+            "005930", intent=committed, reservation=committed_reservation
+        )
+    )
+    assert result["intent_status"] == "SUBMITTED"
+    assert committed_broker.calls == 1
+
+    rolled_back_broker = FakeBroker()
+    with pytest.raises(RuntimeError, match="not in CREATED"):
+        asyncio.run(
+            ExecutionService(
+                rolled_back_broker, intent_store=store
+            ).execute_pre_reserved_buy(
+                "005930", intent=rolled_back, reservation=rolled_back_reservation
+            )
+        )
+    assert rolled_back_broker.calls == 0
+
+
+def test_cancellation_during_pre_reserved_claim_marks_unknown_without_broker(
+    tmp_path, monkeypatch
+):
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore
+
+    db_path = tmp_path / "orders.sqlite"
+    store = IntentStore(db_path)
+    intent = _intent(source_position_id="cancelled-claim")
+    connection = sqlite3.connect(db_path)
+    connection.execute("BEGIN IMMEDIATE")
+    _, reservation = store.reserve_in_transaction(connection, intent)
+    connection.commit()
+    broker = FakeBroker()
+    started = threading.Event()
+    release = threading.Event()
+    real_claim = store.claim_reservation
+
+    def delayed_claim(*args, **kwargs):
+        started.set()
+        assert release.wait(timeout=2)
+        return real_claim(*args, **kwargs)
+
+    monkeypatch.setattr(store, "claim_reservation", delayed_claim)
+
+    async def exercise():
+        task = asyncio.create_task(
+            ExecutionService(
+                broker, intent_store=store
+            ).execute_pre_reserved_buy(
+                "005930", intent=intent, reservation=reservation
+            )
+        )
+        assert await asyncio.to_thread(started.wait, 2)
+        task.cancel()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(exercise())
+
+    assert broker.calls == 0
+    with sqlite3.connect(db_path) as verify:
+        assert verify.execute(
+            "SELECT status FROM order_intents WHERE id=?", (intent.id,)
+        ).fetchone() == ("UNKNOWN",)
+
+
+def test_pre_reserved_claim_write_failure_never_calls_broker(tmp_path, monkeypatch):
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore
+
+    db_path = tmp_path / "orders.sqlite"
+    store = IntentStore(db_path)
+    intent = _intent(source_position_id="claim-write-failure")
+    connection = sqlite3.connect(db_path)
+    connection.execute("BEGIN IMMEDIATE")
+    _, reservation = store.reserve_in_transaction(connection, intent)
+    connection.commit()
+    broker = FakeBroker()
+
+    def fail_mark_submitting(_intent_id):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(store, "mark_submitting", fail_mark_submitting)
+
+    with pytest.raises(sqlite3.OperationalError, match="locked"):
+        asyncio.run(
+            ExecutionService(
+                broker, intent_store=store
+            ).execute_pre_reserved_buy(
+                "005930", intent=intent, reservation=reservation
+            )
+        )
+    assert broker.calls == 0
+
+
+def test_pre_reserved_sync_sell_binds_capability_side_before_broker(tmp_path):
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore
+
+    db_path = tmp_path / "orders.sqlite"
+    store = IntentStore(db_path)
+    sell_intent = _intent(side="sell", source_position_id="sync-sell")
+    connection = sqlite3.connect(db_path)
+    connection.execute("BEGIN IMMEDIATE")
+    _, reservation = store.reserve_in_transaction(connection, sell_intent)
+    connection.commit()
+    broker = FakeBroker()
+
+    result = ExecutionService(
+        broker, intent_store=store
+    ).execute_pre_reserved_reserved_sell(
+        "005930", intent=sell_intent, reservation=reservation
+    )
+
+    assert result["intent_status"] == "SUBMITTED"
+    assert broker.calls == 1
+
+    wrong_side = _intent(source_position_id="wrong-side")
+    connection.execute("BEGIN IMMEDIATE")
+    _, wrong_reservation = store.reserve_in_transaction(connection, wrong_side)
+    connection.commit()
+    with pytest.raises(ValueError, match="side"):
+        ExecutionService(
+            broker, intent_store=store
+        ).execute_pre_reserved_reserved_sell(
+            "005930", intent=wrong_side, reservation=wrong_reservation
+        )
+    assert broker.calls == 1
 
 
 def test_explicit_broker_rejection_is_recorded_as_failed(tmp_path):

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -1,8 +1,11 @@
+import asyncio
 import json
 import sqlite3
 import subprocess
 import sys
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import FrozenInstanceError
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -183,6 +186,652 @@ def test_transition_graph_and_database_check_are_enforced() -> None:
                 "2026-07-18",
             ),
         )
+
+
+def test_prepare_complete_and_fail_entry_require_persisted_matching_intent(
+    tmp_path,
+) -> None:
+    from prism_core.order_intents import IntentStore, OrderIntent
+
+    db_path = tmp_path / "entry.sqlite"
+    IntentStore(db_path)
+    conn = sqlite3.connect(db_path)
+    _legacy_schema(conn)
+    store = PositionStore(conn)
+    store.ensure_schema()
+    intent = OrderIntent.create(
+        market="KR",
+        account_id="acct",
+        symbol="005930",
+        side="BUY",
+        order_style="market",
+        source="test",
+        source_decision_id="decision-1",
+        source_position_id="legacy:KR:1",
+    )
+
+    conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+    with pytest.raises(LookupError):
+        store.prepare_entry(
+            market="KR",
+            legacy_holding_id=1,
+            account_id="acct",
+            account_name="primary",
+            symbol="005930",
+            intent_id=intent.id,
+        )
+    conn.rollback()
+
+    conn.execute("BEGIN IMMEDIATE")
+    created, _ = IntentStore(db_path).reserve_in_transaction(conn, intent)
+    assert created is True
+    assert store.prepare_entry(
+        market="KR",
+        legacy_holding_id=1,
+        account_id="acct",
+        account_name="primary",
+        symbol="005930",
+        intent_id=intent.id,
+        entry_price=71000,
+    )
+    assert store.prepare_entry(
+        market="KR",
+        legacy_holding_id=1,
+        account_id="acct",
+        account_name="primary",
+        symbol="005930",
+        intent_id=intent.id,
+        entry_price=71000,
+    )
+    conn.execute("UPDATE order_intents SET status='QUEUED' WHERE id=?", (intent.id,))
+    with pytest.raises(InvalidPositionTransition, match="requires SUBMITTED"):
+        store.complete_entry(
+            market="KR", legacy_holding_id=1, account_id="acct", symbol="005930",
+            intent_id=intent.id
+        )
+    conn.execute("UPDATE order_intents SET status='SUBMITTED' WHERE id=?", (intent.id,))
+    assert store.complete_entry(
+        market="KR", legacy_holding_id=1, account_id="acct", symbol="005930",
+        intent_id=intent.id
+    )
+    conn.commit()
+
+    assert conn.execute(
+        "SELECT status, entry_intent_id FROM positions"
+    ).fetchone() == ("OPEN", intent.id)
+
+    second = OrderIntent.create(
+        market="KR",
+        account_id="acct",
+        symbol="000660",
+        side="BUY",
+        order_style="market",
+        source="test",
+        source_decision_id="decision-2",
+        source_position_id="legacy:KR:2",
+    )
+    conn.execute("BEGIN IMMEDIATE")
+    IntentStore(db_path).reserve_in_transaction(conn, second)
+    store.prepare_entry(
+        market="KR",
+        legacy_holding_id=2,
+        account_id="acct",
+        account_name="primary",
+        symbol="000660",
+        intent_id=second.id,
+    )
+    conn.execute("UPDATE order_intents SET status='FAILED' WHERE id=?", (second.id,))
+    assert store.fail_entry(
+        market="KR", legacy_holding_id=2, account_id="acct", symbol="000660",
+        intent_id=second.id
+    )
+    conn.commit()
+    assert conn.execute(
+        "SELECT status FROM positions WHERE id='legacy:KR:2'"
+    ).fetchone() == ("ENTRY_FAILED",)
+
+
+def test_exit_many_lifecycle_is_atomic_idempotent_and_blocks_overwrite(tmp_path) -> None:
+    from dataclasses import replace
+
+    from prism_core.order_intents import IntentStore, OrderIntent
+
+    db_path = tmp_path / "exit-many.sqlite"
+    IntentStore(db_path)
+    conn = sqlite3.connect(db_path)
+    _legacy_schema(conn)
+    store = PositionStore(conn)
+    store.ensure_schema()
+    for row_id in (1, 2):
+        _insert_legacy(conn, "us_stock_holdings", row_id, "acct", "AAPL")
+    store.backfill_legacy_positions("US")
+    source_ids = ("legacy:US:1", "legacy:US:2")
+    intent = OrderIntent.create(
+        market="US",
+        account_id="acct",
+        symbol="AAPL",
+        side="SELL",
+        order_style="market",
+        source="test",
+        source_position_id=",".join(source_ids),
+    )
+    conn.commit()
+
+    conn.execute("BEGIN IMMEDIATE")
+    IntentStore(db_path).reserve_in_transaction(conn, intent)
+    assert store.prepare_exit_many(
+        market="US",
+        account_id="acct",
+        symbol="AAPL",
+        position_ids=source_ids,
+        intent_id=intent.id,
+    )
+    assert store.prepare_exit_many(
+        market="US",
+        account_id="acct",
+        symbol="AAPL",
+        position_ids=source_ids,
+        intent_id=intent.id,
+    )
+    assert conn.execute(
+        "SELECT COUNT(*) FROM positions WHERE status='PENDING_EXIT' "
+        "AND exit_intent_id=?", (intent.id,)
+    ).fetchone() == (2,)
+
+    conn.execute("UPDATE order_intents SET status='SUBMITTED' WHERE id=?", (intent.id,))
+    conn.execute(
+        "UPDATE positions SET symbol='MSFT' WHERE id='legacy:US:2'"
+    )
+    before = conn.total_changes
+    with pytest.raises(ValueError, match="position identity mismatch"):
+        store.complete_exit_many(
+            market="US",
+            account_id="acct",
+            symbol="AAPL",
+            position_ids=source_ids,
+            intent_id=intent.id,
+        )
+    assert conn.total_changes == before
+    conn.execute(
+        "UPDATE positions SET symbol='AAPL' WHERE id='legacy:US:2'"
+    )
+    conn.execute("UPDATE order_intents SET status='FAILED' WHERE id=?", (intent.id,))
+    assert store.fail_exit_many(
+        market="US",
+        account_id="acct",
+        symbol="AAPL",
+        position_ids=source_ids,
+        intent_id=intent.id,
+    )
+    assert conn.execute(
+        "SELECT COUNT(*) FROM positions WHERE status='OPEN' AND exit_intent_id=?",
+        (intent.id,),
+    ).fetchone() == (2,)
+    conn.commit()
+
+    replacement = OrderIntent.create(
+        market="US",
+        account_id="acct",
+        symbol="AAPL",
+        side="SELL",
+        order_style="market",
+        source="test",
+        source_decision_id="replacement",
+        source_position_id=",".join(source_ids),
+    )
+    replacement = replace(replacement, idempotency_key="replacement-key")
+    conn.execute("BEGIN IMMEDIATE")
+    IntentStore(db_path).reserve_in_transaction(conn, replacement)
+    with pytest.raises(ValueError):
+        store.prepare_exit_many(
+            market="US",
+            account_id="acct",
+            symbol="AAPL",
+            position_ids=source_ids,
+            intent_id=replacement.id,
+        )
+    conn.rollback()
+
+
+def test_intent_and_pending_entry_rollback_together(tmp_path) -> None:
+    from prism_core.order_intents import IntentStore, OrderIntent
+
+    db_path = tmp_path / "entry-atomic.sqlite"
+    intent_store = IntentStore(db_path)
+    connection = sqlite3.connect(db_path)
+    position_store = PositionStore(connection)
+    position_store.ensure_schema()
+    connection.commit()
+    intent = OrderIntent.create(
+        market="KR",
+        account_id="acct",
+        symbol="005930",
+        side="BUY",
+        order_style="market",
+        source="test",
+        source_decision_id="atomic-entry",
+        source_position_id="legacy:KR:1",
+    )
+
+    connection.execute("BEGIN IMMEDIATE")
+    assert intent_store.reserve_in_transaction(connection, intent)[0] is True
+    assert position_store.prepare_entry(
+        market="KR",
+        legacy_holding_id=1,
+        account_id="acct",
+        account_name="primary",
+        symbol="005930",
+        intent_id=intent.id,
+    )
+    connection.rollback()
+
+    with sqlite3.connect(db_path) as verify:
+        assert verify.execute(
+            "SELECT COUNT(*) FROM order_intents WHERE id=?", (intent.id,)
+        ).fetchone() == (0,)
+        assert verify.execute(
+            "SELECT COUNT(*) FROM positions WHERE id='legacy:KR:1'"
+        ).fetchone() == (0,)
+
+
+def test_exit_many_rolls_back_first_update_when_later_sibling_fails(tmp_path) -> None:
+    from prism_core.order_intents import IntentStore, OrderIntent
+
+    db_path = tmp_path / "exit-savepoint.sqlite"
+    intent_store = IntentStore(db_path)
+    connection = sqlite3.connect(db_path)
+    _legacy_schema(connection)
+    position_store = PositionStore(connection)
+    position_store.ensure_schema()
+    for row_id in (1, 2):
+        _insert_legacy(connection, "us_stock_holdings", row_id, "acct", "AAPL")
+    position_store.backfill_legacy_positions("US")
+    position_ids = ("legacy:US:1", "legacy:US:2")
+    intent = OrderIntent.create(
+        market="US",
+        account_id="acct",
+        symbol="AAPL",
+        side="SELL",
+        order_style="market",
+        source="test",
+        source_position_id=",".join(position_ids),
+    )
+    connection.commit()
+    connection.execute("BEGIN IMMEDIATE")
+    intent_store.reserve_in_transaction(connection, intent)
+    position_store.prepare_exit_many(
+        market="US",
+        account_id="acct",
+        symbol="AAPL",
+        position_ids=position_ids,
+        intent_id=intent.id,
+    )
+    connection.execute(
+        "UPDATE order_intents SET status='SUBMITTED' WHERE id=?", (intent.id,)
+    )
+    connection.execute(
+        """
+        CREATE TEMP TRIGGER fail_second_sibling
+        BEFORE UPDATE OF status ON positions
+        WHEN NEW.id='legacy:US:2' AND NEW.status='CLOSED'
+        BEGIN
+            SELECT RAISE(ABORT, 'forced sibling failure');
+        END
+        """
+    )
+
+    with pytest.raises(sqlite3.IntegrityError, match="forced sibling failure"):
+        position_store.complete_exit_many(
+            market="US",
+            account_id="acct",
+            symbol="AAPL",
+            position_ids=position_ids,
+            intent_id=intent.id,
+        )
+
+    assert connection.execute(
+        "SELECT id, status FROM positions ORDER BY id"
+    ).fetchall() == [
+        ("legacy:US:1", "PENDING_EXIT"),
+        ("legacy:US:2", "PENDING_EXIT"),
+    ]
+    connection.rollback()
+
+
+def test_exit_many_requires_caller_transaction_without_mutating_state(tmp_path) -> None:
+    from prism_core.order_intents import IntentStore, OrderIntent
+
+    db_path = tmp_path / "exit-transaction.sqlite"
+    intent_store = IntentStore(db_path)
+    conn = sqlite3.connect(db_path)
+    _legacy_schema(conn)
+    _insert_legacy(conn, "stock_holdings", 1, "acct", "005930")
+    position_store = PositionStore(conn)
+    position_store.ensure_schema()
+    position_store.backfill_legacy_positions("KR")
+    conn.commit()
+    intent = OrderIntent.create(
+        market="KR",
+        account_id="acct",
+        symbol="005930",
+        side="SELL",
+        order_style="market",
+        source="test",
+        source_position_id="legacy:KR:1",
+    )
+    assert intent_store.reserve(intent)[0] is True
+
+    with pytest.raises(RuntimeError, match="caller-owned transaction"):
+        position_store.prepare_exit_many(
+            market="KR",
+            account_id="acct",
+            symbol="005930",
+            position_ids=("legacy:KR:1",),
+            intent_id=intent.id,
+        )
+
+    assert conn.in_transaction is False
+    assert conn.execute(
+        "SELECT status, exit_intent_id FROM positions WHERE id='legacy:KR:1'"
+    ).fetchone() == ("OPEN", None)
+
+
+def test_concurrent_exit_claim_allows_exactly_one_pre_reserved_broker_call(
+    tmp_path,
+) -> None:
+    from dataclasses import replace
+
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore, OrderIntent
+
+    db_path = tmp_path / "exit-concurrent.sqlite"
+    IntentStore(db_path)
+    setup = sqlite3.connect(db_path)
+    _legacy_schema(setup)
+    _insert_legacy(setup, "stock_holdings", 1, "acct", "005930")
+    setup_store = PositionStore(setup)
+    setup_store.ensure_schema()
+    setup_store.backfill_legacy_positions("KR")
+    setup.commit()
+    setup.close()
+    first = OrderIntent.create(
+        market="KR",
+        account_id="acct",
+        symbol="005930",
+        side="SELL",
+        order_style="market",
+        source="first",
+        source_position_id="legacy:KR:1",
+    )
+    second = OrderIntent.create(
+        market="KR",
+        account_id="acct",
+        symbol="005930",
+        side="SELL",
+        order_style="market",
+        source="second",
+        source_position_id="legacy:KR:1",
+    )
+    second = replace(second, idempotency_key="independent-competing-attempt")
+    barrier = threading.Barrier(2)
+
+    def claim(intent):
+        intent_store = IntentStore(db_path, timeout=1)
+        connection = sqlite3.connect(db_path, timeout=1, check_same_thread=False)
+        barrier.wait(timeout=2)
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            created, reservation = intent_store.reserve_in_transaction(
+                connection, intent
+            )
+            assert created is True
+            PositionStore(connection).prepare_exit_many(
+                market="KR",
+                account_id="acct",
+                symbol="005930",
+                position_ids=("legacy:KR:1",),
+                intent_id=intent.id,
+            )
+            connection.commit()
+            return intent_store, reservation, intent, connection
+        except ValueError:
+            connection.rollback()
+            connection.close()
+            return None
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        claims = list(pool.map(claim, (first, second)))
+    winners = [claim_result for claim_result in claims if claim_result is not None]
+    assert len(winners) == 1
+    intent_store, reservation, winner_intent, winner_connection = winners[0]
+
+    class Broker:
+        def __init__(self):
+            self.calls = 0
+
+        async def async_sell_stock(self, *_args, **_kwargs):
+            self.calls += 1
+            return {"success": True, "order_no": "ONE", "message": "accepted"}
+
+    broker = Broker()
+    result = asyncio.run(
+        ExecutionService(
+            broker, intent_store=intent_store
+        ).execute_pre_reserved_sell(
+            "005930", intent=winner_intent, reservation=reservation
+        )
+    )
+    winner_connection.close()
+
+    assert result["intent_status"] == "SUBMITTED"
+    assert broker.calls == 1
+    with sqlite3.connect(db_path) as verify:
+        assert verify.execute(
+            "SELECT status, exit_intent_id FROM positions WHERE id='legacy:KR:1'"
+        ).fetchone() == ("PENDING_EXIT", winner_intent.id)
+        assert verify.execute(
+            "SELECT COUNT(*) FROM order_intents"
+        ).fetchone() == (1,)
+
+
+def test_entry_lifecycle_rejects_autocommit_without_mutating_state(tmp_path) -> None:
+    from prism_core.order_intents import IntentStore, OrderIntent
+
+    db_path = tmp_path / "entry-transaction.sqlite"
+    intent_store = IntentStore(db_path)
+    intent = OrderIntent.create(
+        market="KR",
+        account_id="acct",
+        symbol="005930",
+        side="BUY",
+        order_style="market",
+        source="test",
+        source_decision_id="autocommit-entry",
+        source_position_id="legacy:KR:1",
+    )
+    assert intent_store.reserve(intent)[0] is True
+    connection = sqlite3.connect(db_path, isolation_level=None)
+    position_store = PositionStore(connection)
+    position_store.ensure_schema()
+
+    with pytest.raises(RuntimeError, match="active caller-owned transaction"):
+        position_store.prepare_entry(
+            market="KR",
+            legacy_holding_id=1,
+            account_id="acct",
+            account_name="primary",
+            symbol="005930",
+            intent_id=intent.id,
+        )
+
+    assert connection.execute(
+        "SELECT COUNT(*) FROM positions WHERE id='legacy:KR:1'"
+    ).fetchone() == (0,)
+
+
+def test_exit_unknown_many_and_comparator_report_status_intent_and_age(tmp_path) -> None:
+    from prism_core.order_intents import IntentStore, OrderIntent
+
+    db_path = tmp_path / "unknown.sqlite"
+    IntentStore(db_path)
+    conn = sqlite3.connect(db_path)
+    _legacy_schema(conn)
+    _insert_legacy(conn, "stock_holdings", 1, "secret-acct", "005930")
+    store = PositionStore(conn)
+    store.ensure_schema()
+    store.backfill_legacy_positions("KR")
+    intent = OrderIntent.create(
+        market="KR",
+        account_id="secret-acct",
+        symbol="005930",
+        side="SELL",
+        order_style="market",
+        source="test",
+        source_position_id="legacy:KR:1",
+    )
+    conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+    IntentStore(db_path).reserve_in_transaction(conn, intent)
+    store.prepare_exit_many(
+        market="KR",
+        account_id="secret-acct",
+        symbol="005930",
+        position_ids=("legacy:KR:1",),
+        intent_id=intent.id,
+    )
+    conn.execute(
+        "UPDATE positions SET updated_at='2020-01-01T00:00:00+00:00'"
+    )
+    conn.execute("UPDATE order_intents SET status='UNKNOWN' WHERE id=?", (intent.id,))
+    store.mark_exit_unknown_many(
+        market="KR",
+        account_id="secret-acct",
+        symbol="005930",
+        position_ids=("legacy:KR:1",),
+        intent_id=intent.id,
+    )
+    conn.commit()
+
+    result = store.compare_legacy_positions("KR", pending_stale_after_seconds=60)
+
+    assert result["matches"] is False
+    assert result["pending_positions"] == []
+    assert result["exit_unknown_positions"][0]["position_id"] == "legacy:KR:1"
+    assert result["exit_unknown_positions"][0]["intent_id"] == intent.id
+    assert result["exit_unknown_positions"][0]["status"] == "EXIT_UNKNOWN"
+    assert "secret-acct" not in json.dumps(result)
+
+
+def test_comparator_distinguishes_fresh_and_stale_pending_positions(tmp_path) -> None:
+    from prism_core.order_intents import IntentStore, OrderIntent
+
+    db_path = tmp_path / "pending-age.sqlite"
+    IntentStore(db_path)
+    conn = sqlite3.connect(db_path)
+    _legacy_schema(conn)
+    store = PositionStore(conn)
+    store.ensure_schema()
+    conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+    intents = []
+    for row_id, symbol in ((1, "005930"), (2, "000660")):
+        intent = OrderIntent.create(
+            market="KR",
+            account_id="acct",
+            symbol=symbol,
+            side="BUY",
+            order_style="market",
+            source="test",
+            source_decision_id=f"decision-{row_id}",
+            source_position_id=f"legacy:KR:{row_id}",
+        )
+        IntentStore(db_path).reserve_in_transaction(conn, intent)
+        store.prepare_entry(
+            market="KR",
+            legacy_holding_id=row_id,
+            account_id="acct",
+            account_name="primary",
+            symbol=symbol,
+            intent_id=intent.id,
+        )
+        intents.append(intent)
+    conn.execute(
+        "UPDATE positions SET updated_at='2020-01-01T00:00:00+00:00' "
+        "WHERE id='legacy:KR:2'"
+    )
+    conn.commit()
+
+    result = store.compare_legacy_positions("KR", pending_stale_after_seconds=60)
+
+    assert [item["position_id"] for item in result["pending_positions"]] == [
+        "legacy:KR:1"
+    ]
+    assert [item["position_id"] for item in result["stale_pending_positions"]] == [
+        "legacy:KR:2"
+    ]
+    assert result["pending_positions"][0]["intent_id"] == intents[0].id
+    assert result["stale_pending_positions"][0]["intent_id"] == intents[1].id
+    assert result["matches"] is False
+
+    conn.execute(
+        "UPDATE positions SET updated_at=CURRENT_TIMESTAMP "
+        "WHERE id='legacy:KR:2'"
+    )
+    fresh_only = store.compare_legacy_positions("KR", pending_stale_after_seconds=60)
+    assert fresh_only["matches"] is False
+    assert len(fresh_only["pending_positions"]) == 2
+
+
+def test_comparator_ages_pending_exit_using_exit_intent(tmp_path) -> None:
+    from prism_core.order_intents import IntentStore, OrderIntent
+
+    db_path = tmp_path / "pending-exit-age.sqlite"
+    intent_store = IntentStore(db_path)
+    connection = sqlite3.connect(db_path)
+    _legacy_schema(connection)
+    _insert_legacy(connection, "stock_holdings", 1, "acct", "005930")
+    position_store = PositionStore(connection)
+    position_store.ensure_schema()
+    position_store.backfill_legacy_positions("KR")
+    connection.commit()
+    intent = OrderIntent.create(
+        market="KR",
+        account_id="acct",
+        symbol="005930",
+        side="SELL",
+        order_style="market",
+        source="test",
+        source_position_id="legacy:KR:1",
+    )
+    connection.execute("BEGIN IMMEDIATE")
+    intent_store.reserve_in_transaction(connection, intent)
+    position_store.prepare_exit_many(
+        market="KR",
+        account_id="acct",
+        symbol="005930",
+        position_ids=("legacy:KR:1",),
+        intent_id=intent.id,
+    )
+    connection.commit()
+
+    fresh = position_store.compare_legacy_positions(
+        "KR", pending_stale_after_seconds=60
+    )
+    assert fresh["matches"] is False
+    assert fresh["pending_positions"][0]["status"] == "PENDING_EXIT"
+    assert fresh["pending_positions"][0]["intent_id"] == intent.id
+
+    connection.execute(
+        "UPDATE positions SET updated_at='2020-01-01T00:00:00+00:00'"
+    )
+    connection.commit()
+    stale = position_store.compare_legacy_positions(
+        "KR", pending_stale_after_seconds=60
+    )
+    assert stale["pending_positions"] == []
+    assert stale["stale_pending_positions"][0]["status"] == "PENDING_EXIT"
+    assert stale["stale_pending_positions"][0]["intent_id"] == intent.id
 
 
 def test_kr_and_us_backfill_is_idempotent_and_skips_invalid_rows() -> None:


### PR DESCRIPTION
## 요약
- caller-owned transaction 안에서 OrderIntent를 예약하는 API를 추가합니다.
- opaque reservation을 요구하는 pre-reserved ExecutionService 경계를 추가합니다.
- Position PENDING entry/exit lifecycle과 comparator 가시성을 추가합니다.
- Phase 4-b2를 4-b2a 기반, 4-b2b KR, 4-b2c US로 분리한 실행 계획을 문서화합니다.

## 운영 안전성
- production agent/loop/pending-batch 호출부 변경: 0
- 기존 legacy holdings/history read source와 주문 순서: 변경 없음
- 신규 API는 아직 운영 경로에 배선되지 않음
- 실제 PENDING 활성화는 후속 시장 단위 gate PR에서만 수행

## 검증
- 신규 intent/position 테스트: 62 passed
- 관련 execution/hardstop/trend/sell concurrency: 105 passed, 1 deselected (로컬 KIS 설정 의존 기존 테스트)
- report contracts: 5 passed
- pyramiding/layer2: 14 passed
- KR/US fill chaser: 38 passed
- Ruff, py_compile, git diff --check 통과
- 독립 architecture/code/test review blocker 0

Closes #412 일부 (Phase 4-b2a)