### PR TITLE
refactor: #412 Phase 4-b2b-0 KR pending safety foundation

### DIFF
--- a/prism_core/execution_service.py
+++ b/prism_core/execution_service.py
@@ -75,10 +75,22 @@ class ExecutionService:
         account_name: str | None = None,
         *,
         db_path: str | Path | None = None,
+        intent_store: IntentStore | None = None,
     ) -> "ExecutionService":
         from trading.domestic_stock_trading import AsyncTradingContext
 
-        store = IntentStore(db_path) if db_path is not None else None
+        if db_path is not None and intent_store is not None:
+            requested_path = Path(db_path).expanduser().resolve()
+            store_path = Path(intent_store.db_path).expanduser().resolve()
+            if requested_path != store_path:
+                raise ValueError(
+                    "db_path must target the originating IntentStore database"
+                )
+        store = (
+            intent_store
+            if intent_store is not None
+            else IntentStore(db_path) if db_path is not None else None
+        )
         return cls(
             AsyncTradingContext(account_name=account_name),
             intent_store=store,

--- a/prism_core/positions.py
+++ b/prism_core/positions.py
@@ -621,7 +621,7 @@ class PositionStore:
         position_ids: Iterable[str],
         intent_id: Any,
         to_status: str,
-        required_intent_status: str,
+        required_intent_status: str | frozenset[str],
         exit_price: Any = None,
         realized_pnl_pct: Any = None,
         exit_kind: str | None = None,
@@ -640,9 +640,15 @@ class PositionStore:
             side="SELL",
             position_ids=source_ids,
         )
-        if str(intent["status"]).upper() != required_intent_status:
+        required_statuses = (
+            frozenset({required_intent_status})
+            if isinstance(required_intent_status, str)
+            else required_intent_status
+        )
+        if str(intent["status"]).upper() not in required_statuses:
+            expected = ", ".join(sorted(required_statuses))
             raise InvalidPositionTransition(
-                f"exit {to_status} requires {required_intent_status} intent"
+                f"exit {to_status} requires one of {expected} intent statuses"
             )
         rows = self._validate_exit_positions(
             market=market,
@@ -686,12 +692,21 @@ class PositionStore:
             to_status="OPEN", required_intent_status="FAILED", **values
         )
 
-    def mark_exit_unknown_many(self, **values: Any) -> bool:
-        """Atomically quarantine exits whose broker outcome is ambiguous."""
+    def quarantine_pending_exit_many(self, **values: Any) -> bool:
+        """Quarantine claimed exits that cannot be finalized with certainty."""
 
         return self._finish_exit_many(
-            to_status="EXIT_UNKNOWN", required_intent_status="UNKNOWN", **values
+            to_status="EXIT_UNKNOWN",
+            required_intent_status=frozenset(
+                {"SUBMITTING", "SUBMITTED", "UNKNOWN", "QUEUED"}
+            ),
+            **values,
         )
+
+    def mark_exit_unknown_many(self, **values: Any) -> bool:
+        """Compatibility wrapper for exit quarantine."""
+
+        return self.quarantine_pending_exit_many(**values)
 
     def transition(
         self,

--- a/tasks/issue-412/12-phase4b2b-kr-execution-plan.md
+++ b/tasks/issue-412/12-phase4b2b-kr-execution-plan.md
@@ -1,0 +1,158 @@
+# Issue #412 Phase 4-b2b 실행 계획 — KR PENDING write-ahead
+
+> 기준: main `de74af0c` (Phase 4-b2a 배포 완료)
+> 운영 기본값: `POSITION_PENDING_KR_ENABLED=false`
+> 최우선 원칙: 중복·유령 주문을 막기 위해 주문 결과가 불명확하면 자동 재주문하지 않는다.
+
+## 1. 범위와 비목표
+
+이번 단계는 KR batch BUY/SELL, enhanced BUY, hardstop SELL, trend-exit SELL을
+동일한 시장 단위 gate 아래 PENDING lifecycle로 연결한다. legacy holdings/history는 계속
+유일한 판단 read source다.
+
+비목표:
+
+- US 주문 경로와 `us_pending_orders` 변경
+- positions read switch
+- 체결·부분체결 추정 또는 reconciliation
+- hardstop/trend owner-lock 통합
+- 운영 gate 활성화
+
+코드는 배포 가능하게 만들되 이번 PR과 배포에서는 gate를 켜지 않는다.
+
+### 안전한 PR 분할
+
+1. **4-b2b-0 기반, 운영 동작 OFF**: originating store 주입, exit quarantine,
+   authoritative 3상태 KIS holding lookup만 추가한다.
+2. **4-b2b-1 KR ENTRY, flag OFF**: 일반/enhanced BUY를 write-ahead로 연결한다.
+3. **4-b2b-2 KR EXIT 전체, flag OFF**: batch/hardstop/trend SELL을 한 lifecycle로 연결하고
+   loop state를 `SOLD/HOLDING/QUARANTINED`로 교정한다.
+4. **4-b2b-3 운영 활성화**: 무거래 창에서 별도 승인·검증 후 시장 gate를 한 번에 켠다.
+
+일부 KR caller만 gate ON으로 전환하는 배포는 금지한다.
+
+## 2. 실패·재시도 정책
+
+### 명시적 `FAILED`
+
+- broker가 명시적으로 거절한 경우에만 해당한다.
+- ENTRY는 같은 transaction에서 신규 legacy holding을 삭제하고 position을 `ENTRY_FAILED`로 확정한다.
+- EXIT는 legacy holding/history를 그대로 두고 position을 `OPEN`으로 되돌린다.
+- subscriber publish와 일반 매수·매도 Telegram 메시지는 보내지 않는다.
+- CRITICAL 운영 알림을 한 번 보낸다.
+- **자동 재주문은 하지 않는다.** 현재 position identity idempotency와 실패 intent linkage를
+  그대로 보존하여 다음 batch/loop도 중복 주문하지 못하게 한다.
+- 운영자는 KIS 계좌가 미접수임을 확인한 뒤 수동 주문하거나, 후속 Phase 5의 감사 가능한
+  reconciliation/new-attempt 도구를 사용한다. 자동 retry 횟수·cooldown을 이번 단계에 추가하지 않는다.
+
+### `UNKNOWN` 또는 coroutine cancellation
+
+- 자동 재주문 금지.
+- EXIT는 legacy holding을 유지하고 `EXIT_UNKNOWN`으로 격리한다.
+- ENTRY는 legacy holding과 `PENDING_ENTRY`를 유지한다.
+- CRITICAL 알림에 market, symbol, side, intent id, 안전한 account fingerprint, action을 포함한다.
+- raw broker payload, token, 계좌 원문은 알림이나 로그에 포함하지 않는다.
+
+### `QUEUED`
+
+- KR broker가 접수한 예약주문은 정상 `SUBMITTED`로 분류되므로 `QUEUED`는 예상 외 상태다.
+- position은 PENDING으로 유지하고 publish하지 않으며 CRITICAL 알림 후 자동 재주문하지 않는다.
+- 현재 KR에는 queued-intent continuation consumer가 없다. domestic broker adapter가 `QUEUED`를
+  생성하지 않는 계약을 테스트로 고정하며, 이 계약이 깨지면 gate 활성화를 금지한다.
+
+## 3. cleanup/refactor 계획
+
+기존 public `buy_stock()`/`sell_stock()` bool 계약과 gate=false 경로를 먼저 테스트로 잠근다.
+그다음 한 smell만 처리하는 작은 단계로 진행한다.
+
+1. feature gate와 의존성 검증을 추가한다.
+   - pending gate=true인데 position shadow가 false면 broker 전에 fail closed한다.
+2. 기존 legacy BUY의 DB INSERT와 메시지 생성을 분리한다.
+   - gate=false는 기존 commit/message 순서를 그대로 사용한다.
+   - gate=true는 holding INSERT + intent CREATED + PENDING_ENTRY를 한 transaction에 commit한다.
+3. 기존 legacy SELL의 DB close와 후속 journal/message 생성을 분리한다.
+   - gate=false는 기존 simulator-first 순서를 그대로 사용한다.
+   - gate=true는 intent CREATED + OPEN→PENDING_EXIT을 먼저 commit하고 broker `SUBMITTED` 뒤에만
+     history INSERT + holding DELETE + CLOSED를 한 transaction으로 확정한다.
+4. 네 KR caller가 중복 구현하지 않도록 StockTrackingAgent의 좁은 private lifecycle helper를 재사용한다.
+5. generic CRITICAL lifecycle alert를 기존 `telegram_config.py` 패턴으로 추가한다.
+6. broker 결과 저장 또는 legacy finalize 실패를 위한 좁은 exit quarantine API를 먼저 추가한다.
+   - intent가 `UNKNOWN`, `SUBMITTING`, `SUBMITTED`, 예상 외 `QUEUED`여도 broker 접수 여부를
+     로컬에서 확정할 수 없으면 `PENDING_EXIT`을 `EXIT_UNKNOWN`으로 격리할 수 있어야 한다.
+   - 정상 `FAILED` 보상이나 정상 `SUBMITTED` close를 대신하지 않고 CRITICAL 경로에서만 사용한다.
+
+새 dependency와 schema table은 추가하지 않는다. 가능한 경우 기존 `IntentStore`, `PositionStore`,
+`ExecutionService` API를 그대로 사용하며, 실제 caller 연결에 꼭 필요한 최소 파라미터만 확장한다.
+단, 운영자 승인 retry와 durable alert outbox는 별도 schema·runbook 설계가 필요하므로
+4-b2b-0에서 성급히 추가하지 않고 gate 활성화 전 별도 안전 PR로 확정한다.
+
+## 4. 상태 순서
+
+### ENTRY
+
+```text
+BEGIN IMMEDIATE
+  holding INSERT
+  intent CREATED reserve
+  position PENDING_ENTRY
+COMMIT
+broker pre-reserved execute
+  SUBMITTED -> transaction: position OPEN -> buy message/publish
+  FAILED    -> transaction: holding DELETE + ENTRY_FAILED -> CRITICAL
+  UNKNOWN   -> PENDING_ENTRY 유지 -> CRITICAL
+  QUEUED    -> PENDING_ENTRY 유지 -> CRITICAL
+```
+
+### EXIT
+
+```text
+BEGIN IMMEDIATE
+  intent CREATED reserve
+  position OPEN -> PENDING_EXIT
+COMMIT
+broker pre-reserved execute
+  SUBMITTED -> transaction: history INSERT + holding DELETE + position CLOSED
+               -> sell message/journal/publish
+  FAILED    -> transaction: position OPEN, legacy 불변 -> CRITICAL
+  UNKNOWN   -> transaction: position EXIT_UNKNOWN, legacy 불변 -> CRITICAL
+  QUEUED    -> PENDING_EXIT 유지, legacy 불변 -> CRITICAL
+```
+
+broker 호출 중에는 SQLite transaction을 열어 두지 않는다.
+
+## 5. TDD gate
+
+### gate=false 회귀
+
+- KR batch/enhanced BUY: simulator commit → broker → Redis → GCP 순서와 횟수 불변.
+- KR batch/hardstop/trend SELL: simulator close → broker → Telegram/publish 순서와 횟수 불변.
+- 기존 bool 반환, pyramiding 수량, sold/buy count 불변.
+
+### gate=true ENTRY
+
+- prepare transaction 실패·lock·disk write 실패 시 holding/intent/position 0, broker 0.
+- broker `SUBMITTED`만 OPEN + 메시지/publish 각 1회.
+- `FAILED`는 holding 삭제 + ENTRY_FAILED, publish 0, alert 1.
+- timeout/exception/cancel은 holding + PENDING_ENTRY 유지, publish 0, alert 1, 후속 broker 0.
+
+### gate=true EXIT
+
+- 두 connection 경쟁 시 하나만 PENDING_EXIT claim하고 broker도 1회.
+- `SUBMITTED`만 history 1 + holding delete + CLOSED + publish/Telegram 각 1회.
+- `FAILED`는 OPEN + legacy/history 불변, publish 0, alert 1, 자동 재시도 0.
+- timeout/exception/cancel은 EXIT_UNKNOWN + legacy/history 불변, publish 0, alert 1.
+- broker 성공 후 legacy/CLOSED transaction 실패는 EXIT_UNKNOWN과 CRITICAL을 남기며 publish 0.
+  intent 결과 저장 실패로 `SUBMITTING`, 저장 성공 후 finalize 실패로 `SUBMITTED`인 두 경우 모두
+  exit quarantine이 가능해야 한다.
+- KIS qty=0 local-flat은 broker 0으로 legacy close와 CLOSED가 한 transaction에서 완료된다.
+- KIS 잔고 응답 헤더가 연속조회(`tr_cont=M/F`)를 알리면 첫 페이지만 보고 FLAT으로
+  확정하지 않고 UNKNOWN으로 차단한다. legacy `get_portfolio()`의 기존 첫 페이지 반환은 유지한다.
+
+## 6. 리뷰·배포 gate
+
+- 독립 architecture, SQLite/concurrency, code, test review blocker 0.
+- Python 3.10/3.11/3.12 CI + Codacy green.
+- db-server Python 3.11 운영동등 worktree에서 실제 cron command startup/import와 관련 회귀 통과.
+- app-server `su - prism` import smoke와 bot 무중단 확인.
+- 배포 후에도 `POSITION_PENDING_KR_ENABLED`는 미설정/false로 유지한다.
+- 별도 활성화 전 PENDING/UNKNOWN 0, 거래 프로세스 0, rollback runbook과 첫 배치 모니터를 준비한다.

--- a/tasks/issue-412/README.md
+++ b/tasks/issue-412/README.md
@@ -2,9 +2,9 @@
 
 > 이슈: [#412 매수/매도 Agent 분리와 KIS 실제 주문 실행 구조 이식 설계](https://github.com/dragon1086/prism-insight/issues/412)
 > 브랜치: `feature/issue-412-execution-architecture`
-> 상태: Phase 4-b1 배포 완료, Phase 4-b2a 기반 API 구현/검증 중
+> 상태: Phase 4-b2a 배포 완료, Phase 4-b2b-0 안전 기반 구현/검증 중
 > (2026-07-06 시작, 2026-07-13 main #432 기준 전면 재검토,
-> **2026-07-19 Phase 4-b1 PR #462, main `9b3ecc58` 배포 완료**)
+> **2026-07-19 Phase 4-b2a PR #463, main `de74af0c` 배포 완료**)
 
 ## 목적
 
@@ -30,6 +30,7 @@ greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 
 | [04-migration-plan.md](04-migration-plan.md) | Phase 0~6 단계별 실행 계획과 각 단계 완료 조건 |
 | [05-verification-plan.md](05-verification-plan.md) | 검증 전략 — 단위/golden/shadow 병행 기록/demo 계좌/서버 배포 절차/롤백 |
 | [11-phase4b2-pending-exit-plan.md](11-phase4b2-pending-exit-plan.md) | Phase 4-b2 분할 계획 — 4-b2a 기반 API, 4-b2b KR 전환, 4-b2c US queue 연속성/전환 |
+| [12-phase4b2b-kr-execution-plan.md](12-phase4b2b-kr-execution-plan.md) | Phase 4-b2b KR 전환 상세 계획 — 4-b2b-0~3 안전 분할, 실패/재시도 정책, 배포 gate |
 
 ## 진행 체크리스트
 
@@ -42,8 +43,11 @@ greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 
 - [x] Phase 3: OrderIntent 영속화 (PR #459, main `8ff33b17`)
 - [x] Phase 4-a: position OPEN/CLOSED shadow 병행 기록 + 대조 (PR #460/#461, main `5ed6f38c`)
 - [x] Phase 4-b1: persisted intent ↔ position linkage, legacy 순서/read 유지 (PR #462, main `9b3ecc58`)
-- [ ] Phase 4-b2a: transaction-aware reserve/PENDING lifecycle 기반 API — 운영 호출부 미배선
-- [ ] Phase 4-b2b: KR 전체 경로 PENDING write-ahead + 실패 보상 (시장 단위 gate)
+- [x] Phase 4-b2a: transaction-aware reserve/PENDING lifecycle 기반 API — 운영 호출부 미배선 (PR #463, main `de74af0c`)
+- [ ] Phase 4-b2b-0: KR 전환 안전 기반 — originating store, exit quarantine, 3상태 holding 조회 (운영 호출부 미배선)
+- [ ] Phase 4-b2b-1: KR ENTRY 전체 경로 PENDING write-ahead (flag OFF)
+- [ ] Phase 4-b2b-2: KR EXIT 전체 경로 PENDING write-ahead + 실패 보상 (flag OFF)
+- [ ] Phase 4-b2b-3: 별도 승인·무거래 창 검증 후 KR 시장 gate 일괄 활성화
 - [ ] Phase 4-b2c: US queued-intent 연속성 + US 전체 경로 전환 (시장 단위 gate)
 - [ ] Phase 4 read switch: 충분한 운영 대조 후 별도 승인
 - [ ] Phase 5: BrokerAdapter 추출 (체결/미체결/정정 포함) + lock 일반화 + reconciliation (alert-only)

--- a/tests/test_execution_service.py
+++ b/tests/test_execution_service.py
@@ -1,5 +1,6 @@
 import asyncio
 import ast
+import sqlite3
 import sys
 import types
 from pathlib import Path
@@ -160,6 +161,148 @@ def test_us_factory_recovers_when_root_trading_package_is_cached(monkeypatch):
 
     assert isinstance(execution._resource, FakeUSContext)
     assert execution._resource.account_name == "us-primary"
+
+
+def test_domestic_factory_accepts_originating_intent_store(monkeypatch, tmp_path):
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore, OrderIntent
+
+    class FakeDomesticContext:
+        def __init__(self, account_name=None):
+            self.account_name = account_name
+            self.trader = FakeTrader()
+
+        async def __aenter__(self):
+            return self.trader
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    fake_module = types.ModuleType("trading.domestic_stock_trading")
+    fake_module.AsyncTradingContext = FakeDomesticContext
+    monkeypatch.setitem(sys.modules, "trading.domestic_stock_trading", fake_module)
+    db_path = tmp_path / "orders.sqlite"
+    intent_store = IntentStore(db_path)
+    intent = OrderIntent.create(
+        market="KR",
+        account_id="acct",
+        symbol="005930",
+        side="BUY",
+        order_style="market",
+        source="test",
+        source_decision_id="decision-1",
+        source_position_id="legacy:KR:1",
+    )
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        created, reservation = intent_store.reserve_in_transaction(connection, intent)
+        assert created is True
+        connection.commit()
+
+    execution = ExecutionService.domestic(
+        account_name="kr-primary",
+        intent_store=intent_store,
+    )
+
+    async def exercise():
+        async with execution:
+            return await execution.execute_pre_reserved_buy(
+                "005930",
+                intent=intent,
+                reservation=reservation,
+            )
+
+    result = asyncio.run(exercise())
+
+    assert isinstance(execution._resource, FakeDomesticContext)
+    assert execution._resource.account_name == "kr-primary"
+    assert execution._intent_store is intent_store
+    assert result["intent_status"] == "SUBMITTED"
+    assert execution._resource.trader.calls == [("buy", ("005930",), {})]
+
+
+def test_domestic_factory_rejects_db_path_with_different_intent_store(
+    monkeypatch, tmp_path
+):
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore
+
+    class FakeDomesticContext:
+        def __init__(self, account_name=None):
+            self.account_name = account_name
+
+    fake_module = types.ModuleType("trading.domestic_stock_trading")
+    fake_module.AsyncTradingContext = FakeDomesticContext
+    monkeypatch.setitem(sys.modules, "trading.domestic_stock_trading", fake_module)
+    requested_path = tmp_path / "requested.sqlite"
+    different_store = IntentStore(tmp_path / "different.sqlite")
+
+    with pytest.raises(ValueError, match="IntentStore|intent store|db_path"):
+        ExecutionService.domestic(
+            account_name="kr-primary",
+            db_path=requested_path,
+            intent_store=different_store,
+        )
+
+
+@pytest.mark.parametrize(
+    ("result", "expected_status", "expected_accepted"),
+    [
+        (
+            {"success": True, "order_no": "KR-ORDER-1", "message": "accepted"},
+            "SUBMITTED",
+            True,
+        ),
+        (
+            {"success": False, "order_no": "", "message": "rejected"},
+            "FAILED",
+            False,
+        ),
+        (
+            {"success": False, "order_no": "", "message": "request timeout"},
+            "UNKNOWN",
+            False,
+        ),
+    ],
+)
+def test_normal_kr_domestic_results_never_classify_as_queued(
+    result, expected_status, expected_accepted
+):
+    from prism_core.execution_service import ExecutionService
+
+    status, accepted, broker = ExecutionService._classify_result(result)
+
+    assert status == expected_status
+    assert status != "QUEUED"
+    assert accepted is expected_accepted
+    assert broker == "KIS"
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        {
+            "success": True,
+            "order_no": "LOCAL-7",
+            "order_type": "queued_buy",
+            "message": "queued locally",
+        },
+        {
+            "success": True,
+            "order_no": "PENDING-7",
+            "order_type": "reserved",
+            "message": "queued locally",
+        },
+    ],
+)
+def test_only_explicit_local_queue_markers_classify_as_queued(result):
+    from prism_core.execution_service import ExecutionService
+
+    status, accepted, broker = ExecutionService._classify_result(result)
+
+    assert status == "QUEUED"
+    assert accepted is True
+    assert broker == "LOCAL_QUEUE"
 
 
 def test_transient_empty_portfolio_is_rechecked_before_sell(monkeypatch):

--- a/tests/test_multi_account_domestic.py
+++ b/tests/test_multi_account_domestic.py
@@ -125,6 +125,171 @@ class FakeDomesticTrader:
         return 7
 
 
+_UNSET = object()
+
+
+class _BalanceResponse:
+    def __init__(self, *, ok=True, output1=_UNSET, output2=None, tr_cont=""):
+        self._ok = ok
+        self._body = SimpleNamespace(
+            output1=[] if output1 is _UNSET else output1,
+            output2=[{}] if output2 is None else output2,
+        )
+        self._header = SimpleNamespace(tr_cont=tr_cont)
+
+    def isOK(self):
+        return self._ok
+
+    def getBody(self):
+        return self._body
+
+    def getHeader(self):
+        return self._header
+
+    def getErrorCode(self):
+        return "E-BALANCE"
+
+    def getErrorMessage(self):
+        return "balance inquiry failed"
+
+
+def _trader_with_balance_response(response):
+    trader = dst.DomesticStockTrading.__new__(dst.DomesticStockTrading)
+    trader.mode = "demo"
+    trader.trenv = SimpleNamespace(my_acct="12345678", my_prod="01")
+    trader._request_with_retry = lambda *_args, **_kwargs: response
+    return trader
+
+
+@pytest.mark.parametrize(
+    ("output1", "expected"),
+    [
+        ([{"pdno": "005930", "hldg_qty": "7"}], ("HELD", 7)),
+        ([{"pdno": "000660", "hldg_qty": "3"}], ("FLAT", 0)),
+        ([], ("FLAT", 0)),
+    ],
+)
+def test_checked_holding_lookup_distinguishes_held_and_authoritative_flat(
+    output1, expected
+):
+    trader = _trader_with_balance_response(
+        _BalanceResponse(ok=True, output1=output1)
+    )
+
+    assert trader.get_holding_quantity_checked("005930") == expected
+
+
+def test_checked_holding_lookup_returns_unknown_on_broker_failure():
+    trader = _trader_with_balance_response(_BalanceResponse(ok=False))
+
+    assert trader.get_holding_quantity_checked("005930") == ("UNKNOWN", None)
+
+
+def test_checked_holding_lookup_returns_unknown_on_request_exception():
+    trader = _trader_with_balance_response(_BalanceResponse(ok=True))
+
+    def fail_request(*_args, **_kwargs):
+        raise RuntimeError("transient balance failure")
+
+    trader._request_with_retry = fail_request
+
+    assert trader.get_holding_quantity_checked("005930") == ("UNKNOWN", None)
+
+
+@pytest.mark.parametrize("tr_cont", ["M", "F", " m "])
+def test_checked_holding_lookup_returns_unknown_when_more_pages_exist(tr_cont):
+    first_page = [{"pdno": "000660", "hldg_qty": "3"}]
+    trader = _trader_with_balance_response(
+        _BalanceResponse(ok=True, output1=first_page, tr_cont=tr_cont)
+    )
+
+    assert trader.get_holding_quantity_checked("005930") == ("UNKNOWN", None)
+    assert trader.get_portfolio() == [
+        {
+            "stock_code": "000660",
+            "stock_name": "",
+            "quantity": 3,
+            "avg_price": 0.0,
+            "current_price": 0.0,
+            "eval_amount": 0.0,
+            "profit_amount": 0.0,
+            "profit_rate": 0.0,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "output1",
+    [
+        None,
+        {},
+        [{}],
+        [{"hldg_qty": "3"}],
+        [{"pdno": "005930"}],
+        [{"pdno": "005930", "hldg_qty": "not-a-number"}],
+        [object()],
+    ],
+)
+def test_checked_holding_lookup_returns_unknown_on_malformed_response(output1):
+    trader = _trader_with_balance_response(
+        _BalanceResponse(ok=True, output1=output1)
+    )
+
+    assert trader.get_holding_quantity_checked("005930") == ("UNKNOWN", None)
+
+
+def test_legacy_portfolio_and_quantity_keep_success_behavior():
+    trader = _trader_with_balance_response(
+        _BalanceResponse(
+            ok=True,
+            output1=[
+                {
+                    "pdno": "005930",
+                    "prdt_name": "Samsung",
+                    "hldg_qty": "7",
+                    "pchs_avg_pric": "70000",
+                    "prpr": "71000",
+                    "evlu_amt": "497000",
+                    "evlu_pfls_amt": "7000",
+                    "evlu_pfls_rt": "1.43",
+                }
+            ],
+        )
+    )
+
+    assert trader.get_portfolio() == [
+        {
+            "stock_code": "005930",
+            "stock_name": "Samsung",
+            "quantity": 7,
+            "avg_price": 70000.0,
+            "current_price": 71000.0,
+            "eval_amount": 497000.0,
+            "profit_amount": 7000.0,
+            "profit_rate": 1.43,
+        }
+    ]
+    assert trader.get_holding_quantity("005930") == 7
+    assert trader.get_holding_quantity("000660") == 0
+
+
+def test_legacy_portfolio_and_quantity_keep_failure_as_empty_and_zero():
+    trader = _trader_with_balance_response(_BalanceResponse(ok=False))
+
+    assert trader.get_portfolio() == []
+    assert trader.get_holding_quantity("005930") == 0
+
+
+@pytest.mark.parametrize("output1", [None, {}])
+def test_legacy_portfolio_and_quantity_keep_malformed_empty_behavior(output1):
+    trader = _trader_with_balance_response(
+        _BalanceResponse(ok=True, output1=output1)
+    )
+
+    assert trader.get_portfolio() == []
+    assert trader.get_holding_quantity("005930") == 0
+
+
 @pytest.mark.asyncio
 async def test_async_trading_context_returns_single_account_trader(monkeypatch):
     FakeDomesticTrader.init_calls = []

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -723,6 +723,121 @@ def test_exit_unknown_many_and_comparator_report_status_intent_and_age(tmp_path)
     assert "secret-acct" not in json.dumps(result)
 
 
+@pytest.mark.parametrize(
+    "intent_status",
+    ["SUBMITTING", "SUBMITTED", "UNKNOWN", "QUEUED"],
+)
+def test_pending_exit_can_be_quarantined_for_nonterminal_or_ambiguous_intent(
+    tmp_path, intent_status
+) -> None:
+    """A claimed exit stays fail-closed when broker/local finalization is uncertain."""
+    from prism_core.order_intents import IntentStore, OrderIntent
+
+    db_path = tmp_path / f"quarantine-{intent_status.lower()}.sqlite"
+    intent_store = IntentStore(db_path)
+    connection = sqlite3.connect(db_path)
+    _legacy_schema(connection)
+    _insert_legacy(connection, "stock_holdings", 1, "acct", "005930")
+    position_store = PositionStore(connection)
+    position_store.ensure_schema()
+    position_store.backfill_legacy_positions("KR")
+    connection.commit()
+    intent = OrderIntent.create(
+        market="KR",
+        account_id="acct",
+        symbol="005930",
+        side="SELL",
+        order_style="market",
+        source="test",
+        source_position_id="legacy:KR:1",
+    )
+
+    connection.execute("BEGIN IMMEDIATE")
+    intent_store.reserve_in_transaction(connection, intent)
+    position_store.prepare_exit_many(
+        market="KR",
+        account_id="acct",
+        symbol="005930",
+        position_ids=("legacy:KR:1",),
+        intent_id=intent.id,
+    )
+    connection.execute(
+        "UPDATE order_intents SET status=? WHERE id=?",
+        (intent_status, intent.id),
+    )
+
+    assert position_store.mark_exit_unknown_many(
+        market="KR",
+        account_id="acct",
+        symbol="005930",
+        position_ids=("legacy:KR:1",),
+        intent_id=intent.id,
+    )
+    connection.commit()
+
+    assert connection.execute(
+        "SELECT status, exit_intent_id FROM positions WHERE id='legacy:KR:1'"
+    ).fetchone() == ("EXIT_UNKNOWN", intent.id)
+    assert connection.execute(
+        "SELECT COUNT(*) FROM stock_holdings WHERE id=1"
+    ).fetchone() == (1,)
+
+
+@pytest.mark.parametrize("intent_status", ["CREATED", "FAILED"])
+def test_pending_exit_quarantine_rejects_definite_unsubmitted_or_failed_intent(
+    tmp_path, intent_status
+) -> None:
+    """CREATED and FAILED have deterministic handling and must not be quarantined."""
+    from prism_core.order_intents import IntentStore, OrderIntent
+
+    db_path = tmp_path / f"no-quarantine-{intent_status.lower()}.sqlite"
+    intent_store = IntentStore(db_path)
+    connection = sqlite3.connect(db_path)
+    _legacy_schema(connection)
+    _insert_legacy(connection, "stock_holdings", 1, "acct", "005930")
+    position_store = PositionStore(connection)
+    position_store.ensure_schema()
+    position_store.backfill_legacy_positions("KR")
+    connection.commit()
+    intent = OrderIntent.create(
+        market="KR",
+        account_id="acct",
+        symbol="005930",
+        side="SELL",
+        order_style="market",
+        source="test",
+        source_position_id="legacy:KR:1",
+    )
+
+    connection.execute("BEGIN IMMEDIATE")
+    intent_store.reserve_in_transaction(connection, intent)
+    position_store.prepare_exit_many(
+        market="KR",
+        account_id="acct",
+        symbol="005930",
+        position_ids=("legacy:KR:1",),
+        intent_id=intent.id,
+    )
+    connection.execute(
+        "UPDATE order_intents SET status=? WHERE id=?",
+        (intent_status, intent.id),
+    )
+
+    with pytest.raises(InvalidPositionTransition):
+        position_store.mark_exit_unknown_many(
+            market="KR",
+            account_id="acct",
+            symbol="005930",
+            position_ids=("legacy:KR:1",),
+            intent_id=intent.id,
+        )
+
+    assert connection.execute(
+        "SELECT status, exit_intent_id FROM positions WHERE id='legacy:KR:1'"
+    ).fetchone() == ("PENDING_EXIT", intent.id)
+    connection.rollback()
+
+
 def test_comparator_distinguishes_fresh_and_stale_pending_positions(tmp_path) -> None:
     from prism_core.order_intents import IntentStore, OrderIntent
 

--- a/trading/domestic_stock_trading.py
+++ b/trading/domestic_stock_trading.py
@@ -1597,6 +1597,12 @@ class DomesticStockTrading:
                 'profit_rate': return rate (%)
             }, ...]
         """
+        _, portfolio = self._get_portfolio_checked()
+        return portfolio
+
+    def _get_portfolio_checked(self) -> tuple[bool, List[Dict[str, Any]]]:
+        """Return whether the KIS balance response was authoritative and its rows."""
+
         api_url = "/uapi/domestic-stock/v1/trading/inquire-balance"
 
         # Set TR ID (real/demo distinction)
@@ -1626,12 +1632,20 @@ class DomesticStockTrading:
                 current_portfolio = []
                 output1 = res.getBody().output1  # Holdings list
                 output2 = res.getBody().output2[0]  # Account summary
+                authoritative = isinstance(output1, list)
 
                 # Handle case when output1 is not a list
                 if not isinstance(output1, list):
                     output1 = [output1] if output1 else []
 
                 for item in output1:
+                    if not (
+                        isinstance(item, dict)
+                        and isinstance(item.get("pdno"), str)
+                        and item["pdno"].strip()
+                        and "hldg_qty" in item
+                    ):
+                        authoritative = False
                     # Only add stocks with quantity > 0
                     quantity = int(item.get('hldg_qty', 0))
                     if quantity > 0:
@@ -1654,15 +1668,44 @@ class DomesticStockTrading:
                     logger.info(f"Account total evaluation: {total_eval:,.0f} KRW, total profit/loss: {total_profit:+,.0f} KRW")
 
                 logger.info(f"Portfolio: {len(current_portfolio)} holdings")
-                return current_portfolio
+                try:
+                    tr_cont = (
+                        str(getattr(res.getHeader(), "tr_cont", ""))
+                        .strip()
+                        .upper()
+                    )
+                except Exception as e:
+                    logger.warning(f"Could not validate balance pagination: {e}")
+                    authoritative = False
+                else:
+                    if tr_cont in {"M", "F"}:
+                        logger.warning(
+                            "Balance inquiry has additional pages; "
+                            "checked holding lookup will remain UNKNOWN"
+                        )
+                        authoritative = False
+                return authoritative, current_portfolio
 
             else:
                 logger.error(f"Balance inquiry failed: {res.getErrorCode()} - {res.getErrorMessage()}")
-                return []
+                return False, []
 
         except Exception as e:
             logger.error(f"Error during balance inquiry: {str(e)}")
-            return []
+            return False, []
+
+    def get_holding_quantity_checked(
+        self, stock_code: str
+    ) -> tuple[str, int | None]:
+        """Distinguish an authoritative flat holding from a balance-query failure."""
+
+        authoritative, portfolio = self._get_portfolio_checked()
+        if not authoritative:
+            return "UNKNOWN", None
+        for stock in portfolio:
+            if stock.get("stock_code") == stock_code:
+                return "HELD", int(stock["quantity"])
+        return "FLAT", 0
 
     def get_account_summary(self) -> None | dict[Any, Any] | dict[str, float]:
         """
@@ -2047,6 +2090,11 @@ class MultiAccountDomesticStockTrading:
 
     def get_holding_quantity(self, stock_code: str) -> int:
         return self._get_primary_trader().get_holding_quantity(stock_code)
+
+    def get_holding_quantity_checked(
+        self, stock_code: str
+    ) -> tuple[str, int | None]:
+        return self._get_primary_trader().get_holding_quantity_checked(stock_code)
 
     def _aggregate_results(self, stock_code: str, results: List[Dict[str, Any]], action: str) -> Dict[str, Any]:
         success_count = sum(1 for result in results if result.get("success"))


### PR DESCRIPTION
## 요약

#412 Phase 4-b2b의 실제 KR 주문 경로 전환 전에 필요한 fail-closed 기반만 추가합니다. 이번 PR은 운영 caller를 연결하지 않아 주문 동작 변화가 없습니다.

- `ExecutionService.domestic()`에 originating `IntentStore` 주입 및 DB 경로 충돌 차단
- `SUBMITTING/SUBMITTED/UNKNOWN/QUEUED` EXIT를 `EXIT_UNKNOWN`으로 격리하는 API
- KIS 보유수량 `HELD/FLAT/UNKNOWN` 권위 판정 추가
- 연속조회(`tr_cont=M/F`)·malformed 성공 응답의 false-flat 차단
- Phase 4-b2b-0~3 안전 분할 및 실패/재시도 정책 문서화

## 운영 안전성

- 신규 API 운영 caller: 0
- KR PENDING gate 활성화: 없음
- 기존 `get_portfolio()` / `get_holding_quantity()` 계약 유지
- 신규 dependency/schema 없음

## 검증

- 관련 회귀: 160 passed
- GitHub Actions 동일 묶음: 261 passed, 1 skipped
- Ruff / py_compile / git diff --check 통과
- 독립 코드 리뷰: APPROVE, blocker 0

다음 PR은 4-b2b-1 KR ENTRY 연결이며 flag OFF 상태로 진행합니다.