### PR TITLE
refactor: harden KR pending entry lifecycle

### DIFF
--- a/prism_core/execution_service.py
+++ b/prism_core/execution_service.py
@@ -229,14 +229,22 @@ class ExecutionService:
         try:
             result = await method(*args, **kwargs)
         except asyncio.CancelledError as exc:
-            await asyncio.to_thread(
-                self._intent_store.record_result,
-                intent,
-                status="UNKNOWN",
-                accepted=False,
-                response=None,
-                error=exc,
-            )
+            try:
+                await asyncio.to_thread(
+                    self._intent_store.record_result,
+                    intent,
+                    status="UNKNOWN",
+                    accepted=False,
+                    response=None,
+                    error=exc,
+                )
+            except Exception as persistence_error:
+                logger.critical(
+                    "[ORDER_INTENT] cancellation UNKNOWN persistence failed "
+                    "id=%s error=%s",
+                    intent.id,
+                    type(persistence_error).__name__,
+                )
             logger.error(
                 "[ORDER_INTENT] UNKNOWN id=%s market=%s side=%s symbol=%s error=%s",
                 intent.id, intent.market, intent.side, intent.symbol,

--- a/prism_core/positions.py
+++ b/prism_core/positions.py
@@ -265,8 +265,10 @@ class PositionStore:
         market: str,
         account_id: Any,
         symbol: Any,
+        allow_existing_open: bool = False,
+        expected_open_count: int | None = None,
     ) -> bool:
-        """Reject a new entry while the same identity has unresolved state."""
+        """Reject duplicate or stale entry attempts for the same identity."""
 
         self._require_active_transaction()
         market = _market(str(market).strip())
@@ -285,6 +287,27 @@ class PositionStore:
             raise InvalidPositionTransition(
                 f"entry attempt blocked by unresolved position status: {row[0]}"
             )
+        open_count = int(
+            self._execute(
+                "SELECT COUNT(*) FROM positions "
+                "WHERE market=? AND account_id=? AND symbol=? AND status='OPEN'",
+                (market, account_id, symbol),
+            ).fetchone()[0]
+        )
+        if not allow_existing_open and open_count:
+            raise InvalidPositionTransition(
+                "entry attempt blocked by existing OPEN position"
+            )
+        if allow_existing_open:
+            if not isinstance(expected_open_count, int) or expected_open_count < 0:
+                raise ValueError(
+                    "expected_open_count is required for an additional entry"
+                )
+            if open_count != expected_open_count:
+                raise InvalidPositionTransition(
+                    "entry attempt blocked by changed OPEN position count: "
+                    f"expected {expected_open_count}, found {open_count}"
+                )
         return True
 
     @staticmethod

--- a/prism_core/positions.py
+++ b/prism_core/positions.py
@@ -259,6 +259,34 @@ class PositionStore:
         ).rowcount
         return changed == 1
 
+    def assert_entry_attempt_allowed(
+        self,
+        *,
+        market: str,
+        account_id: Any,
+        symbol: Any,
+    ) -> bool:
+        """Reject a new entry while the same identity has unresolved state."""
+
+        self._require_active_transaction()
+        market = _market(str(market).strip())
+        account_id = str(account_id or "").strip()
+        symbol = str(symbol or "").strip().upper()
+        if not account_id or not symbol:
+            raise ValueError("account_id and symbol are required")
+        row = self._execute(
+            "SELECT status FROM positions "
+            "WHERE market=? AND account_id=? AND symbol=? "
+            "AND status IN ('PENDING_ENTRY', 'ENTRY_FAILED', "
+            "'PENDING_EXIT', 'EXIT_UNKNOWN') LIMIT 1",
+            (market, account_id, symbol),
+        ).fetchone()
+        if row is not None:
+            raise InvalidPositionTransition(
+                f"entry attempt blocked by unresolved position status: {row[0]}"
+            )
+        return True
+
     @staticmethod
     def _source_position_ids(value: Any) -> tuple[str, ...]:
         if value is None:

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -21,6 +21,7 @@ import os
 import sqlite3
 import sys
 import traceback
+from dataclasses import dataclass
 from datetime import datetime
 from typing import List, Dict, Any, Tuple, Optional
 
@@ -49,7 +50,7 @@ from cores.openai_error_logging import log_openai_error
 from cores.agents.trading_agents import create_trading_scenario_agent
 from cores.utils import parse_llm_json
 from prism_core.execution_service import ExecutionService, OrderOutcomeUnknown
-from prism_core.order_intents import OrderIntent
+from prism_core.order_intents import IntentStore, OrderIntent
 from prism_core.positions import (
     LegacyPositionWriteResult,
     PositionStore,
@@ -97,6 +98,19 @@ from trading import kis_auth as ka
 # Create MCPApp instance
 app = MCPApp(name="stock_tracking")
 
+
+@dataclass(frozen=True)
+class _PreparedKrEntry:
+    legacy_holding_id: int
+    account_id: str
+    account_name: str
+    symbol: str
+    intent: OrderIntent
+    intent_store: IntentStore
+    reservation: Any
+    message: str
+
+
 class StockTrackingAgent:
     """Stock Tracking and Trading Agent"""
 
@@ -137,6 +151,7 @@ class StockTrackingAgent:
         self.position_ledger_shadow_enabled = os.environ.get(
             "POSITION_LEDGER_SHADOW_ENABLED", "true"
         ).strip().lower() not in {"0", "false", "no", "off"}
+        self._position_pending_kr_ready = False
 
         # Set trading journal feature flag
         # Priority: parameter > environment variable > default (False)
@@ -224,6 +239,7 @@ class StockTrackingAgent:
 
     def _initialize_position_ledger(self) -> None:
         """Create/backfill the additive KR shadow ledger without blocking startup."""
+        self._position_pending_kr_ready = False
         if not self._position_ledger_enabled():
             logger.warning("[POSITION-SHADOW][KR] disabled by kill switch")
             return
@@ -269,6 +285,7 @@ class StockTrackingAgent:
             return
         self.conn.execute("RELEASE position_shadow_init")
         self.conn.commit()
+        self._position_pending_kr_ready = True
         logger.info(
             "[POSITION-SHADOW][KR] initialized inserted=%s existing=%s skipped=%s",
             result["inserted"],
@@ -1172,6 +1189,330 @@ class StockTrackingAgent:
             logger.error(f"{ticker} Error saving watchlist: {str(e)}")
             logger.error(traceback.format_exc())
             return False
+
+    @staticmethod
+    def _position_pending_kr_enabled() -> bool:
+        return os.environ.get("POSITION_PENDING_KR_ENABLED", "false").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+
+    def _require_pending_entry_ready(self) -> IntentStore:
+        """Validate the opt-in KR pending dependencies before any entry write."""
+
+        if not self._position_ledger_enabled():
+            raise RuntimeError("KR pending entry requires the position ledger")
+        if getattr(self, "_position_pending_kr_ready", None) is not True:
+            raise RuntimeError("KR pending entry ledger initialization is not ready")
+        if not isinstance(self.conn, sqlite3.Connection) or self.conn.in_transaction:
+            raise RuntimeError("KR pending entry requires an idle agent connection")
+
+        try:
+            intent_store = IntentStore(self.db_path)
+            PositionStore(self.conn).ensure_schema()
+            self.conn.commit()
+        except Exception:
+            if self.conn.in_transaction:
+                self.conn.rollback()
+            raise
+        return intent_store
+
+    def _build_pending_kr_entry_message(
+        self,
+        *,
+        ticker: str,
+        company_name: str,
+        current_price: float,
+        scenario: Dict[str, Any],
+        rank_change_msg: str,
+        trigger_type: str,
+    ) -> str:
+        """Build the existing first-entry message without enqueueing it."""
+
+        message = (
+            f"📈 신규 매수: {company_name}({ticker})\n"
+            f"매수가: {current_price:,.0f}원\n"
+            f"목표가: {scenario.get('target_price', 0):,.0f}원\n"
+            f"손절가: {scenario.get('stop_loss', 0):,.0f}원\n"
+            f"투자기간: {scenario.get('investment_period', '단기')}\n"
+            f"산업군: {scenario.get('sector', '알 수 없음')}\n"
+        )
+
+        trigger_win_rate = self._get_trigger_win_rate(trigger_type)
+        if trigger_win_rate:
+            message += f"{trigger_win_rate}\n"
+        if scenario.get("valuation_analysis"):
+            message += f"밸류에이션: {scenario.get('valuation_analysis')}\n"
+        if scenario.get("sector_outlook"):
+            message += f"업종 전망: {scenario.get('sector_outlook')}\n"
+        if rank_change_msg:
+            message += f"거래대금 분석: {rank_change_msg}\n"
+        message += f"투자근거: {scenario.get('rationale', '정보 없음')}\n"
+
+        journal_reflection = scenario.get("journal_reflection") or {}
+        if isinstance(journal_reflection, dict):
+            if journal_reflection.get("recent_exit_caution"):
+                message += (
+                    "⚠️ 최근 매도 주의: "
+                    f"{journal_reflection.get('recent_exit_caution')}\n"
+                )
+            if journal_reflection.get("applied_lessons"):
+                message += (
+                    "📒 매매일지 반영: "
+                    f"{journal_reflection.get('applied_lessons')}\n"
+                )
+        score_adjustment = scenario.get("score_adjustment") or {}
+        if isinstance(score_adjustment, dict) and score_adjustment.get("value"):
+            reasons = ", ".join(score_adjustment.get("reasons", []) or [])
+            message += (
+                f"📊 경험 기반 점수조정: {score_adjustment.get('value'):+d}점 "
+                f"({reasons})\n"
+            )
+
+        trading_scenarios = scenario.get("trading_scenarios", {})
+        if trading_scenarios and isinstance(trading_scenarios, dict):
+            message += "\n" + "=" * 40 + "\n"
+            message += "📋 매매 시나리오\n"
+            message += "=" * 40 + "\n\n"
+
+            key_levels = trading_scenarios.get("key_levels", {})
+            if key_levels:
+                message += "💰 핵심 가격대:\n"
+                primary_resistance = self._parse_price_value(
+                    key_levels.get("primary_resistance", 0)
+                )
+                secondary_resistance = self._parse_price_value(
+                    key_levels.get("secondary_resistance", 0)
+                )
+                if primary_resistance or secondary_resistance:
+                    message += "  📈 저항선:\n"
+                    if secondary_resistance:
+                        message += f"    • 2차: {secondary_resistance:,.0f}원\n"
+                    if primary_resistance:
+                        message += f"    • 1차: {primary_resistance:,.0f}원\n"
+                message += f"  ━━ 현재가: {current_price:,.0f}원 ━━\n"
+
+                primary_support = self._parse_price_value(
+                    key_levels.get("primary_support", 0)
+                )
+                secondary_support = self._parse_price_value(
+                    key_levels.get("secondary_support", 0)
+                )
+                if primary_support or secondary_support:
+                    message += "  📉 지지선:\n"
+                    if primary_support:
+                        message += f"    • 1차: {primary_support:,.0f}원\n"
+                    if secondary_support:
+                        message += f"    • 2차: {secondary_support:,.0f}원\n"
+                volume_baseline = key_levels.get("volume_baseline", "")
+                if volume_baseline:
+                    message += f"  📊 거래량 기준: {volume_baseline}\n"
+                message += "\n"
+
+            sell_triggers = trading_scenarios.get("sell_triggers", [])
+            if sell_triggers:
+                message += "🔔 매도 시그널:\n"
+                for trigger in sell_triggers:
+                    lowered = trigger.lower()
+                    if any(
+                        marker in lowered
+                        for marker in ("profit", "target", "resistance")
+                    ):
+                        emoji = "✅"
+                    elif any(
+                        marker in lowered
+                        for marker in ("loss", "support", "decline")
+                    ):
+                        emoji = "⛔"
+                    elif "time" in lowered or "sideways" in lowered:
+                        emoji = "⏰"
+                    else:
+                        emoji = "•"
+                    message += f"  {emoji} {trigger}\n"
+                message += "\n"
+
+            hold_conditions = trading_scenarios.get("hold_conditions", [])
+            if hold_conditions:
+                message += "✋ 보유 지속 조건:\n"
+                for condition in hold_conditions:
+                    message += f"  • {condition}\n"
+                message += "\n"
+
+            portfolio_context = trading_scenarios.get("portfolio_context", "")
+            if portfolio_context:
+                message += f"💼 포트폴리오 관점:\n  {portfolio_context}\n"
+
+        return message
+
+    def _prepare_pending_kr_entry(
+        self,
+        *,
+        ticker: str,
+        company_name: str,
+        current_price: float,
+        scenario: Dict[str, Any],
+        rank_change_msg: str,
+        source_decision_id: str,
+    ) -> _PreparedKrEntry:
+        """Atomically persist the legacy holding, intent, and PENDING_ENTRY."""
+
+        intent_store = self._require_pending_entry_ready()
+        account_id, account_name = self._account_scope()
+        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        trigger_info = getattr(self, "trigger_info_map", {}).get(ticker, {})
+        trigger_type = trigger_info.get("trigger_type", "AI Analysis")
+        trigger_mode = trigger_info.get(
+            "trigger_mode", getattr(self, "trigger_mode", "unknown")
+        )
+
+        self.conn.execute("BEGIN IMMEDIATE")
+        try:
+            position_store = PositionStore(self.conn)
+            position_store.assert_entry_attempt_allowed(
+                market="KR", account_id=account_id, symbol=ticker
+            )
+            cursor = self.conn.execute(
+                """
+                INSERT INTO stock_holdings
+                (account_key, account_name, ticker, company_name, buy_price,
+                 buy_date, current_price, last_updated, scenario, target_price,
+                 stop_loss, trigger_type, trigger_mode, sector)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    account_id,
+                    account_name,
+                    ticker,
+                    company_name,
+                    current_price,
+                    now,
+                    current_price,
+                    now,
+                    json.dumps(scenario, ensure_ascii=False),
+                    scenario.get("target_price", 0),
+                    scenario.get("stop_loss", 0),
+                    trigger_type,
+                    trigger_mode,
+                    scenario.get("sector", "알 수 없음"),
+                ),
+            )
+            legacy_holding_id = int(cursor.lastrowid)
+            intent = OrderIntent.create(
+                market="KR",
+                account_id=account_id,
+                symbol=ticker,
+                side="buy",
+                order_style="smart",
+                source="kr_batch",
+                source_decision_id=source_decision_id,
+                source_position_id=legacy_position_id("KR", legacy_holding_id),
+                limit_price=current_price,
+                reason="AI analysis entry",
+            )
+            created, reservation = intent_store.reserve_in_transaction(
+                self.conn, intent
+            )
+            if not created:
+                raise RuntimeError("KR pending entry intent already exists")
+            position_store.prepare_entry(
+                market="KR",
+                legacy_holding_id=legacy_holding_id,
+                account_id=account_id,
+                account_name=account_name,
+                symbol=ticker,
+                intent_id=intent.id,
+                entry_price=current_price,
+                opened_at=now,
+            )
+            message = self._build_pending_kr_entry_message(
+                ticker=ticker,
+                company_name=company_name,
+                current_price=current_price,
+                scenario=scenario,
+                rank_change_msg=rank_change_msg,
+                trigger_type=trigger_type,
+            )
+            self.conn.commit()
+        except BaseException:
+            if self.conn.in_transaction:
+                self.conn.rollback()
+            raise
+
+        return _PreparedKrEntry(
+            legacy_holding_id=legacy_holding_id,
+            account_id=account_id,
+            account_name=account_name,
+            symbol=ticker,
+            intent=intent,
+            intent_store=intent_store,
+            reservation=reservation,
+            message=message,
+        )
+
+    async def _execute_pending_kr_entry(
+        self, prepared: _PreparedKrEntry, *, current_price: float
+    ) -> Dict[str, Any]:
+        async with ExecutionService.domestic(
+            account_name=prepared.account_name,
+            intent_store=prepared.intent_store,
+        ) as trading:
+            return await trading.execute_pre_reserved_buy(
+                stock_code=prepared.symbol,
+                limit_price=current_price,
+                intent=prepared.intent,
+                reservation=prepared.reservation,
+            )
+
+    def _complete_pending_kr_entry(self, prepared: _PreparedKrEntry) -> None:
+        """Commit OPEN before making the prebuilt message externally visible."""
+
+        self.conn.execute("BEGIN IMMEDIATE")
+        try:
+            PositionStore(self.conn).complete_entry(
+                market="KR",
+                legacy_holding_id=prepared.legacy_holding_id,
+                account_id=prepared.account_id,
+                symbol=prepared.symbol,
+                intent_id=prepared.intent.id,
+            )
+            self.conn.commit()
+        except BaseException:
+            if self.conn.in_transaction:
+                self.conn.rollback()
+            raise
+        self._msg_types.append("analysis")
+        self.message_queue.append(prepared.message)
+
+    def _fail_pending_kr_entry(self, prepared: _PreparedKrEntry) -> None:
+        """Atomically remove the legacy holding and tombstone a rejected entry."""
+
+        self.conn.execute("BEGIN IMMEDIATE")
+        try:
+            deleted = self.conn.execute(
+                "DELETE FROM stock_holdings "
+                "WHERE id=? AND account_key=? AND ticker=?",
+                (
+                    prepared.legacy_holding_id,
+                    prepared.account_id,
+                    prepared.symbol,
+                ),
+            ).rowcount
+            if deleted != 1:
+                raise RuntimeError("pending entry holding changed before compensation")
+            PositionStore(self.conn).fail_entry(
+                market="KR",
+                legacy_holding_id=prepared.legacy_holding_id,
+                account_id=prepared.account_id,
+                symbol=prepared.symbol,
+                intent_id=prepared.intent.id,
+            )
+            self.conn.commit()
+        except BaseException:
+            if self.conn.in_transaction:
+                self.conn.rollback()
+            raise
 
     async def buy_stock(self, ticker: str, company_name: str, current_price: float, scenario: Dict[str, Any], rank_change_msg: str = "", is_add: bool = False) -> bool:
         """Preserve the public bool contract while exposing an internal typed result."""
@@ -2351,6 +2692,123 @@ class StockTrackingAgent:
                             _cd_block = _enforce
 
                     if analysis_result.get("decision") == "Enter" and not _cd_block and not _regime_floor_block:
+                        if self._position_pending_kr_enabled():
+                            prepared = None
+                            try:
+                                prepared = self._prepare_pending_kr_entry(
+                                    ticker=ticker,
+                                    company_name=company_name,
+                                    current_price=current_price,
+                                    scenario=scenario,
+                                    rank_change_msg=rank_change_msg,
+                                    source_decision_id=source_decision_id,
+                                )
+                                trade_result = await self._execute_pending_kr_entry(
+                                    prepared, current_price=current_price
+                                )
+                                intent_status = str(
+                                    trade_result.get("intent_status", "UNKNOWN")
+                                ).upper()
+                                if intent_status != "SUBMITTED":
+                                    if intent_status == "FAILED":
+                                        self._fail_pending_kr_entry(prepared)
+                                    logger.critical(
+                                        "[POSITION-PENDING][KR] entry unresolved "
+                                        "account=%s symbol=%s intent=%s status=%s "
+                                        "action=manual_review",
+                                        label,
+                                        ticker,
+                                        prepared.intent.id,
+                                        intent_status,
+                                    )
+                                    state["should_save_watchlist"] = True
+                                    state["skip_reason"] = (
+                                        state["skip_reason"] or "Purchase failed"
+                                    )
+                                    continue
+                                self._complete_pending_kr_entry(prepared)
+                            except Exception as error:
+                                logger.critical(
+                                    "[POSITION-PENDING][KR] entry unresolved "
+                                    "account=%s symbol=%s intent=%s status=%s "
+                                    "action=manual_review error=%s",
+                                    label,
+                                    ticker,
+                                    prepared.intent.id if prepared else "unreserved",
+                                    "UNKNOWN" if prepared else "PREPARE_FAILED",
+                                    type(error).__name__,
+                                )
+                                state["should_save_watchlist"] = True
+                                state["skip_reason"] = (
+                                    state["skip_reason"] or "Purchase failed"
+                                )
+                                continue
+
+                            if trade_result["success"]:
+                                logger.info(
+                                    "Actual purchase successful: "
+                                    f"{trade_result['message']}"
+                                )
+                            else:
+                                logger.error(
+                                    f"Actual purchase failed: {trade_result['message']}"
+                                )
+
+                            if trade_result.get("partial_success"):
+                                successful = trade_result.get(
+                                    "successful_accounts", []
+                                )
+                                failed = trade_result.get("failed_accounts", [])
+                                logger.warning(
+                                    f"{ticker} partial success: {len(successful)}/"
+                                    f"{len(successful) + len(failed)} accounts"
+                                )
+
+                            if ticker not in signaled_tickers:
+                                try:
+                                    from messaging.redis_signal_publisher import publish_buy_signal
+
+                                    await publish_buy_signal(
+                                        ticker=ticker,
+                                        company_name=company_name,
+                                        price=current_price,
+                                        scenario=scenario,
+                                        source="AI Analysis",
+                                        trade_result=trade_result,
+                                    )
+                                except Exception as signal_err:
+                                    logger.warning(
+                                        "Buy signal publish failed (non-critical): "
+                                        f"{signal_err}"
+                                    )
+
+                                try:
+                                    from messaging.gcp_pubsub_signal_publisher import publish_buy_signal as gcp_publish_buy_signal
+
+                                    await gcp_publish_buy_signal(
+                                        ticker=ticker,
+                                        company_name=company_name,
+                                        price=current_price,
+                                        scenario=scenario,
+                                        source="AI Analysis",
+                                        trade_result=trade_result,
+                                    )
+                                except Exception as signal_err:
+                                    logger.warning(
+                                        "GCP buy signal publish failed (non-critical): "
+                                        f"{signal_err}"
+                                    )
+
+                                signaled_tickers.add(ticker)
+
+                            buy_count += 1
+                            state["traded"] = True
+                            logger.info(
+                                f"Purchase complete: {company_name}({ticker}) @ "
+                                f"{current_price:,.0f} KRW"
+                            )
+                            continue
+
                         buy_result = await self._buy_stock_with_position(
                             ticker,
                             company_name,

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -1355,6 +1355,9 @@ class StockTrackingAgent:
         scenario: Dict[str, Any],
         rank_change_msg: str,
         source_decision_id: str,
+        source: str = "kr_batch",
+        is_add: bool = False,
+        expected_open_count: int | None = None,
     ) -> _PreparedKrEntry:
         """Atomically persist the legacy holding, intent, and PENDING_ENTRY."""
 
@@ -1371,7 +1374,11 @@ class StockTrackingAgent:
         try:
             position_store = PositionStore(self.conn)
             position_store.assert_entry_attempt_allowed(
-                market="KR", account_id=account_id, symbol=ticker
+                market="KR",
+                account_id=account_id,
+                symbol=ticker,
+                allow_existing_open=is_add,
+                expected_open_count=expected_open_count,
             )
             cursor = self.conn.execute(
                 """
@@ -1405,7 +1412,7 @@ class StockTrackingAgent:
                 symbol=ticker,
                 side="buy",
                 order_style="smart",
-                source="kr_batch",
+                source=source,
                 source_decision_id=source_decision_id,
                 source_position_id=legacy_position_id("KR", legacy_holding_id),
                 limit_price=current_price,
@@ -2702,6 +2709,7 @@ class StockTrackingAgent:
                                     scenario=scenario,
                                     rank_change_msg=rank_change_msg,
                                     source_decision_id=source_decision_id,
+                                    source="kr_batch",
                                 )
                                 trade_result = await self._execute_pending_kr_entry(
                                     prepared, current_price=current_price
@@ -2727,6 +2735,16 @@ class StockTrackingAgent:
                                     )
                                     continue
                                 self._complete_pending_kr_entry(prepared)
+                            except asyncio.CancelledError:
+                                logger.critical(
+                                    "[POSITION-PENDING][KR] entry cancelled "
+                                    "account=%s symbol=%s intent=%s "
+                                    "status=UNKNOWN action=manual_review",
+                                    label,
+                                    ticker,
+                                    prepared.intent.id if prepared else "unreserved",
+                                )
+                                raise
                             except Exception as error:
                                 logger.critical(
                                     "[POSITION-PENDING][KR] entry unresolved "

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -635,6 +635,131 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
 
                 # Process buy if entry decision
                 if decision == "Enter" and buy_score >= min_score and sector_diverse and not _cd_block:
+                    if self._position_pending_kr_enabled():
+                        prepared = None
+                        active_account = getattr(self, "active_account", None)
+                        account_label = (
+                            self._safe_account_log_label(active_account)
+                            if active_account
+                            else "unavailable"
+                        )
+                        try:
+                            if scenario.get("target_price", 0) <= 0:
+                                scenario["target_price"] = (
+                                    await self._dynamic_target_price(
+                                        ticker, current_price
+                                    )
+                                )
+                            if scenario.get("stop_loss", 0) <= 0:
+                                scenario["stop_loss"] = await self._dynamic_stop_loss(
+                                    ticker, current_price
+                                )
+                            prepared = self._prepare_pending_kr_entry(
+                                ticker=ticker,
+                                company_name=company_name,
+                                current_price=current_price,
+                                scenario=scenario,
+                                rank_change_msg=rank_change_msg,
+                                source_decision_id=(
+                                    f"report:{os.path.basename(pdf_report_path)}"
+                                ),
+                                source="kr_enhanced_batch",
+                                is_add=bool(is_add),
+                                expected_open_count=(
+                                    analysis_result.get("existing_row_count")
+                                    if is_add
+                                    else None
+                                ),
+                            )
+                            trade_result = await self._execute_pending_kr_entry(
+                                prepared, current_price=current_price
+                            )
+                            intent_status = str(
+                                trade_result.get("intent_status", "UNKNOWN")
+                            ).upper()
+                            if intent_status != "SUBMITTED":
+                                if intent_status == "FAILED":
+                                    self._fail_pending_kr_entry(prepared)
+                                logger.critical(
+                                    "[POSITION-PENDING][KR] enhanced entry unresolved "
+                                    "account=%s symbol=%s intent=%s status=%s "
+                                    "action=manual_review",
+                                    account_label,
+                                    ticker,
+                                    prepared.intent.id,
+                                    intent_status,
+                                )
+                                continue
+                            self._complete_pending_kr_entry(prepared)
+                        except asyncio.CancelledError:
+                            logger.critical(
+                                "[POSITION-PENDING][KR] enhanced entry cancelled "
+                                "account=%s symbol=%s intent=%s status=UNKNOWN "
+                                "action=manual_review",
+                                account_label,
+                                ticker,
+                                prepared.intent.id if prepared else "unreserved",
+                            )
+                            raise
+                        except Exception as error:
+                            logger.critical(
+                                "[POSITION-PENDING][KR] enhanced entry unresolved "
+                                "account=%s symbol=%s intent=%s status=%s "
+                                "action=manual_review error=%s",
+                                account_label,
+                                ticker,
+                                prepared.intent.id if prepared else "unreserved",
+                                "UNKNOWN" if prepared else "PREPARE_FAILED",
+                                type(error).__name__,
+                            )
+                            continue
+
+                        if trade_result["success"]:
+                            logger.info(
+                                f"Actual purchase successful: {trade_result['message']}"
+                            )
+                        else:
+                            logger.error(
+                                f"Actual purchase failed: {trade_result['message']}"
+                            )
+
+                        try:
+                            from messaging.redis_signal_publisher import publish_buy_signal
+                            await publish_buy_signal(
+                                ticker=ticker,
+                                company_name=company_name,
+                                price=current_price,
+                                scenario=scenario,
+                                source="AI Analysis",
+                                trade_result=trade_result,
+                            )
+                        except Exception as signal_err:
+                            logger.warning(
+                                f"Buy signal publish failed (non-critical): {signal_err}"
+                            )
+
+                        try:
+                            from messaging.gcp_pubsub_signal_publisher import publish_buy_signal as gcp_publish_buy_signal
+                            await gcp_publish_buy_signal(
+                                ticker=ticker,
+                                company_name=company_name,
+                                price=current_price,
+                                scenario=scenario,
+                                source="AI Analysis",
+                                trade_result=trade_result,
+                            )
+                        except Exception as signal_err:
+                            logger.warning(
+                                f"GCP buy signal publish failed (non-critical): {signal_err}"
+                            )
+
+                        buy_count += 1
+                        logger.info(
+                            f"Purchase complete: {company_name}({ticker}) @ "
+                            f"{current_price:,.0f} KRW"
+                        )
+                        continue
+
                     # Process buy (is_add => pyramiding additional independent row, #288)
                     buy_result = await self._buy_stock_with_position(
                         ticker,

--- a/tasks/issue-412/13-phase4b2b1-kr-entry-plan.md
+++ b/tasks/issue-412/13-phase4b2b1-kr-entry-plan.md
@@ -1,0 +1,143 @@
+# Issue #412 Phase 4-b2b-1 실행 계획 — KR ENTRY 연결, flag OFF
+
+> 기준: main `449e4750` (Phase 4-b2b-0 양 서버 배포 완료)
+> 운영 기본값: `POSITION_PENDING_KR_ENABLED=false`
+> 배포 원칙: 일반/enhanced BUY 코드를 모두 연결해도 Phase 4-b2b-2 EXIT 완료 전에는 gate를 켜지 않는다.
+
+## 1. 목표와 비목표
+
+일반 KR batch BUY와 enhanced BUY가 같은 PENDING_ENTRY lifecycle을 사용하도록 구현한다.
+gate=false에서는 기존 holding commit → message → broker → Redis → GCP 순서와 public bool/count를
+완전히 유지한다. gate=true에서는 broker 전에 holding, intent CREATED, PENDING_ENTRY를 한 transaction으로
+commit하고 SUBMITTED + OPEN finalize 뒤에만 일반 메시지와 publisher를 실행한다.
+
+비목표:
+
+- KR SELL, hardstop, trend-exit 전환(4-b2b-2)
+- gate 활성화 및 운영 실주문 검증(4-b2b-3)
+- FAILED 자동 retry 또는 tombstone 해제 도구
+- durable alert outbox와 reconciliation
+- US 주문 경로
+
+## 2. 구현 전 필수 안전 조건
+
+### 자동 재주문 금지 guard
+
+`OrderIntent` idempotency는 `source_decision_id`를 우선하므로 새 보고서는 새 attempt를 만들 수 있다.
+FAILED 보상으로 legacy holding이 삭제되면 기존 holdings gate도 사라진다. enhanced `is_add=True`는
+holdings gate 자체를 우회한다.
+
+따라서 `BEGIN IMMEDIATE` 안에서 동일 KR account/symbol의 기존 position 중 다음 상태가 하나라도 있으면
+새 holding INSERT와 intent reserve 전에 fail closed한다.
+
+- `PENDING_ENTRY`
+- `ENTRY_FAILED`
+- `PENDING_EXIT`
+- `EXIT_UNKNOWN`
+
+이 guard는 `PositionStore`의 transaction-required API로 구현해 다른 caller도 재사용할 수 있게 하고,
+동시 connection 경쟁 테스트로 한 transaction만 통과함을 증명한다. operator authorization/new-attempt
+도구가 생기기 전에는 tombstone을 자동 해제하지 않는다.
+
+### readiness
+
+`POSITION_PENDING_KR_ENABLED=true`이면 다음을 broker 전에 모두 만족해야 한다.
+
+- `POSITION_LEDGER_SHADOW_ENABLED=true`
+- positions/order_intents schema 초기화 성공
+- originating `IntentStore`가 agent DB와 동일
+
+기존 shadow 초기화는 fail-open이므로 pending 전용 readiness를 별도 상태로 저장한다. readiness가 없으면
+holding/intent/position/broker를 모두 0으로 유지하고 CRITICAL만 남긴다.
+
+## 3. private lifecycle 경계
+
+- `_position_pending_kr_enabled() -> bool`: 기본 false.
+- `_require_pending_entry_ready() -> None`: gate=true dependency를 fail closed 검증.
+- immutable `_PreparedKrEntry`: legacy id, account scope, ticker, intent, opaque reservation,
+  아직 enqueue하지 않은 message를 운반.
+- `_prepare_pending_kr_entry(...)`:
+  1. transaction 밖에서 originating `IntentStore` 준비.
+  2. `BEGIN IMMEDIATE`.
+  3. unresolved account/symbol guard.
+  4. legacy holding INSERT 후 id 확보.
+  5. id로 `OrderIntent` 생성 및 `reserve_in_transaction()`.
+  6. `PositionStore.prepare_entry()`.
+  7. message는 생성만 하고 enqueue하지 않음.
+  8. commit 후 prepared object 반환. 실패/중복은 전체 rollback, broker 0.
+- `_execute_pending_kr_entry(...)`: 동일 `IntentStore`를
+  `ExecutionService.domestic(intent_store=...)`에 주입하고 `execute_pre_reserved_buy()` 실행.
+- `_complete_pending_kr_entry(...)`: 새 transaction에서 `complete_entry()` 후 commit. commit 성공 후에만
+  message enqueue.
+- `_fail_pending_kr_entry(...)`: 한 transaction에서 exact holding DELETE의 account/ticker/id와 rowcount=1을
+  검증한 뒤 `fail_entry()`. 어느 단계든 실패하면 전체 rollback해 holding + PENDING을 보존.
+
+gate=false는 기존 `_buy_stock_with_position()`과 두 caller 블록을 그대로 사용한다. gate=true만 신규
+lifecycle로 분기한다. 공통 message builder 추출이 필요하면 먼저 기존 문자열 golden 테스트를 고정하고,
+OFF 경로의 enqueue 위치는 바꾸지 않는다.
+
+## 4. 결과별 상태와 부작용
+
+- `SUBMITTED`: intent SUBMITTED 확인 → position OPEN transaction commit → message 1 → Redis 1 → GCP 1
+  → buy_count 1.
+- `FAILED`: exact holding delete + position ENTRY_FAILED transaction commit → 일반 message/publish/count 0
+  → CRITICAL 1.
+- `UNKNOWN`, broker exception, result persistence failure, 예상 외 `QUEUED`: holding과 PENDING_ENTRY 유지,
+  일반 message/publish/count 0, CRITICAL 1, 자동 재주문 0.
+- coroutine cancellation: claim 결과에 따라 intent UNKNOWN 보존, position PENDING_ENTRY 유지, shielded
+  CRITICAL 후 `CancelledError` 재전파.
+- broker SUBMITTED 후 OPEN finalize 실패: transaction rollback, holding + PENDING_ENTRY 유지,
+  publish 0, CRITICAL 1.
+- FAILED 보상 transaction 실패: rollback으로 holding + PENDING_ENTRY 유지, publish 0, CRITICAL 1.
+
+CRITICAL에는 market, symbol, side, intent id, 안전한 account fingerprint, status/action만 포함한다.
+raw broker payload, token, account 원문은 금지한다. durable exactly-once는 outbox 전에는 보장하지 않으며
+이 한계 때문에 운영 gate 활성화는 계속 차단한다.
+
+## 5. TDD 순서
+
+### Slice 1 — OFF 회귀 + SUBMITTED happy path
+
+1. 일반 BUY gate=false 이벤트 순서:
+   `legacy commit/message → broker → Redis → GCP`, 각 1회.
+2. enhanced BUY gate=false 이벤트 순서:
+   `_buy_stock_with_position → broker → Redis → GCP`, 각 1회.
+3. 일반 gate=true SUBMITTED:
+   - broker 진입 시 별도 DB connection에서 holding 1, intent SUBMITTING, position PENDING_ENTRY.
+   - publisher 진입 시 intent SUBMITTED, position OPEN, message 1.
+   - 최종 broker/message/Redis/GCP 각 1, CRITICAL 0.
+
+### Slice 2 — fail closed matrix
+
+- explicit FAILED 보상.
+- broker exception/UNKNOWN.
+- broker 성공 후 result persistence failure(SUBMITTING 유지).
+- 예상 외 QUEUED.
+- OPEN finalize 실패.
+- FAILED compensation 실패.
+- prepare/lock/write failure: holding/intent/position/broker 모두 0.
+- pending=true + shadow/readiness=false: 전부 0.
+
+### Slice 3 — cancellation, 경쟁, 재실행
+
+- broker coroutine cancellation은 UNKNOWN/PENDING을 남기고 cancel 재전파.
+- 같은 account/symbol 두 connection 경쟁은 reservation/holding/position/broker 각 1.
+- UNKNOWN 뒤 같은 decision 재실행과 새 decision 재실행 모두 broker 누계 1.
+- ENTRY_FAILED 뒤 새 decision 및 `is_add=True`도 broker 0.
+
+### Slice 4 — enhanced 동일 lifecycle
+
+- enhanced SUBMITTED가 base와 같은 private lifecycle을 사용.
+- enhanced FAILED/UNKNOWN은 대표 1개씩 동일 상태/부작용 계약.
+- 병렬 pre-pass 뒤 sequential holdings/sector gate 순서와 buy_count 불변.
+
+## 6. 검증·배포 gate
+
+- 기존 BUY baseline 22개 이상 전부 유지.
+- order_intents/positions/execution_service, pyramiding, parallel batch, process_reports 관련 회귀 green.
+- 독립 architecture/code/test review blocker 0.
+- Python 3.10/3.11/3.12 CI + Codacy green.
+- db-server 실제 root crontab의 KR orchestrator와 hardstop/trend/fill-chaser compile/import 및 관련 회귀.
+- app-server는 root SSH 후 반드시 `su - prism`; bot/report/core import와 기존 bot 무중단 확인.
+- 배포 후 `POSITION_PENDING_KR_ENABLED`가 미설정/false이고 PENDING/ENTRY_FAILED 신규 행 0인지 확인.
+- bot/cron 재시작 불필요. gate 활성화는 4-b2b-2 완료 후 별도 4-b2b-3 승인에서만 수행.

--- a/tasks/issue-412/README.md
+++ b/tasks/issue-412/README.md
@@ -2,9 +2,9 @@
 
 > 이슈: [#412 매수/매도 Agent 분리와 KIS 실제 주문 실행 구조 이식 설계](https://github.com/dragon1086/prism-insight/issues/412)
 > 브랜치: `feature/issue-412-execution-architecture`
-> 상태: Phase 4-b2a 배포 완료, Phase 4-b2b-0 안전 기반 구현/검증 중
+> 상태: Phase 4-b2b-0 배포 완료, Phase 4-b2b-1 KR ENTRY 구현 준비
 > (2026-07-06 시작, 2026-07-13 main #432 기준 전면 재검토,
-> **2026-07-19 Phase 4-b2a PR #463, main `de74af0c` 배포 완료**)
+> **2026-07-19 Phase 4-b2b-0 PR #464, main `449e4750` 배포 완료**)
 
 ## 목적
 
@@ -31,6 +31,7 @@ greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 
 | [05-verification-plan.md](05-verification-plan.md) | 검증 전략 — 단위/golden/shadow 병행 기록/demo 계좌/서버 배포 절차/롤백 |
 | [11-phase4b2-pending-exit-plan.md](11-phase4b2-pending-exit-plan.md) | Phase 4-b2 분할 계획 — 4-b2a 기반 API, 4-b2b KR 전환, 4-b2c US queue 연속성/전환 |
 | [12-phase4b2b-kr-execution-plan.md](12-phase4b2b-kr-execution-plan.md) | Phase 4-b2b KR 전환 상세 계획 — 4-b2b-0~3 안전 분할, 실패/재시도 정책, 배포 gate |
+| [13-phase4b2b1-kr-entry-plan.md](13-phase4b2b1-kr-entry-plan.md) | Phase 4-b2b-1 KR ENTRY 구현 계획 — no-auto-retry guard, private lifecycle, 결과별 TDD |
 
 ## 진행 체크리스트
 
@@ -44,7 +45,7 @@ greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 
 - [x] Phase 4-a: position OPEN/CLOSED shadow 병행 기록 + 대조 (PR #460/#461, main `5ed6f38c`)
 - [x] Phase 4-b1: persisted intent ↔ position linkage, legacy 순서/read 유지 (PR #462, main `9b3ecc58`)
 - [x] Phase 4-b2a: transaction-aware reserve/PENDING lifecycle 기반 API — 운영 호출부 미배선 (PR #463, main `de74af0c`)
-- [ ] Phase 4-b2b-0: KR 전환 안전 기반 — originating store, exit quarantine, 3상태 holding 조회 (운영 호출부 미배선)
+- [x] Phase 4-b2b-0: KR 전환 안전 기반 — originating store, exit quarantine, 3상태 holding 조회 (PR #464, main `449e4750`)
 - [ ] Phase 4-b2b-1: KR ENTRY 전체 경로 PENDING write-ahead (flag OFF)
 - [ ] Phase 4-b2b-2: KR EXIT 전체 경로 PENDING write-ahead + 실패 보상 (flag OFF)
 - [ ] Phase 4-b2b-3: 별도 승인·무거래 창 검증 후 KR 시장 gate 일괄 활성화

--- a/tests/test_execution_service.py
+++ b/tests/test_execution_service.py
@@ -144,6 +144,44 @@ def test_direct_order_methods_cannot_bypass_service_boundary():
             getattr(execution, method_name)
 
 
+def test_cancellation_propagates_when_unknown_result_persistence_fails(
+    monkeypatch, tmp_path, caplog
+):
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore, OrderIntent
+
+    class CancellingTrader(FakeTrader):
+        async def async_buy_stock(self, *args, **kwargs):
+            self.calls.append(("buy", args, kwargs))
+            raise asyncio.CancelledError()
+
+    intent_store = IntentStore(tmp_path / "cancel-persistence.sqlite")
+    intent = OrderIntent.create(
+        market="KR",
+        account_id="acct",
+        symbol="005930",
+        side="BUY",
+        order_style="smart",
+        source="test",
+        source_decision_id="cancel-persistence-failure",
+    )
+
+    def fail_record_result(*_args, **_kwargs):
+        raise sqlite3.OperationalError("injected UNKNOWN persistence failure")
+
+    monkeypatch.setattr(intent_store, "record_result", fail_record_result)
+    caplog.set_level("CRITICAL")
+    execution = ExecutionService(CancellingTrader(), intent_store=intent_store)
+
+    async def exercise():
+        with pytest.raises(asyncio.CancelledError):
+            await execution.execute_buy("005930", intent=intent)
+
+    asyncio.run(exercise())
+
+    assert "cancellation UNKNOWN persistence failed" in caplog.text
+
+
 def test_us_factory_recovers_when_root_trading_package_is_cached(monkeypatch):
     import trading  # noqa: F401 - cache the root package intentionally
     from prism_core.execution_service import ExecutionService

--- a/tests/test_kr_pending_entry.py
+++ b/tests/test_kr_pending_entry.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import sqlite3
 import sys
@@ -9,7 +10,7 @@ import pytest
 
 import trading.domestic_stock_trading as domestic_trading
 from prism_core.order_intents import IntentStore
-from prism_core.positions import PositionStore
+from prism_core.positions import InvalidPositionTransition, PositionStore
 from stock_tracking_agent import StockTrackingAgent
 from tracking.db_schema import TABLE_STOCK_HOLDINGS
 
@@ -34,6 +35,32 @@ def _entry_state(db_path: Path) -> tuple[int, str | None, str | None]:
         intent[0] if intent else None,
         position[0] if position else None,
     )
+
+
+def _entry_row_counts(db_path: Path) -> tuple[int, int, int, int]:
+    with sqlite3.connect(db_path) as connection:
+        holding_count = connection.execute(
+            "SELECT COUNT(*) FROM stock_holdings "
+            "WHERE account_key='vps:kr-primary:01' AND ticker='005930'"
+        ).fetchone()[0]
+        intent_count = connection.execute(
+            "SELECT COUNT(*) FROM order_intents "
+            "WHERE market='KR' AND account_id='vps:kr-primary:01' "
+            "AND symbol='005930' AND side='BUY'"
+        ).fetchone()[0]
+        position_count = connection.execute(
+            "SELECT COUNT(*) FROM positions "
+            "WHERE market='KR' AND account_id='vps:kr-primary:01' "
+            "AND symbol='005930'"
+        ).fetchone()[0]
+        broker_order_count = connection.execute(
+            "SELECT COUNT(*) FROM broker_orders orders "
+            "JOIN order_intents intents ON intents.id=orders.intent_id "
+            "WHERE intents.market='KR' "
+            "AND intents.account_id='vps:kr-primary:01' "
+            "AND intents.symbol='005930' AND intents.side='BUY'"
+        ).fetchone()[0]
+    return holding_count, intent_count, position_count, broker_order_count
 
 
 def _pending_entry_agent(db_path: Path):
@@ -94,6 +121,8 @@ def _install_pending_entry_runtime(
     db_path: Path,
     broker_result: dict | None = None,
     broker_error: BaseException | None = None,
+    broker_started: asyncio.Event | None = None,
+    broker_release: asyncio.Event | None = None,
 ):
     broker_calls = []
     publish_states = []
@@ -122,6 +151,10 @@ def _install_pending_entry_runtime(
                     "message_count": len(agent.message_queue),
                 }
             )
+            if broker_started is not None:
+                broker_started.set()
+            if broker_release is not None:
+                await broker_release.wait()
             if broker_error is not None:
                 raise broker_error
             return broker_result or {
@@ -151,6 +184,269 @@ def _install_pending_entry_runtime(
     monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
     monkeypatch.setenv("POSITION_LEDGER_SHADOW_ENABLED", "true")
     return broker_calls, publish_states, redis_calls, gcp_calls
+
+
+@pytest.mark.asyncio
+async def test_concurrent_agents_create_one_pending_entry_and_one_broker_order(
+    monkeypatch, tmp_path
+):
+    db_path = tmp_path / "concurrent-pending-entry.sqlite"
+    first_agent, first_connection = _pending_entry_agent(db_path)
+    second_agent, second_connection = _pending_entry_agent(db_path)
+    broker_started = asyncio.Event()
+    broker_release = asyncio.Event()
+    broker_calls, _, _, _ = _install_pending_entry_runtime(
+        monkeypatch,
+        agent=first_agent,
+        db_path=db_path,
+        broker_started=broker_started,
+        broker_release=broker_release,
+    )
+
+    try:
+        first_task = asyncio.create_task(
+            StockTrackingAgent.process_reports(first_agent, ["same-report.pdf"])
+        )
+        await asyncio.wait_for(broker_started.wait(), timeout=1)
+        second_result = await StockTrackingAgent.process_reports(
+            second_agent, ["same-report.pdf"]
+        )
+        broker_release.set()
+        first_result = await asyncio.wait_for(first_task, timeout=1)
+        counts = _entry_row_counts(db_path)
+    finally:
+        broker_release.set()
+        first_connection.close()
+        second_connection.close()
+
+    assert sorted((first_result, second_result)) == [(0, 0), (1, 0)]
+    assert len(broker_calls) == 1
+    assert counts == (1, 1, 1, 1)
+
+
+@pytest.mark.asyncio
+async def test_open_entry_blocks_new_standard_decision_before_broker(
+    monkeypatch, tmp_path
+):
+    db_path = tmp_path / "open-retry-block.sqlite"
+    agent, connection = _pending_entry_agent(db_path)
+    broker_calls, _, _, _ = _install_pending_entry_runtime(
+        monkeypatch, agent=agent, db_path=db_path
+    )
+
+    try:
+        first_result = await StockTrackingAgent.process_reports(
+            agent, ["original-report.pdf"]
+        )
+        new_decision_result = await StockTrackingAgent.process_reports(
+            agent, ["new-report.pdf"]
+        )
+        counts = _entry_row_counts(db_path)
+    finally:
+        connection.close()
+
+    assert first_result == (1, 0)
+    assert new_decision_result == (0, 0)
+    assert len(broker_calls) == 1
+    assert counts == (1, 1, 1, 1)
+
+
+@pytest.mark.asyncio
+async def test_enhanced_add_allows_matching_open_count_once_and_blocks_stale_retry(
+    monkeypatch, tmp_path
+):
+    db_path = tmp_path / "enhanced-add-open-count.sqlite"
+    agent, connection = _pending_entry_agent(db_path)
+    broker_calls, _, _, _ = _install_pending_entry_runtime(
+        monkeypatch, agent=agent, db_path=db_path
+    )
+
+    try:
+        assert await StockTrackingAgent.process_reports(
+            agent, ["original-report.pdf"]
+        ) == (1, 0)
+        prepared = agent._prepare_pending_kr_entry(
+            ticker="005930",
+            company_name="Samsung Electronics",
+            current_price=71000,
+            scenario={"target_price": 81000, "stop_loss": 66000},
+            rank_change_msg="",
+            source_decision_id="enhanced-add:first",
+            source="kr_enhanced_batch",
+            is_add=True,
+            expected_open_count=1,
+        )
+        trade_result = await agent._execute_pending_kr_entry(
+            prepared, current_price=71000
+        )
+        assert trade_result["intent_status"] == "SUBMITTED"
+        agent._complete_pending_kr_entry(prepared)
+
+        with pytest.raises(InvalidPositionTransition, match="changed OPEN.*expected 1"):
+            agent._prepare_pending_kr_entry(
+                ticker="005930",
+                company_name="Samsung Electronics",
+                current_price=72000,
+                scenario={"target_price": 82000, "stop_loss": 67000},
+                rank_change_msg="",
+                source_decision_id="enhanced-add:stale",
+                source="kr_enhanced_batch",
+                is_add=True,
+                expected_open_count=1,
+            )
+        counts = _entry_row_counts(db_path)
+    finally:
+        connection.close()
+
+    assert len(broker_calls) == 2
+    assert counts == (2, 2, 2, 2)
+
+
+@pytest.mark.asyncio
+async def test_unknown_entry_blocks_same_and_new_report_decisions_before_broker(
+    monkeypatch, tmp_path
+):
+    db_path = tmp_path / "unknown-retry-block.sqlite"
+    agent, connection = _pending_entry_agent(db_path)
+    broker_calls, _, _, _ = _install_pending_entry_runtime(
+        monkeypatch,
+        agent=agent,
+        db_path=db_path,
+        broker_error=TimeoutError("broker response timed out"),
+    )
+
+    try:
+        first_result = await StockTrackingAgent.process_reports(
+            agent, ["original-report.pdf"]
+        )
+        counts_after_unknown = _entry_row_counts(db_path)
+        same_decision_result = await StockTrackingAgent.process_reports(
+            agent, ["original-report.pdf"]
+        )
+        new_decision_result = await StockTrackingAgent.process_reports(
+            agent, ["new-report.pdf"]
+        )
+        counts_after_retries = _entry_row_counts(db_path)
+    finally:
+        connection.close()
+
+    assert first_result == same_decision_result == new_decision_result == (0, 0)
+    assert len(broker_calls) == 1
+    assert counts_after_unknown == (1, 1, 1, 1)
+    assert counts_after_retries == counts_after_unknown
+
+
+@pytest.mark.asyncio
+async def test_failed_entry_blocks_new_batch_and_enhanced_add_attempts(
+    monkeypatch, tmp_path
+):
+    db_path = tmp_path / "failed-retry-block.sqlite"
+    agent, connection = _pending_entry_agent(db_path)
+    broker_calls, _, _, _ = _install_pending_entry_runtime(
+        monkeypatch,
+        agent=agent,
+        db_path=db_path,
+        broker_result={"success": False, "message": "order rejected"},
+    )
+
+    try:
+        first_result = await StockTrackingAgent.process_reports(
+            agent, ["original-report.pdf"]
+        )
+        counts_after_failure = _entry_row_counts(db_path)
+        new_decision_result = await StockTrackingAgent.process_reports(
+            agent, ["new-report.pdf"]
+        )
+        with pytest.raises(InvalidPositionTransition, match="ENTRY_FAILED"):
+            agent._prepare_pending_kr_entry(
+                ticker="005930",
+                company_name="Samsung Electronics",
+                current_price=70000,
+                scenario={"target_price": 80000, "stop_loss": 65000},
+                rank_change_msg="",
+                source_decision_id="enhanced-add:new-report.pdf",
+                source="kr_enhanced_batch",
+            )
+        counts_after_retries = _entry_row_counts(db_path)
+    finally:
+        connection.close()
+
+    assert first_result == new_decision_result == (0, 0)
+    assert len(broker_calls) == 1
+    assert counts_after_failure == (0, 1, 1, 1)
+    assert counts_after_retries == counts_after_failure
+
+
+@pytest.mark.asyncio
+async def test_pending_entry_message_exactly_matches_complex_legacy_buy_message(
+    tmp_path,
+):
+    db_path = tmp_path / "pending-entry-message-parity.sqlite"
+    agent, connection = _pending_entry_agent(db_path)
+    agent.active_account = agent.account_configs[0]
+    scenario = {
+        "target_price": 81234,
+        "stop_loss": 65432,
+        "investment_period": "중기",
+        "sector": "반도체",
+        "valuation_analysis": "선행 PER이 업종 평균보다 낮음",
+        "sector_outlook": "AI 서버 수요로 업황 개선",
+        "rationale": "실적과 수급이 동시에 개선",
+        "journal_reflection": {
+            "recent_exit_caution": "직전 돌파 실패 구간을 확인",
+            "applied_lessons": "거래량 확인 후 진입",
+        },
+        "score_adjustment": {
+            "value": 2,
+            "reasons": ["동일 패턴 승률", "수급 개선"],
+        },
+        "trading_scenarios": {
+            "key_levels": {
+                "primary_resistance": "80,500원",
+                "secondary_resistance": 83500,
+                "primary_support": "68,000",
+                "secondary_support": 65100,
+                "volume_baseline": "20일 평균의 150%",
+            },
+            "sell_triggers": [
+                "target resistance breakout",
+                "support decline",
+                "time sideways",
+                "외국인 순매도 전환",
+            ],
+            "hold_conditions": ["20일선 유지", "영업이익 추정치 유지"],
+            "portfolio_context": "반도체 비중 상한 내 신규 편입",
+        },
+    }
+    agent.trigger_info_map = {
+        "005930": {"trigger_type": "Earnings Momentum", "trigger_mode": "live"}
+    }
+    agent._get_trigger_win_rate = lambda trigger: (
+        "트리거 승률: 73%" if trigger == "Earnings Momentum" else ""
+    )
+
+    try:
+        legacy_result = await agent._buy_stock_with_position(
+            "005930",
+            "Samsung Electronics",
+            70123,
+            scenario,
+            "거래대금 순위 18→4위",
+        )
+        pending_message = agent._build_pending_kr_entry_message(
+            ticker="005930",
+            company_name="Samsung Electronics",
+            current_price=70123,
+            scenario=scenario,
+            rank_change_msg="거래대금 순위 18→4위",
+            trigger_type="Earnings Momentum",
+        )
+    finally:
+        connection.close()
+
+    assert legacy_result.success is True
+    assert agent._msg_types == ["analysis"]
+    assert agent.message_queue == [pending_message]
 
 
 @pytest.mark.asyncio
@@ -188,6 +484,59 @@ async def test_pending_kr_buy_opens_position_before_publishing_submitted_order(
 
 
 @pytest.mark.asyncio
+async def test_pending_kr_buy_keeps_submitting_when_broker_result_persistence_fails(
+    monkeypatch, tmp_path, caplog
+):
+    db_path = tmp_path / "result-persistence-failed-entry.sqlite"
+    agent, connection = _pending_entry_agent(db_path)
+    originating_store = IntentStore(db_path)
+    monkeypatch.setattr(
+        agent, "_require_pending_entry_ready", lambda: originating_store
+    )
+    broker_calls, publish_states, redis_calls, gcp_calls = (
+        _install_pending_entry_runtime(
+            monkeypatch,
+            agent=agent,
+            db_path=db_path,
+        )
+    )
+    record_result_calls = []
+
+    def fail_record_result(*args, **kwargs):
+        record_result_calls.append((args, kwargs))
+        raise sqlite3.OperationalError("injected broker result persistence failure")
+
+    monkeypatch.setattr(originating_store, "record_result", fail_record_result)
+    caplog.set_level(logging.CRITICAL)
+
+    try:
+        result = await StockTrackingAgent.process_reports(agent, ["report-a.pdf"])
+        state = _entry_state(db_path)
+    finally:
+        connection.close()
+
+    assert result == (0, 0)
+    assert state == (1, "SUBMITTING", "PENDING_ENTRY")
+    assert len(broker_calls) == 1
+    assert len(record_result_calls) == 1
+    assert agent.message_queue == []
+    assert publish_states == []
+    assert redis_calls == []
+    assert gcp_calls == []
+    critical_records = [
+        record for record in caplog.records if record.levelno >= logging.CRITICAL
+    ]
+    assert critical_records
+    assert len(
+        [
+            record
+            for record in critical_records
+            if "[POSITION-PENDING][KR] entry unresolved" in record.getMessage()
+        ]
+    ) == 1
+
+
+@pytest.mark.asyncio
 async def test_pending_kr_buy_marks_explicit_broker_failure_without_publishing(
     monkeypatch, tmp_path, caplog
 ):
@@ -222,6 +571,45 @@ async def test_pending_kr_buy_marks_explicit_broker_failure_without_publishing(
 
 
 @pytest.mark.asyncio
+async def test_pending_kr_buy_rolls_back_failed_entry_compensation_when_finalize_fails(
+    monkeypatch, tmp_path, caplog
+):
+    db_path = tmp_path / "failed-entry-compensation-rollback.sqlite"
+    agent, connection = _pending_entry_agent(db_path)
+    broker_calls, publish_states, redis_calls, gcp_calls = (
+        _install_pending_entry_runtime(
+            monkeypatch,
+            agent=agent,
+            db_path=db_path,
+            broker_result={"success": False, "message": "order rejected"},
+        )
+    )
+
+    def fail_entry_finalize(_store, **_identity):
+        raise sqlite3.OperationalError("injected ENTRY_FAILED finalize failure")
+
+    monkeypatch.setattr(PositionStore, "fail_entry", fail_entry_finalize)
+    caplog.set_level(logging.CRITICAL)
+
+    try:
+        result = await StockTrackingAgent.process_reports(agent, ["report-a.pdf"])
+        state = _entry_state(db_path)
+    finally:
+        connection.close()
+
+    assert result == (0, 0)
+    assert state == (1, "FAILED", "PENDING_ENTRY")
+    assert len(broker_calls) == 1
+    assert agent.message_queue == []
+    assert publish_states == []
+    assert redis_calls == []
+    assert gcp_calls == []
+    assert len(
+        [record for record in caplog.records if record.levelno >= logging.CRITICAL]
+    ) == 1
+
+
+@pytest.mark.asyncio
 async def test_pending_kr_buy_keeps_unknown_outcome_for_manual_review(
     monkeypatch, tmp_path, caplog
 ):
@@ -244,6 +632,117 @@ async def test_pending_kr_buy_keeps_unknown_outcome_for_manual_review(
         connection.close()
 
     assert result == (0, 0)
+    assert state == (1, "UNKNOWN", "PENDING_ENTRY")
+    assert len(broker_calls) == 1
+    assert agent.message_queue == []
+    assert publish_states == []
+    assert redis_calls == []
+    assert gcp_calls == []
+    assert len(
+        [record for record in caplog.records if record.levelno >= logging.CRITICAL]
+    ) == 1
+
+
+@pytest.mark.asyncio
+async def test_pending_kr_buy_keeps_queued_order_pending_without_publishing(
+    monkeypatch, tmp_path, caplog
+):
+    db_path = tmp_path / "queued-entry.sqlite"
+    agent, connection = _pending_entry_agent(db_path)
+    broker_calls, publish_states, redis_calls, gcp_calls = (
+        _install_pending_entry_runtime(
+            monkeypatch,
+            agent=agent,
+            db_path=db_path,
+            broker_result={
+                "success": True,
+                "message": "Reserved buy order queued",
+                "order_no": "PENDING-7",
+                "order_type": "queued_buy",
+            },
+        )
+    )
+    caplog.set_level(logging.CRITICAL)
+
+    try:
+        result = await StockTrackingAgent.process_reports(agent, ["report-a.pdf"])
+        state = _entry_state(db_path)
+    finally:
+        connection.close()
+
+    assert result == (0, 0)
+    assert state == (1, "QUEUED", "PENDING_ENTRY")
+    assert len(broker_calls) == 1
+    assert agent.message_queue == []
+    assert publish_states == []
+    assert redis_calls == []
+    assert gcp_calls == []
+    assert len(
+        [record for record in caplog.records if record.levelno >= logging.CRITICAL]
+    ) == 1
+
+
+@pytest.mark.asyncio
+async def test_pending_kr_buy_keeps_submitted_position_pending_when_open_finalize_fails(
+    monkeypatch, tmp_path, caplog
+):
+    db_path = tmp_path / "open-finalize-failed-entry.sqlite"
+    agent, connection = _pending_entry_agent(db_path)
+    broker_calls, publish_states, redis_calls, gcp_calls = (
+        _install_pending_entry_runtime(
+            monkeypatch,
+            agent=agent,
+            db_path=db_path,
+        )
+    )
+
+    def fail_complete_entry(_store, **_identity):
+        raise sqlite3.OperationalError("injected OPEN finalize failure")
+
+    monkeypatch.setattr(PositionStore, "complete_entry", fail_complete_entry)
+    caplog.set_level(logging.CRITICAL)
+
+    try:
+        result = await StockTrackingAgent.process_reports(agent, ["report-a.pdf"])
+        state = _entry_state(db_path)
+    finally:
+        connection.close()
+
+    assert result == (0, 0)
+    assert state == (1, "SUBMITTED", "PENDING_ENTRY")
+    assert len(broker_calls) == 1
+    assert agent.message_queue == []
+    assert publish_states == []
+    assert redis_calls == []
+    assert gcp_calls == []
+    assert len(
+        [record for record in caplog.records if record.levelno >= logging.CRITICAL]
+    ) == 1
+
+
+@pytest.mark.asyncio
+async def test_pending_kr_buy_cancellation_is_unknown_and_propagates_without_publishing(
+    monkeypatch, tmp_path, caplog
+):
+    db_path = tmp_path / "cancelled-entry.sqlite"
+    agent, connection = _pending_entry_agent(db_path)
+    broker_calls, publish_states, redis_calls, gcp_calls = (
+        _install_pending_entry_runtime(
+            monkeypatch,
+            agent=agent,
+            db_path=db_path,
+            broker_error=asyncio.CancelledError(),
+        )
+    )
+    caplog.set_level(logging.CRITICAL)
+
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await StockTrackingAgent.process_reports(agent, ["report-a.pdf"])
+        state = _entry_state(db_path)
+    finally:
+        connection.close()
+
     assert state == (1, "UNKNOWN", "PENDING_ENTRY")
     assert len(broker_calls) == 1
     assert agent.message_queue == []

--- a/tests/test_kr_pending_entry.py
+++ b/tests/test_kr_pending_entry.py
@@ -1,0 +1,314 @@
+import logging
+import sqlite3
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+import trading.domestic_stock_trading as domestic_trading
+from prism_core.order_intents import IntentStore
+from prism_core.positions import PositionStore
+from stock_tracking_agent import StockTrackingAgent
+from tracking.db_schema import TABLE_STOCK_HOLDINGS
+
+
+def _entry_state(db_path: Path) -> tuple[int, str | None, str | None]:
+    with sqlite3.connect(db_path) as connection:
+        holding_count = connection.execute(
+            "SELECT COUNT(*) FROM stock_holdings WHERE ticker='005930'"
+        ).fetchone()[0]
+        intent = connection.execute(
+            "SELECT status FROM order_intents "
+            "WHERE market='KR' AND account_id='vps:kr-primary:01' "
+            "AND symbol='005930' AND side='BUY'"
+        ).fetchone()
+        position = connection.execute(
+            "SELECT status FROM positions "
+            "WHERE market='KR' AND account_id='vps:kr-primary:01' "
+            "AND symbol='005930'"
+        ).fetchone()
+    return (
+        holding_count,
+        intent[0] if intent else None,
+        position[0] if position else None,
+    )
+
+
+def _pending_entry_agent(db_path: Path):
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+    connection.execute(TABLE_STOCK_HOLDINGS)
+    PositionStore(connection).ensure_schema()
+    connection.commit()
+    IntentStore(db_path)
+
+    agent = StockTrackingAgent.__new__(StockTrackingAgent)
+    agent.db_path = str(db_path)
+    agent.conn = connection
+    agent.cursor = connection.cursor()
+    agent.account_configs = [
+        {"name": "kr-primary", "account_key": "vps:kr-primary:01"}
+    ]
+    agent.active_account = None
+    agent.max_slots = 10
+    agent.message_queue = []
+    agent._msg_types = []
+    agent.position_ledger_shadow_enabled = True
+    agent._position_pending_kr_ready = True
+    agent.trigger_info_map = {}
+    agent._get_trigger_win_rate = lambda _trigger: ""
+
+    async def analyze_report(_report_path):
+        return {
+            "success": True,
+            "ticker": "005930",
+            "company_name": "Samsung Electronics",
+            "current_price": 70000,
+            "scenario": {
+                "buy_score": 8,
+                "min_score": 7,
+                "sector": "Technology",
+                "target_price": 80000,
+                "stop_loss": 65000,
+            },
+            "decision": "Enter",
+            "sector": "Technology",
+            "rank_change_msg": "Up",
+        }
+
+    agent._analyze_report_core = analyze_report
+    agent.update_holdings = AsyncMock(return_value=[])
+    agent._is_ticker_in_holdings = AsyncMock(return_value=False)
+    agent._get_current_slots_count = AsyncMock(return_value=0)
+    agent._check_sector_diversity = AsyncMock(return_value=True)
+    agent._save_watchlist_item = AsyncMock(return_value=True)
+    return agent, connection
+
+
+def _install_pending_entry_runtime(
+    monkeypatch,
+    *,
+    agent,
+    db_path: Path,
+    broker_result: dict | None = None,
+    broker_error: BaseException | None = None,
+):
+    broker_calls = []
+    publish_states = []
+    redis_calls = []
+    gcp_calls = []
+
+    class BrokerContext:
+        def __init__(self, account_name=None, **_kwargs):
+            self.account_name = account_name
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def async_buy_stock(
+            self, stock_code, limit_price=None, buy_amount=None
+        ):
+            broker_calls.append(
+                {
+                    "stock_code": stock_code,
+                    "limit_price": limit_price,
+                    "buy_amount": buy_amount,
+                    "state": _entry_state(db_path),
+                    "message_count": len(agent.message_queue),
+                }
+            )
+            if broker_error is not None:
+                raise broker_error
+            return broker_result or {
+                "success": True,
+                "message": "submitted",
+                "order_no": "KR-ORDER-1",
+            }
+
+    redis_module = types.ModuleType("messaging.redis_signal_publisher")
+    gcp_module = types.ModuleType("messaging.gcp_pubsub_signal_publisher")
+
+    async def publish_redis(**kwargs):
+        redis_calls.append(kwargs)
+        publish_states.append((_entry_state(db_path), len(agent.message_queue)))
+
+    async def publish_gcp(**kwargs):
+        gcp_calls.append(kwargs)
+        publish_states.append((_entry_state(db_path), len(agent.message_queue)))
+
+    redis_module.publish_buy_signal = publish_redis
+    gcp_module.publish_buy_signal = publish_gcp
+    monkeypatch.setitem(sys.modules, "messaging.redis_signal_publisher", redis_module)
+    monkeypatch.setitem(
+        sys.modules, "messaging.gcp_pubsub_signal_publisher", gcp_module
+    )
+    monkeypatch.setattr(domestic_trading, "AsyncTradingContext", BrokerContext)
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+    monkeypatch.setenv("POSITION_LEDGER_SHADOW_ENABLED", "true")
+    return broker_calls, publish_states, redis_calls, gcp_calls
+
+
+@pytest.mark.asyncio
+async def test_pending_kr_buy_opens_position_before_publishing_submitted_order(
+    monkeypatch, tmp_path, caplog
+):
+    db_path = tmp_path / "pending-entry.sqlite"
+    agent, connection = _pending_entry_agent(db_path)
+    broker_calls, publish_states, redis_calls, gcp_calls = (
+        _install_pending_entry_runtime(
+            monkeypatch,
+            agent=agent,
+            db_path=db_path,
+        )
+    )
+    caplog.set_level(logging.CRITICAL)
+
+    try:
+        result = await StockTrackingAgent.process_reports(agent, ["report-a.pdf"])
+    finally:
+        connection.close()
+
+    assert result == (1, 0)
+    assert len(broker_calls) == 1
+    assert broker_calls[0]["state"] == (1, "SUBMITTING", "PENDING_ENTRY")
+    assert broker_calls[0]["message_count"] == 0
+    assert publish_states == [
+        ((1, "SUBMITTED", "OPEN"), 1),
+        ((1, "SUBMITTED", "OPEN"), 1),
+    ]
+    assert len(agent.message_queue) == 1
+    assert len(redis_calls) == 1
+    assert len(gcp_calls) == 1
+    assert not [record for record in caplog.records if record.levelno >= logging.CRITICAL]
+
+
+@pytest.mark.asyncio
+async def test_pending_kr_buy_marks_explicit_broker_failure_without_publishing(
+    monkeypatch, tmp_path, caplog
+):
+    db_path = tmp_path / "failed-entry.sqlite"
+    agent, connection = _pending_entry_agent(db_path)
+    broker_calls, publish_states, redis_calls, gcp_calls = (
+        _install_pending_entry_runtime(
+            monkeypatch,
+            agent=agent,
+            db_path=db_path,
+            broker_result={"success": False, "message": "order rejected"},
+        )
+    )
+    caplog.set_level(logging.CRITICAL)
+
+    try:
+        result = await StockTrackingAgent.process_reports(agent, ["report-a.pdf"])
+        state = _entry_state(db_path)
+    finally:
+        connection.close()
+
+    assert result == (0, 0)
+    assert state == (0, "FAILED", "ENTRY_FAILED")
+    assert len(broker_calls) == 1
+    assert agent.message_queue == []
+    assert publish_states == []
+    assert redis_calls == []
+    assert gcp_calls == []
+    assert len(
+        [record for record in caplog.records if record.levelno >= logging.CRITICAL]
+    ) == 1
+
+
+@pytest.mark.asyncio
+async def test_pending_kr_buy_keeps_unknown_outcome_for_manual_review(
+    monkeypatch, tmp_path, caplog
+):
+    db_path = tmp_path / "unknown-entry.sqlite"
+    agent, connection = _pending_entry_agent(db_path)
+    broker_calls, publish_states, redis_calls, gcp_calls = (
+        _install_pending_entry_runtime(
+            monkeypatch,
+            agent=agent,
+            db_path=db_path,
+            broker_error=TimeoutError("broker response timed out"),
+        )
+    )
+    caplog.set_level(logging.CRITICAL)
+
+    try:
+        result = await StockTrackingAgent.process_reports(agent, ["report-a.pdf"])
+        state = _entry_state(db_path)
+    finally:
+        connection.close()
+
+    assert result == (0, 0)
+    assert state == (1, "UNKNOWN", "PENDING_ENTRY")
+    assert len(broker_calls) == 1
+    assert agent.message_queue == []
+    assert publish_states == []
+    assert redis_calls == []
+    assert gcp_calls == []
+    assert len(
+        [record for record in caplog.records if record.levelno >= logging.CRITICAL]
+    ) == 1
+
+
+@pytest.mark.asyncio
+async def test_pending_kr_buy_rolls_back_when_position_prepare_fails(
+    monkeypatch, tmp_path, caplog
+):
+    db_path = tmp_path / "prepare-failed-entry.sqlite"
+    agent, connection = _pending_entry_agent(db_path)
+    broker_calls, publish_states, redis_calls, gcp_calls = (
+        _install_pending_entry_runtime(
+            monkeypatch,
+            agent=agent,
+            db_path=db_path,
+        )
+    )
+
+    def fail_prepare_entry(_store, **_kwargs):
+        raise RuntimeError("injected position prepare failure")
+
+    monkeypatch.setattr(PositionStore, "prepare_entry", fail_prepare_entry)
+    caplog.set_level(logging.CRITICAL)
+
+    try:
+        result = await StockTrackingAgent.process_reports(agent, ["report-a.pdf"])
+        state = _entry_state(db_path)
+    finally:
+        connection.close()
+
+    assert result == (0, 0)
+    assert state == (0, None, None)
+    assert broker_calls == []
+    assert agent.message_queue == []
+    assert publish_states == []
+    assert redis_calls == []
+    assert gcp_calls == []
+    assert len(
+        [record for record in caplog.records if record.levelno >= logging.CRITICAL]
+    ) == 1
+
+
+@pytest.mark.parametrize("readiness", [None, False])
+def test_pending_entry_requires_explicit_successful_ledger_readiness(
+    monkeypatch, tmp_path, readiness
+):
+    db_path = tmp_path / "readiness.sqlite"
+    connection = sqlite3.connect(db_path)
+    agent = StockTrackingAgent.__new__(StockTrackingAgent)
+    agent.db_path = str(db_path)
+    agent.conn = connection
+    agent.position_ledger_shadow_enabled = True
+    if readiness is not None:
+        agent._position_pending_kr_ready = readiness
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+
+    try:
+        with pytest.raises(RuntimeError, match="initialization is not ready"):
+            agent._require_pending_entry_ready()
+    finally:
+        connection.close()

--- a/tests/test_parallel_trading_batch.py
+++ b/tests/test_parallel_trading_batch.py
@@ -24,6 +24,7 @@ import sys
 import time
 import types
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -52,6 +53,8 @@ def _make_agent() -> EnhancedStockTrackingAgent:
     agent.trigger_info_map = {}
     agent._get_trigger_win_rate = MagicMock(return_value="")
     agent._save_watchlist_item = AsyncMock(return_value=True)
+    agent._dynamic_target_price = AsyncMock(return_value=81000)
+    agent._dynamic_stop_loss = AsyncMock(return_value=65000)
     return agent
 
 
@@ -322,6 +325,241 @@ async def test_enhanced_pending_gate_false_preserves_legacy_message_broker_publi
     assert (buy_count, sell_count) == (1, 0)
     assert events == ["legacy", "message", "broker", "redis", "gcp"]
     assert len(agent.message_queue) == 1
+
+
+@pytest.mark.asyncio
+async def test_enhanced_pending_gate_true_uses_shared_entry_lifecycle_before_publish(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+    agent = _make_agent()
+    agent.db_path = str(tmp_path / "enhanced-pending-entry.sqlite")
+    events: list[str] = []
+    prepare_calls: list[dict] = []
+    broker_states: list[tuple[int, str, str, int]] = []
+    publish_states: list[tuple[str, str, int]] = []
+    state = {"holding_count": 0, "intent": "NONE", "position": "NONE"}
+
+    async def core_stub(_path):
+        result = _core_ok("005930", "Samsung", decision="Enter")
+        result.update(is_add=True, existing_row_count=2)
+        return result
+
+    async def fake_extract_ticker_info(_path):
+        return "005930", "Samsung"
+
+    def prepare_pending_entry(**kwargs):
+        events.append("prepare")
+        prepare_calls.append(kwargs)
+        state.update(
+            holding_count=1,
+            intent="CREATED",
+            position="PENDING_ENTRY",
+        )
+        return SimpleNamespace(intent=SimpleNamespace(id="intent-enhanced-1"))
+
+    async def execute_pending_entry(_prepared, *, current_price):
+        events.append("execute")
+        state["intent"] = "SUBMITTING"
+        broker_states.append(
+            (
+                state["holding_count"],
+                state["intent"],
+                state["position"],
+                len(agent.message_queue),
+            )
+        )
+        state["intent"] = "SUBMITTED"
+        return {
+            "success": True,
+            "message": "submitted",
+            "intent_id": "intent-enhanced-1",
+            "intent_status": "SUBMITTED",
+        }
+
+    def complete_pending_entry(_prepared):
+        events.append("complete")
+        state["position"] = "OPEN"
+        agent._msg_types.append("analysis")
+        agent.message_queue.append("enhanced pending buy message")
+
+    async def record_publish(**_kwargs):
+        events.append("publish")
+        publish_states.append(
+            (state["intent"], state["position"], len(agent.message_queue))
+        )
+
+    redis_mod = types.ModuleType("messaging.redis_signal_publisher")
+    redis_mod.publish_buy_signal = record_publish
+    gcp_mod = types.ModuleType("messaging.gcp_pubsub_signal_publisher")
+    gcp_mod.publish_buy_signal = record_publish
+    monkeypatch.setitem(sys.modules, "messaging.redis_signal_publisher", redis_mod)
+    monkeypatch.setitem(sys.modules, "messaging.gcp_pubsub_signal_publisher", gcp_mod)
+
+    agent._analyze_report_core = core_stub
+    agent._extract_ticker_info = fake_extract_ticker_info
+    agent._is_ticker_in_holdings = AsyncMock(return_value=False)
+    agent._check_sector_diversity = AsyncMock(return_value=True)
+    agent._prepare_pending_kr_entry = prepare_pending_entry
+    agent._execute_pending_kr_entry = execute_pending_entry
+    agent._complete_pending_kr_entry = complete_pending_entry
+    agent._buy_stock_with_position = AsyncMock(
+        side_effect=AssertionError("pending enhanced BUY used the legacy write path")
+    )
+
+    buy_count, sell_count = await agent.process_reports(
+        ["reports/005930_Samsung_20260101_morning.pdf"]
+    )
+
+    assert (buy_count, sell_count) == (1, 0)
+    assert [event for event in events if event != "publish"] == [
+        "prepare",
+        "execute",
+        "complete",
+    ]
+    assert len(prepare_calls) == 1
+    assert prepare_calls[0]["source"] == "kr_enhanced_batch"
+    assert prepare_calls[0]["is_add"] is True
+    assert prepare_calls[0]["expected_open_count"] == 2
+    assert prepare_calls[0]["scenario"]["target_price"] == 81000
+    assert prepare_calls[0]["scenario"]["stop_loss"] == 65000
+    agent._dynamic_target_price.assert_awaited_once_with("005930", 70000)
+    agent._dynamic_stop_loss.assert_awaited_once_with("005930", 70000)
+    assert broker_states == [(1, "SUBMITTING", "PENDING_ENTRY", 0)]
+    assert publish_states == [
+        ("SUBMITTED", "OPEN", 1),
+        ("SUBMITTED", "OPEN", 1),
+    ]
+    assert agent._buy_stock_with_position.await_count == 0
+    assert len(agent.message_queue) == 1
+    assert events.count("execute") == 1
+    assert events.count("publish") == 2
+
+
+@pytest.mark.asyncio
+async def test_enhanced_pending_gate_true_failed_entry_uses_shared_compensation_only(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+    agent = _make_agent()
+    agent.db_path = str(tmp_path / "enhanced-pending-entry-failed.sqlite")
+    prepared = SimpleNamespace(intent=SimpleNamespace(id="intent-enhanced-failed"))
+    prepare_calls: list[dict] = []
+    execute_calls: list[tuple[object, float]] = []
+
+    async def core_stub(_path):
+        return _core_ok("005930", "Samsung", decision="Enter")
+
+    async def fake_extract_ticker_info(_path):
+        return "005930", "Samsung"
+
+    def prepare_pending_entry(**kwargs):
+        prepare_calls.append(kwargs)
+        return prepared
+
+    async def execute_pending_entry(actual_prepared, *, current_price):
+        execute_calls.append((actual_prepared, current_price))
+        return {
+            "success": False,
+            "message": "broker rejected order",
+            "intent_id": "intent-enhanced-failed",
+            "intent_status": "FAILED",
+        }
+
+    redis_mod = types.ModuleType("messaging.redis_signal_publisher")
+    redis_mod.publish_buy_signal = AsyncMock(return_value=None)
+    gcp_mod = types.ModuleType("messaging.gcp_pubsub_signal_publisher")
+    gcp_mod.publish_buy_signal = AsyncMock(return_value=None)
+    monkeypatch.setitem(sys.modules, "messaging.redis_signal_publisher", redis_mod)
+    monkeypatch.setitem(sys.modules, "messaging.gcp_pubsub_signal_publisher", gcp_mod)
+
+    agent._analyze_report_core = core_stub
+    agent._extract_ticker_info = fake_extract_ticker_info
+    agent._is_ticker_in_holdings = AsyncMock(return_value=False)
+    agent._check_sector_diversity = AsyncMock(return_value=True)
+    agent._prepare_pending_kr_entry = prepare_pending_entry
+    agent._execute_pending_kr_entry = execute_pending_entry
+    agent._fail_pending_kr_entry = MagicMock()
+    agent._complete_pending_kr_entry = MagicMock()
+    agent._buy_stock_with_position = AsyncMock(
+        side_effect=AssertionError("pending enhanced BUY used the legacy write path")
+    )
+
+    buy_count, sell_count = await agent.process_reports(
+        ["reports/005930_Samsung_20260101_morning.pdf"]
+    )
+
+    assert (buy_count, sell_count) == (0, 0)
+    assert len(prepare_calls) == 1
+    assert prepare_calls[0]["source"] == "kr_enhanced_batch"
+    assert execute_calls == [(prepared, 70000)]
+    agent._fail_pending_kr_entry.assert_called_once_with(prepared)
+    agent._complete_pending_kr_entry.assert_not_called()
+    assert agent._buy_stock_with_position.await_count == 0
+    assert agent.message_queue == []
+    assert agent._msg_types == []
+    assert redis_mod.publish_buy_signal.await_count == 0
+    assert gcp_mod.publish_buy_signal.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_enhanced_pending_gate_true_unknown_entry_preserves_pending_without_effects(
+    monkeypatch, tmp_path, caplog
+):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+    agent = _make_agent()
+    agent.db_path = str(tmp_path / "enhanced-pending-entry-unknown.sqlite")
+    prepared = SimpleNamespace(intent=SimpleNamespace(id="intent-enhanced-unknown"))
+
+    async def core_stub(_path):
+        return _core_ok("005930", "Samsung", decision="Enter")
+
+    async def fake_extract_ticker_info(_path):
+        return "005930", "Samsung"
+
+    async def execute_pending_entry(actual_prepared, *, current_price):
+        assert actual_prepared is prepared
+        assert current_price == 70000
+        return {
+            "success": False,
+            "message": "broker result unavailable",
+            "intent_id": "intent-enhanced-unknown",
+            "intent_status": "UNKNOWN",
+        }
+
+    redis_mod = types.ModuleType("messaging.redis_signal_publisher")
+    redis_mod.publish_buy_signal = AsyncMock(return_value=None)
+    gcp_mod = types.ModuleType("messaging.gcp_pubsub_signal_publisher")
+    gcp_mod.publish_buy_signal = AsyncMock(return_value=None)
+    monkeypatch.setitem(sys.modules, "messaging.redis_signal_publisher", redis_mod)
+    monkeypatch.setitem(sys.modules, "messaging.gcp_pubsub_signal_publisher", gcp_mod)
+
+    agent._analyze_report_core = core_stub
+    agent._extract_ticker_info = fake_extract_ticker_info
+    agent._is_ticker_in_holdings = AsyncMock(return_value=False)
+    agent._check_sector_diversity = AsyncMock(return_value=True)
+    agent._prepare_pending_kr_entry = MagicMock(return_value=prepared)
+    agent._execute_pending_kr_entry = execute_pending_entry
+    agent._fail_pending_kr_entry = MagicMock()
+    agent._complete_pending_kr_entry = MagicMock()
+    agent._buy_stock_with_position = AsyncMock(
+        side_effect=AssertionError("pending enhanced BUY used the legacy write path")
+    )
+
+    with caplog.at_level("CRITICAL"):
+        buy_count, sell_count = await agent.process_reports(
+            ["reports/005930_Samsung_20260101_morning.pdf"]
+        )
+
+    assert (buy_count, sell_count) == (0, 0)
+    agent._fail_pending_kr_entry.assert_not_called()
+    agent._complete_pending_kr_entry.assert_not_called()
+    assert agent._buy_stock_with_position.await_count == 0
+    assert agent.message_queue == []
+    assert agent._msg_types == []
+    assert redis_mod.publish_buy_signal.await_count == 0
+    assert gcp_mod.publish_buy_signal.await_count == 0
+    assert "status=UNKNOWN action=manual_review" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_parallel_trading_batch.py
+++ b/tests/test_parallel_trading_batch.py
@@ -256,6 +256,74 @@ async def test_gates_run_sequentially_after_parallel_phase(monkeypatch, tmp_path
     assert buy_count == 1
 
 
+@pytest.mark.asyncio
+async def test_enhanced_pending_gate_false_preserves_legacy_message_broker_publish_order(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "false")
+    agent = _make_agent()
+    agent.db_path = str(tmp_path / "enhanced-legacy-order.sqlite")
+    events: list[str] = []
+
+    async def core_stub(_path):
+        return _core_ok("005930", "Samsung", decision="Enter")
+
+    async def fake_extract_ticker_info(_path):
+        return "005930", "Samsung"
+
+    async def fake_buy_stock_with_position(*_args, **_kwargs):
+        events.append("legacy")
+        agent.message_queue.append("legacy buy message")
+        agent._msg_types.append("analysis")
+        events.append("message")
+        return LegacyPositionWriteResult(True, 1)
+
+    class OrderedTradingContext:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def async_buy_stock(self, stock_code, limit_price=None, buy_amount=None):
+            events.append("broker")
+            return {"success": True, "message": "ok"}
+
+    async def redis_publish(**_kwargs):
+        events.append("redis")
+
+    async def gcp_publish(**_kwargs):
+        events.append("gcp")
+
+    redis_mod = types.ModuleType("messaging.redis_signal_publisher")
+    redis_mod.publish_buy_signal = redis_publish
+    gcp_mod = types.ModuleType("messaging.gcp_pubsub_signal_publisher")
+    gcp_mod.publish_buy_signal = gcp_publish
+    monkeypatch.setitem(sys.modules, "messaging.redis_signal_publisher", redis_mod)
+    monkeypatch.setitem(sys.modules, "messaging.gcp_pubsub_signal_publisher", gcp_mod)
+
+    import trading.domestic_stock_trading as domestic_trading
+
+    monkeypatch.setattr(domestic_trading, "AsyncTradingContext", OrderedTradingContext)
+    agent._analyze_report_core = core_stub
+    agent._extract_ticker_info = fake_extract_ticker_info
+    agent._is_ticker_in_holdings = AsyncMock(return_value=False)
+    agent._check_sector_diversity = AsyncMock(return_value=True)
+    agent._buy_stock_with_position = fake_buy_stock_with_position
+    agent._link_position_entry_intent = MagicMock(return_value=True)
+
+    buy_count, sell_count = await agent.process_reports(
+        ["reports/005930_Samsung_20260101_morning.pdf"]
+    )
+
+    assert (buy_count, sell_count) == (1, 0)
+    assert events == ["legacy", "message", "broker", "redis", "gcp"]
+    assert len(agent.message_queue) == 1
+
+
 # ---------------------------------------------------------------------------
 # 3. One core failure does not kill the batch
 # ---------------------------------------------------------------------------

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -322,7 +322,6 @@ def test_entry_attempt_guard_blocks_unresolved_same_account_symbol(status) -> No
 @pytest.mark.parametrize(
     ("status", "existing_account", "existing_symbol"),
     (
-        ("OPEN", "acct", "005930"),
         ("CLOSED", "acct", "005930"),
         ("PENDING_ENTRY", "other-acct", "005930"),
         ("PENDING_ENTRY", "acct", "000660"),
@@ -348,6 +347,71 @@ def test_entry_attempt_guard_allows_resolved_or_different_identity(
     assert store.assert_entry_attempt_allowed(
         market="KR", account_id="acct", symbol="005930"
     )
+
+    conn.rollback()
+
+
+def test_entry_attempt_guard_blocks_open_unless_add_count_matches() -> None:
+    conn = sqlite3.connect(":memory:")
+    store = PositionStore(conn)
+    store.ensure_schema()
+    store.open_legacy_position(
+        market="KR",
+        legacy_holding_id=1,
+        account_id="acct",
+        account_name="primary",
+        symbol="005930",
+    )
+    conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+
+    with pytest.raises(InvalidPositionTransition, match="existing OPEN"):
+        store.assert_entry_attempt_allowed(
+            market="KR", account_id="acct", symbol="005930"
+        )
+
+    assert store.assert_entry_attempt_allowed(
+        market="KR",
+        account_id="acct",
+        symbol="005930",
+        allow_existing_open=True,
+        expected_open_count=1,
+    )
+    with pytest.raises(InvalidPositionTransition, match="changed OPEN.*expected 0"):
+        store.assert_entry_attempt_allowed(
+            market="KR",
+            account_id="acct",
+            symbol="005930",
+            allow_existing_open=True,
+            expected_open_count=0,
+        )
+
+    conn.rollback()
+
+
+def test_entry_attempt_guard_never_allows_unresolved_add() -> None:
+    conn = sqlite3.connect(":memory:")
+    store = PositionStore(conn)
+    store.ensure_schema()
+    store.open_legacy_position(
+        market="KR",
+        legacy_holding_id=1,
+        account_id="acct",
+        account_name="primary",
+        symbol="005930",
+    )
+    conn.execute("UPDATE positions SET status='PENDING_ENTRY'")
+    conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+
+    with pytest.raises(InvalidPositionTransition, match="PENDING_ENTRY"):
+        store.assert_entry_attempt_allowed(
+            market="KR",
+            account_id="acct",
+            symbol="005930",
+            allow_existing_open=True,
+            expected_open_count=0,
+        )
 
     conn.rollback()
 

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -292,6 +292,78 @@ def test_prepare_complete_and_fail_entry_require_persisted_matching_intent(
     ).fetchone() == ("ENTRY_FAILED",)
 
 
+@pytest.mark.parametrize(
+    "status",
+    ("PENDING_ENTRY", "ENTRY_FAILED", "PENDING_EXIT", "EXIT_UNKNOWN"),
+)
+def test_entry_attempt_guard_blocks_unresolved_same_account_symbol(status) -> None:
+    conn = sqlite3.connect(":memory:")
+    store = PositionStore(conn)
+    store.ensure_schema()
+    store.open_legacy_position(
+        market="KR",
+        legacy_holding_id=1,
+        account_id="acct",
+        account_name="primary",
+        symbol="005930",
+    )
+    conn.execute("UPDATE positions SET status=? WHERE id='legacy:KR:1'", (status,))
+    conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+
+    with pytest.raises(InvalidPositionTransition, match="entry attempt"):
+        store.assert_entry_attempt_allowed(
+            market="KR", account_id="acct", symbol="005930"
+        )
+
+    conn.rollback()
+
+
+@pytest.mark.parametrize(
+    ("status", "existing_account", "existing_symbol"),
+    (
+        ("OPEN", "acct", "005930"),
+        ("CLOSED", "acct", "005930"),
+        ("PENDING_ENTRY", "other-acct", "005930"),
+        ("PENDING_ENTRY", "acct", "000660"),
+    ),
+)
+def test_entry_attempt_guard_allows_resolved_or_different_identity(
+    status, existing_account, existing_symbol
+) -> None:
+    conn = sqlite3.connect(":memory:")
+    store = PositionStore(conn)
+    store.ensure_schema()
+    store.open_legacy_position(
+        market="KR",
+        legacy_holding_id=1,
+        account_id=existing_account,
+        account_name="primary",
+        symbol=existing_symbol,
+    )
+    conn.execute("UPDATE positions SET status=? WHERE id='legacy:KR:1'", (status,))
+    conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+
+    assert store.assert_entry_attempt_allowed(
+        market="KR", account_id="acct", symbol="005930"
+    )
+
+    conn.rollback()
+
+
+def test_entry_attempt_guard_requires_caller_owned_transaction() -> None:
+    conn = sqlite3.connect(":memory:")
+    store = PositionStore(conn)
+    store.ensure_schema()
+    conn.commit()
+
+    with pytest.raises(RuntimeError, match="active caller-owned transaction"):
+        store.assert_entry_attempt_allowed(
+            market="KR", account_id="acct", symbol="005930"
+        )
+
+
 def test_exit_many_lifecycle_is_atomic_idempotent_and_blocks_overwrite(tmp_path) -> None:
     from dataclasses import replace
 

--- a/tests/test_stock_tracking_agent_process_reports.py
+++ b/tests/test_stock_tracking_agent_process_reports.py
@@ -6,6 +6,7 @@ import threading
 import types
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -417,6 +418,79 @@ async def test_process_reports_analyzes_once_and_dedupes_signals(monkeypatch, ca
     assert len(redis_calls) == 1
     assert len(gcp_calls) == 1
     assert "partial success" in caplog.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_kr_pending_gate_false_preserves_legacy_message_broker_publish_order(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "false")
+    agent = StockTrackingAgent.__new__(StockTrackingAgent)
+    agent.db_path = str(tmp_path / "legacy-order.sqlite")
+    agent.account_configs = [
+        {"name": "kr-primary", "account_key": "vps:kr-primary:01"},
+    ]
+    agent.active_account = None
+    agent.max_slots = 10
+    agent.message_queue = []
+    agent._msg_types = []
+    events = []
+
+    async def fake_core(_report_path):
+        return {
+            "success": True,
+            "ticker": "005930",
+            "company_name": "Samsung Electronics",
+            "current_price": 70000,
+            "scenario": {"buy_score": 8, "min_score": 7, "sector": "Technology"},
+            "decision": "Enter",
+            "sector": "Technology",
+            "rank_change_msg": "Up",
+            "rank_change_percentage": 12.0,
+        }
+
+    async def fake_buy_stock(*_args, **_kwargs):
+        events.append("legacy")
+        agent.message_queue.append("legacy buy message")
+        agent._msg_types.append("analysis")
+        events.append("message")
+        return LegacyPositionWriteResult(True, 1)
+
+    class OrderedTradingContext(_FakeAsyncTradingContext):
+        async def async_buy_stock(self, stock_code, limit_price=None, buy_amount=None):
+            events.append("broker")
+            return await super().async_buy_stock(
+                stock_code, limit_price=limit_price, buy_amount=buy_amount
+            )
+
+    class OrderedCalls(list):
+        def __init__(self, event):
+            super().__init__()
+            self.event = event
+
+        def append(self, value):
+            events.append(self.event)
+            super().append(value)
+
+    agent._analyze_report_core = fake_core
+    agent.update_holdings = AsyncMock(return_value=[])
+    agent._is_ticker_in_holdings = AsyncMock(return_value=False)
+    agent._get_current_slots_count = AsyncMock(return_value=0)
+    agent._check_sector_diversity = AsyncMock(return_value=True)
+    agent._buy_stock_with_position = fake_buy_stock
+    agent._link_position_entry_intent = MagicMock(return_value=True)
+    monkeypatch.setattr(domestic_trading, "AsyncTradingContext", OrderedTradingContext)
+    redis_calls = OrderedCalls("redis")
+    gcp_calls = OrderedCalls("gcp")
+    _install_signal_modules(monkeypatch, redis_calls, gcp_calls)
+
+    result = await StockTrackingAgent.process_reports(agent, ["report-a.pdf"])
+
+    assert result == (1, 0)
+    assert events == ["legacy", "message", "broker", "redis", "gcp"]
+    assert len(agent.message_queue) == 1
+    assert len(redis_calls) == 1
+    assert len(gcp_calls) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add gate-off KR pending-entry regression boundaries
- route standard and enhanced KR entries through persisted intent/PENDING_ENTRY lifecycle
- preserve UNKNOWN/FAILED/cancellation states without duplicate side effects
- atomically block stale standard entries and stale enhanced pyramid adds

## Safety
- `POSITION_PENDING_KR_ENABLED` remains default OFF
- gate=false standard/enhanced behavior and side-effect order are regression-tested
- unresolved or stale attempts fail closed before broker execution

## Verification
- 137 related tests passed
- independent verifier APPROVE, blockers 0
- Ruff, py_compile, git diff --check passed

Refs #412