### PR TITLE
feat(#412): add alert-only KR pending readiness preflight

### DIFF
--- a/tasks/issue-412/15-phase4b2b3-readiness-plan.md
+++ b/tasks/issue-412/15-phase4b2b3-readiness-plan.md
@@ -1,0 +1,110 @@
+# Issue #412 Phase 4-b2b-3 — KR gate 활성화 readiness 계획
+
+> 기준: main `2bfc9162` (Phase 4-b2b-2 gate OFF 배포 완료)
+> 브랜치: `feature/issue-412-phase4b2b3-readiness`
+> 운영 기본값: `POSITION_PENDING_KR_ENABLED=false`
+> 활성화: 이 작업에서는 금지. 별도 사용자 승인과 무거래 창이 필요하다.
+
+## 1. 목적과 완료 경계
+
+Phase 4-b2b-3 활성화 판단 전에 실행할 **mutation 없는 alert-only KR preflight**를 만든다.
+preflight는 환경, crontab, 로컬 원장, legacy holdings, KIS 현재 미체결 SELL을 읽어
+`ready`, `blocked`, `unknown` 중 하나를 JSON으로 보고한다.
+
+이번 slice의 완료 조건은 다음과 같다.
+
+1. `.env`/현재 process env와 모든 active cron inline에서
+   `POSITION_PENDING_KR_ENABLED`가 unset 또는 명시적 false인지 확인한다.
+2. KR position의 `PENDING_ENTRY`, `PENDING_EXIT`, `EXIT_UNKNOWN`, `ENTRY_FAILED`가 모두 0인지
+   확인하고, comparator의 `failed_exit_linked_open_positions`도 0인지 확인한다.
+3. 기존 `PositionStore.compare_legacy_positions("KR")` 결과가 완전 match인지 확인한다.
+4. `stock_holdings`의 같은 account/ticker 다중 row(피라미딩)를 활성화 blocker로 보고한다.
+5. accepted KR SELL broker order의 broker order id 누락 및 현재 KIS open SELL과의 연결 불일치를
+   경고한다. 이 정보로 FILLED/CANCELLED/REJECTED를 추정하거나 상태를 바꾸지 않는다.
+6. KIS 조회 실패, malformed response, 미처리 pagination, crontab/DB 읽기 실패는 PASS가 아니라
+   `unknown`과 비정상 종료(exit 2)로 보고한다.
+7. 정상 readiness 위반은 `blocked`와 exit 1, 모든 검사가 깨끗할 때만 `ready`와 exit 0이다.
+
+## 2. 비목표와 절대 안전선
+
+- `POSITION_PENDING_KR_ENABLED` 값을 쓰거나 활성화하지 않는다.
+- `positions`, `order_intents`, `broker_orders`, legacy holdings/history를 수정하지 않는다.
+- KIS 주문, 정정, 취소를 호출하지 않는다. 현재 정정취소가능 주문 조회만 사용한다.
+- open-order 목록에서 사라진 주문을 FILLED/CANCELLED/REJECTED로 분류하지 않는다.
+- intent/position/legacy 자동 보상 또는 수동 복구 명령을 추가하지 않는다.
+- durable CLOSED 이후 journal/Redis/GCP replay, 다중 프로세스 통합 계약, execution history 기반
+  reconciliation은 다음 slice/Phase 5로 남긴다.
+- hardstop/trend lifecycle 중복 공통화는 별도 회귀 PR 전까지 건드리지 않는다.
+
+## 3. cleanup/refactor 계획
+
+코드 수정 전 현재 동작을 테스트로 잠그고, 새 추상화는 읽기 경계에만 둔다.
+
+1. `DomesticStockTrading.get_revisable_orders()`의 기존 `list`/실패 시 `[]` 계약은 유지한다.
+2. 같은 KIS 응답을 해석하되 성공 여부를 잃지 않는
+   `get_revisable_orders_checked() -> (authoritative, rows)`를 추가한다.
+3. 기존 public wrapper는 checked 결과의 rows만 반환하도록 최소 위임하되, 정상/실패/부분 파싱
+   결과가 기존과 같음을 회귀로 고정한다.
+4. preflight의 DB 판정은 순수 함수로 분리하고 CLI는 read-only SQLite URI로만 연다.
+5. 계좌 번호는 출력하지 않고 기존 `account_fingerprint()`만 사용한다.
+6. 기존 comparator, feature gate truthy 규칙, KIS account resolver를 재사용하며 새 dependency/table은
+   추가하지 않는다.
+
+## 4. 판정 계약
+
+우선순위는 `unknown > blocked > ready`다.
+
+- `unknown`
+  - `.env`, active crontab, SQLite, KIS 계좌 설정/인증/조회 중 하나라도 신뢰할 수 없음.
+  - KIS output이 list가 아님, row 필수 필드/수량/side가 malformed, 응답에 다음 페이지가 있음.
+- `blocked`
+  - gate가 어느 source에서든 truthy 또는 비표준 값.
+  - 대상 position 상태/failed-exit link/comparator mismatch/pyramiding이 하나라도 존재.
+  - accepted SELL의 broker id 누락, accepted SELL↔현재 open SELL 불일치, 현재 open SELL의 ledger 누락.
+  - 현재 KIS open SELL이 하나라도 남아 있음(연결이 맞아도 accepted-but-unfilled 활성화 blocker).
+- `ready`
+  - 모든 source를 authoritative하게 읽었고 위 blocker가 전부 0.
+
+accepted SELL이 현재 open 목록에 없다는 사실은 상태 추정 근거가 아니다. preflight는 해당 주문을
+`accepted_sell_not_currently_open`으로만 노출하고 `broker_orders`나 `positions`를 갱신하지 않는다.
+
+## 5. TDD slices
+
+### Slice A — checked KIS inquiry
+
+- 정상 empty/list 응답은 authoritative.
+- API failure/exception, non-list output, malformed row, pagination은 non-authoritative.
+- legacy `get_revisable_orders()` 반환은 기존과 동일.
+
+### Slice B — pure/read-only database audit
+
+- clean comparator + 상태 0 + non-pyramided holdings는 통과.
+- 각 PENDING/UNKNOWN/FAILED 상태, failed-exit-linked OPEN, comparator mismatch를 개별 검출.
+- account/ticker별 pyramiding 검출과 account fingerprint redaction.
+- broker id 누락, accepted↔open 양방향 mismatch 검출.
+- audit 전후 SQLite `total_changes == 0` 및 DB bytes 불변.
+
+### Slice C — CLI/result aggregation
+
+- env/process/active cron 어느 하나라도 truthy면 blocked.
+- commented cron은 무시하고 모든 active inline assignment를 검사.
+- invalid gate value는 blocked, crontab/KIS/DB read failure는 unknown.
+- exit code 0/1/2와 JSON schema 고정.
+
+## 6. 검증과 후속 활성화 gate
+
+- 로컬 실행 명령:
+  `python tools/check_kr_pending_readiness.py --db-path stock_tracking_db.sqlite`
+- 로컬 구현 검증(2026-07-19): 관련 259 passed, 신규 파일 Ruff/format, 변경 파일 compile,
+  `git diff --check` 통과. 운영 DB/KIS 실조회, PR/CI/배포는 아직 수행하지 않았다.
+- 신규/관련 pytest, Ruff, `py_compile`, `git diff --check` 통과.
+- 실제 운영 DB 검증 시에도 read-only URI와 KIS inquiry 외 호출 0을 확인한다.
+- 양 서버 `.env`와 모든 active cron inline이 OFF이고, preflight `ready`가 확인돼도 이 PR에서는
+  gate를 켜지 않는다.
+- 실제 ON 전에 durable CLOSED 이후 외부효과 outbox/replay와 batch↔hardstop↔trend 다중 프로세스
+  통합 테스트, operator recovery runbook을 별도 구현·검증하고 사용자 승인을 받는다.
+
+## 7. 롤백 원칙
+
+이 slice는 gate OFF/read-only이므로 문제 시 새 preflight CLI만 제거한다. checked inquiry는 기존
+public list 계약을 보존해야 하며, 회귀 실패 시 production caller 변경 없이 되돌린다.

--- a/tasks/issue-412/README.md
+++ b/tasks/issue-412/README.md
@@ -2,7 +2,7 @@
 
 > 이슈: [#412 매수/매도 Agent 분리와 KIS 실제 주문 실행 구조 이식 설계](https://github.com/dragon1086/prism-insight/issues/412)
 > 브랜치: `feature/issue-412-execution-architecture`
-> 상태: Phase 4-b2b-2 KR EXIT 게이트 OFF 배포 완료, Phase 4-b2b-3 활성화 준비 대기
+> 상태: Phase 4-b2b-2 KR EXIT 게이트 OFF 배포 완료, Phase 4-b2b-3 alert-only preflight 로컬 구현·검증 완료
 > (2026-07-06 시작, 2026-07-13 main #432 기준 전면 재검토,
 > **2026-07-19 Phase 4-b2b-2 PR #467, main `693c8838` 게이트 OFF 배포 완료**)
 
@@ -33,6 +33,7 @@ greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 
 | [12-phase4b2b-kr-execution-plan.md](12-phase4b2b-kr-execution-plan.md) | Phase 4-b2b KR 전환 상세 계획 — 4-b2b-0~3 안전 분할, 실패/재시도 정책, 배포 gate |
 | [13-phase4b2b1-kr-entry-plan.md](13-phase4b2b1-kr-entry-plan.md) | Phase 4-b2b-1 KR ENTRY 구현 계획 — no-auto-retry guard, private lifecycle, 결과별 TDD |
 | [14-phase4b2b2-kr-exit-plan.md](14-phase4b2b2-kr-exit-plan.md) | Phase 4-b2b-2 KR EXIT 구현 계획 — write-ahead claim, legacy finalize, loop 상태 행렬 |
+| [15-phase4b2b3-readiness-plan.md](15-phase4b2b3-readiness-plan.md) | Phase 4-b2b-3 활성화 전 alert-only KR preflight — gate/원장/KIS open SELL 검증 |
 
 ## 진행 체크리스트
 
@@ -49,7 +50,8 @@ greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 
 - [x] Phase 4-b2b-0: KR 전환 안전 기반 — originating store, exit quarantine, 3상태 holding 조회 (PR #464, main `449e4750`)
 - [x] Phase 4-b2b-1: KR ENTRY 전체 경로 PENDING write-ahead (PR #465, flag OFF 배포)
 - [x] Phase 4-b2b-2: KR EXIT 전체 경로 PENDING write-ahead + 실패 보상 (PR #467, flag OFF 배포)
-- [ ] Phase 4-b2b-3: 별도 승인·무거래 창 검증 후 KR 시장 gate 일괄 활성화
+- [ ] Phase 4-b2b-3: alert-only preflight 로컬 구현 완료. outbox/replay·다중 프로세스 검증과
+  별도 승인·무거래 창 검증 후에만 KR 시장 gate 일괄 활성화
 - [ ] Phase 4-b2c: US queued-intent 연속성 + US 전체 경로 전환 (시장 단위 gate)
 - [ ] Phase 4 read switch: 충분한 운영 대조 후 별도 승인
 - [ ] Phase 5: BrokerAdapter 추출 (체결/미체결/정정 포함) + lock 일반화 + reconciliation (alert-only)

--- a/tests/test_kr_pending_readiness.py
+++ b/tests/test_kr_pending_readiness.py
@@ -1,0 +1,335 @@
+"""Read-only activation preflight tests for issue #412 Phase 4-b2b-3."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from prism_core.order_intents import IntentStore, OrderIntent
+from prism_core.positions import PositionStore, account_fingerprint
+from tools import check_kr_pending_readiness as readiness
+from tracking.db_schema import TABLE_STOCK_HOLDINGS
+
+
+ACCOUNT = "vps:12345678:01"
+
+
+def _seed_clean_db(path: Path, *, rows: int = 1) -> None:
+    IntentStore(path)
+    with sqlite3.connect(path) as connection:
+        connection.execute(TABLE_STOCK_HOLDINGS)
+        position_store = PositionStore(connection)
+        position_store.ensure_schema()
+        for index in range(rows):
+            holding_id = connection.execute(
+                """INSERT INTO stock_holdings (
+                       account_key, account_name, ticker, company_name,
+                       buy_price, buy_date
+                   ) VALUES (?, 'primary', '005930', 'Samsung', ?, '2026-07-19')""",
+                (ACCOUNT, 70000 - index * 1000),
+            ).lastrowid
+            assert position_store.open_legacy_position(
+                market="KR",
+                legacy_holding_id=holding_id,
+                account_id=ACCOUNT,
+                account_name="primary",
+                symbol="005930",
+                entry_price=70000 - index * 1000,
+                opened_at="2026-07-19",
+            )
+
+
+def _kis_ok(*orders: dict) -> dict[str, dict]:
+    return {ACCOUNT: {"authoritative": True, "orders": list(orders)}}
+
+
+def _accepted_sell(path: Path, *, order_no: str | None = "KR-1") -> None:
+    intent_store = IntentStore(path)
+    intent = OrderIntent.create(
+        market="KR",
+        account_id=ACCOUNT,
+        symbol="005930",
+        side="SELL",
+        order_style="market",
+        source="test",
+        source_position_id="legacy:KR:1",
+        quantity=1,
+    )
+    created, _ = intent_store.reserve(intent)
+    assert created
+    intent_store.mark_submitting(intent.id)
+    response = {"success": True, "quantity": 1}
+    if order_no is not None:
+        response["order_no"] = order_no
+    intent_store.record_result(
+        intent,
+        status="SUBMITTED",
+        accepted=True,
+        response=response,
+    )
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            "UPDATE positions SET exit_intent_id=? WHERE id='legacy:KR:1'",
+            (intent.id,),
+        )
+
+
+def test_clean_readiness_is_ready_and_does_not_mutate_database(tmp_path):
+    db_path = tmp_path / "clean.sqlite"
+    _seed_clean_db(db_path)
+    before = db_path.read_bytes()
+
+    report = readiness.audit_database(db_path, _kis_ok())
+
+    assert report["status"] == "ready"
+    assert report["blockers"] == []
+    assert report["position_status_counts"] == {
+        "PENDING_ENTRY": 0,
+        "PENDING_EXIT": 0,
+        "EXIT_UNKNOWN": 0,
+        "ENTRY_FAILED": 0,
+    }
+    assert report["comparator"]["matches"] is True
+    assert report["pyramided_holdings"] == []
+    assert report["kis_inquiries"] == [
+        {
+            "account_ref": account_fingerprint(ACCOUNT),
+            "authoritative": True,
+            "open_order_count": 0,
+            "error_type": None,
+        }
+    ]
+    assert before == db_path.read_bytes()
+
+
+@pytest.mark.parametrize(
+    "status",
+    ["PENDING_ENTRY", "PENDING_EXIT", "EXIT_UNKNOWN", "ENTRY_FAILED"],
+)
+def test_each_unresolved_position_state_is_a_blocker(tmp_path, status):
+    db_path = tmp_path / f"{status.lower()}.sqlite"
+    _seed_clean_db(db_path)
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            "UPDATE positions SET status=? WHERE id='legacy:KR:1'",
+            (status,),
+        )
+
+    report = readiness.audit_database(db_path, _kis_ok())
+
+    assert report["status"] == "blocked"
+    assert report["position_status_counts"][status] == 1
+    assert "blocking_position_states" in report["blockers"]
+
+
+def test_pyramiding_is_a_blocker_with_masked_account(tmp_path):
+    db_path = tmp_path / "blocked.sqlite"
+    _seed_clean_db(db_path, rows=2)
+
+    report = readiness.audit_database(db_path, _kis_ok())
+
+    assert report["status"] == "blocked"
+    assert report["pyramided_holdings"] == [
+        {
+            "account_ref": account_fingerprint(ACCOUNT),
+            "symbol": "005930",
+            "row_count": 2,
+        }
+    ]
+    serialized = json.dumps(report, sort_keys=True)
+    assert ACCOUNT not in serialized
+
+
+def test_failed_exit_linked_open_position_is_an_explicit_blocker(tmp_path):
+    db_path = tmp_path / "failed-exit.sqlite"
+    _seed_clean_db(db_path)
+    _accepted_sell(db_path, order_no="KR-FAILED")
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("UPDATE order_intents SET status='FAILED' WHERE side='SELL'")
+
+    report = readiness.audit_database(db_path, _kis_ok())
+
+    assert report["comparator"]["counts"]["failed_exit_linked_open_positions"] == 1
+    assert "failed_exit_linked_open_positions" in report["blockers"]
+
+
+def test_missing_position_mirror_blocks_on_comparator_mismatch(tmp_path):
+    db_path = tmp_path / "comparator.sqlite"
+    _seed_clean_db(db_path)
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("DELETE FROM positions")
+
+    report = readiness.audit_database(db_path, _kis_ok())
+
+    assert report["comparator"]["matches"] is False
+    assert "legacy_position_comparator_mismatch" in report["blockers"]
+
+
+def test_accepted_sell_open_order_linkage_is_reported_without_state_change(tmp_path):
+    db_path = tmp_path / "open.sqlite"
+    _seed_clean_db(db_path)
+    _accepted_sell(db_path, order_no="KR-1")
+    before = db_path.read_bytes()
+
+    report = readiness.audit_database(
+        db_path,
+        _kis_ok(
+            {
+                "order_no": "KR-1",
+                "ticker": "005930",
+                "side": "SELL",
+                "unfilled_qty": 1,
+            }
+        ),
+    )
+
+    assert report["status"] == "blocked"
+    assert report["broker_order_audit"]["matched"] == 1
+    assert report["broker_order_audit"]["accepted_without_broker_order_id"] == []
+    assert report["broker_order_audit"]["accepted_not_currently_open"] == []
+    assert report["broker_order_audit"]["open_sell_without_accepted_ledger"] == []
+    assert report["broker_order_audit"]["current_open_sell_count"] == 1
+    assert before == db_path.read_bytes()
+
+
+def test_broker_order_missing_id_and_bidirectional_mismatch_block(tmp_path):
+    db_path = tmp_path / "mismatch.sqlite"
+    _seed_clean_db(db_path)
+    _accepted_sell(db_path, order_no=None)
+
+    report = readiness.audit_database(
+        db_path,
+        _kis_ok(
+            {
+                "order_no": "UNTRACKED-1",
+                "ticker": "005930",
+                "side": "SELL",
+                "unfilled_qty": 1,
+            }
+        ),
+    )
+
+    broker = report["broker_order_audit"]
+    assert report["status"] == "blocked"
+    assert len(broker["accepted_without_broker_order_id"]) == 1
+    assert len(broker["open_sell_without_accepted_ledger"]) == 1
+
+
+def test_same_order_number_with_different_symbol_is_not_a_match(tmp_path):
+    db_path = tmp_path / "symbol-mismatch.sqlite"
+    _seed_clean_db(db_path)
+    _accepted_sell(db_path, order_no="KR-1")
+
+    report = readiness.audit_database(
+        db_path,
+        _kis_ok(
+            {
+                "order_no": "KR-1",
+                "ticker": "000660",
+                "side": "SELL",
+                "unfilled_qty": 1,
+            }
+        ),
+    )
+
+    broker = report["broker_order_audit"]
+    assert broker["matched"] == 0
+    assert len(broker["accepted_not_currently_open"]) == 1
+    assert len(broker["open_sell_without_accepted_ledger"]) == 1
+
+
+def test_non_authoritative_kis_result_is_unknown(tmp_path):
+    db_path = tmp_path / "unknown.sqlite"
+    _seed_clean_db(db_path)
+
+    report = readiness.audit_database(
+        db_path,
+        {ACCOUNT: {"authoritative": False, "orders": [], "error_type": "TimeoutError"}},
+    )
+
+    assert report["status"] == "unknown"
+    assert report["unknowns"] == ["kis_open_orders"]
+    assert report["broker_order_audit"] is None
+    assert report["kis_inquiries"] == [
+        {
+            "account_ref": account_fingerprint(ACCOUNT),
+            "authoritative": False,
+            "open_order_count": 0,
+            "error_type": "TimeoutError",
+        }
+    ]
+    assert ACCOUNT not in json.dumps(report, sort_keys=True)
+
+
+def test_gate_sources_check_process_dotenv_and_every_active_cron_line():
+    cron = "\n".join(
+        [
+            "# * * * * POSITION_PENDING_KR_ENABLED=true ignored.py",
+            "* * * * * POSITION_PENDING_KR_ENABLED=false first.py",
+            "* * * * * POSITION_PENDING_KR_ENABLED=true second.py",
+        ]
+    )
+
+    report = readiness.evaluate_gate_sources(
+        process_value="false",
+        dotenv_value="false",
+        crontab_text=cron,
+    )
+
+    assert report["status"] == "blocked"
+    assert report["cron_values"] == ["false", "true"]
+
+
+def test_invalid_gate_value_is_blocked_not_silently_off():
+    report = readiness.evaluate_gate_sources(
+        process_value=None,
+        dotenv_value="maybe",
+        crontab_text="",
+    )
+
+    assert report["status"] == "blocked"
+    assert report["invalid_values"] == [{"source": "dotenv", "value": "maybe"}]
+
+
+def test_combine_reports_prioritizes_unknown_over_blocked():
+    combined = readiness.combine_reports(
+        {"status": "blocked", "blockers": ["position_pending_kr_gate"]},
+        {"status": "unknown", "unknowns": ["kis_open_orders"]},
+    )
+
+    assert combined["status"] == "unknown"
+    assert readiness.exit_code(combined) == 2
+    assert readiness.exit_code({"status": "blocked"}) == 1
+    assert readiness.exit_code({"status": "ready"}) == 0
+
+
+def test_cli_emits_json_and_ready_exit_code(tmp_path, monkeypatch, capsys):
+    db_path = tmp_path / "cli.sqlite"
+    _seed_clean_db(db_path)
+    monkeypatch.delenv(readiness.GATE, raising=False)
+    monkeypatch.setattr(
+        readiness,
+        "_read_dotenv_gate",
+        lambda _path: (True, "false", None),
+    )
+    monkeypatch.setattr(
+        readiness,
+        "_read_crontab",
+        lambda: (True, "", None),
+    )
+
+    async def fake_inquiry():
+        return _kis_ok()
+
+    monkeypatch.setattr(readiness, "inquire_kis_open_sells", fake_inquiry)
+
+    result = readiness.main(["--db-path", str(db_path)])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert result == 0
+    assert payload["status"] == "ready"
+    assert payload["gate"]["status"] == "ready"
+    assert payload["database"]["status"] == "ready"

--- a/tests/test_multi_account_domestic.py
+++ b/tests/test_multi_account_domestic.py
@@ -153,12 +153,149 @@ class _BalanceResponse:
         return "balance inquiry failed"
 
 
+class _RevisableOrdersResponse:
+    def __init__(self, *, ok=True, output=_UNSET, tr_cont=""):
+        self._ok = ok
+        self._body = SimpleNamespace(output=[] if output is _UNSET else output)
+        self._header = SimpleNamespace(tr_cont=tr_cont)
+
+    def isOK(self):
+        return self._ok
+
+    def getBody(self):
+        return self._body
+
+    def getHeader(self):
+        return self._header
+
+    def getErrorCode(self):
+        return "E-OPEN-ORDERS"
+
+    def getErrorMessage(self):
+        return "revisable-order inquiry failed"
+
+
 def _trader_with_balance_response(response):
     trader = dst.DomesticStockTrading.__new__(dst.DomesticStockTrading)
     trader.mode = "demo"
     trader.trenv = SimpleNamespace(my_acct="12345678", my_prod="01")
     trader._request_with_retry = lambda *_args, **_kwargs: response
     return trader
+
+
+def _trader_with_revisable_orders_response(response):
+    trader = dst.DomesticStockTrading.__new__(dst.DomesticStockTrading)
+    trader.mode = "demo"
+    trader.trenv = SimpleNamespace(my_acct="12345678", my_prod="01")
+    trader._request = lambda *_args, **_kwargs: response
+    return trader
+
+
+def test_checked_revisable_orders_preserves_authoritative_empty_and_rows():
+    raw = {
+        "odno": "000123",
+        "orgn_odno": "000123",
+        "pdno": "005930",
+        "ord_qty": "7",
+        "ord_unpr": "70000",
+        "tot_ccld_qty": "2",
+        "psbl_qty": "5",
+        "sll_buy_dvsn_cd": "01",
+        "ord_dvsn_cd": "00",
+        "ord_gno_brno": "GNO1",
+    }
+    trader = _trader_with_revisable_orders_response(
+        _RevisableOrdersResponse(output=[raw])
+    )
+
+    authoritative, rows = trader.get_revisable_orders_checked()
+
+    assert authoritative is True
+    assert rows == [
+        {
+            "order_no": "000123",
+            "orgn_odno": "000123",
+            "stock_code": "005930",
+            "ord_qty": 7,
+            "ord_unpr": 70000,
+            "tot_ccld_qty": 2,
+            "psbl_qty": 5,
+            "sll_buy_dvsn_cd": "01",
+            "ord_dvsn": "00",
+            "krx_fwdg_ord_orgno": "GNO1",
+        }
+    ]
+    assert trader.get_revisable_orders() == rows
+
+
+@pytest.mark.parametrize(
+    ("response", "expected_rows"),
+    [
+        (_RevisableOrdersResponse(ok=False), []),
+        (_RevisableOrdersResponse(output=None), []),
+        (_RevisableOrdersResponse(output={}), []),
+        (_RevisableOrdersResponse(output=[{}]), [
+            {
+                "order_no": "",
+                "orgn_odno": "",
+                "stock_code": "",
+                "ord_qty": 0,
+                "ord_unpr": 0,
+                "tot_ccld_qty": 0,
+                "psbl_qty": 0,
+                "sll_buy_dvsn_cd": "",
+                "ord_dvsn": "",
+                "krx_fwdg_ord_orgno": "",
+            }
+        ]),
+        (_RevisableOrdersResponse(
+            output=[{
+                "odno": "1",
+                "pdno": "005930",
+                "psbl_qty": "bad",
+                "sll_buy_dvsn_cd": "01",
+            }]
+        ), [
+            {
+                "order_no": "1",
+                "orgn_odno": "",
+                "stock_code": "005930",
+                "ord_qty": 0,
+                "ord_unpr": 0,
+                "tot_ccld_qty": 0,
+                "psbl_qty": 0,
+                "sll_buy_dvsn_cd": "01",
+                "ord_dvsn": "",
+                "krx_fwdg_ord_orgno": "",
+            }
+        ]),
+        (_RevisableOrdersResponse(output=[], tr_cont="M"), []),
+    ],
+)
+def test_checked_revisable_orders_marks_untrusted_response_unknown_but_keeps_legacy_rows(
+    response, expected_rows
+):
+    trader = _trader_with_revisable_orders_response(response)
+
+    authoritative, rows = trader.get_revisable_orders_checked()
+
+    assert authoritative is False
+    assert rows == expected_rows
+    assert trader.get_revisable_orders() == expected_rows
+
+
+def test_checked_revisable_orders_marks_request_exception_unknown():
+    trader = _trader_with_revisable_orders_response(
+        _RevisableOrdersResponse()
+    )
+
+    def fail_request(*_args, **_kwargs):
+        raise RuntimeError("KIS unavailable")
+
+    trader._request = fail_request
+
+    assert trader.get_revisable_orders_checked() == (False, [])
+    assert trader.get_revisable_orders() == []
 
 
 @pytest.mark.parametrize(

--- a/tools/check_kr_pending_readiness.py
+++ b/tools/check_kr_pending_readiness.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""Read-only KR PENDING-ledger activation preflight for issue #412.
+
+This command never places/amends/cancels orders and opens SQLite in read-only
+mode. It reports readiness only; it never changes a persisted state or feature
+gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from prism_core.positions import PositionStore, account_fingerprint  # noqa: E402
+from tools.feature_status import _cron_get_all_inline_env  # noqa: E402
+
+
+GATE = "POSITION_PENDING_KR_ENABLED"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_FALSEY = frozenset({"0", "false", "no", "off", ""})
+_BLOCKING_POSITION_STATUSES = (
+    "PENDING_ENTRY",
+    "PENDING_EXIT",
+    "EXIT_UNKNOWN",
+    "ENTRY_FAILED",
+)
+
+
+def _normalized_gate_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value).strip().strip('"').strip("'").lower()
+
+
+def evaluate_gate_sources(
+    *,
+    process_value: Any,
+    dotenv_value: Any,
+    crontab_text: str,
+) -> dict[str, Any]:
+    """Conservatively require every effective source to be unset/false."""
+
+    values = [
+        ("process_env", _normalized_gate_value(process_value)),
+        ("dotenv", _normalized_gate_value(dotenv_value)),
+    ]
+    cron_values = [
+        _normalized_gate_value(value) or ""
+        for value in _cron_get_all_inline_env(crontab_text, GATE)
+    ]
+    values.extend(("crontab_inline", value) for value in cron_values)
+
+    enabled_sources = [
+        {"source": source, "value": value}
+        for source, value in values
+        if value in _TRUTHY
+    ]
+    invalid_values = [
+        {"source": source, "value": value}
+        for source, value in values
+        if value is not None and value not in _TRUTHY | _FALSEY
+    ]
+    blockers = []
+    if enabled_sources:
+        blockers.append("position_pending_kr_gate_enabled")
+    if invalid_values:
+        blockers.append("position_pending_kr_gate_invalid")
+    return {
+        "status": "blocked" if blockers else "ready",
+        "gate": GATE,
+        "process_value": _normalized_gate_value(process_value),
+        "dotenv_value": _normalized_gate_value(dotenv_value),
+        "cron_values": cron_values,
+        "enabled_sources": enabled_sources,
+        "invalid_values": invalid_values,
+        "blockers": blockers,
+    }
+
+
+def _read_dotenv_gate(path: Path) -> tuple[bool, str | None, str | None]:
+    if not path.exists():
+        return True, None, None
+    try:
+        value = None
+        with path.open(encoding="utf-8") as handle:
+            for raw_line in handle:
+                line = raw_line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, _, candidate = line.partition("=")
+                normalized_key = key.strip()
+                if normalized_key.startswith("export "):
+                    normalized_key = normalized_key.removeprefix("export ").strip()
+                if normalized_key == GATE:
+                    value = candidate.strip()
+        return True, value, None
+    except OSError as error:
+        return False, None, type(error).__name__
+
+
+def _read_crontab() -> tuple[bool, str, str | None]:
+    try:
+        result = subprocess.run(
+            ["crontab", "-l"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except Exception as error:
+        return False, "", type(error).__name__
+    if result.returncode == 0:
+        return True, result.stdout, None
+    if "no crontab for" in result.stderr.lower():
+        return True, "", None
+    return False, "", "CrontabReadError"
+
+
+def _read_only_connection(db_path: str | Path) -> sqlite3.Connection:
+    uri = Path(db_path).expanduser().resolve().as_uri() + "?mode=ro"
+    connection = sqlite3.connect(uri, uri=True)
+    connection.execute("PRAGMA query_only = ON")
+    return connection
+
+
+def _position_status_counts(connection: sqlite3.Connection) -> dict[str, int]:
+    counts = {status: 0 for status in _BLOCKING_POSITION_STATUSES}
+    placeholders = ",".join("?" for _ in _BLOCKING_POSITION_STATUSES)
+    rows = connection.execute(
+        f"SELECT status, COUNT(*) FROM positions "
+        f"WHERE market='KR' AND status IN ({placeholders}) GROUP BY status",
+        _BLOCKING_POSITION_STATUSES,
+    ).fetchall()
+    counts.update({str(status): int(count) for status, count in rows})
+    return counts
+
+
+def _pyramided_holdings(connection: sqlite3.Connection) -> list[dict[str, Any]]:
+    rows = connection.execute(
+        """SELECT account_key, ticker, COUNT(*) AS row_count
+           FROM stock_holdings
+           GROUP BY account_key, ticker
+           HAVING COUNT(*) > 1
+           ORDER BY account_key, ticker"""
+    ).fetchall()
+    return [
+        {
+            "account_ref": account_fingerprint(account_id),
+            "symbol": str(symbol).upper(),
+            "row_count": int(row_count),
+        }
+        for account_id, symbol, row_count in rows
+    ]
+
+
+def _accepted_kr_sells(connection: sqlite3.Connection) -> list[dict[str, Any]]:
+    rows = connection.execute(
+        """SELECT bo.id, bo.broker_order_id, oi.id, oi.account_id, oi.symbol
+           FROM broker_orders AS bo
+           JOIN order_intents AS oi ON oi.id = bo.intent_id
+           WHERE oi.market='KR' AND oi.side='SELL' AND bo.accepted=1
+           ORDER BY bo.submitted_at, bo.id"""
+    ).fetchall()
+    return [
+        {
+            "broker_record_id": str(broker_record_id),
+            "broker_order_id": (
+                str(broker_order_id).strip() if broker_order_id is not None else ""
+            ),
+            "intent_id": str(intent_id),
+            "account_id": str(account_id),
+            "account_ref": account_fingerprint(account_id),
+            "symbol": str(symbol).upper(),
+        }
+        for broker_record_id, broker_order_id, intent_id, account_id, symbol in rows
+    ]
+
+
+def _normalized_open_sells(
+    inquiries: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    orders: list[dict[str, Any]] = []
+    for account_id, result in inquiries.items():
+        for order in result.get("orders", []):
+            if str(order.get("side", "")).upper() != "SELL":
+                continue
+            orders.append(
+                {
+                    "account_id": str(account_id),
+                    "account_ref": account_fingerprint(account_id),
+                    "broker_order_id": str(order.get("order_no", "")).strip(),
+                    "symbol": str(order.get("ticker", "")).upper(),
+                    "unfilled_qty": int(order.get("unfilled_qty", 0)),
+                }
+            )
+    return orders
+
+
+def _kis_inquiry_audit(
+    inquiries: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "account_ref": account_fingerprint(account_id),
+            "authoritative": bool(result.get("authoritative")),
+            "open_order_count": len(result.get("orders", [])),
+            "error_type": result.get("error_type"),
+        }
+        for account_id, result in sorted(inquiries.items())
+    ]
+
+
+def _safe_broker_item(item: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in item.items() if key != "account_id"}
+
+
+def _broker_order_audit(
+    accepted: list[dict[str, Any]],
+    open_sells: list[dict[str, Any]],
+) -> dict[str, Any]:
+    accepted_with_id = [item for item in accepted if item["broker_order_id"]]
+    missing_id = [item for item in accepted if not item["broker_order_id"]]
+    accepted_keys = {
+        (item["account_id"], item["broker_order_id"], item["symbol"])
+        for item in accepted_with_id
+    }
+    open_keys = {
+        (item["account_id"], item["broker_order_id"], item["symbol"])
+        for item in open_sells
+    }
+    accepted_not_open = [
+        item
+        for item in accepted_with_id
+        if (item["account_id"], item["broker_order_id"], item["symbol"])
+        not in open_keys
+    ]
+    open_not_accepted = [
+        item
+        for item in open_sells
+        if (item["account_id"], item["broker_order_id"], item["symbol"])
+        not in accepted_keys
+    ]
+    return {
+        "accepted_sell_count": len(accepted),
+        "current_open_sell_count": len(open_sells),
+        "matched": sum(
+            (item["account_id"], item["broker_order_id"], item["symbol"]) in open_keys
+            for item in accepted_with_id
+        ),
+        "accepted_without_broker_order_id": [
+            _safe_broker_item(item) for item in missing_id
+        ],
+        "accepted_not_currently_open": [
+            _safe_broker_item(item) for item in accepted_not_open
+        ],
+        "open_sell_without_accepted_ledger": [
+            _safe_broker_item(item) for item in open_not_accepted
+        ],
+        "current_open_sells": [_safe_broker_item(item) for item in open_sells],
+    }
+
+
+def audit_database(
+    db_path: str | Path,
+    kis_inquiries: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Audit persisted KR state without making any database changes."""
+
+    unknown_kis = (
+        any(not bool(result.get("authoritative")) for result in kis_inquiries.values())
+        or not kis_inquiries
+    )
+    with _read_only_connection(db_path) as connection:
+        position_counts = _position_status_counts(connection)
+        comparator = PositionStore(connection).compare_legacy_positions("KR")
+        pyramids = _pyramided_holdings(connection)
+        accepted = _accepted_kr_sells(connection)
+        broker_audit = None
+        if not unknown_kis:
+            broker_audit = _broker_order_audit(
+                accepted,
+                _normalized_open_sells(kis_inquiries),
+            )
+
+    blockers: list[str] = []
+    if any(position_counts.values()):
+        blockers.append("blocking_position_states")
+    if not comparator["matches"]:
+        blockers.append("legacy_position_comparator_mismatch")
+    if comparator["counts"]["failed_exit_linked_open_positions"]:
+        blockers.append("failed_exit_linked_open_positions")
+    if pyramids:
+        blockers.append("pyramided_kr_holdings")
+    if broker_audit is not None:
+        if broker_audit["accepted_without_broker_order_id"]:
+            blockers.append("accepted_sell_missing_broker_order_id")
+        if broker_audit["accepted_not_currently_open"]:
+            blockers.append("accepted_sell_not_currently_open")
+        if broker_audit["open_sell_without_accepted_ledger"]:
+            blockers.append("open_sell_without_accepted_ledger")
+        if broker_audit["current_open_sell_count"]:
+            blockers.append("current_open_sell_orders")
+
+    unknowns = ["kis_open_orders"] if unknown_kis else []
+    status = "unknown" if unknowns else "blocked" if blockers else "ready"
+    return {
+        "status": status,
+        "database": str(Path(db_path).expanduser().resolve()),
+        "kis_inquiries": _kis_inquiry_audit(kis_inquiries),
+        "position_status_counts": position_counts,
+        "comparator": comparator,
+        "pyramided_holdings": pyramids,
+        "broker_order_audit": broker_audit,
+        "blockers": blockers,
+        "unknowns": unknowns,
+    }
+
+
+async def inquire_kis_open_sells() -> dict[str, dict[str, Any]]:
+    """Read authoritative open SELLs for every configured active KR account."""
+
+    from prism_core.execution_service import ExecutionService
+    from trading import domestic_stock_trading as domestic
+
+    default_mode = str(domestic.ka.getEnv().get("default_mode", "demo")).lower()
+    server = "vps" if default_mode == "demo" else "prod"
+    accounts = domestic.ka.get_configured_accounts(svr=server, market="kr")
+    results: dict[str, dict[str, Any]] = {}
+    for account in accounts:
+        account_id = str(account["account_key"])
+        try:
+            async with ExecutionService.domestic(
+                account_name=account["name"]
+            ) as trader:
+                authoritative, rows = await asyncio.to_thread(
+                    trader.get_revisable_orders_checked
+                )
+            orders = [
+                {
+                    "order_no": str(row.get("order_no", "")).strip(),
+                    "ticker": str(row.get("stock_code", "")).upper(),
+                    "side": (
+                        "SELL"
+                        if str(row.get("sll_buy_dvsn_cd", "")).strip() == "01"
+                        else "BUY"
+                    ),
+                    "unfilled_qty": int(row.get("psbl_qty", 0)),
+                }
+                for row in rows
+                if int(row.get("psbl_qty", 0)) > 0
+            ]
+            results[account_id] = {
+                "authoritative": authoritative,
+                "orders": orders,
+            }
+        except Exception as error:
+            results[account_id] = {
+                "authoritative": False,
+                "orders": [],
+                "error_type": type(error).__name__,
+            }
+    return results
+
+
+def combine_reports(*reports: dict[str, Any]) -> dict[str, Any]:
+    statuses = {report.get("status") for report in reports}
+    status = (
+        "unknown"
+        if "unknown" in statuses
+        else "blocked"
+        if "blocked" in statuses
+        else "ready"
+    )
+    return {
+        "status": status,
+        "gate": reports[0] if reports else None,
+        "database": reports[1] if len(reports) > 1 else None,
+    }
+
+
+def exit_code(report: dict[str, Any]) -> int:
+    return {"ready": 0, "blocked": 1}.get(str(report.get("status")), 2)
+
+
+def _unknown_report(component: str, error_type: str) -> dict[str, Any]:
+    return {
+        "status": "unknown",
+        "component": component,
+        "error_type": error_type,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--db-path",
+        default=(
+            os.getenv("STOCK_TRACKING_DB")
+            or str(PROJECT_ROOT / "stock_tracking_db.sqlite")
+        ),
+    )
+    parser.add_argument(
+        "--env-file",
+        default=str(PROJECT_ROOT / ".env"),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    env_ok, dotenv_value, env_error = _read_dotenv_gate(Path(args.env_file))
+    cron_ok, crontab_text, cron_error = _read_crontab()
+    if env_ok and cron_ok:
+        gate_report = evaluate_gate_sources(
+            process_value=os.environ.get(GATE),
+            dotenv_value=dotenv_value,
+            crontab_text=crontab_text,
+        )
+    else:
+        gate_report = _unknown_report(
+            "gate_sources",
+            env_error or cron_error or "GateSourceReadError",
+        )
+
+    try:
+        kis_inquiries = asyncio.run(inquire_kis_open_sells())
+        database_report = audit_database(args.db_path, kis_inquiries)
+    except Exception as error:
+        database_report = _unknown_report("database_or_kis_audit", type(error).__name__)
+
+    report = combine_reports(gate_report, database_report)
+    print(json.dumps(report, ensure_ascii=False, sort_keys=True))
+    return exit_code(report)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_kr_pending_readiness.py
+++ b/tools/check_kr_pending_readiness.py
@@ -13,7 +13,9 @@ import asyncio
 import json
 import os
 import sqlite3
-import subprocess
+
+# Fixed read-only crontab command; never executes caller-controlled input.
+import subprocess  # nosec B404
 import sys
 from pathlib import Path
 from typing import Any, Sequence
@@ -111,8 +113,9 @@ def _read_dotenv_gate(path: Path) -> tuple[bool, str | None, str | None]:
 
 def _read_crontab() -> tuple[bool, str, str | None]:
     try:
-        result = subprocess.run(
-            ["crontab", "-l"],
+        # Absolute executable and constant argv; shell is never used.
+        result = subprocess.run(  # nosec B603
+            ["/usr/bin/crontab", "-l"],
             capture_output=True,
             text=True,
             timeout=5,
@@ -136,10 +139,9 @@ def _read_only_connection(db_path: str | Path) -> sqlite3.Connection:
 
 def _position_status_counts(connection: sqlite3.Connection) -> dict[str, int]:
     counts = {status: 0 for status in _BLOCKING_POSITION_STATUSES}
-    placeholders = ",".join("?" for _ in _BLOCKING_POSITION_STATUSES)
     rows = connection.execute(
-        f"SELECT status, COUNT(*) FROM positions "
-        f"WHERE market='KR' AND status IN ({placeholders}) GROUP BY status",
+        "SELECT status, COUNT(*) FROM positions "
+        "WHERE market='KR' AND status IN (?, ?, ?, ?) GROUP BY status",
         _BLOCKING_POSITION_STATUSES,
     ).fetchall()
     counts.update({str(status): int(count) for status, count in rows})

--- a/trading/domestic_stock_trading.py
+++ b/trading/domestic_stock_trading.py
@@ -1951,6 +1951,19 @@ class DomesticStockTrading:
                     tot_ccld_qty, psbl_qty, sll_buy_dvsn_cd, ord_dvsn,
                     krx_fwdg_ord_orgno}.
         """
+        _, orders = self.get_revisable_orders_checked(stock_code)
+        return orders
+
+    def get_revisable_orders_checked(
+        self, stock_code: str = None
+    ) -> tuple[bool, List[Dict[str, Any]]]:
+        """Return whether the open-order response is authoritative and its rows.
+
+        The legacy public wrapper intentionally discards the boolean and keeps its
+        historical ``[]``-on-failure contract. Readiness/reconciliation callers
+        must use this checked form so a failed or incomplete inquiry is never
+        mistaken for an authoritative empty open-order list.
+        """
         api_url = "/uapi/domestic-stock/v1/trading/inquire-psbl-rvsecncl"
 
         # TODO(live-validate): paper tr_id VTTC0084R is UNVERIFIED in the KIS
@@ -1975,16 +1988,30 @@ class DomesticStockTrading:
             if not res.isOK():
                 error_msg = f"{res.getErrorCode()} - {res.getErrorMessage()}"
                 logger.warning(f"Revisable-order inquiry failed: {error_msg}")
-                return out
+                return False, out
 
             output1 = res.getBody().output
-            if not isinstance(output1, list):
+            authoritative = isinstance(output1, list)
+            if not authoritative:
                 output1 = [output1] if output1 else []
 
             for row in output1:
+                if not isinstance(row, dict):
+                    authoritative = False
+                    break
                 code = str(row.get('pdno', '') or '').strip()
                 if stock_code and code != stock_code:
                     continue
+                side = str(row.get('sll_buy_dvsn_cd', '') or '').strip()
+                order_no = str(row.get('odno', '') or '').strip()
+                try:
+                    raw_remaining = row['psbl_qty']
+                    remaining_text = str(raw_remaining).strip()
+                    remaining = int(remaining_text)
+                    if not remaining_text or remaining < 0:
+                        raise ValueError
+                except (KeyError, TypeError, ValueError):
+                    authoritative = False
                 out.append({
                     'order_no': row.get('odno', ''),
                     'orgn_odno': row.get('orgn_odno', ''),
@@ -1997,11 +2024,28 @@ class DomesticStockTrading:
                     'ord_dvsn': row.get('ord_dvsn_cd', ''),
                     'krx_fwdg_ord_orgno': row.get('ord_gno_brno', ''),
                 })
-            return out
+                if not order_no or not code or side not in {'01', '02'}:
+                    authoritative = False
+
+            try:
+                tr_cont = (
+                    str(getattr(res.getHeader(), "tr_cont", "")).strip().upper()
+                )
+            except Exception as e:
+                logger.warning(f"Could not validate open-order pagination: {e}")
+                authoritative = False
+            else:
+                if tr_cont in {"M", "F"}:
+                    logger.warning(
+                        "Revisable-order inquiry has additional pages; "
+                        "checked result will remain non-authoritative"
+                    )
+                    authoritative = False
+            return authoritative, out
 
         except Exception as e:
             logger.warning(f"Error during revisable-order inquiry: {str(e)}")
-            return out
+            return False, out
 
 
 class MultiAccountDomesticStockTrading:


### PR DESCRIPTION
## What changed

- add a read-only `tools/check_kr_pending_readiness.py` preflight with `ready|blocked|unknown` JSON and exit codes 0/1/2
- verify `POSITION_PENDING_KR_ENABLED` across process env, `.env`, and every active crontab inline assignment
- block on unresolved KR position states, comparator mismatches, failed-exit-linked OPEN positions, pyramided holdings, and current open SELLs
- compare accepted KR SELL broker records with authoritative KIS open SELLs by account, order number, and symbol
- add `get_revisable_orders_checked()` while preserving the legacy list/`[]` contract
- redact account identifiers with the existing fingerprint helper
- document the Phase 4-b2b-3 readiness boundary and activation blockers

## Why

The existing KIS revisable-order wrapper collapses failed and empty inquiries to the same `[]` result. That is safe for fill-chaser no-op behavior but unsafe for an activation preflight. This change retains the legacy behavior while exposing whether the inquiry is authoritative.

Open-order absence is reported only as a mismatch. The preflight does not infer FILLED, CANCELLED, or REJECTED and never mutates intent, position, or legacy state.

## Safety / impact

- alert-only and read-only
- no order, amend, or cancel calls
- SQLite is opened with `mode=ro` and `PRAGMA query_only`
- no new table or dependency
- `POSITION_PENDING_KR_ENABLED` remains OFF
- no production DB/KIS run, deployment, or activation in this PR

## Validation

- 259 related tests passed
- Ruff check and format check passed for new files
- changed Python files compile
- `git diff --check` passed

Closes no phase automatically; this is a readiness slice for #412.