### PR TITLE
feat: add durable KR exit effect outbox foundation

### DIFF
--- a/prism_core/exit_effects.py
+++ b/prism_core/exit_effects.py
@@ -1,0 +1,187 @@
+"""Durable effect candidates created atomically with a completed exit."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+
+EXIT_EFFECT_TYPES = ("JOURNAL", "TELEGRAM", "REDIS", "GCP")
+
+_EXIT_EFFECT_SCHEMA = """
+CREATE TABLE IF NOT EXISTS exit_effect_outbox (
+    id TEXT PRIMARY KEY,
+    intent_id TEXT NOT NULL,
+    market TEXT NOT NULL,
+    account_id TEXT NOT NULL,
+    symbol TEXT NOT NULL,
+    source TEXT NOT NULL,
+    effect_type TEXT NOT NULL
+        CHECK (effect_type IN ('JOURNAL', 'TELEGRAM', 'REDIS', 'GCP')),
+    payload_json TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'PENDING'
+        CHECK (status IN ('PENDING', 'IN_PROGRESS', 'DELIVERED', 'DEAD')),
+    attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+    next_attempt_at TEXT,
+    lease_owner TEXT,
+    lease_expires_at TEXT,
+    remote_id TEXT,
+    last_error TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    completed_at TEXT,
+    UNIQUE(intent_id, effect_type)
+)
+"""
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _canonical_json(payload: Mapping[str, Any]) -> str:
+    return json.dumps(
+        dict(payload),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+class ExitEffectStore:
+    """Transaction-neutral storage for post-CLOSED effect candidates."""
+
+    def __init__(
+        self, connection_or_cursor: sqlite3.Connection | sqlite3.Cursor
+    ) -> None:
+        if not isinstance(connection_or_cursor, (sqlite3.Connection, sqlite3.Cursor)):
+            raise TypeError("ExitEffectStore requires a sqlite3 Connection or Cursor")
+        self._db = connection_or_cursor
+
+    @property
+    def _connection(self) -> sqlite3.Connection:
+        if isinstance(self._db, sqlite3.Connection):
+            return self._db
+        return self._db.connection
+
+    def _execute(self, sql: str, parameters: tuple[Any, ...] = ()) -> sqlite3.Cursor:
+        return self._db.execute(sql, parameters)
+
+    def _require_active_transaction(self) -> None:
+        if not self._connection.in_transaction:
+            raise RuntimeError(
+                "exit effect enqueue requires an active caller-owned transaction"
+            )
+
+    def ensure_schema(self) -> None:
+        """Create the additive outbox schema without committing caller work."""
+
+        self._execute(_EXIT_EFFECT_SCHEMA)
+        self._execute(
+            "CREATE INDEX IF NOT EXISTS idx_exit_effect_outbox_pending "
+            "ON exit_effect_outbox(status, next_attempt_at, created_at)"
+        )
+        self._execute(
+            "CREATE INDEX IF NOT EXISTS idx_exit_effect_outbox_intent "
+            "ON exit_effect_outbox(intent_id, effect_type)"
+        )
+
+    def enqueue_exit_effects(
+        self,
+        *,
+        intent_id: str,
+        market: str,
+        account_id: str,
+        symbol: str,
+        source: str,
+        payload: Mapping[str, Any],
+    ) -> int:
+        """Insert four deterministic effect candidates in the caller transaction."""
+
+        self._require_active_transaction()
+        identity = {
+            "intent_id": str(intent_id or "").strip(),
+            "market": str(market or "").strip().upper(),
+            "account_id": str(account_id or "").strip(),
+            "symbol": str(symbol or "").strip().upper(),
+            "source": str(source or "").strip(),
+        }
+        if not all(identity.values()):
+            raise ValueError("exit effect identity fields are required")
+        if payload.get("event_id") != identity["intent_id"]:
+            raise ValueError("exit effect payload event_id must match intent_id")
+
+        payload_json = _canonical_json(payload)
+        now = _utc_now()
+        inserted = 0
+        for effect_type in EXIT_EFFECT_TYPES:
+            effect_id = f"{identity['intent_id']}:{effect_type.lower()}"
+            changed = self._execute(
+                """
+                INSERT INTO exit_effect_outbox (
+                    id, intent_id, market, account_id, symbol, source,
+                    effect_type, payload_json, status, attempt_count,
+                    created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'PENDING', 0, ?, ?)
+                ON CONFLICT(intent_id, effect_type) DO NOTHING
+                """,
+                (
+                    effect_id,
+                    identity["intent_id"],
+                    identity["market"],
+                    identity["account_id"],
+                    identity["symbol"],
+                    identity["source"],
+                    effect_type,
+                    payload_json,
+                    now,
+                    now,
+                ),
+            ).rowcount
+            if changed == 1:
+                inserted += 1
+                continue
+
+            existing = self._execute(
+                """
+                SELECT id, market, account_id, symbol, source, payload_json
+                FROM exit_effect_outbox
+                WHERE intent_id=? AND effect_type=?
+                """,
+                (identity["intent_id"], effect_type),
+            ).fetchone()
+            expected = (
+                effect_id,
+                identity["market"],
+                identity["account_id"],
+                identity["symbol"],
+                identity["source"],
+                payload_json,
+            )
+            if existing is None or tuple(existing) != expected:
+                raise ValueError(
+                    "exit effect payload conflict for existing intent/effect identity"
+                )
+        return inserted
+
+    def list_for_intent(self, intent_id: str) -> list[dict[str, Any]]:
+        """Return decoded effect rows for audit and tests without mutation."""
+
+        cursor = self._execute(
+            "SELECT * FROM exit_effect_outbox WHERE intent_id=?",
+            (str(intent_id or ""),),
+        )
+        columns = [column[0] for column in cursor.description or ()]
+        order = {
+            effect_type: index for index, effect_type in enumerate(EXIT_EFFECT_TYPES)
+        }
+        rows = []
+        for value in cursor.fetchall():
+            row = dict(zip(columns, value))
+            row["payload"] = json.loads(row.pop("payload_json"))
+            rows.append(row)
+        rows.sort(key=lambda row: order[str(row["effect_type"])])
+        return rows

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -54,6 +54,7 @@ from prism_core.execution_service import (
     OrderOutcomeUnknown,
     normalize_checked_holding,
 )
+from prism_core.exit_effects import ExitEffectStore
 from prism_core.order_intents import IntentStore, OrderIntent
 from prism_core.positions import (
     LegacyPositionWriteResult,
@@ -282,8 +283,10 @@ class StockTrackingAgent:
 
         self.conn.commit()
         store = PositionStore(self.cursor)
+        effect_store = ExitEffectStore(self.cursor)
         try:
             store.ensure_schema()
+            effect_store.ensure_schema()
             self.conn.commit()
         except Exception as error:
             self.conn.rollback()
@@ -1248,6 +1251,7 @@ class StockTrackingAgent:
         try:
             intent_store = IntentStore(self.db_path)
             PositionStore(self.conn).ensure_schema()
+            ExitEffectStore(self.conn).ensure_schema()
             self.conn.commit()
         except Exception:
             if self.conn.in_transaction:
@@ -1782,7 +1786,7 @@ class StockTrackingAgent:
             )
 
     def _complete_pending_kr_exit(self, prepared: _PreparedKrExit) -> None:
-        """Atomically close legacy and ledger state, then expose the message."""
+        """Atomically close legacy/ledger state and persist effect candidates."""
 
         self.conn.execute("BEGIN IMMEDIATE")
         try:
@@ -1842,6 +1846,31 @@ class StockTrackingAgent:
                 realized_pnl_pct=prepared.profit_rate,
                 exit_kind=prepared.exit_kind,
                 closed_at=prepared.sell_date,
+            )
+            ExitEffectStore(self.conn).enqueue_exit_effects(
+                intent_id=prepared.intent.id,
+                market="KR",
+                account_id=prepared.account_id,
+                symbol=prepared.symbol,
+                source=prepared.intent.source,
+                payload={
+                    "version": 1,
+                    "event_id": prepared.intent.id,
+                    "market": "KR",
+                    "source": prepared.intent.source,
+                    "account_id": prepared.account_id,
+                    "account_name": prepared.account_name,
+                    "symbol": prepared.symbol,
+                    "company_name": prepared.company_name,
+                    "sell_price": prepared.sell_price,
+                    "buy_price": prepared.buy_price,
+                    "profit_rate": prepared.profit_rate,
+                    "holding_days": prepared.holding_days,
+                    "sell_reason": prepared.sell_reason,
+                    "exit_kind": prepared.exit_kind,
+                    "message": prepared.message,
+                    "journal_stock_data": prepared.journal_stock_data,
+                },
             )
             self.conn.commit()
         except BaseException:

--- a/tasks/issue-412/16-phase4b2b3-outbox-plan.md
+++ b/tasks/issue-412/16-phase4b2b3-outbox-plan.md
@@ -1,0 +1,122 @@
+# Issue #412 Phase 4-b2b-3 — durable CLOSED effect outbox 계획
+
+> 기준: main `0499d096` (PR #469 readiness preflight 병합)
+> 브랜치: `feature/issue-412-phase4b2b3-outbox`
+> 운영 기본값: `POSITION_PENDING_KR_ENABLED=false`
+> 활성화·배포: 이 작업에서는 금지. 별도 사용자 승인과 무거래 창이 필요하다.
+
+## 1. 문제와 확인된 취소 구간
+
+KR pending exit는 broker `SUBMITTED` 뒤 한 SQLite transaction에서 legacy holding/history와
+`positions.status=CLOSED`를 확정한다. 그러나 다음 효과는 commit 뒤 process memory/외부 서비스에서
+순차 실행된다.
+
+1. trading journal 생성
+2. Telegram message queue 적재·flush
+3. Redis sell signal publish
+4. GCP Pub/Sub sell signal publish
+
+batch, hardstop, trend-exit 모두 CLOSED 이후 `CancelledError`, process crash, transport failure가 나면
+position은 올바르게 CLOSED/SOLD로 남지만 어떤 효과가 누락됐는지 내구적으로 알 수 없다. 현재
+회귀 테스트도 CLOSED가 quarantine으로 되돌아가지 않는지만 검증하며 누락 효과의 복구 근거는
+검증하지 않는다.
+
+Redis/GCP publisher는 성공 시 message id, 실패·미설정 시 `None`을 반환한다. 반면 journal은 exit
+intent 고유키가 없고 Telegram은 전송 후 DB 완료 기록 전 crash를 제거할 exactly-once API가 없다.
+따라서 전체 replay를 한 번에 연결하지 않고 원자적 이벤트 기반부터 작게 잠근다.
+
+## 2. 이번 foundation slice의 완료 경계
+
+이번 slice는 **외부 행동을 바꾸지 않는 atomic outbox foundation**까지만 구현한다.
+
+1. additive SQLite `exit_effect_outbox` schema와 transaction-neutral store를 추가한다.
+2. effect identity는 `(intent_id, effect_type)`로 결정론적으로 고정한다.
+3. `JOURNAL`, `TELEGRAM`, `REDIS`, `GCP` 네 effect가 동일한 versioned payload를 가진다.
+4. `_complete_pending_kr_exit()`가 history 삭제/position CLOSED와 같은 caller-owned transaction에서
+   네 effect를 적재한다.
+5. position ledger 초기화와 pending readiness 경계에서 schema를 idempotent하게 보장한다.
+6. CLOSED 이후 cancellation이 발생해도 네 PENDING effect가 남고, CLOSED transaction rollback 시
+   effect도 하나도 남지 않음을 회귀 테스트로 고정한다.
+7. 동일 intent/effect의 동일 payload 재적재는 중복 없이 허용하고, 다른 payload 충돌은 실패시킨다.
+
+## 3. 비목표와 절대 안전선
+
+- `POSITION_PENDING_KR_ENABLED`를 켜거나 운영 `.env`/cron을 수정하지 않는다.
+- 운영 DB, KIS, Telegram, Redis, GCP를 호출하지 않는다.
+- 이번 slice에서 outbox row를 claim, dispatch, retry, `DELIVERED` 처리하지 않는다.
+- 기존 journal/Telegram/Redis/GCP 즉시 실행 순서와 public 반환 계약을 바꾸지 않는다.
+- PENDING row가 있다고 즉시 전송 누락이라고 단정하지 않는다. 기존 즉시 경로가 아직 완료 상태를
+  기록하지 않으므로 foundation 단계에서는 durable recovery candidate 의미만 가진다.
+- journal exactly-once, Telegram at-least-once 운영 정책, Redis/GCP message-id 완료 기록은 다음
+  replay slice에서 테스트 우선으로 결정한다.
+- hardstop/trend duplicated orchestration refactor와 gate ON은 하지 않는다.
+- 계좌 식별자는 외부 출력이나 로그에 기록하지 않는다.
+
+## 4. cleanup/구현 계획
+
+1. `prism_core`의 기존 `PositionStore`처럼 caller transaction을 소유하지 않는 작은 store를 만든다.
+2. schema creation은 additive `CREATE TABLE/INDEX IF NOT EXISTS`만 사용하고 migration dependency를
+   추가하지 않는다.
+3. JSON payload는 canonical serialization으로 저장해 동일 이벤트 재적재 비교를 안정화한다.
+4. `_PreparedKrExit`에 이미 있는 값을 재사용하고 별도 DTO/외부 dependency를 추가하지 않는다.
+5. `_complete_pending_kr_exit()`의 기존 history/delete/CLOSED/message 동작은 유지하고 transaction
+   내부에 enqueue 한 단계만 추가한다.
+6. 테스트 fixture만 새 schema를 보장하도록 갱신하고 production 전송 caller는 건드리지 않는다.
+
+## 5. payload v1 계약
+
+payload는 향후 각 effect dispatcher가 동일한 CLOSED 사실을 재구성할 수 있도록 다음 필드를 가진다.
+
+- `version`, `event_id`(exit intent id), `market`, `source`
+- `account_id`, `account_name`, `symbol`, `company_name`
+- `sell_price`, `buy_price`, `profit_rate`, `holding_days`, `sell_reason`, `exit_kind`
+- `message`, `journal_stock_data`
+
+DB 내부 account identity는 올바른 account scope 재생에 필요하지만 CLI/로그에서는 fingerprint 또는
+redaction만 허용한다. payload는 생성 후 수정하지 않으며 effect별 delivery metadata만 별도 column에
+기록한다.
+
+## 6. TDD slices
+
+### Slice A — store contract
+
+- active caller transaction 밖 enqueue 거부.
+- 네 effect 원자 적재와 결정론적 id/상태 확인.
+- 동일 payload 재적재는 0건 추가, 다른 payload는 conflict 오류.
+- rollback 뒤 row 0건.
+
+### Slice B — CLOSED transaction integration
+
+- 정상 completion에서 history/CLOSED/outbox 4건이 함께 commit.
+- position finalize 또는 outbox enqueue 실패 시 holding/history/CLOSED/outbox가 함께 rollback.
+- message queue는 commit 뒤에만 기존과 같이 적재.
+
+### Slice C — post-CLOSED cancellation evidence
+
+- batch post-commit cancellation 뒤 position CLOSED, history 1, outbox PENDING 4 유지.
+- broker pre-completion cancellation/FAILED/UNKNOWN에는 outbox 0.
+- 이 slice에서는 hardstop/trend fake-agent 테스트를 outbox 구현처럼 꾸미지 않는다. 실제 DB를 공유하는
+  다중 process 통합 테스트는 dispatcher가 생기는 다음 slice에서 추가한다.
+
+## 7. 다음 replay slice의 진입 조건
+
+1. Journal row에 exit intent 고유 연결을 추가해 LLM 재실행/DB insert 중복을 방지한다.
+2. Telegram은 at-least-once 한계와 operator-visible event id를 명시하고 bool 성공만 완료 처리한다.
+3. Redis/GCP는 반환 message id가 있을 때만 개별 effect를 완료 처리한다.
+4. lease/attempt/backoff를 가진 bounded replay worker와 read-only audit/dry-run CLI를 구현한다.
+5. batch↔hardstop↔trend 세 process가 같은 DB에서 하나의 exit intent/effect set만 만드는 통합 테스트를
+   통과한다.
+6. readiness preflight가 unresolved outbox를 blocker/unknown 중 올바른 범주로 판정한다.
+
+## 8. 검증과 롤백
+
+- 신규 store unit test, KR pending exit 관련 pytest, hardstop/trend 회귀 테스트를 실행한다.
+- Ruff, format check, `py_compile`, `git diff --check`를 통과한다.
+- 기존 전송 함수와 운영 설정 diff가 없음을 확인한다.
+- 문제 시 additive store/schema와 `_complete_pending_kr_exit()` enqueue만 되돌린다. gate OFF이므로
+  production pending exit 동작은 활성화되지 않는다.
+
+구현 검증(2026-07-20): outbox/KR pending entry·exit/hardstop/trend/position/intent/report 관련
+`220 passed`, 신규·변경 범위 Ruff, 신규 파일 format check, 변경 Python compile,
+`git diff --check`를 통과했다. 테스트 import용 git-ignore 로컬 KIS placeholder 외 운영 설정 변경은 없고,
+운영 DB·KIS·Telegram·Redis·GCP 호출, 배포, gate 활성화는 수행하지 않았다.

--- a/tests/test_exit_effect_outbox.py
+++ b/tests/test_exit_effect_outbox.py
@@ -1,0 +1,112 @@
+import sqlite3
+
+import pytest
+
+from prism_core.exit_effects import EXIT_EFFECT_TYPES, ExitEffectStore
+
+
+INTENT_ID = "intent-exit-1"
+
+
+def _payload(**overrides):
+    payload = {
+        "version": 1,
+        "event_id": INTENT_ID,
+        "market": "KR",
+        "source": "kr_batch",
+        "account_id": "vps:kr-primary:01",
+        "account_name": "kr-primary",
+        "symbol": "005930",
+        "company_name": "Samsung Electronics",
+        "sell_price": 72000.0,
+        "buy_price": 70000.0,
+        "profit_rate": 2.85,
+        "holding_days": 19,
+        "sell_reason": "risk exit",
+        "exit_kind": "stop",
+        "message": "sold",
+        "journal_stock_data": {"ticker": "005930"},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _store(connection: sqlite3.Connection) -> ExitEffectStore:
+    store = ExitEffectStore(connection)
+    store.ensure_schema()
+    connection.commit()
+    return store
+
+
+def _enqueue(store: ExitEffectStore, payload=None) -> int:
+    return store.enqueue_exit_effects(
+        intent_id=INTENT_ID,
+        market="KR",
+        account_id="vps:kr-primary:01",
+        symbol="005930",
+        source="kr_batch",
+        payload=payload or _payload(),
+    )
+
+
+def test_enqueue_requires_active_caller_transaction():
+    connection = sqlite3.connect(":memory:")
+    store = _store(connection)
+    try:
+        with pytest.raises(RuntimeError, match="active caller-owned transaction"):
+            _enqueue(store)
+    finally:
+        connection.close()
+
+
+def test_enqueue_is_atomic_deterministic_and_idempotent():
+    connection = sqlite3.connect(":memory:")
+    connection.row_factory = sqlite3.Row
+    store = _store(connection)
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        assert _enqueue(store) == len(EXIT_EFFECT_TYPES)
+        assert _enqueue(store) == 0
+        connection.commit()
+
+        rows = store.list_for_intent(INTENT_ID)
+    finally:
+        connection.close()
+
+    assert [row["effect_type"] for row in rows] == list(EXIT_EFFECT_TYPES)
+    assert {row["id"] for row in rows} == {
+        f"{INTENT_ID}:{effect_type.lower()}" for effect_type in EXIT_EFFECT_TYPES
+    }
+    assert {row["status"] for row in rows} == {"PENDING"}
+    assert {row["attempt_count"] for row in rows} == {0}
+    assert all(row["payload"]["event_id"] == INTENT_ID for row in rows)
+
+
+def test_enqueue_rejects_same_effect_identity_with_different_payload():
+    connection = sqlite3.connect(":memory:")
+    store = _store(connection)
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        _enqueue(store)
+        connection.commit()
+
+        connection.execute("BEGIN IMMEDIATE")
+        with pytest.raises(ValueError, match="payload conflict"):
+            _enqueue(store, _payload(sell_price=71000.0))
+        connection.rollback()
+    finally:
+        connection.close()
+
+
+def test_enqueue_rolls_back_with_caller_transaction():
+    connection = sqlite3.connect(":memory:")
+    store = _store(connection)
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        assert _enqueue(store) == len(EXIT_EFFECT_TYPES)
+        connection.rollback()
+        rows = store.list_for_intent(INTENT_ID)
+    finally:
+        connection.close()
+
+    assert rows == []

--- a/tests/test_kr_pending_exit.py
+++ b/tests/test_kr_pending_exit.py
@@ -11,6 +11,7 @@ import pytest
 
 import trading.domestic_stock_trading as domestic_trading
 from prism_core.execution_service import OrderOutcomeUnknown
+from prism_core.exit_effects import EXIT_EFFECT_TYPES, ExitEffectStore
 from prism_core.order_intents import IntentStore
 from prism_core.positions import InvalidPositionTransition, PositionStore
 from stock_tracking_agent import StockTrackingAgent
@@ -27,6 +28,7 @@ def _pending_exit_agent(db_path: Path):
     connection.execute(TABLE_STOCK_HOLDINGS)
     connection.execute(TABLE_TRADING_HISTORY)
     PositionStore(connection).ensure_schema()
+    ExitEffectStore(connection).ensure_schema()
     connection.commit()
     IntentStore(db_path)
 
@@ -112,6 +114,10 @@ def _state(db_path: Path, intent_id: str) -> tuple[int, int, str, str]:
             "SELECT status FROM positions WHERE exit_intent_id=?", (intent_id,)
         ).fetchone()[0]
     return holdings, history, intent_status, position_status
+
+
+def _effects(connection: sqlite3.Connection, intent_id: str) -> list[dict]:
+    return ExitEffectStore(connection).list_for_intent(intent_id)
 
 
 def test_prepare_persists_created_pending_exit_without_external_effects(
@@ -265,10 +271,38 @@ def test_complete_exit_rolls_back_legacy_writes_when_position_finalize_fails(
         with pytest.raises(sqlite3.OperationalError):
             agent._complete_pending_kr_exit(prepared)
         state = _state(db_path, prepared.intent.id)
+        effects = _effects(connection, prepared.intent.id)
     finally:
         connection.close()
 
     assert state == (1, 0, "SUBMITTED", "PENDING_EXIT")
+    assert effects == []
+    assert agent.message_queue == []
+
+
+def test_complete_exit_rolls_back_closed_state_when_effect_enqueue_fails(
+    monkeypatch, tmp_path
+):
+    db_path = tmp_path / "complete-outbox-rollback.sqlite"
+    agent, connection = _pending_exit_agent(db_path)
+    stock = _insert_open_holding(connection)
+    prepared = _prepare(agent, stock)
+    _set_intent_status(db_path, prepared.intent.id, "SUBMITTED")
+
+    def fail_enqueue(_store, **_kwargs):
+        raise sqlite3.OperationalError("injected effect enqueue failure")
+
+    monkeypatch.setattr(ExitEffectStore, "enqueue_exit_effects", fail_enqueue)
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            agent._complete_pending_kr_exit(prepared)
+        state = _state(db_path, prepared.intent.id)
+        effects = _effects(connection, prepared.intent.id)
+    finally:
+        connection.close()
+
+    assert state == (1, 0, "SUBMITTED", "PENDING_EXIT")
+    assert effects == []
     assert agent.message_queue == []
 
 
@@ -294,12 +328,18 @@ def test_complete_exit_deletes_only_target_pyramid_row_and_queues_message(tmp_pa
             "SELECT status FROM positions WHERE id=?",
             (f"legacy:KR:{target['id']}",),
         ).fetchone()[0]
+        effects = _effects(connection, prepared.intent.id)
     finally:
         connection.close()
 
     assert remaining_ids == [sibling["id"]]
     assert tuple(history) == (70000, 72000, "stop")
     assert state == "CLOSED"
+    assert [effect["effect_type"] for effect in effects] == list(EXIT_EFFECT_TYPES)
+    assert {effect["status"] for effect in effects} == {"PENDING"}
+    assert all(
+        effect["payload"]["event_id"] == prepared.intent.id for effect in effects
+    )
     assert len(agent.message_queue) == 1
     assert agent._msg_types == ["analysis"]
 
@@ -649,6 +689,32 @@ async def test_batch_post_closed_cancellation_does_not_quarantine(
         connection.close()
 
     assert events == ["prepare", "execute", "complete", "post-commit"]
+
+
+@pytest.mark.asyncio
+async def test_post_closed_cancellation_keeps_durable_effect_candidates(tmp_path):
+    db_path = tmp_path / "post-closed-effect-candidates.sqlite"
+    agent, connection = _pending_exit_agent(db_path)
+    stock = _insert_open_holding(connection)
+    prepared = _prepare(agent, stock)
+    _set_intent_status(db_path, prepared.intent.id, "SUBMITTED")
+    agent._complete_pending_kr_exit(prepared)
+
+    async def cancel_post_commit(_prepared):
+        raise asyncio.CancelledError
+
+    agent._run_pending_kr_exit_post_commit = cancel_post_commit
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await agent._run_pending_kr_exit_post_commit(prepared)
+        state = _state(db_path, prepared.intent.id)
+        effects = _effects(connection, prepared.intent.id)
+    finally:
+        connection.close()
+
+    assert state == (0, 1, "SUBMITTED", "CLOSED")
+    assert [effect["effect_type"] for effect in effects] == list(EXIT_EFFECT_TYPES)
+    assert {effect["status"] for effect in effects} == {"PENDING"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add a transaction-neutral SQLite outbox for JOURNAL, TELEGRAM, REDIS, and GCP exit effects
- enqueue deterministic effect candidates in the same transaction as KR legacy/history and position CLOSED
- lock rollback, idempotency, payload conflict, and post-CLOSED cancellation behavior with tests

## Safety boundary
- `POSITION_PENDING_KR_ENABLED` remains OFF
- no deployment or production DB/KIS/Telegram/Redis/GCP operation
- existing immediate journal/Telegram/Redis/GCP behavior is unchanged
- this foundation does not claim, dispatch, retry, or mark effects delivered yet

## Verification
- 220 related tests passed
- Ruff passed for new/changed scope; existing stock agent legacy findings excluded explicitly
- new files format check passed
- py_compile and git diff --check passed

## Follow-up
- add journal intent idempotency and transport-specific completion recording
- implement bounded lease/replay and read-only audit tooling
- add batch/hardstop/trend multi-process integration tests before any gate activation

Part of #412