### PR TITLE
refactor: wire KR pending exit lifecycle (#412)

### DIFF
--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -3,7 +3,7 @@
 > **단일 진실원(intended state).** 릴리즈가 늘어도 "무엇이 실거래에 적용 중인지" 한눈에 보기 위한 문서.
 > 실제 런타임 상태(서버 .env·crontab 기준)는 `tools/feature_status.py`로 대조 — 이 문서와 어긋나면 그 도구가 진실.
 > 관리 주체 = 코딩 에이전트(cokac-bot). 매 릴리즈/승격 시 갱신.
-> 최종 갱신: 2026-07-12.
+> 최종 갱신: 2026-07-19.
 
 ## 상태 정의
 - **LIVE** = 실거래/실발행에 실제 영향. **SHADOW** = 코드 동작하나 로그/관측만(영향 0). **OFF** = 미실행(코드만 존재). **N/A** = 미구현.
@@ -31,6 +31,7 @@
 | Loop A — 고빈도 하드스톱(−7%/시나리오손절) | **LIVE** | `.env HARDSTOP_LIVE=true` (구 `LOOP_A_LIVE`, alias 유효) + cron 10분 | SHADOW 관측 후 승격(06-20) | KR 9–15 / US 9–16. 킬: `HARDSTOP_ENABLED=false` |
 | Loop B — 50MA 종가확인 추세이탈 | **LIVE** | `.env TREND_EXIT_LIVE=true` (구 `LOOP_B_LIVE`) + cron(KR 9–15 / US 9–16) | 백테스트 KR/US 순효과(휩쏘0·추가DD0) + 사용자 승인(06-24) | 코드: `tools/trend_exit_seller.py` (구 `tools/loop_b_trend_exit.py` shim 유효). 킬: `TREND_EXIT_ENABLED=false` |
 | Loop C — 미체결 추격 + KIS TR 래퍼 | **SHADOW** | cron(KR/US */2분, `FILL_CHASER_LIVE` 미설정; 구 `LOOP_C_LIVE` alias) | **신규 KIS 정정/취소 TR 실 KIS 수락 검증**(dry-run/`--selftest`로 페이로드 필드는 검증됨) | 코드: `tools/fill_chaser.py` (구 `tools/loop_c_fill_chaser.py` shim 유효). 매수=체결우선 cross(예산 `FILL_CHASER_BUY_MAX_PREMIUM_PCT`=3%, `FILL_CHASER_BUY_CROSS`=on). 상세로깅 `[LOOP_C][SHADOW]` |
+| KR 주문 선기록(PENDING ENTRY/EXIT) | **OFF** | `.env` 또는 cron inline `POSITION_PENDING_KR_ENABLED=true` (기본 off) | 피라미딩 fill reconciliation + post-CLOSED 외부효과 복구 검증/사용자 승인 | gate OFF 배포만 허용. gate=true에서 피라미딩은 주문 전 차단. 활성화 전 `failed_exit_linked_open_positions`, PENDING/EXIT_UNKNOWN 0 확인 필수 |
 | 재진입 쿨다운 게이트(매수측) | **SHADOW** | `REENTRY_COOLDOWN_LIVE` 미설정 | SHADOW 며칠 관측(`[REENTRY_COOLDOWN][SHADOW] WOULD_BLOCK` ↔ 실매수 대조) → LIVE 승격 | 코드: `reentry_cooldown.py` (KR/US 매수 caller 훅). 손실매도 후 24h 재매수 차단(승리후 0h). prod 이력검증=리벤지 3건 차단·오탐0 |
 | 비전 배관(S1) / 렌더QA(S2) | **ON(log-only)** | `PRISM_FEATURE_VISION=on` | 무손상 인프라 | 렌더QA 비차단 경고만 |
 | 비전 매수 품질검사(S3 + S3.5 오닐 일/주봉·RS) | **SHADOW** | `PRISM_FEATURE_VISION=on` + `PRISM_VISION_SHADOW=true` | **A/B 홀드아웃 측정(승률·손절률·MDD 순효과)** → 미정 | 관측 로그 `[BUY_QUALITY][SHADOW]`. 매매영향 0 |
@@ -55,6 +56,7 @@ SHADOW→LIVE **자동 승격**은 아래를 **모두** 충족할 때만:
 - **비전 매수게이트(S3)**: A/B 측정 설계 확정·데이터 축적 후 — **수익영향이라 사용자 확인 후**.
 
 ## 변경 이력
+- 2026-07-19: **KR PENDING EXIT 배선 추가, gate OFF 유지** — batch/hardstop/trend에 broker-first lifecycle을 연결하고 `feature_status.py`에 `.env`와 모든 active cron inline gate 상태를 노출. 피라미딩 accepted-but-unfilled 재시작 방어 및 post-CLOSED 외부효과 복구 절차를 포함한 운영 reconciliation 완료 전 활성화 금지.
 - 2026-06-23: 레지스트리 신설. 현황 기록(Loop A LIVE / B·C SHADOW미스케줄 / 비전 SHADOW관측).
 - 2026-06-24: S6 발행 게이트 갱신 — 배선 구현 완료 반영. 게이트 `PRISM_FEATURE_INSIGHT_IMAGE=on` + `vision_available()`(이전 "발행 배선 미구현" 기재 정정). `feature_status.py`도 동일 로직으로 LIVE/OFF 보고.
 - 2026-06-24: **승격·활성화 반영** — Loop B → **LIVE**(`LOOP_B_LIVE=true`+cron, 백테스트 KR/US 통과+승인). Loop C → **SHADOW**(cron 설치, `LOOP_C_LIVE` 미설정; 상세로깅+selftest 추가). S6 발행 → **LIVE**(`PRISM_FEATURE_INSIGHT_IMAGE=on`, 사용자 승인; 매매마커·용어설명 포함).

--- a/prism_core/execution_service.py
+++ b/prism_core/execution_service.py
@@ -20,6 +20,22 @@ from prism_core.order_intents import IntentStore, OrderIntent
 logger = logging.getLogger(__name__)
 
 
+def normalize_checked_holding(result: Any) -> tuple[str, int | None]:
+    """Return only authoritative HELD/FLAT results; collapse malformed data."""
+
+    if not isinstance(result, tuple) or len(result) != 2:
+        return "UNKNOWN", None
+    state = str(result[0] or "UNKNOWN").upper()
+    quantity = result[1]
+    if state == "HELD" and type(quantity) is int and quantity > 0:
+        return "HELD", quantity
+    if state == "FLAT" and type(quantity) is int and quantity == 0:
+        return "FLAT", 0
+    if state == "UNKNOWN" and quantity is None:
+        return "UNKNOWN", None
+    return "UNKNOWN", None
+
+
 class OrderOutcomeUnknown(RuntimeError):
     """The broker may have accepted the order, so callers must not mark rejection."""
 
@@ -33,6 +49,14 @@ class OrderOutcomeUnknown(RuntimeError):
         super().__init__(f"order outcome unknown for intent {intent_id}")
         self.intent_id = intent_id
         self.broker_result = broker_result
+        self.cause = cause
+
+
+class _LocalFlatPersistenceError(RuntimeError):
+    """Keep capability validation errors distinct from ledger write failures."""
+
+    def __init__(self, cause: BaseException):
+        super().__init__(str(cause))
         self.cause = cause
 
 
@@ -315,6 +339,22 @@ class ExecutionService:
         side: str,
         **kwargs,
     ):
+        await self._claim_pre_reserved(
+            intent=intent,
+            reservation=reservation,
+            side=side,
+        )
+        return await self._execute_submitting_order(
+            method, *args, intent=intent, **kwargs
+        )
+
+    async def _claim_pre_reserved(
+        self,
+        *,
+        intent: OrderIntent,
+        reservation: Any,
+        side: str,
+    ) -> None:
         if self._intent_store is None:
             raise RuntimeError(
                 "pre-reserved execution requires the originating IntentStore"
@@ -358,9 +398,6 @@ class ExecutionService:
                         type(persistence_error).__name__,
                     )
             raise
-        return await self._execute_submitting_order(
-            method, *args, intent=intent, **kwargs
-        )
 
     def _execute_order_sync(
         self,
@@ -527,6 +564,88 @@ class ExecutionService:
             reservation=reservation,
             side="SELL",
             **kwargs,
+        )
+
+    async def execute_pre_reserved_local_flat_sell(
+        self,
+        *,
+        intent: OrderIntent,
+        reservation: Any,
+    ) -> dict[str, Any]:
+        """Audit a committed SELL intent when broker holdings are already flat."""
+
+        if self._intent_store is None:
+            raise RuntimeError(
+                "pre-reserved execution requires the originating IntentStore"
+            )
+        result = {
+            "success": True,
+            "local_flat": True,
+            "quantity": 0,
+        }
+        broker = "LOCAL_RECONCILIATION"
+        intent_store = self._intent_store
+
+        def reconcile_local_flat() -> None:
+            intent_store.claim_reservation(
+                reservation,
+                intent,
+                expected_side="SELL",
+            )
+            try:
+                intent_store.record_result(
+                    intent,
+                    status="SUBMITTED",
+                    accepted=True,
+                    broker=broker,
+                    response=result,
+                )
+            except Exception as exc:
+                raise _LocalFlatPersistenceError(exc) from exc
+
+        reconciliation_task = asyncio.create_task(
+            asyncio.to_thread(reconcile_local_flat)
+        )
+        try:
+            await asyncio.shield(reconciliation_task)
+        except asyncio.CancelledError as cancellation:
+            while not reconciliation_task.done():
+                try:
+                    await asyncio.shield(reconciliation_task)
+                except asyncio.CancelledError:
+                    continue
+                except Exception as reconciliation_error:
+                    logger.critical(
+                        "[ORDER_INTENT] cancelled local-flat reconciliation failed "
+                        "id=%s error=%s",
+                        intent.id,
+                        type(reconciliation_error).__name__,
+                    )
+                    break
+            raise cancellation
+        except _LocalFlatPersistenceError as exc:
+            logger.critical(
+                "[ORDER_INTENT] local-flat persistence failed id=%s",
+                intent.id,
+            )
+            raise OrderOutcomeUnknown(
+                intent.id,
+                broker_result=result,
+                cause=exc.cause,
+            ) from exc
+        logger.info(
+            "[ORDER_INTENT] SUBMITTED id=%s market=%s side=%s symbol=%s broker=%s",
+            intent.id,
+            intent.market,
+            intent.side,
+            intent.symbol,
+            broker,
+        )
+        return self._with_intent_metadata(
+            result,
+            intent=intent,
+            status="SUBMITTED",
+            broker=broker,
         )
 
     async def amend_or_cancel(self, action: str, *args, **kwargs):

--- a/prism_core/positions.py
+++ b/prism_core/positions.py
@@ -1364,15 +1364,20 @@ class PositionStore:
                 str(row[1])
                 for row in self._execute("PRAGMA table_info(order_intents)").fetchall()
             }
-            status_expression = (
-                "status" if "status" in intent_columns else "NULL AS status"
-            )
-            intent_rows = self._fetchall(
-                "SELECT id, account_id, symbol, side, source_position_id, "
-                f"{status_expression} "
-                "FROM order_intents WHERE market=? AND source_position_id IS NOT NULL",
-                (market,),
-            )
+            if "status" in intent_columns:
+                intent_rows = self._fetchall(
+                    "SELECT id, account_id, symbol, side, source_position_id, status "
+                    "FROM order_intents "
+                    "WHERE market=? AND source_position_id IS NOT NULL",
+                    (market,),
+                )
+            else:
+                intent_rows = self._fetchall(
+                    "SELECT id, account_id, symbol, side, source_position_id, "
+                    "NULL AS status FROM order_intents "
+                    "WHERE market=? AND source_position_id IS NOT NULL",
+                    (market,),
+                )
             intents_by_id = {str(row["id"]): row for row in intent_rows}
             for position in position_rows:
                 exit_intent_id = position["exit_intent_id"]

--- a/prism_core/positions.py
+++ b/prism_core/positions.py
@@ -310,6 +310,39 @@ class PositionStore:
                 )
         return True
 
+    def assert_exit_attempt_allowed(
+        self,
+        *,
+        market: str,
+        account_id: Any,
+        symbol: Any,
+    ) -> bool:
+        """Reject exits while the same position identity has unresolved state."""
+
+        self._require_active_transaction()
+        market = _market(str(market).strip())
+        account_id = str(account_id or "").strip()
+        symbol = str(symbol or "").strip().upper()
+        if not account_id or not symbol:
+            raise ValueError("account_id and symbol are required")
+        row = self._execute(
+            "SELECT status, exit_intent_id FROM positions "
+            "WHERE market=? AND account_id=? AND symbol=? "
+            "AND (status IN ('PENDING_ENTRY', 'ENTRY_FAILED', "
+            "'PENDING_EXIT', 'EXIT_UNKNOWN') "
+            "OR (status='OPEN' AND exit_intent_id IS NOT NULL)) LIMIT 1",
+            (market, account_id, symbol),
+        ).fetchone()
+        if row is not None:
+            status, exit_intent_id = row
+            detail = status
+            if status == "OPEN" and exit_intent_id:
+                detail = f"OPEN position linked to exit intent {exit_intent_id}"
+            raise InvalidPositionTransition(
+                f"exit attempt blocked by unresolved position state: {detail}"
+            )
+        return True
+
     @staticmethod
     def _source_position_ids(value: Any) -> tuple[str, ...]:
         if value is None:
@@ -1321,16 +1354,51 @@ class PositionStore:
             (market,),
         )
         intent_link_mismatches: list[dict[str, Any]] = []
+        failed_exit_linked_open_positions: list[dict[str, Any]] = []
         has_intent_table = self._execute(
             "SELECT 1 FROM sqlite_master WHERE type='table' "
             "AND name='order_intents'"
         ).fetchone()
         if has_intent_table:
+            intent_columns = {
+                str(row[1])
+                for row in self._execute("PRAGMA table_info(order_intents)").fetchall()
+            }
+            status_expression = (
+                "status" if "status" in intent_columns else "NULL AS status"
+            )
             intent_rows = self._fetchall(
-                "SELECT id, account_id, symbol, side, source_position_id "
+                "SELECT id, account_id, symbol, side, source_position_id, "
+                f"{status_expression} "
                 "FROM order_intents WHERE market=? AND source_position_id IS NOT NULL",
                 (market,),
             )
+            intents_by_id = {str(row["id"]): row for row in intent_rows}
+            for position in position_rows:
+                exit_intent_id = position["exit_intent_id"]
+                intent = (
+                    intents_by_id.get(str(exit_intent_id))
+                    if exit_intent_id is not None
+                    else None
+                )
+                if (
+                    str(position["status"]) == "OPEN"
+                    and intent is not None
+                    and str(intent["side"]).upper() == "SELL"
+                    and str(intent["status"]).upper() == "FAILED"
+                ):
+                    failed_exit_linked_open_positions.append(
+                        {
+                            "position_id": str(position["id"]),
+                            "legacy_holding_id": str(position["legacy_holding_id"]),
+                            "account_ref": account_fingerprint(
+                                position["account_id"]
+                            ),
+                            "symbol": str(position["symbol"]).upper(),
+                            "intent_id": str(exit_intent_id),
+                            "intent_status": "FAILED",
+                        }
+                    )
             canonical_prefix = f"legacy:{market}:"
             for intent in intent_rows:
                 source_ids = tuple(
@@ -1388,6 +1456,7 @@ class PositionStore:
             pending_positions,
             stale_pending_positions,
             exit_unknown_positions,
+            failed_exit_linked_open_positions,
         )
         return {
             "market": market,
@@ -1401,6 +1470,9 @@ class PositionStore:
                 "pending_positions": len(pending_positions),
                 "stale_pending_positions": len(stale_pending_positions),
                 "exit_unknown_positions": len(exit_unknown_positions),
+                "failed_exit_linked_open_positions": len(
+                    failed_exit_linked_open_positions
+                ),
             },
             "missing_positions": missing_positions,
             "extra_open_positions": extra_open_positions,
@@ -1413,6 +1485,9 @@ class PositionStore:
             "pending_positions": pending_positions,
             "stale_pending_positions": stale_pending_positions,
             "exit_unknown_positions": exit_unknown_positions,
+            "failed_exit_linked_open_positions": (
+                failed_exit_linked_open_positions
+            ),
         }
 
 

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -49,7 +49,11 @@ from cores.llm.openai_responses_llm import OpenAIResponsesLLM as OpenAIAugmented
 from cores.openai_error_logging import log_openai_error
 from cores.agents.trading_agents import create_trading_scenario_agent
 from cores.utils import parse_llm_json
-from prism_core.execution_service import ExecutionService, OrderOutcomeUnknown
+from prism_core.execution_service import (
+    ExecutionService,
+    OrderOutcomeUnknown,
+    normalize_checked_holding,
+)
 from prism_core.order_intents import IntentStore, OrderIntent
 from prism_core.positions import (
     LegacyPositionWriteResult,
@@ -97,6 +101,7 @@ from trading import kis_auth as ka
 
 # Create MCPApp instance
 app = MCPApp(name="stock_tracking")
+_DEFAULT_KR_EXIT_LIMIT = object()
 
 
 @dataclass(frozen=True)
@@ -109,6 +114,37 @@ class _PreparedKrEntry:
     intent_store: IntentStore
     reservation: Any
     message: str
+
+
+@dataclass(frozen=True)
+class _PreparedKrExit:
+    legacy_holding_id: int
+    position_ids: tuple[str, ...]
+    account_id: str
+    account_name: str
+    symbol: str
+    intent: OrderIntent
+    intent_store: IntentStore
+    reservation: Any
+    order_style: str
+    quantity: int | None
+    limit_price: float | None
+    sell_price: float
+    sell_date: str
+    profit_rate: float
+    holding_days: int
+    exit_kind: str | None
+    sell_reason: str
+    delete_by_id: bool
+    company_name: str
+    buy_price: float
+    buy_date: str
+    scenario_json: str
+    trigger_type: str
+    trigger_mode: str
+    sector: str | None
+    message: str
+    journal_stock_data: Dict[str, Any]
 
 
 class StockTrackingAgent:
@@ -1521,6 +1557,378 @@ class StockTrackingAgent:
                 self.conn.rollback()
             raise
 
+    def _build_pending_kr_exit_message(
+        self,
+        *,
+        ticker: str,
+        company_name: str,
+        buy_price: float,
+        sell_price: float,
+        profit_rate: float,
+        holding_days: int,
+        sell_reason: str,
+        trigger_type: str,
+    ) -> str:
+        """Build the existing KR sell message without making it visible."""
+
+        arrow = "⬆️" if profit_rate > 0 else "⬇️" if profit_rate < 0 else "➖"
+        message = (
+            f"📉 매도: {company_name}({ticker})\n"
+            f"매수가: {buy_price:,.0f}원\n"
+            f"매도가: {sell_price:,.0f}원\n"
+            f"수익률: {arrow} {abs(profit_rate):.2f}%\n"
+            f"보유기간: {holding_days}일\n"
+            f"매도이유: {sell_reason}"
+        )
+        trigger_win_rate = self._get_trigger_win_rate(trigger_type)
+        if trigger_win_rate:
+            message += f"\n{trigger_win_rate}"
+        return message
+
+    def _prepare_pending_kr_exit(
+        self,
+        *,
+        stock_data: Dict[str, Any],
+        sell_reason: str,
+        exit_kind: Optional[str] = None,
+        source: str = "kr_batch",
+        source_decision_id: str | None = None,
+        quantity: int | None = None,
+        order_style: str = "smart",
+        limit_price: Any = _DEFAULT_KR_EXIT_LIMIT,
+    ) -> _PreparedKrExit:
+        """Atomically reserve one live KR holding and mark it PENDING_EXIT."""
+
+        intent_store = self._require_pending_entry_ready()
+        symbol = str(stock_data.get("ticker") or "").strip().upper()
+        if not symbol:
+            raise ValueError("ticker is required for KR pending exit")
+        account_id = str(
+            stock_data.get("account_key") or self._account_scope()[0]
+        ).strip()
+        account_name = str(
+            stock_data.get("account_name") or self._account_scope()[1]
+        )
+        requested_id = stock_data.get("id")
+
+        self.conn.execute("BEGIN IMMEDIATE")
+        try:
+            position_store = PositionStore(self.conn)
+            position_store.assert_exit_attempt_allowed(
+                market="KR", account_id=account_id, symbol=symbol
+            )
+            if requested_id is None:
+                rows = self.conn.execute(
+                    "SELECT * FROM stock_holdings "
+                    "WHERE ticker=? AND account_key=? ORDER BY id",
+                    (symbol, account_id),
+                ).fetchall()
+                if len(rows) != 1:
+                    raise RuntimeError(
+                        "KR pending exit requires one exact legacy holding id"
+                    )
+                row = rows[0]
+                ticker_row_count = 1
+            else:
+                row = self.conn.execute(
+                    "SELECT * FROM stock_holdings "
+                    "WHERE id=? AND ticker=? AND account_key=? LIMIT 1",
+                    (requested_id, symbol, account_id),
+                ).fetchone()
+                if row is None:
+                    raise RuntimeError("KR pending exit legacy holding is not live")
+                ticker_row_count = int(
+                    self.conn.execute(
+                        "SELECT COUNT(*) FROM stock_holdings "
+                        "WHERE ticker=? AND account_key=?",
+                        (symbol, account_id),
+                    ).fetchone()[0]
+                )
+
+            live = dict(row)
+            legacy_holding_id = int(live["id"])
+            position_id = legacy_position_id("KR", legacy_holding_id)
+            sell_price = float(stock_data.get("current_price") or 0)
+            buy_price = float(live.get("buy_price") or 0)
+            if buy_price <= 0 or sell_price <= 0:
+                raise ValueError("buy_price and current_price must be positive")
+            buy_date = str(live.get("buy_date") or "")
+            buy_datetime = datetime.strptime(buy_date, "%Y-%m-%d %H:%M:%S")
+            now_datetime = datetime.now()
+            sell_date = now_datetime.strftime("%Y-%m-%d %H:%M:%S")
+            profit_rate = ((sell_price - buy_price) / buy_price) * 100
+            holding_days = (now_datetime - buy_datetime).days
+            normalized_order_style = str(order_style).strip().lower()
+            if normalized_order_style not in {"smart", "market"}:
+                raise ValueError("KR pending exit order_style must be smart or market")
+            resolved_limit_price = (
+                sell_price
+                if limit_price is _DEFAULT_KR_EXIT_LIMIT
+                else None if limit_price is None else float(limit_price)
+            )
+            try:
+                from reentry_cooldown import classify_exit_kind
+
+                classified_exit_kind = classify_exit_kind(sell_reason, exit_kind)
+            except Exception:
+                classified_exit_kind = exit_kind
+
+            intent = OrderIntent.create(
+                market="KR",
+                account_id=account_id,
+                symbol=symbol,
+                side="sell",
+                order_style=normalized_order_style,
+                source=source,
+                source_decision_id=source_decision_id,
+                source_position_id=position_id,
+                quantity=quantity,
+                limit_price=resolved_limit_price,
+                reason=sell_reason,
+            )
+            created, reservation = intent_store.reserve_in_transaction(
+                self.conn, intent
+            )
+            if not created:
+                raise RuntimeError("KR pending exit intent already exists")
+            position_store.prepare_exit_many(
+                market="KR",
+                account_id=account_id,
+                symbol=symbol,
+                position_ids=(position_id,),
+                intent_id=intent.id,
+            )
+            company_name = str(live.get("company_name") or "")
+            trigger_type = str(live.get("trigger_type") or "AI Analysis")
+            message = self._build_pending_kr_exit_message(
+                ticker=symbol,
+                company_name=company_name,
+                buy_price=buy_price,
+                sell_price=sell_price,
+                profit_rate=profit_rate,
+                holding_days=holding_days,
+                sell_reason=sell_reason,
+                trigger_type=trigger_type,
+            )
+            journal_stock_data = dict(live)
+            journal_stock_data["current_price"] = sell_price
+            self.conn.commit()
+        except BaseException:
+            if self.conn.in_transaction:
+                self.conn.rollback()
+            raise
+
+        return _PreparedKrExit(
+            legacy_holding_id=legacy_holding_id,
+            position_ids=(position_id,),
+            account_id=account_id,
+            account_name=account_name,
+            symbol=symbol,
+            intent=intent,
+            intent_store=intent_store,
+            reservation=reservation,
+            order_style=normalized_order_style,
+            quantity=quantity,
+            limit_price=resolved_limit_price,
+            sell_price=sell_price,
+            sell_date=sell_date,
+            profit_rate=profit_rate,
+            holding_days=holding_days,
+            exit_kind=classified_exit_kind,
+            sell_reason=sell_reason,
+            delete_by_id=requested_id is not None and ticker_row_count > 1,
+            company_name=company_name,
+            buy_price=buy_price,
+            buy_date=buy_date,
+            scenario_json=str(live.get("scenario") or "{}"),
+            trigger_type=trigger_type,
+            trigger_mode=str(live.get("trigger_mode") or "unknown"),
+            sector=live.get("sector"),
+            message=message,
+            journal_stock_data=journal_stock_data,
+        )
+
+    async def _execute_pending_kr_exit(
+        self, prepared: _PreparedKrExit
+    ) -> Dict[str, Any]:
+        """Execute one committed pre-reserved KR exit through its originating store."""
+
+        async with ExecutionService.domestic(
+            account_name=prepared.account_name,
+            intent_store=prepared.intent_store,
+        ) as trading:
+            order_kwargs = {
+                "stock_code": prepared.symbol,
+                "quantity": prepared.quantity,
+                "intent": prepared.intent,
+                "reservation": prepared.reservation,
+            }
+            if prepared.limit_price is not None:
+                order_kwargs["limit_price"] = prepared.limit_price
+            return await trading.execute_pre_reserved_sell(**order_kwargs)
+
+    async def _execute_pending_kr_local_flat_exit(
+        self, prepared: _PreparedKrExit
+    ) -> Dict[str, Any]:
+        """Consume the reservation as an audited local-flat reconciliation."""
+
+        async with ExecutionService.domestic(
+            account_name=prepared.account_name,
+            intent_store=prepared.intent_store,
+        ) as trading:
+            return await trading.execute_pre_reserved_local_flat_sell(
+                intent=prepared.intent,
+                reservation=prepared.reservation,
+            )
+
+    def _complete_pending_kr_exit(self, prepared: _PreparedKrExit) -> None:
+        """Atomically close legacy and ledger state, then expose the message."""
+
+        self.conn.execute("BEGIN IMMEDIATE")
+        try:
+            self.conn.execute(
+                """
+                INSERT INTO trading_history
+                (account_key, account_name, ticker, company_name, buy_price,
+                 buy_date, sell_price, sell_date, profit_rate, holding_days,
+                 scenario, trigger_type, trigger_mode, sector, exit_kind)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    prepared.account_id,
+                    prepared.account_name,
+                    prepared.symbol,
+                    prepared.company_name,
+                    prepared.buy_price,
+                    prepared.buy_date,
+                    prepared.sell_price,
+                    prepared.sell_date,
+                    prepared.profit_rate,
+                    prepared.holding_days,
+                    prepared.scenario_json,
+                    prepared.trigger_type,
+                    prepared.trigger_mode,
+                    prepared.sector,
+                    prepared.exit_kind,
+                ),
+            )
+            if prepared.delete_by_id:
+                deleted = self.conn.execute(
+                    "DELETE FROM stock_holdings "
+                    "WHERE id=? AND ticker=? AND account_key=?",
+                    (
+                        prepared.legacy_holding_id,
+                        prepared.symbol,
+                        prepared.account_id,
+                    ),
+                ).rowcount
+            else:
+                deleted = self.conn.execute(
+                    "DELETE FROM stock_holdings "
+                    "WHERE ticker=? AND account_key=?",
+                    (prepared.symbol, prepared.account_id),
+                ).rowcount
+            if deleted != 1:
+                raise RuntimeError(
+                    "pending exit legacy holding changed before completion"
+                )
+            PositionStore(self.conn).complete_exit_many(
+                market="KR",
+                account_id=prepared.account_id,
+                symbol=prepared.symbol,
+                position_ids=prepared.position_ids,
+                intent_id=prepared.intent.id,
+                exit_price=prepared.sell_price,
+                realized_pnl_pct=prepared.profit_rate,
+                exit_kind=prepared.exit_kind,
+                closed_at=prepared.sell_date,
+            )
+            self.conn.commit()
+        except BaseException:
+            if self.conn.in_transaction:
+                self.conn.rollback()
+            raise
+
+        self._msg_types.append("analysis")
+        self.message_queue.append(prepared.message)
+        logger.info(
+            "%s(%s) pending exit complete (return: %.2f%%)",
+            prepared.symbol,
+            prepared.company_name,
+            prepared.profit_rate,
+        )
+
+    def _fail_pending_kr_exit(self, prepared: _PreparedKrExit) -> None:
+        """Return an explicitly rejected exit to OPEN without legacy effects."""
+
+        self.conn.execute("BEGIN IMMEDIATE")
+        try:
+            PositionStore(self.conn).fail_exit_many(
+                market="KR",
+                account_id=prepared.account_id,
+                symbol=prepared.symbol,
+                position_ids=prepared.position_ids,
+                intent_id=prepared.intent.id,
+            )
+            self.conn.commit()
+        except BaseException:
+            if self.conn.in_transaction:
+                self.conn.rollback()
+            raise
+
+    def _quarantine_pending_kr_exit(self, prepared: _PreparedKrExit) -> None:
+        """Quarantine an uncertain broker outcome without legacy effects."""
+
+        self.conn.execute("BEGIN IMMEDIATE")
+        try:
+            PositionStore(self.conn).quarantine_pending_exit_many(
+                market="KR",
+                account_id=prepared.account_id,
+                symbol=prepared.symbol,
+                position_ids=prepared.position_ids,
+                intent_id=prepared.intent.id,
+            )
+            self.conn.commit()
+        except BaseException:
+            if self.conn.in_transaction:
+                self.conn.rollback()
+            raise
+
+    async def _after_pending_kr_exit_closed(
+        self, prepared: _PreparedKrExit
+    ) -> None:
+        """Post-CLOSED extension point for enhanced-agent deferred cleanup."""
+
+    async def _run_pending_kr_exit_post_commit(
+        self, prepared: _PreparedKrExit
+    ) -> None:
+        """Run journal and subclass cleanup only after durable CLOSED state."""
+
+        row = self.conn.execute(
+            "SELECT status, exit_intent_id FROM positions "
+            "WHERE id=? AND market='KR' AND account_id=?",
+            (prepared.position_ids[0], prepared.account_id),
+        ).fetchone()
+        if (
+            row is None
+            or str(row[0]) != "CLOSED"
+            or str(row[1]) != prepared.intent.id
+        ):
+            raise RuntimeError("KR pending exit post-commit requires durable CLOSED")
+        try:
+            await self._create_journal_entry(
+                stock_data=prepared.journal_stock_data,
+                sell_price=prepared.sell_price,
+                profit_rate=prepared.profit_rate,
+                holding_days=prepared.holding_days,
+                sell_reason=prepared.sell_reason,
+            )
+        except Exception as journal_err:
+            logger.warning(
+                "Journal entry creation failed (non-critical): %s", journal_err
+            )
+        await self._after_pending_kr_exit_closed(prepared)
+
     async def buy_stock(self, ticker: str, company_name: str, current_price: float, scenario: Dict[str, Any], rank_change_msg: str = "", is_add: bool = False) -> bool:
         """Preserve the public bool contract while exposing an internal typed result."""
 
@@ -2184,6 +2592,254 @@ class StockTrackingAgent:
             scope, scope_context, condition, action, reason, priority, source_journal_id
         )
 
+    async def _process_pending_kr_batch_exit(
+        self,
+        *,
+        stock: Dict[str, Any],
+        sell_reason: str,
+        remaining_rows: int,
+        blocked_tickers: set[str],
+    ) -> bool:
+        """Run the opt-in broker-first KR batch exit for one legacy row."""
+
+        ticker = str(stock.get("ticker") or "")
+        company_name = stock.get("company_name")
+        if remaining_rows > 1:
+            blocked_tickers.add(ticker)
+            logger.critical(
+                "[POSITION-PENDING][KR] pyramided batch exit blocked "
+                "symbol=%s rows=%s action=requires_fill_reconciliation",
+                ticker,
+                remaining_rows,
+            )
+            return False
+        async with ExecutionService.domestic(
+            account_name=stock.get("account_name"),
+            db_path=self.db_path,
+        ) as trading:
+            checked = await asyncio.to_thread(
+                trading.get_holding_quantity_checked, ticker
+            )
+        holding_state, checked_quantity = normalize_checked_holding(checked)
+
+        if holding_state == "UNKNOWN":
+            blocked_tickers.add(ticker)
+            logger.critical(
+                "[POSITION-PENDING][KR] batch holdings UNKNOWN symbol=%s; "
+                "no intent/order/effects",
+                ticker,
+            )
+            return False
+        if holding_state == "HELD" and (
+            not isinstance(checked_quantity, int) or checked_quantity <= 0
+        ):
+            blocked_tickers.add(ticker)
+            logger.critical(
+                "[POSITION-PENDING][KR] invalid HELD quantity symbol=%s; "
+                "no intent/order/effects",
+                ticker,
+            )
+            return False
+
+        try:
+            prepared = self._prepare_pending_kr_exit(
+                stock_data=stock,
+                sell_reason=sell_reason,
+                source="kr_batch",
+                quantity=None,
+            )
+        except Exception as error:
+            blocked_tickers.add(ticker)
+            logger.critical(
+                "[POSITION-PENDING][KR] batch prepare blocked symbol=%s error=%s",
+                ticker,
+                type(error).__name__,
+            )
+            return False
+
+        try:
+            if holding_state == "FLAT":
+                trade_result = await self._execute_pending_kr_local_flat_exit(
+                    prepared
+                )
+            else:
+                trade_result = await self._execute_pending_kr_exit(prepared)
+        except asyncio.CancelledError:
+            try:
+                self._quarantine_pending_kr_exit(prepared)
+            except Exception as quarantine_error:
+                logger.critical(
+                    "[POSITION-PENDING][KR] cancelled batch exit remains unresolved "
+                    "symbol=%s error=%s",
+                    ticker,
+                    type(quarantine_error).__name__,
+                )
+            blocked_tickers.add(ticker)
+            raise
+        except OrderOutcomeUnknown:
+            try:
+                self._quarantine_pending_kr_exit(prepared)
+            except Exception as quarantine_error:
+                logger.critical(
+                    "[POSITION-PENDING][KR] unknown batch exit quarantine failed "
+                    "symbol=%s error=%s",
+                    ticker,
+                    type(quarantine_error).__name__,
+                )
+            blocked_tickers.add(ticker)
+            return False
+        except Exception as error:
+            try:
+                self._quarantine_pending_kr_exit(prepared)
+            except Exception as quarantine_error:
+                logger.critical(
+                    "[POSITION-PENDING][KR] batch execution unresolved symbol=%s "
+                    "error=%s quarantine_error=%s",
+                    ticker,
+                    type(error).__name__,
+                    type(quarantine_error).__name__,
+                )
+            blocked_tickers.add(ticker)
+            return False
+
+        if not isinstance(trade_result, dict):
+            try:
+                self._quarantine_pending_kr_exit(prepared)
+            except Exception as error:
+                logger.critical(
+                    "[POSITION-PENDING][KR] opaque batch result quarantine failed "
+                    "symbol=%s error=%s",
+                    ticker,
+                    type(error).__name__,
+                )
+            blocked_tickers.add(ticker)
+            return False
+        result_intent_id = str(trade_result.get("intent_id") or "")
+        if result_intent_id != prepared.intent.id:
+            try:
+                self._quarantine_pending_kr_exit(prepared)
+            except Exception as error:
+                logger.critical(
+                    "[POSITION-PENDING][KR] batch intent mismatch quarantine failed "
+                    "symbol=%s expected=%s actual=%s error=%s",
+                    ticker,
+                    prepared.intent.id,
+                    result_intent_id or "missing",
+                    type(error).__name__,
+                )
+            blocked_tickers.add(ticker)
+            return False
+        intent_status = str(trade_result.get("intent_status") or "").upper()
+        if intent_status == "SUBMITTED":
+            try:
+                self._complete_pending_kr_exit(prepared)
+            except Exception as error:
+                try:
+                    self._quarantine_pending_kr_exit(prepared)
+                except Exception as quarantine_error:
+                    logger.critical(
+                        "[POSITION-PENDING][KR] batch finalize unresolved symbol=%s "
+                        "error=%s quarantine_error=%s",
+                        ticker,
+                        type(error).__name__,
+                        type(quarantine_error).__name__,
+                    )
+                blocked_tickers.add(ticker)
+                return False
+            await self._run_pending_kr_exit_post_commit(prepared)
+        elif intent_status == "FAILED":
+            try:
+                self._fail_pending_kr_exit(prepared)
+            except Exception as error:
+                logger.critical(
+                    "[POSITION-PENDING][KR] batch FAILED finalize unresolved "
+                    "symbol=%s error=%s",
+                    ticker,
+                    type(error).__name__,
+                )
+            blocked_tickers.add(ticker)
+            logger.critical(
+                "[POSITION-PENDING][KR] batch exit rejected symbol=%s "
+                "intent=%s status=FAILED action=manual_review",
+                ticker,
+                prepared.intent.id,
+            )
+            return False
+        elif intent_status in {"UNKNOWN", "SUBMITTING"}:
+            try:
+                self._quarantine_pending_kr_exit(prepared)
+            except Exception as error:
+                logger.critical(
+                    "[POSITION-PENDING][KR] batch quarantine failed symbol=%s "
+                    "status=%s error=%s",
+                    ticker,
+                    intent_status,
+                    type(error).__name__,
+                )
+            blocked_tickers.add(ticker)
+            return False
+        elif intent_status == "QUEUED":
+            blocked_tickers.add(ticker)
+            logger.critical(
+                "[POSITION-PENDING][KR] queued batch exit remains PENDING_EXIT "
+                "symbol=%s",
+                ticker,
+            )
+            return False
+        else:
+            try:
+                self._quarantine_pending_kr_exit(prepared)
+            except Exception as error:
+                logger.critical(
+                    "[POSITION-PENDING][KR] unexpected batch intent status "
+                    "symbol=%s status=%s error=%s",
+                    ticker,
+                    intent_status or "MISSING",
+                    type(error).__name__,
+                )
+            blocked_tickers.add(ticker)
+            return False
+
+        logger.info(
+            "Actual pending sell successful: %s",
+            trade_result.get("message", "submitted"),
+        )
+        try:
+            from messaging.redis_signal_publisher import publish_sell_signal
+
+            await publish_sell_signal(
+                ticker=ticker,
+                company_name=company_name,
+                price=prepared.sell_price,
+                buy_price=stock.get("buy_price", 0),
+                profit_rate=prepared.profit_rate,
+                sell_reason=sell_reason,
+                trade_result=trade_result,
+            )
+        except Exception as signal_err:
+            logger.warning(
+                "Sell signal publish failed (non-critical): %s", signal_err
+            )
+        try:
+            from messaging.gcp_pubsub_signal_publisher import (
+                publish_sell_signal as gcp_publish_sell_signal,
+            )
+
+            await gcp_publish_sell_signal(
+                ticker=ticker,
+                company_name=company_name,
+                price=prepared.sell_price,
+                buy_price=stock.get("buy_price", 0),
+                profit_rate=prepared.profit_rate,
+                sell_reason=sell_reason,
+                trade_result=trade_result,
+            )
+        except Exception as signal_err:
+            logger.warning(
+                "GCP sell signal publish failed (non-critical): %s", signal_err
+            )
+        return True
+
     async def update_holdings(self) -> List[Dict[str, Any]]:
         """
         Update holdings information and make sell decisions
@@ -2240,10 +2896,19 @@ class StockTrackingAgent:
             # independent of fill timing.
             pass_total_qty: Dict[str, int] = {}   # ticker -> snapshot total qty
             pass_sold_qty: Dict[str, int] = {}    # ticker -> cumulative ordered qty
+            blocked_tickers: set[str] = set()
+            pending_kr_enabled = self._position_pending_kr_enabled()
 
             for stock in holdings:
                 ticker = stock.get('ticker')
                 company_name = stock.get('company_name')
+                if pending_kr_enabled and ticker in blocked_tickers:
+                    logger.warning(
+                        "[POSITION-PENDING][KR] skipping unresolved batch sibling "
+                        "symbol=%s",
+                        ticker,
+                    )
+                    continue
 
                 # Query current stock price
                 current_price = await self._get_current_stock_price(ticker)
@@ -2281,6 +2946,36 @@ class StockTrackingAgent:
                 should_sell, sell_reason = await self._analyze_sell_decision(stock)
 
                 if should_sell:
+                    if pending_kr_enabled:
+                        remaining_rows = get_existing_position_for_ticker(
+                            self.cursor,
+                            ticker,
+                            account_key=stock.get("account_key"),
+                        ).get("row_count", 1)
+                        sell_success = await self._process_pending_kr_batch_exit(
+                            stock=stock,
+                            sell_reason=sell_reason,
+                            remaining_rows=remaining_rows,
+                            blocked_tickers=blocked_tickers,
+                        )
+                        if sell_success:
+                            account_label = self._safe_account_log_label(
+                                {
+                                    "name": stock.get("account_name"),
+                                    "account_key": stock.get("account_key"),
+                                }
+                            )
+                            sold_stocks.append({
+                                "ticker": ticker,
+                                "company_name": company_name,
+                                "buy_price": stock.get('buy_price', 0),
+                                "sell_price": current_price,
+                                "profit_rate": ((current_price - stock.get('buy_price', 0)) / stock.get('buy_price', 0) * 100),
+                                "reason": sell_reason,
+                                "account_name": stock.get("account_name"),
+                                "account_label": account_label,
+                            })
+                        continue
                     # Pyramiding (#288): compute remaining row count N for this
                     # (ticker, account) BEFORE the DB row is deleted by sell_stock.
                     # N>1 => fractional KIS sell (floor(total/N)); N==1 => sell all

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -1356,8 +1356,11 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                 # ===== Core: DB processing based on should_sell branch (main flow continues even if errors occur) =====
                 try:
                     if should_sell:
-                        # When sell decision: delete from holding_decisions table
-                        await self._delete_holding_decision(ticker)
+                        # Broker-first pending exits keep decision context until the
+                        # exact legacy position is durably CLOSED. Gate-off retains
+                        # the legacy decision-time cleanup unchanged.
+                        if not self._position_pending_kr_enabled():
+                            await self._delete_holding_decision(ticker)
 
                         # Add analysis_summary to sell_reason when selling
                         if analysis_summary:
@@ -1723,6 +1726,11 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
             logger.error(f"{ticker} Hold decision save failed (main flow continues): {str(e)}")
             logger.error(traceback.format_exc())
             return False
+
+    async def _after_pending_kr_exit_closed(self, prepared) -> None:
+        """Delete enhanced decision context only after durable KR CLOSED."""
+
+        await self._delete_holding_decision(prepared.symbol)
 
     async def _delete_holding_decision(self, ticker: str) -> bool:
         """

--- a/tasks/issue-412/14-phase4b2b2-kr-exit-plan.md
+++ b/tasks/issue-412/14-phase4b2b2-kr-exit-plan.md
@@ -1,0 +1,181 @@
+# Issue #412 Phase 4-b2b-2 — KR EXIT PENDING write-ahead 실행 계획
+
+> 기준: main `2576c67e` (Phase 4-b2b-1 gate OFF 배포 완료)
+> 브랜치: `feature/issue-412-phase4b2b2-kr-exit`
+> 운영 기본값: `POSITION_PENDING_KR_ENABLED=false`
+> 활성화: 이 단계에서는 금지. Phase 4-b2b-3의 별도 승인·무거래 창에서만 수행한다.
+
+## 1. 목적과 완료 경계
+
+KR SELL의 세 production caller를 같은 write-ahead lifecycle로 연결한다.
+
+1. `StockTrackingAgent.update_holdings()` batch SELL
+2. `tools/hardstop_seller.py` KR LIVE SELL
+3. `tools/trend_exit_seller.py` KR LIVE SELL
+
+gate=true에서는 legacy holding/history를 broker 전에 닫지 않는다. 먼저 SELL intent와
+`OPEN -> PENDING_EXIT` claim을 한 transaction으로 commit하고, broker 결과가 확정된 뒤에만
+legacy close와 position finalize를 수행한다. legacy holdings/history는 계속 판단 read source다.
+
+비목표:
+
+- US SELL 또는 `us_pending_orders` 변경
+- positions read switch
+- 체결/부분체결 추정, amend/cancel, reconciliation
+- loop owner-lock 통합 또는 schema 추가
+- FAILED/UNKNOWN 자동 retry
+- 운영 gate 활성화
+
+## 2. 현재 동작과 보존해야 할 계약
+
+현재 gate=false 순서는 다음과 같다.
+
+- batch: legacy history INSERT + holding DELETE + message/journal -> broker -> Redis -> GCP
+- hardstop/trend: legacy close + queued message/journal -> KIS qty 조회/주문 -> Telegram flush
+  -> Redis/GCP loop publish -> inflight 기록 -> owner state `SOLD`
+- loop KIS qty=0: broker 주문 없이 legacy close와 외부 알림을 완료한다.
+- hardstop/trend는 pyramided ticker를 건드리지 않고 batch만 fractional quantity를 계산한다.
+
+gate=false에서는 위 순서, public bool, 수량, 메시지, journal, publish 횟수, loop summary/inflight/
+owner state를 변경하지 않는다.
+
+## 3. cleanup/refactor 계획
+
+코드 수정 전 아래 순서로 기존 동작을 잠근다.
+
+1. **회귀 먼저**
+   - batch gate=false의 legacy/message/journal -> broker -> Redis -> GCP 순서.
+   - hardstop/trend gate=false의 sim -> KIS -> Telegram/publish -> inflight/SOLD 순서.
+   - multi-row fractional quantity와 local-flat broker 0 계약.
+2. **legacy close 경계만 분리**
+   - `sell_stock()` public bool 계약은 유지한다.
+   - DB history/delete와 position close를 한 transaction에 두고, message/journal은 commit 뒤에만 노출한다.
+   - pending finalize가 전달된 경우 legacy close와 `PENDING_EXIT -> CLOSED`를 같은 transaction에서
+     처리하며, 실패를 bool로 숨기지 않고 caller가 quarantine할 수 있게 한다.
+3. **좁은 KR EXIT lifecycle helper 재사용**
+   - prepare: exact legacy row 검증 + same account/symbol unresolved guard + intent CREATED reserve +
+     OPEN claim을 `BEGIN IMMEDIATE`에서 수행.
+   - execute: originating IntentStore의 pre-reserved SELL만 허용.
+   - complete/fail/quarantine: 기존 PositionStore API를 재사용하고 새 table/dependency를 만들지 않는다.
+4. **caller별 최소 연결**
+- batch gate=false는 기존 in-pass quantity accumulator를 그대로 사용한다.
+- batch gate=true의 pyramided ticker는 accepted-but-unfilled 주문의 재시작 과매도를
+  영속적으로 대조할 fill reconciliation이 아직 없으므로 주문 전에 전부 차단한다.
+   - hardstop/trend는 KR gate=true에서만 authoritative checked holding lookup을 사용한다.
+   - US와 gate=false 분기는 기존 코드를 그대로 실행한다.
+5. **외부 효과는 성공 뒤에만**
+   - SUBMITTED/local-flat finalize 뒤 message/journal/publish/count/SOLD.
+   - FAILED/UNKNOWN/QUEUED/cancellation/finalize 실패에는 일반 SELL 효과 0.
+   - enhanced `_analyze_sell_decision()`의 `holding_decisions`/`portfolio_adjustment_log` 삭제도
+     gate=true에서는 판단 시점에 하지 않고 성공 finalize 뒤로 미룬다.
+
+새 추상화는 위 세 caller의 중복 lifecycle 제거에 필요한 private dataclass/helper로 제한한다.
+
+## 4. 상태와 부작용 행렬
+
+### prepare
+
+```text
+BEGIN IMMEDIATE
+  exact stock_holdings(id, account_key, ticker) 존재 검증
+  same account/symbol의 PENDING_ENTRY, ENTRY_FAILED, PENDING_EXIT, EXIT_UNKNOWN 또는
+    failed exit intent가 연결된 OPEN이 있으면 차단
+  SELL intent CREATED reserve (position-first idempotency)
+  position OPEN -> PENDING_EXIT
+COMMIT
+```
+
+claim 성공 전 broker 호출은 0이다. 같은 position에 대한 다른 process/decision은 persisted intent 또는
+position claim에서 fail-closed된다. gate=true의 피라미딩은 fill reconciliation이 추가될 때까지
+종목 전체를 차단해 같은 pass뿐 아니라 프로세스 재시작 뒤의 accepted-but-unfilled 과매도도 막는다.
+
+### 결과
+
+- `SUBMITTED`
+  - 한 transaction에서 history 1 + exact holding delete 1 + position CLOSED.
+  - commit 뒤 message 1 + journal best-effort + caller publish/count.
+- `LOCAL_FLAT`
+  - checked KIS 상태가 명확한 FLAT일 때 broker 주문 0.
+  - pre-reserved capability를 local result로 소진하고 intent를 감사 가능한 SUBMITTED/local-flat으로 기록.
+  - 이후 SUBMITTED와 같은 legacy/CLOSED finalize.
+- `FAILED`
+  - position `PENDING_EXIT -> OPEN`; legacy/history/message/publish 불변.
+  - failed intent linkage는 보존하여 자동 재주문을 막는다.
+- `UNKNOWN` 또는 cancellation
+  - position `EXIT_UNKNOWN`; legacy/history/message/publish 불변.
+  - cancellation은 quarantine 후 원래 `CancelledError`를 재전파한다.
+- pre-reserved claim 자체의 pre-broker 실패/cancellation
+  - claim이 `SUBMITTING`에 도달했다면 UNKNOWN/EXIT_UNKNOWN으로 격리한다.
+  - `mark_submitting` 실패로 intent가 여전히 CREATED임이 확인되면 broker 0이므로 position은
+    PENDING_EXIT로 보존하고 CRITICAL/manual review로 남긴다. CREATED를 EXIT_UNKNOWN으로 바꾸는
+    허위 상태 전이는 하지 않는다.
+- `QUEUED`
+  - position `PENDING_EXIT` 유지; legacy/history/message/publish 불변.
+  - KR에서는 예상 외이므로 CRITICAL/manual review.
+- broker result persistence 또는 legacy/CLOSED finalize 실패
+  - intent `SUBMITTING` 또는 `SUBMITTED`를 허용해 position을 `EXIT_UNKNOWN`으로 quarantine.
+  - legacy transaction은 rollback, 외부 효과 0.
+
+## 5. loop 상태 계약
+
+KR gate=true에서 hardstop/trend는 다음 상태만 사용한다.
+
+- 성공 또는 authoritative local-flat: inflight `FILLED`, owner `SOLD`, `sold += 1`.
+- explicit FAILED: inflight `REJECTED`, owner `HOLDING`, 일반 알림/publish/sold count 0.
+- UNKNOWN: inflight `UNKNOWN`, owner `QUARANTINED`, 일반 알림/publish/sold count 0.
+- QUEUED: inflight `QUEUED`, owner `QUARANTINED`, 일반 알림/publish/sold count 0.
+- prepare failure/duplicate claim: broker 0, owner `HOLDING`, 일반 효과 0.
+- pre-broker claim failure로 CREATED/PENDING이 남은 경우: broker 0, owner `QUARANTINED`, 일반 효과 0.
+- cancellation: UNKNOWN/quarantine 기록과 lock release 후 재전파.
+
+US 및 gate=false loop state는 변경하지 않는다.
+
+## 6. TDD slices
+
+### Slice A — production 변화 0
+
+- 계획/README 갱신.
+- batch/hardstop/trend gate=false 순서와 외부 효과 golden test.
+- exact legacy row, same/new decision 경쟁, pyramiding 수량 기준선.
+
+### Slice B — core/private lifecycle, caller 미배선
+
+- local-flat pre-reserved result capability와 분류 회귀.
+- `_PreparedKrExit` prepare/FAILED/UNKNOWN/QUEUED/SUBMITTED finalize helper.
+- transaction rollback, cancellation, persistence/finalize failure injection.
+
+### Slice C — batch gate=true
+
+- single-row SUBMITTED, FAILED, UNKNOWN, QUEUED, local-flat-equivalent 경계.
+- multi-row는 checked lookup/intent/broker 이전에 완전 차단.
+- message/journal/Redis/GCP/sold count와 broker 호출 수.
+- 두 SQLite connection 경쟁 및 다음 batch 자동 재주문 0.
+
+### Slice D — hardstop/trend KR gate=true
+
+- 양 loop 대표 성공/FAILED/UNKNOWN/QUEUED/local-flat/cancellation.
+- checked holding `HELD/FLAT/UNKNOWN`과 pagination/malformed fail-closed.
+- inflight/owner/summary 상태 행렬.
+- gate=false 및 US 경로 무변경.
+
+## 7. 검증·배포 gate
+
+- 관련 전체 pytest, Ruff, py_compile, `git diff --check` 통과.
+- 독립 architecture, concurrency/SQLite, code, test review blocker 0.
+- GitHub Python 3.10/3.11/3.12 + Codacy green.
+- db-server 실제 crontab wrapper(`loop_a_hardstop.py`, `loop_b_trend_exit.py`)와 batch import/compile,
+  관련 회귀, 최근 fatal 로그 확인.
+- app-server는 반드시 `root -> su - prism`; bot/core import, PID/cwd/stdout/fatal 확인.
+- 양 서버 incoming/local overlap 0, `POSITION_PENDING_KR_ENABLED` 미설정/false 확인 후 배포.
+- 배포 후에도 gate OFF. 실제 활성화는 Phase 4-b2b-3에서 사용자 판단을 받는다.
+- Phase 4-b2b-3 활성화 전에는 broker accepted-but-unfilled/피라미딩 대조뿐 아니라,
+  durable CLOSED 직후 cancellation으로 journal/Redis/GCP가 누락된 경우를 탐지·복구하는
+  운영 reconciliation/runbook도 검증한다.
+- hardstop/trend의 중복된 lifecycle 구현은 gate OFF 배포 안정성을 위해 이번 단계에서
+  합치지 않는다. 공통 상태기계 추출은 동일한 다중 프로세스 회귀를 갖춘 후 별도 변경으로 수행한다.
+
+## 8. 롤백 원칙
+
+gate OFF 배포이므로 문제 시 코드 rollback보다 먼저 gate가 계속 OFF인지 확인한다. gate 활성화 이후에는
+PENDING/EXIT_UNKNOWN 0을 확인하지 않고 flag만 내리는 롤백을 금지한다. UNKNOWN은 자동 주문하지 않고
+KIS 계좌와 intent/position/legacy를 수동 대조한다.

--- a/tasks/issue-412/README.md
+++ b/tasks/issue-412/README.md
@@ -2,7 +2,7 @@
 
 > 이슈: [#412 매수/매도 Agent 분리와 KIS 실제 주문 실행 구조 이식 설계](https://github.com/dragon1086/prism-insight/issues/412)
 > 브랜치: `feature/issue-412-execution-architecture`
-> 상태: Phase 4-b2b-1 KR ENTRY 배포 완료, Phase 4-b2b-2 KR EXIT 구현 준비
+> 상태: Phase 4-b2b-1 KR ENTRY 배포 완료, Phase 4-b2b-2 KR EXIT 구현·로컬 검증 완료(PR 준비, gate OFF)
 > (2026-07-06 시작, 2026-07-13 main #432 기준 전면 재검토,
 > **2026-07-19 Phase 4-b2b-1 PR #465, main `3361550f` 게이트 OFF 배포 완료**)
 
@@ -32,6 +32,7 @@ greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 
 | [11-phase4b2-pending-exit-plan.md](11-phase4b2-pending-exit-plan.md) | Phase 4-b2 분할 계획 — 4-b2a 기반 API, 4-b2b KR 전환, 4-b2c US queue 연속성/전환 |
 | [12-phase4b2b-kr-execution-plan.md](12-phase4b2b-kr-execution-plan.md) | Phase 4-b2b KR 전환 상세 계획 — 4-b2b-0~3 안전 분할, 실패/재시도 정책, 배포 gate |
 | [13-phase4b2b1-kr-entry-plan.md](13-phase4b2b1-kr-entry-plan.md) | Phase 4-b2b-1 KR ENTRY 구현 계획 — no-auto-retry guard, private lifecycle, 결과별 TDD |
+| [14-phase4b2b2-kr-exit-plan.md](14-phase4b2b2-kr-exit-plan.md) | Phase 4-b2b-2 KR EXIT 구현 계획 — write-ahead claim, legacy finalize, loop 상태 행렬 |
 
 ## 진행 체크리스트
 

--- a/tests/test_feature_status.py
+++ b/tests/test_feature_status.py
@@ -256,7 +256,7 @@ def test_json_output_contains_all_features(capsys):
     out = {r["id"]: {"state": r["state"], "evidence": r["evidence"]} for r in results}
     data = json.loads(json.dumps(out, ensure_ascii=False))
 
-    expected_ids = {"oauth_llm", "loop_a", "loop_b", "loop_c",
+    expected_ids = {"oauth_llm", "loop_a", "loop_b", "loop_c", "position_pending_kr",
                     "vision_pipeline", "vision_buy_qa", "vision_publish"}
     assert expected_ids == set(data.keys())
     assert data["oauth_llm"]["state"] == "LIVE"
@@ -269,7 +269,63 @@ def test_json_output_contains_all_features(capsys):
 def test_empty_env_and_crontab_does_not_raise():
     """evaluate_all must never raise even with completely empty inputs."""
     results = fs.evaluate_all(env={}, crontab="")
-    assert len(results) == 7  # one entry per feature
+    assert len(results) == 8  # one entry per feature
+
+
+def test_position_pending_kr_reports_off_by_default_and_live_when_enabled():
+    off = _results_by_id(fs.evaluate_all(env={}, crontab=CRON_EMPTY))
+    live = _results_by_id(
+        fs.evaluate_all(
+            env={"POSITION_PENDING_KR_ENABLED": "true"},
+            crontab=CRON_EMPTY,
+        )
+    )
+
+    assert off["position_pending_kr"]["state"] == "OFF"
+    assert "unset" in off["position_pending_kr"]["evidence"]
+    assert live["position_pending_kr"]["state"] == "LIVE"
+
+
+def test_position_pending_kr_reports_live_from_crontab_inline():
+    cron = (
+        "*/10 * * * * POSITION_PENDING_KR_ENABLED=true "
+        "/usr/bin/python tools/hardstop_seller.py\n"
+    )
+    result = _results_by_id(fs.evaluate_all(env={}, crontab=cron))
+
+    assert result["position_pending_kr"]["state"] == "LIVE"
+    assert "crontab inline" in result["position_pending_kr"]["evidence"]
+
+
+def test_position_pending_kr_reports_off_from_crontab_inline_false():
+    cron = (
+        "*/10 * * * * POSITION_PENDING_KR_ENABLED=false "
+        "/usr/bin/python tools/hardstop_seller.py\n"
+    )
+    result = _results_by_id(fs.evaluate_all(env={}, crontab=cron))
+
+    assert result["position_pending_kr"]["state"] == "OFF"
+    assert "crontab inline" in result["position_pending_kr"]["evidence"]
+
+
+@pytest.mark.parametrize(
+    "values",
+    [("false", "true"), ("true", "false")],
+)
+def test_position_pending_kr_reports_live_if_any_cron_inline_is_true(values):
+    cron = "\n".join(
+        f"*/10 * * * * POSITION_PENDING_KR_ENABLED={value} "
+        f"/usr/bin/python tools/{script}"
+        for value, script in zip(
+            values,
+            ("hardstop_seller.py", "trend_exit_seller.py"),
+            strict=True,
+        )
+    )
+    result = _results_by_id(fs.evaluate_all(env={}, crontab=cron))
+
+    assert result["position_pending_kr"]["state"] == "LIVE"
+    assert "crontab inline" in result["position_pending_kr"]["evidence"]
 
 
 def test_cron_commented_line_not_counted():

--- a/tests/test_hardstop_seller.py
+++ b/tests/test_hardstop_seller.py
@@ -12,9 +12,11 @@ Telegram stay consistent. Safety-critical guards covered:
 Run in the KR (root) pytest session.
 """
 import asyncio
+import os
 import sys
 import sqlite3
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -25,17 +27,31 @@ import tools.hardstop_seller as la  # noqa: E402
 
 # ── Fakes ──────────────────────────────────────────────────────────────────────
 class FakeTrader:
-    def __init__(self, prices, holding_qty=None, sell_result=None, calls=None):
+    def __init__(
+        self,
+        prices,
+        holding_qty=None,
+        sell_result=None,
+        calls=None,
+        holding_check=None,
+    ):
         self._prices = prices
         self._holding_qty = holding_qty or {}
         self._sell_result = sell_result or {"success": True, "order_no": "ORD1", "message": "ok"}
         self.calls = calls if calls is not None else []
+        self._holding_check = holding_check
 
     def get_current_price(self, ticker, exchange=None):
         return {"current_price": self._prices.get(ticker, 0)}
 
     def get_holding_quantity(self, ticker):
         return self._holding_qty.get(ticker, 0)
+
+    def get_holding_quantity_checked(self, ticker):
+        if self._holding_check is not None:
+            return self._holding_check
+        quantity = int(self._holding_qty.get(ticker, 0) or 0)
+        return ("HELD", quantity) if quantity > 0 else ("FLAT", 0)
 
     async def async_sell_stock(self, ticker, exchange=None, timeout=30.0,
                                limit_price=None, use_moo=False, quantity=None):
@@ -67,9 +83,81 @@ class FakeAgent:
         self.calls.append(f"link:{kwargs.get('legacy_holding_id')}")
         return True
 
+    @staticmethod
+    def _position_pending_kr_enabled():
+        return os.getenv("POSITION_PENDING_KR_ENABLED", "false").lower() == "true"
+
     async def send_telegram_message(self, chat_id, language="ko", **kwargs):
         self.calls.append("tg")
         return True
+
+
+class PendingFakeAgent(FakeAgent):
+    def __init__(
+        self,
+        calls,
+        *,
+        status="SUBMITTED",
+        failure=None,
+        result_intent_id="intent-hardstop-1",
+    ):
+        super().__init__(calls)
+        self.status = status
+        self.failure = failure
+        self.result_intent_id = result_intent_id
+        self.prepared = SimpleNamespace(
+            intent=SimpleNamespace(id="intent-hardstop-1")
+        )
+        self.prepare_kwargs = None
+
+    def _prepare_pending_kr_exit(self, **kwargs):
+        self.prepare_kwargs = kwargs
+        self.calls.append(f"prepare:{kwargs.get('quantity')}")
+        if self.failure == "prepare":
+            raise RuntimeError("prepare failed")
+        return self.prepared
+
+    async def _execute_pending_kr_exit(self, prepared):
+        self.calls.append("broker")
+        if self.failure == "cancel":
+            raise asyncio.CancelledError
+        if self.failure == "outcome_unknown":
+            from prism_core.execution_service import OrderOutcomeUnknown
+
+            raise OrderOutcomeUnknown(
+                prepared.intent.id,
+                broker_result={"order_no": "UNCERTAIN-1"},
+            )
+        return {
+            "success": self.status == "SUBMITTED",
+            "intent_id": self.result_intent_id,
+            "intent_status": self.status,
+            "order_no": "ORDER-1",
+        }
+
+    async def _execute_pending_kr_local_flat_exit(self, prepared):
+        self.calls.append("local-flat")
+        return {
+            "success": True,
+            "local_flat": True,
+            "quantity": 0,
+            "intent_id": self.result_intent_id,
+            "intent_status": self.status,
+        }
+
+    def _complete_pending_kr_exit(self, prepared):
+        self.calls.append("complete")
+        if self.failure == "finalize":
+            raise RuntimeError("finalize failed")
+
+    def _fail_pending_kr_exit(self, prepared):
+        self.calls.append("fail")
+
+    def _quarantine_pending_kr_exit(self, prepared):
+        self.calls.append("quarantine")
+
+    async def _run_pending_kr_exit_post_commit(self, prepared):
+        self.calls.append("postcommit")
 
 
 @pytest.fixture
@@ -135,6 +223,20 @@ def _inflight(db, status=None):
         conn.close()
 
 
+def _owner_state(db):
+    with sqlite3.connect(db) as conn:
+        return conn.execute(
+            "SELECT state FROM loop_a_position_state "
+            "WHERE ticker='005930' AND market='KR'"
+        ).fetchone()[0]
+
+
+def _enable_pending_live(monkeypatch):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+    monkeypatch.setattr(la, "HARDSTOP_LIVE", True)
+    monkeypatch.setattr(la, "HARDSTOP_ENABLED", True)
+
+
 def test_shadow_touches_no_agent_and_no_order(tmp_db, monkeypatch):
     monkeypatch.setattr(la, "HARDSTOP_LIVE", False)
     monkeypatch.setattr(la, "HARDSTOP_ENABLED", True)
@@ -153,6 +255,7 @@ def test_shadow_touches_no_agent_and_no_order(tmp_db, monkeypatch):
 
 
 def test_live_order_is_sim_then_kis_then_telegram(tmp_db, monkeypatch):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "false")
     monkeypatch.setattr(la, "HARDSTOP_LIVE", True)
     monkeypatch.setattr(la, "HARDSTOP_ENABLED", True)
     monkeypatch.setattr(la, "CHAT_ID", "chat1")
@@ -160,6 +263,11 @@ def test_live_order_is_sim_then_kis_then_telegram(tmp_db, monkeypatch):
     calls = []
     trader = FakeTrader({"005930": 92.0}, holding_qty={"005930": 10}, calls=calls)
     _patch(monkeypatch, trader, agent_holder=FakeAgent(calls))
+
+    async def publish_loop_sell(**_kwargs):
+        calls.append("publish")
+
+    monkeypatch.setattr("sell_broadcast.publish_loop_sell", publish_loop_sell)
 
     summary = asyncio.run(la.run_market("KR", "run1"))
 
@@ -172,9 +280,377 @@ def test_live_order_is_sim_then_kis_then_telegram(tmp_db, monkeypatch):
         "kis:005930:10",
         "link:1",
         "tg",
+        "publish",
         "tg",
     ]  # exact order
     assert _inflight(tmp_db, "FILLED") == 1
+
+
+def test_pending_kr_gate_does_not_change_us_legacy_path(tmp_db, monkeypatch):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+    monkeypatch.setattr(la, "HARDSTOP_LIVE", True)
+    calls = []
+    trader = FakeTrader({"AAPL": 92.0}, holding_qty={"AAPL": 4}, calls=calls)
+    agent = FakeAgent(calls)
+    _patch(monkeypatch, trader, agent_holder=agent)
+
+    async def publish_loop_sell(**_kwargs):
+        calls.append("publish")
+
+    monkeypatch.setattr("sell_broadcast.publish_loop_sell", publish_loop_sell)
+    stock = {
+        "id": 1,
+        "ticker": "AAPL",
+        "company_name": "Apple",
+        "buy_price": 100.0,
+        "current_price": 92.0,
+        "account_key": "us-acc",
+        "account_name": "primary",
+    }
+    summary = {
+        "market": "US",
+        "checked": 1,
+        "triggered": 1,
+        "sold": 0,
+        "shadow": 0,
+        "skipped": 0,
+        "pyramided_skipped": 0,
+    }
+    with sqlite3.connect(tmp_db) as connection:
+        la._ensure_schema(connection)
+        asyncio.run(
+            la._act_on_trigger(
+                connection,
+                "US",
+                "AAPL",
+                stock,
+                "hard stop",
+                "run-us",
+                {"ref": agent},
+                summary,
+            )
+        )
+
+    assert summary["sold"] == 1
+    assert calls == ["sim:AAPL", "kis:AAPL:4", "link:1", "tg", "publish"]
+    assert not any(call.startswith("prepare:") for call in calls)
+
+
+@pytest.mark.parametrize(
+    ("intent_status", "expected_calls", "inflight", "owner", "sold"),
+    [
+        (
+            "SUBMITTED",
+            [
+                "prepare:7",
+                "broker",
+                "complete",
+                "postcommit",
+                "tg",
+                "publish",
+                "tg",
+            ],
+            "FILLED",
+            "SOLD",
+            1,
+        ),
+        ("FAILED", ["prepare:7", "broker", "fail"], "REJECTED", "HOLDING", 0),
+        (
+            "UNKNOWN",
+            ["prepare:7", "broker", "quarantine"],
+            "UNKNOWN",
+            "QUARANTINED",
+            0,
+        ),
+        (
+            "SUBMITTING",
+            ["prepare:7", "broker", "quarantine"],
+            "UNKNOWN",
+            "QUARANTINED",
+            0,
+        ),
+        ("QUEUED", ["prepare:7", "broker"], "QUEUED", "QUARANTINED", 0),
+    ],
+)
+def test_pending_kr_live_maps_intent_status_without_early_effects(
+    tmp_db,
+    monkeypatch,
+    intent_status,
+    expected_calls,
+    inflight,
+    owner,
+    sold,
+):
+    _enable_pending_live(monkeypatch)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 92.0}, holding_check=("HELD", 7), calls=calls
+    )
+    pending_agent = PendingFakeAgent(calls, status=intent_status)
+    _patch(monkeypatch, trader, agent_holder=pending_agent)
+
+    async def publish_loop_sell(**_kwargs):
+        calls.append("publish")
+
+    monkeypatch.setattr("sell_broadcast.publish_loop_sell", publish_loop_sell)
+
+    summary = asyncio.run(la.run_market("KR", f"run-{intent_status.lower()}"))
+
+    assert summary["sold"] == sold
+    assert calls == expected_calls
+    assert not any(call.startswith("sim:") for call in calls)
+    assert not any(call.startswith("link:") for call in calls)
+    assert pending_agent.prepare_kwargs["order_style"] == "market"
+    assert pending_agent.prepare_kwargs["limit_price"] is None
+    assert _inflight(tmp_db, inflight) == 1
+    assert _owner_state(tmp_db) == owner
+
+
+def test_pending_kr_live_local_flat_closes_without_broker(tmp_db, monkeypatch):
+    _enable_pending_live(monkeypatch)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 92.0}, holding_check=("FLAT", 0), calls=calls
+    )
+    pending_agent = PendingFakeAgent(calls, status="SUBMITTED")
+    _patch(
+        monkeypatch,
+        trader,
+        agent_holder=pending_agent,
+    )
+
+    async def publish_loop_sell(**_kwargs):
+        calls.append("publish")
+
+    monkeypatch.setattr("sell_broadcast.publish_loop_sell", publish_loop_sell)
+
+    summary = asyncio.run(la.run_market("KR", "run-flat"))
+
+    assert summary["sold"] == 1
+    assert calls == [
+        "prepare:None",
+        "local-flat",
+        "complete",
+        "postcommit",
+        "tg",
+        "publish",
+        "tg",
+    ]
+    assert "broker" not in calls
+    assert pending_agent.prepare_kwargs["order_style"] == "market"
+    assert pending_agent.prepare_kwargs["limit_price"] is None
+    assert _inflight(tmp_db, "FILLED") == 1
+    assert _owner_state(tmp_db) == "SOLD"
+
+
+def test_pending_kr_unknown_balance_retries_without_prepare_or_effects(
+    tmp_db, monkeypatch
+):
+    _enable_pending_live(monkeypatch)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 92.0}, holding_check=("UNKNOWN", None), calls=calls
+    )
+    _patch(monkeypatch, trader, agent_holder=PendingFakeAgent(calls))
+
+    summary = asyncio.run(la.run_market("KR", "run-balance-unknown"))
+
+    assert summary["sold"] == 0
+    assert calls == []
+    assert _inflight(tmp_db) == 0
+    assert _owner_state(tmp_db) == "HOLDING"
+
+
+def test_pending_kr_malformed_flat_quantity_never_closes(tmp_db, monkeypatch):
+    _enable_pending_live(monkeypatch)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 92.0}, holding_check=("FLAT", 7), calls=calls
+    )
+    pending_agent = PendingFakeAgent(calls)
+    _patch(monkeypatch, trader, agent_holder=pending_agent)
+
+    summary = asyncio.run(la.run_market("KR", "run-malformed-flat"))
+
+    assert summary["sold"] == 0
+    assert calls == []
+    assert pending_agent.prepare_kwargs is None
+    assert _inflight(tmp_db) == 0
+    assert _owner_state(tmp_db) == "HOLDING"
+
+
+def test_pending_kr_prepare_failure_has_no_broker_or_effects(tmp_db, monkeypatch):
+    _enable_pending_live(monkeypatch)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 92.0}, holding_check=("HELD", 7), calls=calls
+    )
+    _patch(
+        monkeypatch,
+        trader,
+        agent_holder=PendingFakeAgent(calls, failure="prepare"),
+    )
+
+    summary = asyncio.run(la.run_market("KR", "run-prepare-failed"))
+
+    assert summary["sold"] == 0
+    assert calls == ["prepare:7"]
+    assert _inflight(tmp_db) == 0
+    assert _owner_state(tmp_db) == "HOLDING"
+
+
+def test_pending_kr_mismatched_intent_id_quarantines_without_effects(
+    tmp_db, monkeypatch
+):
+    _enable_pending_live(monkeypatch)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 92.0}, holding_check=("HELD", 7), calls=calls
+    )
+    _patch(
+        monkeypatch,
+        trader,
+        agent_holder=PendingFakeAgent(
+            calls, status="SUBMITTED", result_intent_id="foreign-intent"
+        ),
+    )
+
+    summary = asyncio.run(la.run_market("KR", "run-intent-mismatch"))
+
+    assert summary["sold"] == 0
+    assert calls == ["prepare:7", "broker", "quarantine"]
+    assert _inflight(tmp_db, "UNKNOWN") == 1
+    assert _owner_state(tmp_db) == "QUARANTINED"
+
+
+@pytest.mark.parametrize("failure", ["outcome_unknown", "finalize"])
+def test_pending_kr_uncertain_exception_quarantines_without_effects(
+    tmp_db, monkeypatch, failure
+):
+    _enable_pending_live(monkeypatch)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 92.0}, holding_check=("HELD", 7), calls=calls
+    )
+    _patch(
+        monkeypatch,
+        trader,
+        agent_holder=PendingFakeAgent(calls, failure=failure),
+    )
+
+    summary = asyncio.run(la.run_market("KR", f"run-{failure}"))
+
+    assert summary["sold"] == 0
+    assert calls[-1] == "quarantine"
+    assert "tg" not in calls and "publish" not in calls
+    assert _inflight(tmp_db, "UNKNOWN") == 1
+    assert _owner_state(tmp_db) == "QUARANTINED"
+
+
+def test_pending_kr_non_dict_outcome_unknown_still_quarantines(
+    tmp_db, monkeypatch
+):
+    from prism_core.execution_service import OrderOutcomeUnknown
+
+    _enable_pending_live(monkeypatch)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 92.0}, holding_check=("HELD", 7), calls=calls
+    )
+    pending_agent = PendingFakeAgent(calls)
+
+    async def raise_non_dict(_prepared):
+        calls.append("broker")
+        raise OrderOutcomeUnknown(
+            "intent-hardstop-1", broker_result="opaque broker response"
+        )
+
+    pending_agent._execute_pending_kr_exit = raise_non_dict
+    _patch(monkeypatch, trader, agent_holder=pending_agent)
+
+    summary = asyncio.run(la.run_market("KR", "run-opaque-unknown"))
+
+    assert summary["sold"] == 0
+    assert calls == ["prepare:7", "broker", "quarantine"]
+    assert _inflight(tmp_db, "UNKNOWN") == 1
+    assert _owner_state(tmp_db) == "QUARANTINED"
+
+
+def test_pending_kr_cancellation_quarantines_and_reraises(tmp_db, monkeypatch):
+    _enable_pending_live(monkeypatch)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 92.0}, holding_check=("HELD", 7), calls=calls
+    )
+    _patch(
+        monkeypatch,
+        trader,
+        agent_holder=PendingFakeAgent(calls, failure="cancel"),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(la.run_market("KR", "run-cancel"))
+
+    assert calls == ["prepare:7", "broker", "quarantine"]
+    assert _inflight(tmp_db, "UNKNOWN") == 1
+    assert _owner_state(tmp_db) == "QUARANTINED"
+
+
+def test_pending_kr_quarantine_blocks_next_cycle_without_state_downgrade(
+    tmp_db, monkeypatch
+):
+    _enable_pending_live(monkeypatch)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 92.0}, holding_check=("HELD", 7), calls=calls
+    )
+    pending_agent = PendingFakeAgent(calls, status="UNKNOWN")
+    _patch(monkeypatch, trader, agent_holder=pending_agent)
+
+    first = asyncio.run(la.run_market("KR", "run-unknown-first"))
+    first_calls = list(calls)
+    second = asyncio.run(la.run_market("KR", "run-unknown-second"))
+
+    assert first["sold"] == 0 and second["sold"] == 0
+    assert calls == first_calls
+    assert _owner_state(tmp_db) == "QUARANTINED"
+    assert _inflight(tmp_db, "UNKNOWN") == 1
+
+
+def test_pending_kr_post_closed_cancellation_keeps_sold_state(
+    tmp_db, monkeypatch
+):
+    _enable_pending_live(monkeypatch)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 92.0}, holding_check=("HELD", 7), calls=calls
+    )
+    pending_agent = PendingFakeAgent(calls, status="SUBMITTED")
+
+    async def cancel_post_commit(_prepared):
+        calls.append("postcommit")
+        raise asyncio.CancelledError
+
+    pending_agent._run_pending_kr_exit_post_commit = cancel_post_commit
+    _patch(monkeypatch, trader, agent_holder=pending_agent)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(la.run_market("KR", "run-post-closed-cancel"))
+
+    assert "quarantine" not in calls
+    assert _inflight(tmp_db, "FILLED") == 1
+    assert _owner_state(tmp_db) == "SOLD"
 
 
 def test_ledger_failure_after_broker_success_records_unknown(tmp_db, monkeypatch):

--- a/tests/test_kr_pending_exit.py
+++ b/tests/test_kr_pending_exit.py
@@ -1,0 +1,966 @@
+import asyncio
+import sqlite3
+import sys
+import threading
+import types
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import trading.domestic_stock_trading as domestic_trading
+from prism_core.execution_service import OrderOutcomeUnknown
+from prism_core.order_intents import IntentStore
+from prism_core.positions import InvalidPositionTransition, PositionStore
+from stock_tracking_agent import StockTrackingAgent
+from tracking.db_schema import TABLE_STOCK_HOLDINGS, TABLE_TRADING_HISTORY
+
+
+ACCOUNT_ID = "vps:kr-primary:01"
+TICKER = "005930"
+
+
+def _pending_exit_agent(db_path: Path):
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+    connection.execute(TABLE_STOCK_HOLDINGS)
+    connection.execute(TABLE_TRADING_HISTORY)
+    PositionStore(connection).ensure_schema()
+    connection.commit()
+    IntentStore(db_path)
+
+    agent = StockTrackingAgent.__new__(StockTrackingAgent)
+    agent.db_path = str(db_path)
+    agent.conn = connection
+    agent.cursor = connection.cursor()
+    agent.account_configs = [
+        {"name": "kr-primary", "account_key": ACCOUNT_ID}
+    ]
+    agent.active_account = None
+    agent.message_queue = []
+    agent._msg_types = []
+    agent.position_ledger_shadow_enabled = True
+    agent._position_pending_kr_ready = True
+    agent._get_trigger_win_rate = lambda _trigger: ""
+    return agent, connection
+
+
+def _insert_open_holding(
+    connection: sqlite3.Connection,
+    *,
+    buy_price: float = 70000,
+    buy_date: str = "2026-07-01 09:00:00",
+) -> dict:
+    cursor = connection.execute(
+        """
+        INSERT INTO stock_holdings
+        (account_key, account_name, ticker, company_name, buy_price, buy_date,
+         current_price, scenario, trigger_type, trigger_mode, sector)
+        VALUES (?, 'kr-primary', ?, 'Samsung Electronics', ?, ?, 72000,
+                '{}', 'AI Analysis', 'live', 'Technology')
+        """,
+        (ACCOUNT_ID, TICKER, buy_price, buy_date),
+    )
+    legacy_holding_id = int(cursor.lastrowid)
+    PositionStore(connection).open_legacy_position(
+        market="KR",
+        legacy_holding_id=legacy_holding_id,
+        account_id=ACCOUNT_ID,
+        account_name="kr-primary",
+        symbol=TICKER,
+        entry_price=buy_price,
+        opened_at=buy_date,
+    )
+    connection.commit()
+    row = connection.execute(
+        "SELECT * FROM stock_holdings WHERE id=?", (legacy_holding_id,)
+    ).fetchone()
+    return dict(row)
+
+
+def _prepare(agent: StockTrackingAgent, stock: dict, **kwargs):
+    return agent._prepare_pending_kr_exit(
+        stock_data={**stock, "current_price": 72000},
+        sell_reason="risk exit",
+        exit_kind="stop",
+        source="kr_batch",
+        quantity=3,
+        **kwargs,
+    )
+
+
+def _set_intent_status(db_path: Path, intent_id: str, status: str) -> None:
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            "UPDATE order_intents SET status=? WHERE id=?", (status, intent_id)
+        )
+
+
+def _state(db_path: Path, intent_id: str) -> tuple[int, int, str, str]:
+    with sqlite3.connect(db_path) as connection:
+        holdings = connection.execute(
+            "SELECT COUNT(*) FROM stock_holdings WHERE ticker=?", (TICKER,)
+        ).fetchone()[0]
+        history = connection.execute(
+            "SELECT COUNT(*) FROM trading_history WHERE ticker=?", (TICKER,)
+        ).fetchone()[0]
+        intent_status = connection.execute(
+            "SELECT status FROM order_intents WHERE id=?", (intent_id,)
+        ).fetchone()[0]
+        position_status = connection.execute(
+            "SELECT status FROM positions WHERE exit_intent_id=?", (intent_id,)
+        ).fetchone()[0]
+    return holdings, history, intent_status, position_status
+
+
+def test_prepare_persists_created_pending_exit_without_external_effects(
+    monkeypatch, tmp_path
+):
+    db_path = tmp_path / "prepare.sqlite"
+    agent, connection = _pending_exit_agent(db_path)
+    stock = _insert_open_holding(connection)
+    journal_calls = []
+    broker_context_calls = []
+
+    def unexpected_broker_context(**kwargs):
+        broker_context_calls.append(kwargs)
+        raise AssertionError("prepare must not enter the broker context")
+
+    monkeypatch.setattr(
+        "stock_tracking_agent.ExecutionService.domestic",
+        unexpected_broker_context,
+    )
+
+    async def journal(**kwargs):
+        journal_calls.append(kwargs)
+
+    agent._create_journal_entry = journal
+    try:
+        prepared = _prepare(agent, stock)
+        state = _state(db_path, prepared.intent.id)
+        source_position_id = connection.execute(
+            "SELECT source_position_id FROM order_intents WHERE id=?",
+            (prepared.intent.id,),
+        ).fetchone()[0]
+        broker_order_count = connection.execute(
+            "SELECT COUNT(*) FROM broker_orders WHERE intent_id=?",
+            (prepared.intent.id,),
+        ).fetchone()[0]
+    finally:
+        connection.close()
+
+    assert state == (1, 0, "CREATED", "PENDING_EXIT")
+    assert source_position_id == f"legacy:KR:{stock['id']}"
+    assert prepared.intent_store is not None
+    assert prepared.reservation["id"] == prepared.intent.id
+    assert prepared.order_style == "smart"
+    assert prepared.limit_price == 72000
+    assert broker_order_count == 0
+    assert broker_context_calls == []
+    assert agent.message_queue == []
+    assert journal_calls == []
+
+
+@pytest.mark.parametrize(
+    ("order_style", "limit_price", "expected_limit"),
+    [("smart", "default", 72000), ("market", None, None)],
+)
+@pytest.mark.asyncio
+async def test_pending_exit_preserves_smart_and_market_broker_contracts(
+    monkeypatch, tmp_path, order_style, limit_price, expected_limit
+):
+    db_path = tmp_path / f"{order_style}-order.sqlite"
+    agent, connection = _pending_exit_agent(db_path)
+    stock = _insert_open_holding(connection)
+    calls = []
+
+    class ExecutionContext:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def execute_pre_reserved_sell(self, **kwargs):
+            calls.append(kwargs)
+            return {"success": True, "intent_status": "SUBMITTED"}
+
+    monkeypatch.setattr(
+        "stock_tracking_agent.ExecutionService.domestic",
+        lambda **_kwargs: ExecutionContext(),
+    )
+    try:
+        prepare_kwargs = {"order_style": order_style}
+        if limit_price != "default":
+            prepare_kwargs["limit_price"] = limit_price
+        prepared = _prepare(agent, stock, **prepare_kwargs)
+        result = await agent._execute_pending_kr_exit(prepared)
+    finally:
+        connection.close()
+
+    assert result["intent_status"] == "SUBMITTED"
+    assert prepared.order_style == prepared.intent.order_style == order_style
+    assert prepared.limit_price == expected_limit
+    if expected_limit is None:
+        assert prepared.intent.limit_price is None
+    else:
+        assert float(prepared.intent.limit_price) == expected_limit
+    assert len(calls) == 1
+    if expected_limit is None:
+        assert "limit_price" not in calls[0]
+    else:
+        assert calls[0]["limit_price"] == expected_limit
+
+
+def test_explicit_failed_exit_reopens_without_legacy_effects(tmp_path):
+    db_path = tmp_path / "failed.sqlite"
+    agent, connection = _pending_exit_agent(db_path)
+    stock = _insert_open_holding(connection)
+    try:
+        prepared = _prepare(agent, stock)
+        _set_intent_status(db_path, prepared.intent.id, "FAILED")
+        agent._fail_pending_kr_exit(prepared)
+        state = _state(db_path, prepared.intent.id)
+    finally:
+        connection.close()
+
+    assert state == (1, 0, "FAILED", "OPEN")
+    assert agent.message_queue == []
+
+
+@pytest.mark.parametrize("intent_status", ["UNKNOWN", "QUEUED", "SUBMITTING"])
+def test_uncertain_exit_is_quarantined_without_legacy_effects(
+    tmp_path, intent_status
+):
+    db_path = tmp_path / f"quarantine-{intent_status.lower()}.sqlite"
+    agent, connection = _pending_exit_agent(db_path)
+    stock = _insert_open_holding(connection)
+    try:
+        prepared = _prepare(agent, stock)
+        _set_intent_status(db_path, prepared.intent.id, intent_status)
+        agent._quarantine_pending_kr_exit(prepared)
+        state = _state(db_path, prepared.intent.id)
+    finally:
+        connection.close()
+
+    assert state == (1, 0, intent_status, "EXIT_UNKNOWN")
+    assert agent.message_queue == []
+
+
+def test_complete_exit_rolls_back_legacy_writes_when_position_finalize_fails(
+    monkeypatch, tmp_path
+):
+    db_path = tmp_path / "complete-rollback.sqlite"
+    agent, connection = _pending_exit_agent(db_path)
+    stock = _insert_open_holding(connection)
+    prepared = _prepare(agent, stock)
+    _set_intent_status(db_path, prepared.intent.id, "SUBMITTED")
+
+    def fail_complete(_store, **_kwargs):
+        raise sqlite3.OperationalError("injected CLOSED finalize failure")
+
+    monkeypatch.setattr(PositionStore, "complete_exit_many", fail_complete)
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            agent._complete_pending_kr_exit(prepared)
+        state = _state(db_path, prepared.intent.id)
+    finally:
+        connection.close()
+
+    assert state == (1, 0, "SUBMITTED", "PENDING_EXIT")
+    assert agent.message_queue == []
+
+
+def test_complete_exit_deletes_only_target_pyramid_row_and_queues_message(tmp_path):
+    db_path = tmp_path / "complete-pyramid.sqlite"
+    agent, connection = _pending_exit_agent(db_path)
+    target = _insert_open_holding(connection, buy_price=70000)
+    sibling = _insert_open_holding(connection, buy_price=68000)
+    try:
+        prepared = _prepare(agent, target)
+        _set_intent_status(db_path, prepared.intent.id, "SUBMITTED")
+        agent._complete_pending_kr_exit(prepared)
+        remaining_ids = [
+            row[0]
+            for row in connection.execute(
+                "SELECT id FROM stock_holdings ORDER BY id"
+            ).fetchall()
+        ]
+        history = connection.execute(
+            "SELECT buy_price, sell_price, exit_kind FROM trading_history"
+        ).fetchone()
+        state = connection.execute(
+            "SELECT status FROM positions WHERE id=?",
+            (f"legacy:KR:{target['id']}",),
+        ).fetchone()[0]
+    finally:
+        connection.close()
+
+    assert remaining_ids == [sibling["id"]]
+    assert tuple(history) == (70000, 72000, "stop")
+    assert state == "CLOSED"
+    assert len(agent.message_queue) == 1
+    assert agent._msg_types == ["analysis"]
+
+
+def test_prepare_blocks_when_same_symbol_sibling_is_unresolved(tmp_path):
+    db_path = tmp_path / "sibling-guard.sqlite"
+    agent, connection = _pending_exit_agent(db_path)
+    target = _insert_open_holding(connection, buy_price=70000)
+    sibling = _insert_open_holding(connection, buy_price=68000)
+    connection.execute(
+        "UPDATE positions SET status='EXIT_UNKNOWN' WHERE id=?",
+        (f"legacy:KR:{sibling['id']}",),
+    )
+    connection.commit()
+    try:
+        with pytest.raises(InvalidPositionTransition, match="exit attempt"):
+            _prepare(agent, target)
+        counts = connection.execute(
+            "SELECT COUNT(*) FROM order_intents"
+        ).fetchone()[0]
+    finally:
+        connection.close()
+
+    assert counts == 0
+    assert agent.message_queue == []
+
+
+def test_concurrent_prepare_claims_exact_position_once(tmp_path):
+    db_path = tmp_path / "concurrent-prepare.sqlite"
+    _setup_agent, setup_connection = _pending_exit_agent(db_path)
+    stock = _insert_open_holding(setup_connection)
+    setup_connection.close()
+    barrier = threading.Barrier(2)
+
+    def contender():
+        connection = sqlite3.connect(db_path, timeout=2)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA busy_timeout=2000")
+        agent = StockTrackingAgent.__new__(StockTrackingAgent)
+        agent.db_path = str(db_path)
+        agent.conn = connection
+        agent.cursor = connection.cursor()
+        agent.message_queue = []
+        agent._msg_types = []
+        agent.position_ledger_shadow_enabled = True
+        agent._position_pending_kr_ready = True
+        agent._account_scope = lambda: (ACCOUNT_ID, "kr-primary")
+        agent._get_trigger_win_rate = lambda _trigger: ""
+        try:
+            barrier.wait(timeout=2)
+            prepared = _prepare(agent, stock)
+            return "claimed", prepared.intent.id
+        except Exception as error:
+            return "blocked", type(error).__name__
+        finally:
+            connection.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(lambda _index: contender(), range(2)))
+
+    with sqlite3.connect(db_path) as verify:
+        intent_count = verify.execute(
+            "SELECT COUNT(*) FROM order_intents"
+        ).fetchone()[0]
+        pending_count = verify.execute(
+            "SELECT COUNT(*) FROM positions WHERE status='PENDING_EXIT'"
+        ).fetchone()[0]
+
+    assert sorted(result[0] for result in results) == ["blocked", "claimed"]
+    assert intent_count == 1
+    assert pending_count == 1
+
+
+def test_pre_broker_created_exit_remains_pending_for_manual_review(tmp_path):
+    db_path = tmp_path / "created-cancel.sqlite"
+    agent, connection = _pending_exit_agent(db_path)
+    stock = _insert_open_holding(connection)
+    try:
+        prepared = _prepare(agent, stock)
+        with pytest.raises(InvalidPositionTransition, match="requires one of"):
+            agent._quarantine_pending_kr_exit(prepared)
+        state = _state(db_path, prepared.intent.id)
+    finally:
+        connection.close()
+
+    assert state == (1, 0, "CREATED", "PENDING_EXIT")
+    assert agent.message_queue == []
+
+
+@pytest.mark.asyncio
+async def test_post_commit_effects_create_journal_and_run_closed_hook(tmp_path):
+    db_path = tmp_path / "post-commit.sqlite"
+    agent, connection = _pending_exit_agent(db_path)
+    stock = _insert_open_holding(connection)
+    prepared = _prepare(agent, stock)
+    _set_intent_status(db_path, prepared.intent.id, "SUBMITTED")
+    journal_states = []
+    hook_states = []
+
+    async def journal(**_kwargs):
+        journal_states.append(_state(db_path, prepared.intent.id))
+
+    async def hook(value):
+        hook_states.append((value, _state(db_path, prepared.intent.id)))
+
+    agent._create_journal_entry = journal
+    agent._after_pending_kr_exit_closed = hook
+    try:
+        agent._complete_pending_kr_exit(prepared)
+        await agent._run_pending_kr_exit_post_commit(prepared)
+    finally:
+        connection.close()
+
+    assert journal_states == [(0, 1, "SUBMITTED", "CLOSED")]
+    assert hook_states == [(prepared, (0, 1, "SUBMITTED", "CLOSED"))]
+
+
+@pytest.mark.asyncio
+async def test_post_commit_effects_reject_pending_position_before_journal(tmp_path):
+    db_path = tmp_path / "premature-post-commit.sqlite"
+    agent, connection = _pending_exit_agent(db_path)
+    stock = _insert_open_holding(connection)
+    prepared = _prepare(agent, stock)
+    journal_calls = []
+
+    async def journal(**kwargs):
+        journal_calls.append(kwargs)
+
+    agent._create_journal_entry = journal
+    try:
+        with pytest.raises(RuntimeError, match="durable CLOSED"):
+            await agent._run_pending_kr_exit_post_commit(prepared)
+    finally:
+        connection.close()
+
+    assert journal_calls == []
+
+
+def _batch_agent(db_path: Path, *, rows: int = 1):
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+    connection.execute(TABLE_STOCK_HOLDINGS)
+    for index in range(rows):
+        connection.execute(
+            """
+            INSERT INTO stock_holdings
+            (account_key, account_name, ticker, company_name, buy_price, buy_date,
+             current_price, scenario, trigger_type, trigger_mode, sector)
+            VALUES (?, 'kr-primary', ?, 'Samsung Electronics', ?,
+                    '2026-07-01 09:00:00', 71000, '{}', 'AI Analysis',
+                    'live', 'Technology')
+            """,
+            (ACCOUNT_ID, TICKER, 70000 - index * 1000),
+        )
+    connection.commit()
+
+    agent = StockTrackingAgent.__new__(StockTrackingAgent)
+    agent.db_path = str(db_path)
+    agent.conn = connection
+    agent.cursor = connection.cursor()
+    agent.active_account = {
+        "name": "kr-primary",
+        "account_key": ACCOUNT_ID,
+    }
+    agent.message_queue = []
+    agent._msg_types = []
+    agent._get_live_regime_safe = lambda: None
+
+    async def current_price(_ticker):
+        return 72000
+
+    async def sell_decision(_stock):
+        return True, "risk exit"
+
+    agent._get_current_stock_price = current_price
+    agent._analyze_sell_decision = sell_decision
+    return agent, connection
+
+
+def _install_batch_runtime(
+    monkeypatch,
+    *,
+    agent,
+    checked_result=("HELD", 10),
+    intent_status="SUBMITTED",
+    execute_error: BaseException | None = None,
+    complete_error: BaseException | None = None,
+    prepare_error: BaseException | None = None,
+):
+    events = []
+    prepared_quantities = []
+    checked_calls = []
+    broker_calls = []
+
+    class CheckedContext:
+        def __init__(self, account_name=None, **_kwargs):
+            self.account_name = account_name
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def get_holding_quantity_checked(self, ticker):
+            checked_calls.append(ticker)
+            return checked_result
+
+        def get_holding_quantity(self, _ticker):
+            raise AssertionError("gate=true must use the checked quantity API")
+
+        async def async_sell_stock(self, *args, **kwargs):
+            broker_calls.append((args, kwargs))
+            raise AssertionError("stubbed pending helper owns broker execution")
+
+    monkeypatch.setattr(domestic_trading, "AsyncTradingContext", CheckedContext)
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+
+    corporate_module = types.ModuleType("cores.corporate_status")
+
+    async def fetch_status_codes(*_args, **_kwargs):
+        return {}
+
+    corporate_module.fetch_status_codes = fetch_status_codes
+    monkeypatch.setitem(sys.modules, "cores.corporate_status", corporate_module)
+
+    def prepare(**kwargs):
+        events.append("prepare")
+        prepared_quantities.append(kwargs["quantity"])
+        if prepare_error is not None:
+            raise prepare_error
+        return SimpleNamespace(
+            symbol=kwargs["stock_data"]["ticker"],
+            intent=SimpleNamespace(id="intent-1"),
+            sell_price=kwargs["stock_data"]["current_price"],
+            profit_rate=(
+                (kwargs["stock_data"]["current_price"] - kwargs["stock_data"]["buy_price"])
+                / kwargs["stock_data"]["buy_price"]
+                * 100
+            ),
+        )
+
+    async def execute(prepared):
+        events.append("execute")
+        if execute_error is not None:
+            raise execute_error
+        return {
+            "success": intent_status == "SUBMITTED",
+            "intent_id": prepared.intent.id,
+            "intent_status": intent_status,
+            "message": intent_status.lower(),
+        }
+
+    async def local_flat(prepared):
+        events.append("local-flat")
+        return {
+            "success": True,
+            "local_flat": True,
+            "intent_id": prepared.intent.id,
+            "intent_status": "SUBMITTED",
+            "message": "local flat",
+        }
+
+    def complete(_prepared):
+        events.append("complete")
+        if complete_error is not None:
+            raise complete_error
+
+    def fail(_prepared):
+        events.append("fail")
+
+    def quarantine(_prepared):
+        events.append("quarantine")
+
+    async def post_commit(_prepared):
+        events.append("post-commit")
+
+    agent._prepare_pending_kr_exit = prepare
+    agent._execute_pending_kr_exit = execute
+    agent._execute_pending_kr_local_flat_exit = local_flat
+    agent._complete_pending_kr_exit = complete
+    agent._fail_pending_kr_exit = fail
+    agent._quarantine_pending_kr_exit = quarantine
+    agent._run_pending_kr_exit_post_commit = post_commit
+
+    redis_module = types.ModuleType("messaging.redis_signal_publisher")
+    gcp_module = types.ModuleType("messaging.gcp_pubsub_signal_publisher")
+
+    async def publish_redis(**_kwargs):
+        events.append("redis")
+
+    async def publish_gcp(**_kwargs):
+        events.append("gcp")
+
+    redis_module.publish_sell_signal = publish_redis
+    gcp_module.publish_sell_signal = publish_gcp
+    monkeypatch.setitem(sys.modules, "messaging.redis_signal_publisher", redis_module)
+    monkeypatch.setitem(
+        sys.modules, "messaging.gcp_pubsub_signal_publisher", gcp_module
+    )
+    return events, prepared_quantities, checked_calls, broker_calls
+
+
+@pytest.mark.asyncio
+async def test_batch_pending_exit_submitted_completes_before_publish(
+    monkeypatch, tmp_path
+):
+    agent, connection = _batch_agent(tmp_path / "batch-submitted.sqlite")
+    events, quantities, checked, direct_broker = _install_batch_runtime(
+        monkeypatch, agent=agent
+    )
+    try:
+        sold = await agent.update_holdings()
+    finally:
+        connection.close()
+
+    assert [item["ticker"] for item in sold] == [TICKER]
+    assert quantities == [None]
+    assert checked == [TICKER]
+    assert direct_broker == []
+    assert events == [
+        "prepare",
+        "execute",
+        "complete",
+        "post-commit",
+        "redis",
+        "gcp",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_batch_post_closed_cancellation_does_not_quarantine(
+    monkeypatch, tmp_path
+):
+    agent, connection = _batch_agent(tmp_path / "batch-post-closed-cancel.sqlite")
+    events, _, _, _ = _install_batch_runtime(monkeypatch, agent=agent)
+
+    async def cancel_post_commit(_prepared):
+        events.append("post-commit")
+        raise asyncio.CancelledError
+
+    agent._run_pending_kr_exit_post_commit = cancel_post_commit
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await agent.update_holdings()
+    finally:
+        connection.close()
+
+    assert events == ["prepare", "execute", "complete", "post-commit"]
+
+
+@pytest.mark.parametrize(
+    ("intent_status", "terminal_event"),
+    [("FAILED", "fail"), ("UNKNOWN", "quarantine"), ("SUBMITTING", "quarantine")],
+)
+@pytest.mark.asyncio
+async def test_batch_pending_exit_non_submitted_has_no_publish_or_sold(
+    monkeypatch, tmp_path, intent_status, terminal_event
+):
+    agent, connection = _batch_agent(
+        tmp_path / f"batch-{intent_status.lower()}.sqlite"
+    )
+    events, _, _, _ = _install_batch_runtime(
+        monkeypatch, agent=agent, intent_status=intent_status
+    )
+    try:
+        sold = await agent.update_holdings()
+    finally:
+        connection.close()
+
+    assert sold == []
+    assert events == ["prepare", "execute", terminal_event]
+
+
+@pytest.mark.asyncio
+async def test_batch_pending_exit_queued_stays_pending_without_effects(
+    monkeypatch, tmp_path
+):
+    agent, connection = _batch_agent(tmp_path / "batch-queued.sqlite")
+    events, _, _, _ = _install_batch_runtime(
+        monkeypatch, agent=agent, intent_status="QUEUED"
+    )
+    try:
+        sold = await agent.update_holdings()
+    finally:
+        connection.close()
+
+    assert sold == []
+    assert events == ["prepare", "execute"]
+
+
+@pytest.mark.asyncio
+async def test_batch_pending_exit_local_flat_uses_reconciliation_not_broker(
+    monkeypatch, tmp_path
+):
+    agent, connection = _batch_agent(tmp_path / "batch-flat.sqlite")
+    events, quantities, checked, direct_broker = _install_batch_runtime(
+        monkeypatch, agent=agent, checked_result=("FLAT", 0)
+    )
+    try:
+        sold = await agent.update_holdings()
+    finally:
+        connection.close()
+
+    assert [item["ticker"] for item in sold] == [TICKER]
+    assert quantities == [None]
+    assert checked == [TICKER]
+    assert direct_broker == []
+    assert events == [
+        "prepare",
+        "local-flat",
+        "complete",
+        "post-commit",
+        "redis",
+        "gcp",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_batch_checked_unknown_stops_before_prepare_and_effects(
+    monkeypatch, tmp_path
+):
+    agent, connection = _batch_agent(tmp_path / "batch-checked-unknown.sqlite")
+    events, _, checked, direct_broker = _install_batch_runtime(
+        monkeypatch, agent=agent, checked_result=("UNKNOWN", None)
+    )
+    try:
+        sold = await agent.update_holdings()
+    finally:
+        connection.close()
+
+    assert sold == []
+    assert events == []
+    assert checked == [TICKER]
+    assert direct_broker == []
+
+
+@pytest.mark.asyncio
+async def test_batch_malformed_flat_quantity_stops_before_prepare_and_effects(
+    monkeypatch, tmp_path
+):
+    agent, connection = _batch_agent(tmp_path / "batch-malformed-flat.sqlite")
+    events, _, checked, direct_broker = _install_batch_runtime(
+        monkeypatch, agent=agent, checked_result=("FLAT", 7)
+    )
+    try:
+        sold = await agent.update_holdings()
+    finally:
+        connection.close()
+
+    assert sold == []
+    assert events == []
+    assert checked == [TICKER]
+    assert direct_broker == []
+
+
+@pytest.mark.asyncio
+async def test_batch_opaque_result_is_quarantined_without_effects(
+    monkeypatch, tmp_path
+):
+    agent, connection = _batch_agent(tmp_path / "batch-opaque-result.sqlite")
+    events, _, _, _ = _install_batch_runtime(monkeypatch, agent=agent)
+
+    async def opaque_result(_prepared):
+        events.append("execute")
+        return "opaque broker response"
+
+    agent._execute_pending_kr_exit = opaque_result
+    try:
+        sold = await agent.update_holdings()
+    finally:
+        connection.close()
+
+    assert sold == []
+    assert events == ["prepare", "execute", "quarantine"]
+
+
+@pytest.mark.asyncio
+async def test_batch_pyramided_ticker_is_blocked_before_balance_and_broker(
+    monkeypatch, tmp_path
+):
+    agent, connection = _batch_agent(tmp_path / "batch-pyramid-blocked.sqlite", rows=2)
+    events, quantities, checked, _ = _install_batch_runtime(
+        monkeypatch, agent=agent, intent_status="SUBMITTED"
+    )
+    try:
+        sold = await agent.update_holdings()
+    finally:
+        connection.close()
+
+    assert sold == []
+    assert quantities == []
+    assert checked == []
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_batch_finalize_failure_quarantines_without_publish(
+    monkeypatch, tmp_path
+):
+    agent, connection = _batch_agent(tmp_path / "batch-finalize-fail.sqlite")
+    events, _, _, _ = _install_batch_runtime(
+        monkeypatch,
+        agent=agent,
+        complete_error=sqlite3.OperationalError("injected finalize rollback"),
+    )
+    try:
+        sold = await agent.update_holdings()
+    finally:
+        connection.close()
+
+    assert sold == []
+    assert events == ["prepare", "execute", "complete", "quarantine"]
+
+
+@pytest.mark.asyncio
+async def test_batch_order_outcome_unknown_quarantines_without_effects(
+    monkeypatch, tmp_path
+):
+    agent, connection = _batch_agent(tmp_path / "batch-order-unknown.sqlite")
+    events, _, _, _ = _install_batch_runtime(
+        monkeypatch,
+        agent=agent,
+        execute_error=OrderOutcomeUnknown("intent-1"),
+    )
+    try:
+        sold = await agent.update_holdings()
+    finally:
+        connection.close()
+
+    assert sold == []
+    assert events == ["prepare", "execute", "quarantine"]
+
+
+@pytest.mark.asyncio
+async def test_batch_prepare_conflict_stops_before_broker(
+    monkeypatch, tmp_path
+):
+    agent, connection = _batch_agent(tmp_path / "batch-prepare-conflict.sqlite")
+    events, _, _, _ = _install_batch_runtime(
+        monkeypatch,
+        agent=agent,
+        prepare_error=InvalidPositionTransition("failed exit tombstone"),
+    )
+    try:
+        sold = await agent.update_holdings()
+    finally:
+        connection.close()
+
+    assert sold == []
+    assert events == ["prepare"]
+
+
+@pytest.mark.asyncio
+async def test_batch_cancellation_quarantines_when_possible_then_reraises(
+    monkeypatch, tmp_path
+):
+    agent, connection = _batch_agent(tmp_path / "batch-cancel.sqlite")
+    events, _, _, _ = _install_batch_runtime(
+        monkeypatch, agent=agent, execute_error=asyncio.CancelledError()
+    )
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await agent.update_holdings()
+    finally:
+        connection.close()
+
+    assert events == ["prepare", "execute", "quarantine"]
+
+
+@pytest.mark.parametrize(
+    ("checked_result", "expected_broker_calls"),
+    [(('HELD', 10), 1), (('FLAT', 0), 0)],
+    ids=["held", "local-flat"],
+)
+@pytest.mark.asyncio
+async def test_batch_pending_exit_real_lifecycle_reaches_closed(
+    monkeypatch, tmp_path, checked_result, expected_broker_calls
+):
+    db_path = tmp_path / f"real-{checked_result[0].lower()}.sqlite"
+    agent, connection = _pending_exit_agent(db_path)
+    _insert_open_holding(connection)
+    agent.active_account = agent.account_configs[0]
+    agent._get_live_regime_safe = lambda: None
+    broker_calls = []
+
+    async def current_price(_ticker):
+        return 72000
+
+    async def sell_decision(_stock):
+        return True, "risk exit"
+
+    async def journal(**_kwargs):
+        return True
+
+    agent._get_current_stock_price = current_price
+    agent._analyze_sell_decision = sell_decision
+    agent._create_journal_entry = journal
+
+    class BrokerContext:
+        def __init__(self, account_name=None, **_kwargs):
+            self.account_name = account_name
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def get_holding_quantity_checked(self, _ticker):
+            return checked_result
+
+        async def async_sell_stock(self, **kwargs):
+            broker_calls.append(kwargs)
+            return {
+                "success": True,
+                "message": "submitted",
+                "order_no": "KR-1",
+            }
+
+    monkeypatch.setattr(domestic_trading, "AsyncTradingContext", BrokerContext)
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+    monkeypatch.setenv("POSITION_LEDGER_SHADOW_ENABLED", "true")
+    corporate_module = types.ModuleType("cores.corporate_status")
+
+    async def fetch_status_codes(*_args, **_kwargs):
+        return {}
+
+    corporate_module.fetch_status_codes = fetch_status_codes
+    monkeypatch.setitem(sys.modules, "cores.corporate_status", corporate_module)
+    redis_module = types.ModuleType("messaging.redis_signal_publisher")
+    gcp_module = types.ModuleType("messaging.gcp_pubsub_signal_publisher")
+    signal_calls = []
+
+    async def publish(**_kwargs):
+        signal_calls.append(_kwargs)
+
+    redis_module.publish_sell_signal = publish
+    gcp_module.publish_sell_signal = publish
+    monkeypatch.setitem(sys.modules, "messaging.redis_signal_publisher", redis_module)
+    monkeypatch.setitem(
+        sys.modules, "messaging.gcp_pubsub_signal_publisher", gcp_module
+    )
+
+    try:
+        sold = await agent.update_holdings()
+        lifecycle = connection.execute(
+            """
+            SELECT i.status, p.status,
+                   (SELECT COUNT(*) FROM stock_holdings),
+                   (SELECT COUNT(*) FROM trading_history),
+                   (SELECT COUNT(*) FROM broker_orders)
+            FROM order_intents i
+            JOIN positions p ON p.exit_intent_id=i.id
+            WHERE i.side='SELL'
+            """
+        ).fetchone()
+    finally:
+        connection.close()
+
+    assert [item["ticker"] for item in sold] == [TICKER]
+    assert tuple(lifecycle) == ("SUBMITTED", "CLOSED", 0, 1, 1)
+    assert len(broker_calls) == expected_broker_calls
+    assert len(signal_calls) == 2

--- a/tests/test_order_intents.py
+++ b/tests/test_order_intents.py
@@ -480,6 +480,381 @@ def test_pre_reserved_sync_sell_binds_capability_side_before_broker(tmp_path):
     assert broker.calls == 1
 
 
+def test_pre_reserved_local_flat_sell_consumes_capability_without_broker(
+    tmp_path, monkeypatch
+):
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore
+
+    db_path = tmp_path / "orders.sqlite"
+    store = IntentStore(db_path)
+    intent = _intent(side="sell", source_position_id="local-flat")
+    connection = sqlite3.connect(db_path)
+    connection.execute("BEGIN IMMEDIATE")
+    _, reservation = store.reserve_in_transaction(connection, intent)
+    connection.commit()
+    broker = FakeBroker()
+    observed_statuses = []
+    real_record_result = store.record_result
+
+    def observe_submitting(*args, **kwargs):
+        with sqlite3.connect(db_path) as verify:
+            observed_statuses.append(
+                verify.execute(
+                    "SELECT status FROM order_intents WHERE id=?", (intent.id,)
+                ).fetchone()[0]
+            )
+        return real_record_result(*args, **kwargs)
+
+    monkeypatch.setattr(store, "record_result", observe_submitting)
+
+    result = asyncio.run(
+        ExecutionService(
+            broker, intent_store=store
+        ).execute_pre_reserved_local_flat_sell(
+            intent=intent, reservation=reservation
+        )
+    )
+
+    assert broker.calls == 0
+    assert observed_statuses == ["SUBMITTING"]
+    assert result == {
+        "success": True,
+        "local_flat": True,
+        "quantity": 0,
+        "intent_id": intent.id,
+        "intent_status": "SUBMITTED",
+        "intent_broker": "LOCAL_RECONCILIATION",
+    }
+    with sqlite3.connect(db_path) as verify:
+        assert verify.execute(
+            "SELECT status FROM order_intents WHERE id=?", (intent.id,)
+        ).fetchone() == ("SUBMITTED",)
+        rows = verify.execute(
+            "SELECT broker, accepted, status, raw_response_json "
+            "FROM broker_orders WHERE intent_id=?",
+            (intent.id,),
+        ).fetchall()
+    assert len(rows) == 1
+    assert rows[0][:3] == ("LOCAL_RECONCILIATION", 1, "SUBMITTED")
+    assert '"success": true' in rows[0][3]
+    assert '"local_flat": true' in rows[0][3]
+    assert '"quantity": 0' in rows[0][3]
+
+
+def test_pre_reserved_local_flat_sell_rejects_wrong_side_without_audit(tmp_path):
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore
+
+    db_path = tmp_path / "orders.sqlite"
+    store = IntentStore(db_path)
+    intent = _intent(side="buy", source_position_id="local-flat-wrong-side")
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        _, reservation = store.reserve_in_transaction(connection, intent)
+        connection.commit()
+    broker = FakeBroker()
+
+    with pytest.raises(ValueError, match="side"):
+        asyncio.run(
+            ExecutionService(
+                broker, intent_store=store
+            ).execute_pre_reserved_local_flat_sell(
+                intent=intent, reservation=reservation
+            )
+        )
+
+    assert broker.calls == 0
+    intents, orders = _rows(db_path)
+    assert intents[0][0] == "CREATED"
+    assert orders == []
+
+
+def test_pre_reserved_local_flat_sell_rejects_foreign_capability_without_audit(
+    tmp_path,
+):
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore
+
+    originating_store = IntentStore(tmp_path / "origin.sqlite")
+    foreign_store = IntentStore(tmp_path / "foreign.sqlite")
+    intent = _intent(side="sell", source_position_id="local-flat-foreign")
+    with sqlite3.connect(originating_store.db_path) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        _, reservation = originating_store.reserve_in_transaction(connection, intent)
+        connection.commit()
+    broker = FakeBroker()
+
+    with pytest.raises(TypeError, match="valid unused"):
+        asyncio.run(
+            ExecutionService(
+                broker, intent_store=foreign_store
+            ).execute_pre_reserved_local_flat_sell(
+                intent=intent, reservation=reservation
+            )
+        )
+
+    assert broker.calls == 0
+    assert _rows(originating_store.db_path)[1] == []
+    assert _rows(foreign_store.db_path) == ([], [])
+
+
+def test_pre_reserved_local_flat_sell_rejects_used_capability_without_new_audit(
+    tmp_path,
+):
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore
+
+    db_path = tmp_path / "orders.sqlite"
+    store = IntentStore(db_path)
+    intent = _intent(side="sell", source_position_id="local-flat-used")
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        _, reservation = store.reserve_in_transaction(connection, intent)
+        connection.commit()
+    broker = FakeBroker()
+    service = ExecutionService(broker, intent_store=store)
+
+    asyncio.run(
+        service.execute_pre_reserved_local_flat_sell(
+            intent=intent, reservation=reservation
+        )
+    )
+    with pytest.raises(TypeError, match="valid unused"):
+        asyncio.run(
+            service.execute_pre_reserved_local_flat_sell(
+                intent=intent, reservation=reservation
+            )
+        )
+
+    assert broker.calls == 0
+    assert len(_rows(db_path)[1]) == 1
+
+
+def test_pre_reserved_local_flat_sell_rejects_rolled_back_capability_without_audit(
+    tmp_path,
+):
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore
+
+    db_path = tmp_path / "orders.sqlite"
+    store = IntentStore(db_path)
+    intent = _intent(side="sell", source_position_id="local-flat-rolled-back")
+    connection = sqlite3.connect(db_path)
+    connection.execute("BEGIN IMMEDIATE")
+    _, reservation = store.reserve_in_transaction(connection, intent)
+    connection.rollback()
+    broker = FakeBroker()
+
+    with pytest.raises(RuntimeError, match="not in CREATED"):
+        asyncio.run(
+            ExecutionService(
+                broker, intent_store=store
+            ).execute_pre_reserved_local_flat_sell(
+                intent=intent, reservation=reservation
+            )
+        )
+
+    assert broker.calls == 0
+    assert _rows(db_path) == ([], [])
+
+
+def test_pre_reserved_local_flat_sell_joins_cancelled_delayed_claim(
+    tmp_path, monkeypatch
+):
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore
+
+    db_path = tmp_path / "orders.sqlite"
+    store = IntentStore(db_path)
+    intent = _intent(side="sell", source_position_id="local-flat-cancel-claim")
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        _, reservation = store.reserve_in_transaction(connection, intent)
+        connection.commit()
+    broker = FakeBroker()
+    started = threading.Event()
+    release = threading.Event()
+    real_claim = store.claim_reservation
+
+    def delayed_claim(*args, **kwargs):
+        started.set()
+        assert release.wait(timeout=2)
+        return real_claim(*args, **kwargs)
+
+    monkeypatch.setattr(store, "claim_reservation", delayed_claim)
+
+    async def exercise():
+        task = asyncio.create_task(
+            ExecutionService(
+                broker, intent_store=store
+            ).execute_pre_reserved_local_flat_sell(
+                intent=intent, reservation=reservation
+            )
+        )
+        assert await asyncio.to_thread(started.wait, 2)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(exercise())
+
+    assert broker.calls == 0
+    intents, orders = _rows(db_path)
+    assert intents[0][0] == "SUBMITTED"
+    assert len(orders) == 1
+    assert orders[0][0:2] == (1, "SUBMITTED")
+    assert orders[0][4] == "LOCAL_RECONCILIATION"
+
+
+def test_pre_reserved_local_flat_sell_joins_cancelled_delayed_record(
+    tmp_path, monkeypatch
+):
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore
+
+    db_path = tmp_path / "orders.sqlite"
+    store = IntentStore(db_path)
+    intent = _intent(side="sell", source_position_id="local-flat-cancel-record")
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        _, reservation = store.reserve_in_transaction(connection, intent)
+        connection.commit()
+    broker = FakeBroker()
+    started = threading.Event()
+    release = threading.Event()
+    real_record = store.record_result
+
+    def delayed_record(*args, **kwargs):
+        started.set()
+        assert release.wait(timeout=2)
+        return real_record(*args, **kwargs)
+
+    monkeypatch.setattr(store, "record_result", delayed_record)
+
+    async def exercise():
+        task = asyncio.create_task(
+            ExecutionService(
+                broker, intent_store=store
+            ).execute_pre_reserved_local_flat_sell(
+                intent=intent, reservation=reservation
+            )
+        )
+        assert await asyncio.to_thread(started.wait, 2)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(exercise())
+
+    assert broker.calls == 0
+    intents, orders = _rows(db_path)
+    assert intents[0][0] == "SUBMITTED"
+    assert len(orders) == 1
+    assert orders[0][0:2] == (1, "SUBMITTED")
+    assert orders[0][4] == "LOCAL_RECONCILIATION"
+
+
+def test_pre_reserved_local_flat_sell_joins_after_repeated_cancellation(
+    tmp_path, monkeypatch
+):
+    from prism_core.execution_service import ExecutionService
+    from prism_core.order_intents import IntentStore
+
+    db_path = tmp_path / "orders.sqlite"
+    store = IntentStore(db_path)
+    intent = _intent(side="sell", source_position_id="local-flat-repeat-cancel")
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        _, reservation = store.reserve_in_transaction(connection, intent)
+        connection.commit()
+    broker = FakeBroker()
+    started = threading.Event()
+    release = threading.Event()
+    real_record = store.record_result
+
+    def delayed_record(*args, **kwargs):
+        started.set()
+        assert release.wait(timeout=2)
+        return real_record(*args, **kwargs)
+
+    monkeypatch.setattr(store, "record_result", delayed_record)
+
+    async def exercise():
+        task = asyncio.create_task(
+            ExecutionService(
+                broker, intent_store=store
+            ).execute_pre_reserved_local_flat_sell(
+                intent=intent, reservation=reservation
+            )
+        )
+        assert await asyncio.to_thread(started.wait, 2)
+        task.cancel()
+        await asyncio.sleep(0)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(exercise())
+
+    assert broker.calls == 0
+    intents, orders = _rows(db_path)
+    assert intents[0][0] == "SUBMITTED"
+    assert len(orders) == 1
+    assert orders[0][0:2] == (1, "SUBMITTED")
+    assert orders[0][4] == "LOCAL_RECONCILIATION"
+
+
+def test_pre_reserved_local_flat_sell_record_failure_is_unknown_without_audit(
+    tmp_path, monkeypatch
+):
+    from prism_core.execution_service import ExecutionService, OrderOutcomeUnknown
+    from prism_core.order_intents import IntentStore
+
+    db_path = tmp_path / "orders.sqlite"
+    store = IntentStore(db_path)
+    intent = _intent(side="sell", source_position_id="local-flat-record-failure")
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        _, reservation = store.reserve_in_transaction(connection, intent)
+        connection.commit()
+    broker = FakeBroker()
+
+    def fail_record(*_args, **_kwargs):
+        raise sqlite3.OperationalError("simulated local-flat audit failure")
+
+    monkeypatch.setattr(store, "record_result", fail_record)
+
+    with pytest.raises(OrderOutcomeUnknown) as raised:
+        asyncio.run(
+            ExecutionService(
+                broker, intent_store=store
+            ).execute_pre_reserved_local_flat_sell(
+                intent=intent, reservation=reservation
+            )
+        )
+
+    assert isinstance(raised.value.cause, sqlite3.OperationalError)
+    assert raised.value.broker_result == {
+        "success": True,
+        "local_flat": True,
+        "quantity": 0,
+    }
+    assert broker.calls == 0
+    intents, orders = _rows(db_path)
+    assert intents[0][0] == "SUBMITTING"
+    assert orders == []
+
+
 def test_explicit_broker_rejection_is_recorded_as_failed(tmp_path):
     from prism_core.execution_service import ExecutionService
     from prism_core.order_intents import IntentStore

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -428,6 +428,109 @@ def test_entry_attempt_guard_requires_caller_owned_transaction() -> None:
         )
 
 
+def test_exit_attempt_guard_allows_clean_open_siblings() -> None:
+    conn = sqlite3.connect(":memory:")
+    store = PositionStore(conn)
+    store.ensure_schema()
+    for row_id in (1, 2):
+        store.open_legacy_position(
+            market="KR", legacy_holding_id=row_id, account_id="acct",
+            account_name="primary", symbol="005930"
+        )
+    conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+
+    assert store.assert_exit_attempt_allowed(
+        market="KR", account_id="acct", symbol="005930"
+    )
+
+    conn.rollback()
+
+
+def test_exit_attempt_guard_requires_caller_owned_transaction() -> None:
+    conn = sqlite3.connect(":memory:")
+    store = PositionStore(conn)
+    store.ensure_schema()
+    conn.commit()
+
+    with pytest.raises(RuntimeError, match="active caller-owned transaction"):
+        store.assert_exit_attempt_allowed(
+            market="KR", account_id="acct", symbol="005930"
+        )
+
+
+@pytest.mark.parametrize(
+    "status",
+    ("PENDING_ENTRY", "ENTRY_FAILED", "PENDING_EXIT", "EXIT_UNKNOWN"),
+)
+def test_exit_attempt_guard_blocks_unresolved_same_account_symbol(status) -> None:
+    conn = sqlite3.connect(":memory:")
+    store = PositionStore(conn)
+    store.ensure_schema()
+    store.open_legacy_position(
+        market="KR", legacy_holding_id=1, account_id="acct",
+        account_name="primary", symbol="005930"
+    )
+    conn.execute("UPDATE positions SET status=?", (status,))
+    conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+
+    with pytest.raises(InvalidPositionTransition, match="exit attempt"):
+        store.assert_exit_attempt_allowed(
+            market="KR", account_id="acct", symbol="005930"
+        )
+
+    conn.rollback()
+
+
+def test_exit_attempt_guard_blocks_open_with_failed_exit_link() -> None:
+    conn = sqlite3.connect(":memory:")
+    store = PositionStore(conn)
+    store.ensure_schema()
+    store.open_legacy_position(
+        market="KR", legacy_holding_id=1, account_id="acct",
+        account_name="primary", symbol="005930"
+    )
+    conn.execute(
+        "UPDATE positions SET exit_intent_id='failed-sell-intent' "
+        "WHERE id='legacy:KR:1'"
+    )
+    conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+
+    with pytest.raises(InvalidPositionTransition, match="exit attempt"):
+        store.assert_exit_attempt_allowed(
+            market="KR", account_id="acct", symbol="005930"
+        )
+
+    conn.rollback()
+
+
+@pytest.mark.parametrize(
+    ("existing_account", "existing_symbol"),
+    (("other-acct", "005930"), ("acct", "000660")),
+)
+def test_exit_attempt_guard_allows_unresolved_different_identity(
+    existing_account, existing_symbol
+) -> None:
+    conn = sqlite3.connect(":memory:")
+    store = PositionStore(conn)
+    store.ensure_schema()
+    store.open_legacy_position(
+        market="KR", legacy_holding_id=1, account_id=existing_account,
+        account_name="primary", symbol=existing_symbol
+    )
+    conn.execute("UPDATE positions SET status='EXIT_UNKNOWN'")
+    conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+
+    assert store.assert_exit_attempt_allowed(
+        market="KR", account_id="acct", symbol="005930"
+    )
+
+    conn.rollback()
+
+
 def test_exit_many_lifecycle_is_atomic_idempotent_and_blocks_overwrite(tmp_path) -> None:
     from dataclasses import replace
 
@@ -1645,6 +1748,58 @@ def test_compare_detects_entry_fingerprint_drift_without_exposing_account() -> N
     assert len(result["entry_mismatches"]) == 1
     payload = json.dumps(result, sort_keys=True)
     assert "secret-account" not in payload
+
+
+def test_compare_exposes_failed_exit_linked_open_position(tmp_path) -> None:
+    from prism_core.order_intents import IntentStore, OrderIntent
+
+    db_path = tmp_path / "failed-exit-comparison.sqlite"
+    intent_store = IntentStore(db_path)
+    conn = sqlite3.connect(db_path)
+    _legacy_schema(conn)
+    _insert_legacy(conn, "stock_holdings", 1, "secret-account", "005930")
+    position_store = PositionStore(conn)
+    position_store.ensure_schema()
+    position_store.backfill_legacy_positions("KR")
+    conn.commit()
+    intent = OrderIntent.create(
+        market="KR",
+        account_id="secret-account",
+        symbol="005930",
+        side="SELL",
+        order_style="smart",
+        source="test",
+        source_position_id="legacy:KR:1",
+    )
+    assert intent_store.reserve(intent)[0]
+    intent_store.mark_submitting(intent.id)
+    intent_store.record_result(
+        intent,
+        status="FAILED",
+        accepted=False,
+        response={"success": False, "message": "rejected"},
+    )
+    conn.execute(
+        "UPDATE positions SET exit_intent_id=? WHERE id='legacy:KR:1'",
+        (intent.id,),
+    )
+    conn.commit()
+
+    result = position_store.compare_legacy_positions("KR")
+
+    assert result["matches"] is False
+    assert result["counts"]["failed_exit_linked_open_positions"] == 1
+    assert result["failed_exit_linked_open_positions"] == [
+        {
+            "position_id": "legacy:KR:1",
+            "legacy_holding_id": "1",
+            "account_ref": account_fingerprint("secret-account"),
+            "symbol": "005930",
+            "intent_id": intent.id,
+            "intent_status": "FAILED",
+        }
+    ]
+    assert "secret-account" not in json.dumps(result, sort_keys=True)
 
 
 def test_mirror_error_redacts_credentials() -> None:

--- a/tests/test_stock_tracking_agent_process_reports.py
+++ b/tests/test_stock_tracking_agent_process_reports.py
@@ -568,6 +568,86 @@ async def test_process_reports_saves_watchlist_once_when_not_traded(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_update_holdings_gate_false_preserves_legacy_broker_publish_order(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "false")
+    events = []
+    db_path = tmp_path / "stock_tracking.sqlite"
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute(TABLE_STOCK_HOLDINGS)
+    conn.execute(
+        """INSERT INTO stock_holdings
+           (account_key, account_name, ticker, company_name, buy_price, buy_date,
+            current_price, scenario)
+           VALUES ('ACC1', 'primary', '005930', 'Samsung', 70000,
+                   '2026-07-01 09:00:00', 71000, '{}')"""
+    )
+    conn.commit()
+
+    agent = StockTrackingAgent.__new__(StockTrackingAgent)
+    agent.db_path = str(db_path)
+    agent.conn = conn
+    agent.cursor = conn.cursor()
+    agent.active_account = {"name": "primary", "account_key": "ACC1"}
+    agent.message_queue = []
+    agent._msg_types = []
+    agent._get_live_regime_safe = lambda: None
+
+    async def current_price(_ticker):
+        return 72000
+
+    async def sell_decision(_stock):
+        return True, "Take profit"
+
+    async def legacy_close_and_message(_stock, _reason, exit_kind=None):
+        events.append("legacy/message")
+        return True
+
+    def link_exit(**_kwargs):
+        events.append("exit-link")
+        return True
+
+    class OrderedTradingContext(_FakeAsyncTradingContext):
+        async def async_sell_stock(self, stock_code, limit_price=None, quantity=None):
+            events.append("broker")
+            return {"success": True, "message": "sold"}
+
+    agent._get_current_stock_price = current_price
+    agent._analyze_sell_decision = sell_decision
+    agent.sell_stock = legacy_close_and_message
+    agent._link_position_exit_intent = link_exit
+    monkeypatch.setattr(domestic_trading, "AsyncTradingContext", OrderedTradingContext)
+
+    redis_module = types.ModuleType("messaging.redis_signal_publisher")
+    gcp_module = types.ModuleType("messaging.gcp_pubsub_signal_publisher")
+
+    async def publish_redis(**_kwargs):
+        events.append("redis")
+
+    async def publish_gcp(**_kwargs):
+        events.append("gcp")
+
+    redis_module.publish_sell_signal = publish_redis
+    gcp_module.publish_sell_signal = publish_gcp
+    monkeypatch.setitem(sys.modules, "messaging.redis_signal_publisher", redis_module)
+    monkeypatch.setitem(sys.modules, "messaging.gcp_pubsub_signal_publisher", gcp_module)
+
+    sold = await StockTrackingAgent.update_holdings(agent)
+
+    assert [stock["ticker"] for stock in sold] == ["005930"]
+    assert events == [
+        "legacy/message",
+        "broker",
+        "exit-link",
+        "redis",
+        "gcp",
+    ]
+    conn.close()
+
+
+@pytest.mark.asyncio
 async def test_update_holdings_masks_sold_account_payload(monkeypatch, tmp_path):
     agent = StockTrackingAgent.__new__(StockTrackingAgent)
     agent.db_path = str(tmp_path / "stock_tracking.sqlite")

--- a/tests/test_stock_tracking_enhanced_pending_exit.py
+++ b/tests/test_stock_tracking_enhanced_pending_exit.py
@@ -1,0 +1,133 @@
+import json
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+
+from stock_tracking_enhanced_agent import EnhancedStockTrackingAgent
+from tracking.db_schema import TABLE_STOCK_HOLDINGS
+
+
+def _enhanced_agent(db_path):
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+    connection.execute(TABLE_STOCK_HOLDINGS)
+    connection.execute(
+        """
+        CREATE TABLE holding_decisions (
+            ticker TEXT NOT NULL
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE TABLE portfolio_adjustment_log (
+            ticker TEXT NOT NULL,
+            account_key TEXT,
+            adjusted_at TEXT,
+            old_target_price REAL,
+            new_target_price REAL,
+            old_stop_loss REAL,
+            new_stop_loss REAL,
+            adjustment_reason TEXT,
+            urgency TEXT
+        )
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO stock_holdings
+        (account_key, account_name, ticker, company_name, buy_price, buy_date,
+         current_price, scenario, target_price, stop_loss)
+        VALUES ('ACC1', 'primary', '005930', 'Samsung', 70000,
+                '2026-07-01 09:00:00', 72000, ?, 80000, 65000)
+        """,
+        (json.dumps({"highest_price": 73000, "sector": "Technology"}),),
+    )
+    connection.execute("INSERT INTO holding_decisions VALUES ('005930')")
+    connection.execute(
+        """
+        INSERT INTO portfolio_adjustment_log
+        (ticker, account_key, adjusted_at, adjustment_reason, urgency)
+        VALUES ('005930', 'ACC1', '2026-07-18 09:00:00', 'test', 'low')
+        """
+    )
+    connection.commit()
+
+    agent = EnhancedStockTrackingAgent.__new__(EnhancedStockTrackingAgent)
+    agent.db_path = str(db_path)
+    agent.conn = connection
+    agent.cursor = connection.cursor()
+    agent.active_account = {"name": "primary", "account_key": "ACC1"}
+    agent.max_slots = 10
+    agent.language = "ko"
+
+    class LLM:
+        async def generate_str(self, **_kwargs):
+            return json.dumps(
+                {
+                    "should_sell": True,
+                    "sell_reason": "risk exit",
+                    "confidence": 9,
+                    "analysis_summary": {"technical_trend": "weak"},
+                    "portfolio_adjustment": {"needed": False},
+                }
+            )
+
+    class DecisionAgent:
+        async def attach_llm(self, _factory):
+            return LLM()
+
+    agent.sell_decision_agent = DecisionAgent()
+    stock = dict(
+        connection.execute(
+            "SELECT * FROM stock_holdings WHERE ticker='005930'"
+        ).fetchone()
+    )
+    return agent, connection, stock
+
+
+def _cleanup_counts(connection):
+    return (
+        connection.execute("SELECT COUNT(*) FROM holding_decisions").fetchone()[0],
+        connection.execute(
+            "SELECT COUNT(*) FROM portfolio_adjustment_log"
+        ).fetchone()[0],
+    )
+
+
+@pytest.mark.asyncio
+async def test_enhanced_gate_false_keeps_legacy_decision_time_cleanup(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "false")
+    agent, connection, stock = _enhanced_agent(tmp_path / "enhanced-legacy.sqlite")
+    try:
+        should_sell, _reason = await agent._analyze_sell_decision(stock)
+        counts = _cleanup_counts(connection)
+    finally:
+        connection.close()
+
+    assert should_sell is True
+    assert counts == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_enhanced_gate_true_defers_cleanup_until_closed_hook(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+    agent, connection, stock = _enhanced_agent(tmp_path / "enhanced-pending.sqlite")
+    try:
+        should_sell, _reason = await agent._analyze_sell_decision(stock)
+        before_closed = _cleanup_counts(connection)
+        await agent._after_pending_kr_exit_closed(
+            SimpleNamespace(symbol="005930")
+        )
+        after_closed = _cleanup_counts(connection)
+    finally:
+        connection.close()
+
+    assert should_sell is True
+    assert before_closed == (1, 1)
+    assert after_closed == (0, 0)

--- a/tests/test_trend_exit_seller.py
+++ b/tests/test_trend_exit_seller.py
@@ -18,9 +18,11 @@ ma_50 and the LIVE regime fetch are network-bound, so they are monkeypatched to
 constants — these tests are fully network-free. Run in the KR (root) session.
 """
 import asyncio
+import os
 import sys
 import sqlite3
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -31,10 +33,12 @@ import tools.trend_exit_seller as lb  # noqa: E402
 
 # ── Fakes ──────────────────────────────────────────────────────────────────────
 class FakeTrader:
-    def __init__(self, prices, holding_qty=None, sell_result=None, calls=None):
+    def __init__(self, prices, holding_qty=None, sell_result=None, calls=None,
+                 checked_holding=None):
         self._prices = prices
         self._holding_qty = holding_qty or {}
         self._sell_result = sell_result or {"success": True, "order_no": "ORD1", "message": "ok"}
+        self._checked_holding = checked_holding
         self.calls = calls if calls is not None else []
 
     def get_current_price(self, ticker, exchange=None):
@@ -42,6 +46,13 @@ class FakeTrader:
 
     def get_holding_quantity(self, ticker):
         return self._holding_qty.get(ticker, 0)
+
+    def get_holding_quantity_checked(self, ticker):
+        self.calls.append(f"checked:{ticker}")
+        if self._checked_holding is not None:
+            return self._checked_holding
+        quantity = self._holding_qty.get(ticker, 0)
+        return ("HELD", quantity) if quantity > 0 else ("FLAT", 0)
 
     async def async_sell_stock(self, ticker, exchange=None, timeout=30.0,
                                limit_price=None, use_moo=False, quantity=None):
@@ -61,9 +72,20 @@ class FakeCtx:
 
 
 class FakeAgent:
-    def __init__(self, calls):
+    def __init__(self, calls, *, pending_result=None, pending_error=None,
+                 complete_error=None):
         self.calls = calls
         self.conn = None
+        self.pending_result = pending_result or {
+            "success": True,
+            "intent_status": "SUBMITTED",
+            "intent_id": "intent-1",
+            "order_no": "ORD1",
+            "message": "ok",
+        }
+        self.pending_error = pending_error
+        self.complete_error = complete_error
+        self.prepare_kwargs = None
 
     async def sell_stock(self, stock_data, sell_reason, **kwargs):
         self.calls.append(f"sim:{stock_data.get('ticker')}")
@@ -72,6 +94,53 @@ class FakeAgent:
     def _link_position_exit_intent(self, **kwargs):
         self.calls.append(f"link:{kwargs.get('legacy_holding_id')}")
         return True
+
+    @staticmethod
+    def _position_pending_kr_enabled():
+        return os.environ.get("POSITION_PENDING_KR_ENABLED", "false").lower() in {
+            "1", "true", "yes", "on"
+        }
+
+    def _prepare_pending_kr_exit(self, **kwargs):
+        self.prepare_kwargs = kwargs
+        self.calls.append(f"prepare:{kwargs.get('quantity')}")
+        return SimpleNamespace(
+            intent=SimpleNamespace(id="intent-1"),
+            symbol=kwargs["stock_data"]["ticker"],
+            quantity=kwargs.get("quantity"),
+        )
+
+    async def _execute_pending_kr_exit(self, prepared):
+        self.calls.append(f"kis:{prepared.symbol}:{prepared.quantity}")
+        if self.pending_error is not None:
+            raise self.pending_error
+        return dict(self.pending_result)
+
+    async def _execute_pending_kr_local_flat_exit(self, prepared):
+        self.calls.append("local-flat")
+        if self.pending_error is not None:
+            raise self.pending_error
+        return {
+            "success": True,
+            "local_flat": True,
+            "intent_status": "SUBMITTED",
+            "intent_id": prepared.intent.id,
+            "quantity": 0,
+        }
+
+    def _complete_pending_kr_exit(self, _prepared):
+        self.calls.append("complete")
+        if self.complete_error is not None:
+            raise self.complete_error
+
+    def _fail_pending_kr_exit(self, _prepared):
+        self.calls.append("fail")
+
+    def _quarantine_pending_kr_exit(self, _prepared):
+        self.calls.append("quarantine")
+
+    async def _run_pending_kr_exit_post_commit(self, _prepared):
+        self.calls.append("postcommit")
 
     async def send_telegram_message(self, chat_id, language="ko", **kwargs):
         self.calls.append("tg")
@@ -142,6 +211,18 @@ def _inflight(db, status=None):
                 "SELECT COUNT(*) FROM loop_b_inflight_orders WHERE status=?", (status,)
             ).fetchone()[0]
         return conn.execute("SELECT COUNT(*) FROM loop_b_inflight_orders").fetchone()[0]
+    finally:
+        conn.close()
+
+
+def _position_state(db, ticker="005930", market="KR"):
+    conn = sqlite3.connect(db)
+    try:
+        row = conn.execute(
+            "SELECT state FROM loop_b_position_state WHERE ticker=? AND market=?",
+            (ticker, market),
+        ).fetchone()
+        return row[0] if row else None
     finally:
         conn.close()
 
@@ -321,12 +402,18 @@ def test_shadow_touches_no_agent_and_no_order(tmp_db, monkeypatch):
 
 
 def test_live_order_is_sim_then_kis_then_telegram(tmp_db, monkeypatch):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "false")
     _enable(monkeypatch, live=True, confirm=1, close_window=True)
     monkeypatch.setattr(lb, "CHAT_ID", "chat1")
     _seed(tmp_db, [_row(1, "005930", 100.0)])
     calls = []
     trader = FakeTrader({"005930": 98.0}, holding_qty={"005930": 10}, calls=calls)
     _patch(monkeypatch, trader, agent_holder=FakeAgent(calls), ma50=105.0)
+
+    async def publish_loop_sell(**_kwargs):
+        calls.append("publish")
+
+    monkeypatch.setattr("sell_broadcast.publish_loop_sell", publish_loop_sell)
 
     summary = asyncio.run(lb.run_market("KR", "run1"))
 
@@ -339,9 +426,381 @@ def test_live_order_is_sim_then_kis_then_telegram(tmp_db, monkeypatch):
         "kis:005930:10",
         "link:1",
         "tg",
+        "publish",
         "tg",
     ]  # exact order
     assert _inflight(tmp_db, "FILLED") == 1
+
+
+def test_pending_kr_gate_does_not_change_us_live_order(tmp_db, monkeypatch):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+    _enable(monkeypatch, live=True, confirm=1, close_window=True)
+    calls = []
+    trader = FakeTrader({"AAPL": 92.0}, holding_qty={"AAPL": 10}, calls=calls)
+    agent = FakeAgent(calls)
+    _patch(monkeypatch, trader, agent_holder=agent, ma50=105.0)
+
+    async def publish_loop_sell(**_kwargs):
+        calls.append("publish")
+
+    monkeypatch.setattr("sell_broadcast.publish_loop_sell", publish_loop_sell)
+    conn = lb._connect()
+    lb._ensure_schema(conn)
+    summary = {"sold": 0, "skipped": 0}
+    stock = {
+        "id": 1,
+        "ticker": "AAPL",
+        "company_name": "Apple",
+        "buy_price": 100.0,
+        "buy_date": "2026-06-01 10:00:00",
+        "current_price": 92.0,
+        "account_key": "us:account:01",
+        "account_name": "primary",
+    }
+    try:
+        asyncio.run(
+            lb._act_on_trigger(
+                conn, "US", "AAPL", stock, "trend exit", 1,
+                "run-us", {"ref": agent}, summary,
+            )
+        )
+    finally:
+        conn.close()
+
+    assert summary["sold"] == 1
+    assert calls == [
+        "sim:AAPL",
+        "kis:AAPL:10",
+        "link:1",
+        "tg",
+        "publish",
+    ]
+    assert agent.prepare_kwargs is None
+
+
+def test_pending_kr_submitted_closes_before_telegram_and_publish(tmp_db, monkeypatch):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+    _enable(monkeypatch, live=True, confirm=1, close_window=True)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 98.0},
+        holding_qty={"005930": 10},
+        calls=calls,
+    )
+    agent = FakeAgent(calls)
+    _patch(monkeypatch, trader, agent_holder=agent, ma50=105.0)
+
+    async def publish_loop_sell(**_kwargs):
+        calls.append("publish")
+
+    monkeypatch.setattr("sell_broadcast.publish_loop_sell", publish_loop_sell)
+
+    summary = asyncio.run(lb.run_market("KR", "run1"))
+
+    assert summary["sold"] == 1
+    assert calls == [
+        "checked:005930",
+        "prepare:10",
+        "kis:005930:10",
+        "complete",
+        "postcommit",
+        "tg",
+        "publish",
+        "tg",
+    ]
+    assert agent.prepare_kwargs["source"] == "trend_exit"
+    assert agent.prepare_kwargs["exit_kind"] == "trend_exit"
+    assert agent.prepare_kwargs["order_style"] == "market"
+    assert agent.prepare_kwargs["limit_price"] is None
+    assert _inflight(tmp_db, "FILLED") == 1
+    assert _position_state(tmp_db) == "SOLD"
+
+
+@pytest.mark.parametrize(
+    ("intent_status", "transition_call", "inflight_status", "owner_state"),
+    [
+        ("FAILED", "fail", "REJECTED", "HOLDING"),
+        ("UNKNOWN", "quarantine", "UNKNOWN", "QUARANTINED"),
+        ("SUBMITTING", "quarantine", "UNKNOWN", "QUARANTINED"),
+        ("QUEUED", None, "QUEUED", "QUARANTINED"),
+    ],
+)
+def test_pending_kr_unresolved_matrix_has_no_external_effects(
+    tmp_db, monkeypatch, intent_status, transition_call, inflight_status, owner_state
+):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+    _enable(monkeypatch, live=True, confirm=1, close_window=True)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 98.0}, holding_qty={"005930": 10}, calls=calls
+    )
+    agent = FakeAgent(
+        calls,
+        pending_result={
+            "success": False,
+            "intent_status": intent_status,
+            "intent_id": "intent-1",
+            "order_no": None,
+            "message": intent_status,
+        },
+    )
+    _patch(monkeypatch, trader, agent_holder=agent, ma50=105.0)
+
+    async def unexpected_publish(**_kwargs):
+        raise AssertionError("unresolved pending exit must not publish")
+
+    monkeypatch.setattr("sell_broadcast.publish_loop_sell", unexpected_publish)
+
+    summary = asyncio.run(lb.run_market("KR", "run1"))
+
+    assert summary["sold"] == 0
+    assert "complete" not in calls
+    assert "postcommit" not in calls
+    assert "tg" not in calls
+    assert "publish" not in calls
+    if transition_call is None:
+        assert "fail" not in calls and "quarantine" not in calls
+    else:
+        assert transition_call in calls
+    assert _inflight(tmp_db, inflight_status) == 1
+    assert _position_state(tmp_db) == owner_state
+
+
+def test_pending_kr_authoritative_unknown_blocks_before_prepare(tmp_db, monkeypatch):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+    _enable(monkeypatch, live=True, confirm=1, close_window=True)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 98.0}, checked_holding=("UNKNOWN", None), calls=calls
+    )
+    agent = FakeAgent(calls)
+    _patch(monkeypatch, trader, agent_holder=agent, ma50=105.0)
+
+    summary = asyncio.run(lb.run_market("KR", "run1"))
+
+    assert summary["sold"] == 0
+    assert calls == ["checked:005930"]
+    assert agent.prepare_kwargs is None
+    assert _inflight(tmp_db) == 0
+    assert _position_state(tmp_db) == "HOLDING"
+
+
+def test_pending_kr_malformed_flat_quantity_never_closes(tmp_db, monkeypatch):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+    _enable(monkeypatch, live=True, confirm=1, close_window=True)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 98.0}, checked_holding=("FLAT", 7), calls=calls
+    )
+    agent = FakeAgent(calls)
+    _patch(monkeypatch, trader, agent_holder=agent, ma50=105.0)
+
+    summary = asyncio.run(lb.run_market("KR", "run-malformed-flat"))
+
+    assert summary["sold"] == 0
+    assert calls == ["checked:005930"]
+    assert agent.prepare_kwargs is None
+    assert _inflight(tmp_db) == 0
+    assert _position_state(tmp_db) == "HOLDING"
+
+
+def test_pending_kr_local_flat_is_audited_without_broker_call(tmp_db, monkeypatch):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+    _enable(monkeypatch, live=True, confirm=1, close_window=True)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 98.0}, checked_holding=("FLAT", 0), calls=calls
+    )
+    agent = FakeAgent(calls)
+    _patch(monkeypatch, trader, agent_holder=agent, ma50=105.0)
+
+    async def publish_loop_sell(**_kwargs):
+        calls.append("publish")
+
+    monkeypatch.setattr("sell_broadcast.publish_loop_sell", publish_loop_sell)
+
+    summary = asyncio.run(lb.run_market("KR", "run1"))
+
+    assert summary["sold"] == 1
+    assert calls == [
+        "checked:005930",
+        "prepare:None",
+        "local-flat",
+        "complete",
+        "postcommit",
+        "tg",
+        "publish",
+        "tg",
+    ]
+    assert not any(call.startswith("kis:") for call in calls)
+    assert agent.prepare_kwargs["quantity"] is None
+    assert _inflight(tmp_db, "FILLED") == 1
+    assert _position_state(tmp_db) == "SOLD"
+
+
+def test_pending_kr_finalize_failure_quarantines_without_external_effects(
+    tmp_db, monkeypatch
+):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+    _enable(monkeypatch, live=True, confirm=1, close_window=True)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 98.0}, holding_qty={"005930": 10}, calls=calls
+    )
+    agent = FakeAgent(
+        calls, complete_error=sqlite3.OperationalError("injected finalize failure")
+    )
+    _patch(monkeypatch, trader, agent_holder=agent, ma50=105.0)
+
+    summary = asyncio.run(lb.run_market("KR", "run1"))
+
+    assert summary["sold"] == 0
+    assert "complete" in calls and "quarantine" in calls
+    assert "postcommit" not in calls and "tg" not in calls
+    assert _inflight(tmp_db, "UNKNOWN") == 1
+    assert _position_state(tmp_db) == "QUARANTINED"
+
+
+def test_pending_kr_order_outcome_unknown_quarantines_without_external_effects(
+    tmp_db, monkeypatch
+):
+    from prism_core.execution_service import OrderOutcomeUnknown
+
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+    _enable(monkeypatch, live=True, confirm=1, close_window=True)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 98.0}, holding_qty={"005930": 10}, calls=calls
+    )
+    agent = FakeAgent(
+        calls,
+        pending_error=OrderOutcomeUnknown(
+            "intent-1", broker_result="opaque non-dict broker result"
+        ),
+    )
+    _patch(monkeypatch, trader, agent_holder=agent, ma50=105.0)
+
+    summary = asyncio.run(lb.run_market("KR", "run1"))
+
+    assert summary["sold"] == 0
+    assert "quarantine" in calls
+    assert "complete" not in calls and "tg" not in calls
+    assert _inflight(tmp_db, "UNKNOWN") == 1
+    assert _position_state(tmp_db) == "QUARANTINED"
+
+
+def test_pending_kr_prepare_failure_has_no_broker_or_external_effects(
+    tmp_db, monkeypatch
+):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+    _enable(monkeypatch, live=True, confirm=1, close_window=True)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 98.0}, holding_qty={"005930": 10}, calls=calls
+    )
+    agent = FakeAgent(calls)
+
+    def fail_prepare(**_kwargs):
+        calls.append("prepare-failed")
+        raise sqlite3.OperationalError("injected prepare failure")
+
+    agent._prepare_pending_kr_exit = fail_prepare
+    _patch(monkeypatch, trader, agent_holder=agent, ma50=105.0)
+
+    summary = asyncio.run(lb.run_market("KR", "run1"))
+
+    assert summary["sold"] == 0
+    assert calls == ["checked:005930", "prepare-failed"]
+    assert _inflight(tmp_db) == 0
+    assert _position_state(tmp_db) == "HOLDING"
+
+
+def test_pending_kr_cancellation_quarantines_releases_and_propagates(
+    tmp_db, monkeypatch
+):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+    _enable(monkeypatch, live=True, confirm=1, close_window=True)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 98.0}, holding_qty={"005930": 10}, calls=calls
+    )
+    agent = FakeAgent(calls, pending_error=asyncio.CancelledError())
+    _patch(monkeypatch, trader, agent_holder=agent, ma50=105.0)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(lb.run_market("KR", "run1"))
+
+    assert "quarantine" in calls
+    assert "tg" not in calls and "publish" not in calls
+    assert _inflight(tmp_db, "UNKNOWN") == 1
+    assert _position_state(tmp_db) == "QUARANTINED"
+
+
+def test_pending_kr_quarantine_blocks_next_cycle_without_state_downgrade(
+    tmp_db, monkeypatch
+):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+    _enable(monkeypatch, live=True, confirm=1, close_window=True)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 98.0}, holding_qty={"005930": 10}, calls=calls
+    )
+    agent = FakeAgent(
+        calls,
+        pending_result={
+            "success": False,
+            "intent_status": "UNKNOWN",
+            "intent_id": "intent-1",
+            "order_no": None,
+        },
+    )
+    _patch(monkeypatch, trader, agent_holder=agent, ma50=105.0)
+
+    first = asyncio.run(lb.run_market("KR", "run-unknown-first"))
+    first_calls = list(calls)
+    second = asyncio.run(lb.run_market("KR", "run-unknown-second"))
+
+    assert first["sold"] == 0 and second["sold"] == 0
+    assert calls == first_calls
+    assert _position_state(tmp_db) == "QUARANTINED"
+    assert _inflight(tmp_db, "UNKNOWN") == 1
+
+
+def test_pending_kr_post_closed_cancellation_keeps_sold_state(
+    tmp_db, monkeypatch
+):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
+    _enable(monkeypatch, live=True, confirm=1, close_window=True)
+    _seed(tmp_db, [_row(1, "005930", 100.0)])
+    calls = []
+    trader = FakeTrader(
+        {"005930": 98.0}, holding_qty={"005930": 10}, calls=calls
+    )
+    agent = FakeAgent(calls)
+
+    async def cancel_post_commit(_prepared):
+        calls.append("postcommit")
+        raise asyncio.CancelledError
+
+    agent._run_pending_kr_exit_post_commit = cancel_post_commit
+    _patch(monkeypatch, trader, agent_holder=agent, ma50=105.0)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(lb.run_market("KR", "run-post-closed-cancel"))
+
+    assert "quarantine" not in calls
+    assert _inflight(tmp_db, "FILLED") == 1
+    assert _position_state(tmp_db) == "SOLD"
 
 
 def test_ledger_failure_after_broker_success_records_unknown(tmp_db, monkeypatch):

--- a/tools/feature_status.py
+++ b/tools/feature_status.py
@@ -93,6 +93,20 @@ def _cron_get_inline_env(crontab_text: str, var_name: str) -> str:
     return ""
 
 
+def _cron_get_all_inline_env(crontab_text: str, var_name: str) -> list[str]:
+    """Return every active inline assignment for ``var_name`` in cron order."""
+    prefix = f"{var_name}="
+    values = []
+    for line in crontab_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        for token in stripped.split():
+            if token.startswith(prefix):
+                values.append(token[len(prefix):])
+    return values
+
+
 # ── Feature definitions ───────────────────────────────────────────────────────
 # Each tuple: (feature_id, label_ko, decision_fn)
 # decision_fn(env, crontab) -> (state, evidence)
@@ -225,12 +239,39 @@ def _decide_vision_publish(env: dict, crontab: str):
     return "LIVE", "PRISM_FEATURE_INSIGHT_IMAGE=on + vision 가용"
 
 
+def _decide_position_pending_kr(env: dict, crontab: str):
+    truthy = {"1", "true", "yes", "on"}
+    env_raw = str(env.get("POSITION_PENDING_KR_ENABLED", "")).strip().lower()
+    cron_values = [
+        value.strip().strip('"').strip("'").lower()
+        for value in _cron_get_all_inline_env(
+            crontab, "POSITION_PENDING_KR_ENABLED"
+        )
+    ]
+    live_cron_value = next((value for value in cron_values if value in truthy), "")
+    if live_cron_value:
+        return (
+            "LIVE",
+            f"POSITION_PENDING_KR_ENABLED={live_cron_value} (crontab inline)",
+        )
+    if env_raw in truthy:
+        return "LIVE", f"POSITION_PENDING_KR_ENABLED={env_raw} (env)"
+    if cron_values:
+        return (
+            "OFF",
+            "POSITION_PENDING_KR_ENABLED="
+            f"{','.join(cron_values)} (crontab inline)",
+        )
+    return "OFF", f"POSITION_PENDING_KR_ENABLED={env_raw or '(unset)'}"
+
+
 # Registry: (id, korean label, decision function)
 FEATURES = [
     ("oauth_llm",        "OAuth LLM 백엔드(ChatGPT 구독)",          _decide_oauth_llm),
     ("loop_a",           "Hardstop — 고빈도 손절 (구 Loop A)",                  _decide_loop_a),
     ("loop_b",           "Trend-exit — 50MA 추세이탈 매도 (구 Loop B)",                   _decide_loop_b),
     ("loop_c",           "Fill-chaser — 미체결 추격 (구 Loop C)",                     _decide_loop_c),
+    ("position_pending_kr", "KR 주문 선기록(PENDING ENTRY/EXIT)", _decide_position_pending_kr),
     ("vision_pipeline",  "비전 배관·렌더QA (S1/S2)",                  _decide_vision_pipeline),
     ("vision_buy_qa",    "비전 매수 품질검사 (S3/S3.5)",               _decide_vision_buy_qa),
     ("vision_publish",   "비전 이미지 발행 (S6)",                     _decide_vision_publish),

--- a/tools/hardstop_seller.py
+++ b/tools/hardstop_seller.py
@@ -209,6 +209,7 @@ def claim_lock(conn: sqlite3.Connection, ticker: str, market: str, run_id: str) 
         cur = conn.execute(
             "UPDATE loop_a_position_state SET owner_lock=?, lock_expires_at=?, last_eval_ts=? "
             "WHERE ticker=? AND market=? "
+            "AND state != 'QUARANTINED' "
             "AND (owner_lock IS NULL OR lock_expires_at IS NULL OR lock_expires_at < ?)",
             (run_id, expires, _iso(now), ticker, market, _iso(now)),
         )
@@ -366,10 +367,263 @@ async def run_market(market: str, run_id: str) -> Dict[str, Any]:
     return summary
 
 
+async def _act_on_pending_kr_trigger(
+    conn: sqlite3.Connection,
+    ticker: str,
+    stock_data: Dict[str, Any],
+    reason: str,
+    run_id: str,
+    ag: Any,
+    summary: Dict[str, Any],
+) -> None:
+    """Run one gate-enabled KR exit without exposing legacy effects early."""
+
+    from prism_core.execution_service import (
+        OrderOutcomeUnknown,
+        normalize_checked_holding,
+    )
+
+    prepared = None
+    sold_qty = 0
+    order_no = None
+    completed = False
+
+    def quarantine_if_allowed() -> None:
+        if prepared is None:
+            return
+        try:
+            ag._quarantine_pending_kr_exit(prepared)
+        except Exception as quarantine_error:
+            logger.critical(
+                "[POSITION-PENDING][KR] hardstop quarantine failed "
+                "symbol=%s intent=%s error=%s",
+                ticker,
+                prepared.intent.id,
+                type(quarantine_error).__name__,
+            )
+
+    def finish_uncertain(status: str = "UNKNOWN") -> None:
+        record_inflight(
+            conn,
+            ticker,
+            "KR",
+            run_id,
+            sold_qty,
+            status,
+            reason,
+            str(order_no) if order_no else None,
+        )
+        release_lock(
+            conn, ticker, "KR", run_id, new_state="QUARANTINED"
+        )
+
+    try:
+        async with _open_context(
+            "KR", account_name=stock_data.get("account_name")
+        ) as seller:
+            checked_holding = await asyncio.to_thread(
+                seller.get_holding_quantity_checked, ticker
+            )
+        holding_state, checked_qty = normalize_checked_holding(checked_holding)
+        if holding_state == "UNKNOWN":
+            logger.critical(
+                "[POSITION-PENDING][KR] hardstop balance UNKNOWN "
+                "symbol=%s action=retry",
+                ticker,
+            )
+            release_lock(conn, ticker, "KR", run_id, new_state="HOLDING")
+            return
+        if holding_state == "HELD":
+            sold_qty = int(checked_qty or 0)
+            if sold_qty <= 0:
+                logger.critical(
+                    "[POSITION-PENDING][KR] hardstop invalid HELD quantity "
+                    "symbol=%s quantity=%s action=retry",
+                    ticker,
+                    checked_qty,
+                )
+                release_lock(conn, ticker, "KR", run_id, new_state="HOLDING")
+                return
+            prepared = ag._prepare_pending_kr_exit(
+                stock_data=stock_data,
+                sell_reason=reason,
+                exit_kind="stop",
+                source="hardstop",
+                quantity=sold_qty,
+                order_style="market",
+                limit_price=None,
+            )
+            result = await ag._execute_pending_kr_exit(prepared)
+        elif holding_state == "FLAT":
+            prepared = ag._prepare_pending_kr_exit(
+                stock_data=stock_data,
+                sell_reason=reason,
+                exit_kind="stop",
+                source="hardstop",
+                quantity=None,
+                order_style="market",
+                limit_price=None,
+            )
+            result = await ag._execute_pending_kr_local_flat_exit(prepared)
+        else:
+            logger.critical(
+                "[POSITION-PENDING][KR] hardstop invalid balance state "
+                "symbol=%s state=%s action=retry",
+                ticker,
+                holding_state,
+            )
+            release_lock(conn, ticker, "KR", run_id, new_state="HOLDING")
+            return
+
+        result_intent_id = str((result or {}).get("intent_id") or "")
+        intent_status = str(
+            (result or {}).get("intent_status") or "UNKNOWN"
+        ).upper()
+        order_no = (result or {}).get("order_no")
+        if result_intent_id != prepared.intent.id:
+            logger.critical(
+                "[POSITION-PENDING][KR] hardstop intent mismatch "
+                "symbol=%s expected=%s actual=%s action=quarantine",
+                ticker,
+                prepared.intent.id,
+                result_intent_id or "missing",
+            )
+            quarantine_if_allowed()
+            finish_uncertain()
+            return
+        logger.warning(
+            "[POSITION-PENDING][KR] hardstop result symbol=%s intent=%s status=%s",
+            ticker,
+            prepared.intent.id,
+            intent_status,
+        )
+        if intent_status == "SUBMITTED":
+            ag._complete_pending_kr_exit(prepared)
+            record_inflight(
+                conn,
+                ticker,
+                "KR",
+                run_id,
+                sold_qty,
+                "FILLED",
+                reason,
+                str(order_no) if order_no else None,
+            )
+            release_lock(conn, ticker, "KR", run_id, new_state="SOLD")
+            summary["sold"] += 1
+            completed = True
+            try:
+                await ag._run_pending_kr_exit_post_commit(prepared)
+            except Exception as post_commit_error:
+                logger.warning(
+                    "[KR] %s post-CLOSED effects failed: %s",
+                    ticker,
+                    post_commit_error,
+                )
+            try:
+                await ag.send_telegram_message(CHAT_ID, await_broadcast=True)
+            except Exception as telegram_error:
+                logger.warning(
+                    "[KR] %s telegram flush failed: %s", ticker, telegram_error
+                )
+            try:
+                from sell_broadcast import publish_loop_sell
+
+                await publish_loop_sell(
+                    market="KR",
+                    ticker=ticker,
+                    company_name=stock_data.get("company_name", ticker),
+                    price=float(stock_data.get("current_price", 0) or 0),
+                    buy_price=float(stock_data.get("buy_price", 0) or 0),
+                    sell_reason=reason,
+                    trade_result=result,
+                )
+            except Exception as publish_error:
+                logger.warning(
+                    "[KR] %s sell signal publish failed (non-critical): %s",
+                    ticker,
+                    publish_error,
+                )
+            return
+        if intent_status == "FAILED":
+            ag._fail_pending_kr_exit(prepared)
+            record_inflight(
+                conn,
+                ticker,
+                "KR",
+                run_id,
+                sold_qty,
+                "REJECTED",
+                reason,
+                str(order_no) if order_no else None,
+            )
+            release_lock(conn, ticker, "KR", run_id, new_state="HOLDING")
+            logger.critical(
+                "[POSITION-PENDING][KR] hardstop exit rejected symbol=%s "
+                "intent=%s status=FAILED action=manual_review",
+                ticker,
+                prepared.intent.id,
+            )
+            return
+        if intent_status == "QUEUED":
+            finish_uncertain("QUEUED")
+            return
+
+        quarantine_if_allowed()
+        finish_uncertain()
+    except asyncio.CancelledError:
+        if completed:
+            raise
+        quarantine_if_allowed()
+        finish_uncertain()
+        raise
+    except OrderOutcomeUnknown as error:
+        broker_result = (
+            error.broker_result
+            if isinstance(error.broker_result, dict)
+            else {}
+        )
+        order_no = broker_result.get("order_no")
+        quarantine_if_allowed()
+        logger.critical(
+            "[POSITION-PENDING][KR] hardstop outcome UNKNOWN "
+            "symbol=%s intent=%s",
+            ticker,
+            error.intent_id,
+        )
+        finish_uncertain()
+    except Exception as error:
+        if completed:
+            logger.critical(
+                "[POSITION-PENDING][KR] hardstop post-CLOSED failure "
+                "symbol=%s error=%s",
+                ticker,
+                type(error).__name__,
+            )
+            return
+        if prepared is None:
+            logger.error(
+                "[POSITION-PENDING][KR] hardstop prepare failed "
+                "symbol=%s error=%s",
+                ticker,
+                type(error).__name__,
+            )
+            release_lock(conn, ticker, "KR", run_id, new_state="HOLDING")
+            return
+        quarantine_if_allowed()
+        logger.critical(
+            "[POSITION-PENDING][KR] hardstop unresolved "
+            "symbol=%s intent=%s error=%s",
+            ticker,
+            prepared.intent.id,
+            type(error).__name__,
+        )
+        finish_uncertain()
+
+
 async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, Any],
                           reason: str, run_id: str, agent: Dict[str, Any],
                           summary: Dict[str, Any]) -> None:
-    qty_hint = 0
     # Guard 1: an inflight SELL for this ticker already exists -> leave it alone.
     if has_open_inflight(conn, ticker, market):
         summary["skipped"] += 1
@@ -396,6 +650,17 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
             agent["ref"] = await _make_agent(market)
         ag = agent["ref"]
         logger.warning("[LIVE][%s] SELLING %s reason=%s", market, ticker, reason)
+        if market == "KR" and ag._position_pending_kr_enabled():
+            await _act_on_pending_kr_trigger(
+                conn,
+                ticker,
+                stock_data,
+                reason,
+                run_id,
+                ag,
+                summary,
+            )
+            return
         # Hardstop is the catastrophic hard-stop => always a 'stop' exit (recorded in
         # trading_history.exit_kind so the re-entry cooldown treats it as churn-risk
         # even if it tags out at a marginal profit).

--- a/tools/trend_exit_seller.py
+++ b/tools/trend_exit_seller.py
@@ -264,6 +264,7 @@ def claim_lock(conn: sqlite3.Connection, ticker: str, market: str, run_id: str) 
         cur = conn.execute(
             "UPDATE loop_b_position_state SET owner_lock=?, lock_expires_at=?, last_eval_ts=? "
             "WHERE ticker=? AND market=? "
+            "AND state != 'QUARANTINED' "
             "AND (owner_lock IS NULL OR lock_expires_at IS NULL OR lock_expires_at < ?)",
             (run_id, expires, _iso(now), ticker, market, _iso(now)),
         )
@@ -579,6 +580,225 @@ def _holding_age_min(buy_date) -> Optional[float]:
         return None
 
 
+async def _act_on_pending_kr_trigger(
+    conn: sqlite3.Connection,
+    ticker: str,
+    stock_data: Dict[str, Any],
+    reason: str,
+    run_id: str,
+    ag: Any,
+    summary: Dict[str, Any],
+) -> None:
+    """Run one gate-enabled KR trend exit without early legacy effects."""
+
+    from prism_core.execution_service import (
+        OrderOutcomeUnknown,
+        normalize_checked_holding,
+    )
+
+    prepared = None
+    sold_qty = 0
+    order_no = None
+    completed = False
+
+    def quarantine_if_allowed() -> None:
+        if prepared is None:
+            return
+        try:
+            ag._quarantine_pending_kr_exit(prepared)
+        except Exception as quarantine_error:
+            logger.critical(
+                "[POSITION-PENDING][KR] trend-exit quarantine failed "
+                "symbol=%s intent=%s error=%s",
+                ticker,
+                prepared.intent.id,
+                type(quarantine_error).__name__,
+            )
+
+    def finish_uncertain(status: str = "UNKNOWN") -> None:
+        record_inflight(
+            conn, ticker, "KR", run_id, sold_qty, status, reason,
+            str(order_no) if order_no else None,
+        )
+        release_lock(conn, ticker, "KR", run_id, new_state="QUARANTINED")
+
+    try:
+        async with _open_context(
+            "KR", account_name=stock_data.get("account_name")
+        ) as seller:
+            checked_holding = await asyncio.to_thread(
+                seller.get_holding_quantity_checked, ticker
+            )
+        holding_state, checked_qty = normalize_checked_holding(checked_holding)
+        if holding_state == "UNKNOWN":
+            logger.critical(
+                "[POSITION-PENDING][KR] trend-exit balance UNKNOWN "
+                "symbol=%s action=retry", ticker,
+            )
+            release_lock(conn, ticker, "KR", run_id, new_state="HOLDING")
+            return
+        if holding_state == "HELD":
+            sold_qty = int(checked_qty or 0)
+            if sold_qty <= 0:
+                logger.critical(
+                    "[POSITION-PENDING][KR] trend-exit invalid HELD quantity "
+                    "symbol=%s quantity=%s action=retry", ticker, checked_qty,
+                )
+                release_lock(conn, ticker, "KR", run_id, new_state="HOLDING")
+                return
+            prepared = ag._prepare_pending_kr_exit(
+                stock_data=stock_data,
+                sell_reason=reason,
+                exit_kind="trend_exit",
+                source="trend_exit",
+                quantity=sold_qty,
+                order_style="market",
+                limit_price=None,
+            )
+            result = await ag._execute_pending_kr_exit(prepared)
+        elif holding_state == "FLAT":
+            prepared = ag._prepare_pending_kr_exit(
+                stock_data=stock_data,
+                sell_reason=reason,
+                exit_kind="trend_exit",
+                source="trend_exit",
+                quantity=None,
+                order_style="market",
+                limit_price=None,
+            )
+            result = await ag._execute_pending_kr_local_flat_exit(prepared)
+        else:
+            logger.critical(
+                "[POSITION-PENDING][KR] trend-exit invalid balance state "
+                "symbol=%s state=%s action=retry", ticker, holding_state,
+            )
+            release_lock(conn, ticker, "KR", run_id, new_state="HOLDING")
+            return
+
+        result_intent_id = str((result or {}).get("intent_id") or "")
+        intent_status = str(
+            (result or {}).get("intent_status") or "UNKNOWN"
+        ).upper()
+        order_no = (result or {}).get("order_no")
+        if result_intent_id != prepared.intent.id:
+            logger.critical(
+                "[POSITION-PENDING][KR] trend-exit intent mismatch "
+                "symbol=%s expected=%s actual=%s action=quarantine",
+                ticker, prepared.intent.id, result_intent_id or "missing",
+            )
+            quarantine_if_allowed()
+            finish_uncertain()
+            return
+        logger.warning(
+            "[POSITION-PENDING][KR] trend-exit result "
+            "symbol=%s intent=%s status=%s",
+            ticker, prepared.intent.id, intent_status,
+        )
+        if intent_status == "SUBMITTED":
+            ag._complete_pending_kr_exit(prepared)
+            record_inflight(
+                conn, ticker, "KR", run_id, sold_qty, "FILLED", reason,
+                str(order_no) if order_no else None,
+            )
+            release_lock(conn, ticker, "KR", run_id, new_state="SOLD")
+            summary["sold"] += 1
+            completed = True
+            try:
+                await ag._run_pending_kr_exit_post_commit(prepared)
+            except Exception as post_commit_error:
+                logger.warning(
+                    "[KR] %s post-CLOSED effects failed: %s",
+                    ticker,
+                    post_commit_error,
+                )
+            try:
+                await ag.send_telegram_message(CHAT_ID, await_broadcast=True)
+            except Exception as telegram_error:
+                logger.warning(
+                    "[KR] %s telegram flush failed: %s", ticker, telegram_error
+                )
+            try:
+                from sell_broadcast import publish_loop_sell
+
+                await publish_loop_sell(
+                    market="KR",
+                    ticker=ticker,
+                    company_name=stock_data.get("company_name", ticker),
+                    price=float(stock_data.get("current_price", 0) or 0),
+                    buy_price=float(stock_data.get("buy_price", 0) or 0),
+                    sell_reason=reason,
+                    trade_result=result,
+                )
+            except Exception as publish_error:
+                logger.warning(
+                    "[KR] %s sell signal publish failed (non-critical): %s",
+                    ticker, publish_error,
+                )
+            return
+        if intent_status == "FAILED":
+            ag._fail_pending_kr_exit(prepared)
+            record_inflight(
+                conn, ticker, "KR", run_id, sold_qty, "REJECTED", reason,
+                str(order_no) if order_no else None,
+            )
+            release_lock(conn, ticker, "KR", run_id, new_state="HOLDING")
+            logger.critical(
+                "[POSITION-PENDING][KR] trend-exit rejected symbol=%s "
+                "intent=%s status=FAILED action=manual_review",
+                ticker,
+                prepared.intent.id,
+            )
+            return
+        if intent_status == "QUEUED":
+            finish_uncertain("QUEUED")
+            return
+
+        quarantine_if_allowed()
+        finish_uncertain()
+    except asyncio.CancelledError:
+        if completed:
+            raise
+        quarantine_if_allowed()
+        finish_uncertain()
+        raise
+    except OrderOutcomeUnknown as error:
+        broker_result = (
+            error.broker_result
+            if isinstance(error.broker_result, dict)
+            else {}
+        )
+        order_no = broker_result.get("order_no")
+        quarantine_if_allowed()
+        logger.critical(
+            "[POSITION-PENDING][KR] trend-exit outcome UNKNOWN "
+            "symbol=%s intent=%s", ticker, error.intent_id,
+        )
+        finish_uncertain()
+    except Exception as error:
+        if completed:
+            logger.critical(
+                "[POSITION-PENDING][KR] trend-exit post-CLOSED failure "
+                "symbol=%s error=%s",
+                ticker,
+                type(error).__name__,
+            )
+            return
+        if prepared is None:
+            logger.error(
+                "[POSITION-PENDING][KR] trend-exit prepare failed "
+                "symbol=%s error=%s", ticker, type(error).__name__,
+            )
+            release_lock(conn, ticker, "KR", run_id, new_state="HOLDING")
+            return
+        quarantine_if_allowed()
+        logger.critical(
+            "[POSITION-PENDING][KR] trend-exit unresolved "
+            "symbol=%s intent=%s error=%s",
+            ticker, prepared.intent.id, type(error).__name__,
+        )
+        finish_uncertain()
+
+
 async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, Any],
                           reason: str, streak: int, run_id: str, agent: Dict[str, Any],
                           summary: Dict[str, Any]) -> None:
@@ -617,6 +837,17 @@ async def _act_on_trigger(conn, market: str, ticker: str, stock_data: Dict[str, 
             agent["ref"] = await _make_agent(market)
         ag = agent["ref"]
         logger.warning("[LIVE][%s] SELLING %s streak=%d reason=%s", market, ticker, streak, reason)
+        if market == "KR" and ag._position_pending_kr_enabled():
+            await _act_on_pending_kr_trigger(
+                conn,
+                ticker,
+                stock_data,
+                reason,
+                run_id,
+                ag,
+                summary,
+            )
+            return
         # Trend-exit is the trend-exit => always a 'trend_exit' exit (recorded in
         # trading_history.exit_kind so the re-entry cooldown treats it as churn-risk
         # regardless of realised P&L sign).


### PR DESCRIPTION
## 요약
- KR batch/hardstop/trend SELL을 opt-in PENDING_EXIT write-ahead lifecycle에 연결
- strict KIS holding 3-state 판정과 local-flat reconciliation 추가
- FAILED/UNKNOWN/QUEUED/cancellation/finalize 실패를 fail-closed 처리
- failed SELL-linked OPEN comparator 가시성과 feature_status gate 진단 추가
- gate=false 및 US legacy 실행 순서 보존

## 안전 경계
- `POSITION_PENDING_KR_ENABLED` 기본 OFF, 이번 PR/배포에서 활성화 금지
- gate=true 피라미딩 종목은 fill reconciliation 전 주문 전에 전부 차단
- gate ON은 Phase 4-b2b-3 사용자 승인, unresolved 0, 운영 복구 검증 후 별도 수행

## 검증
- 집중 회귀 238 passed
- 실행 서비스/TTL 호환 회귀 19 passed
- py_compile, Ruff, git diff --check 통과
- 독립 3관점 재리뷰: HIGH 이상 0, gate-OFF 배포 승인

Closes no issue; advances #412 Phase 4-b2b-2.