### PR TITLE
feat: add bounded exit effect replay core

### DIFF
--- a/prism_core/exit_effect_replay.py
+++ b/prism_core/exit_effect_replay.py
@@ -1,0 +1,181 @@
+"""Bounded, transport-agnostic replay for durable exit effects."""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from collections.abc import Awaitable, Callable, Mapping
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from prism_core.exit_effects import (
+    EXIT_EFFECT_TYPES,
+    REMOTE_ID_EFFECT_TYPES,
+    ExitEffectStore,
+)
+
+
+EffectHandler = Callable[[dict[str, Any]], Awaitable[str | bool | None]]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _delivery_result(
+    effect_type: str, result: str | bool | None
+) -> tuple[bool, str | None]:
+    if effect_type in REMOTE_ID_EFFECT_TYPES:
+        if isinstance(result, str) and result.strip():
+            return True, result.strip()
+        return False, None
+    if result is True:
+        return True, None
+    if isinstance(result, str) and result.strip():
+        return True, result.strip()
+    return False, None
+
+
+def _retry_delay(
+    attempt_count: int, *, base_delay_seconds: int, max_delay_seconds: int
+) -> int:
+    delay = base_delay_seconds
+    for _ in range(max(0, int(attempt_count) - 1)):
+        delay = min(max_delay_seconds, delay * 2)
+        if delay == max_delay_seconds:
+            break
+    return delay
+
+
+async def run_exit_effect_replay(
+    db_path: str | Path,
+    *,
+    handlers: Mapping[str, EffectHandler],
+    owner: str,
+    limit: int = 10,
+    lease_seconds: int = 60,
+    handler_timeout_seconds: float = 30,
+    max_attempts: int = 5,
+    base_delay_seconds: int = 30,
+    max_delay_seconds: int = 3600,
+    now: Callable[[], datetime] = _utc_now,
+) -> dict[str, int]:
+    """Claim and process at most ``limit`` effects without holding I/O locks."""
+
+    effect_types = tuple(
+        effect_type for effect_type in EXIT_EFFECT_TYPES if effect_type in handlers
+    )
+    unsupported = set(handlers) - set(EXIT_EFFECT_TYPES)
+    if unsupported:
+        raise ValueError("unsupported exit effect handler")
+    if any(not callable(handler) for handler in handlers.values()):
+        raise TypeError("exit effect handlers must be callable")
+    summary = {"claimed": 0, "delivered": 0, "rescheduled": 0, "dead": 0}
+    if not effect_types:
+        return summary
+    if handler_timeout_seconds <= 0 or handler_timeout_seconds >= lease_seconds:
+        raise ValueError("handler timeout must be positive and shorter than the lease")
+    if base_delay_seconds < 1 or max_delay_seconds < base_delay_seconds:
+        raise ValueError("invalid replay delay bounds")
+    if not isinstance(max_attempts, int) or max_attempts < 1:
+        raise ValueError("max_attempts must be a positive integer")
+
+    resolved_db_path = Path(db_path).expanduser().resolve()
+    if not resolved_db_path.is_file():
+        raise FileNotFoundError("exit effect replay database does not exist")
+    connection = sqlite3.connect(resolved_db_path, timeout=30)
+    connection.row_factory = sqlite3.Row
+    store = ExitEffectStore(connection)
+    try:
+        table = connection.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type='table' AND name='exit_effect_outbox'"
+        ).fetchone()
+        if table is None:
+            raise RuntimeError("exit effect outbox schema is missing")
+        connection.execute("BEGIN IMMEDIATE")
+        claimed = store.claim_ready_effects(
+            owner=owner,
+            limit=limit,
+            effect_types=effect_types,
+            now=now(),
+            lease_seconds=lease_seconds,
+        )
+        connection.commit()
+        summary["claimed"] = len(claimed)
+
+        for effect in claimed:
+            if connection.in_transaction:
+                raise RuntimeError("replay handler cannot run inside a DB transaction")
+            effect_type = str(effect["effect_type"])
+            handler = handlers[effect_type]
+            error_type = None
+            try:
+                result = await asyncio.wait_for(
+                    handler(effect["payload"]), timeout=handler_timeout_seconds
+                )
+                delivered, remote_id = _delivery_result(effect_type, result)
+                if not delivered:
+                    error_type = "DeliveryNotConfirmed"
+            except asyncio.CancelledError:
+                try:
+                    current = now()
+                    delay = _retry_delay(
+                        effect["attempt_count"],
+                        base_delay_seconds=base_delay_seconds,
+                        max_delay_seconds=max_delay_seconds,
+                    )
+                    connection.execute("BEGIN IMMEDIATE")
+                    store.record_failure(
+                        effect_id=effect["id"],
+                        owner=owner,
+                        error_type="CancelledError",
+                        next_attempt_at=current + timedelta(seconds=delay),
+                        max_attempts=max_attempts,
+                        now=current,
+                    )
+                    connection.commit()
+                except BaseException:
+                    if connection.in_transaction:
+                        connection.rollback()
+                raise
+            except Exception as error:
+                delivered = False
+                remote_id = None
+                error_type = type(error).__name__
+
+            current = now()
+            connection.execute("BEGIN IMMEDIATE")
+            try:
+                if delivered:
+                    store.mark_delivered(
+                        effect_id=effect["id"],
+                        owner=owner,
+                        remote_id=remote_id,
+                        now=current,
+                    )
+                    summary["delivered"] += 1
+                else:
+                    delay = _retry_delay(
+                        effect["attempt_count"],
+                        base_delay_seconds=base_delay_seconds,
+                        max_delay_seconds=max_delay_seconds,
+                    )
+                    status = store.record_failure(
+                        effect_id=effect["id"],
+                        owner=owner,
+                        error_type=error_type or "DeliveryNotConfirmed",
+                        next_attempt_at=current + timedelta(seconds=delay),
+                        max_attempts=max_attempts,
+                        now=current,
+                    )
+                    summary["dead" if status == "DEAD" else "rescheduled"] += 1
+                connection.commit()
+            except BaseException:
+                if connection.in_transaction:
+                    connection.rollback()
+                raise
+    finally:
+        connection.close()
+    return summary

--- a/prism_core/exit_effects.py
+++ b/prism_core/exit_effects.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
-from datetime import datetime, timezone
-from typing import Any, Mapping
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable, Mapping
 
 
 EXIT_EFFECT_TYPES = ("JOURNAL", "TELEGRAM", "REDIS", "GCP")
+REMOTE_ID_EFFECT_TYPES = frozenset({"REDIS", "GCP"})
+_ERROR_TYPE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]{0,119}$")
 
 _EXIT_EFFECT_SCHEMA = """
 CREATE TABLE IF NOT EXISTS exit_effect_outbox (
@@ -39,6 +42,17 @@ CREATE TABLE IF NOT EXISTS exit_effect_outbox (
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _utc_datetime(value: datetime | None = None) -> datetime:
+    resolved = value or datetime.now(timezone.utc)
+    if resolved.tzinfo is None:
+        raise ValueError("effect timestamps must be timezone-aware")
+    return resolved.astimezone(timezone.utc)
+
+
+def _utc_iso(value: datetime | None = None) -> str:
+    return _utc_datetime(value).isoformat(timespec="seconds")
 
 
 def _canonical_json(payload: Mapping[str, Any]) -> str:
@@ -75,6 +89,34 @@ class ExitEffectStore:
             raise RuntimeError(
                 "exit effect enqueue requires an active caller-owned transaction"
             )
+
+    @staticmethod
+    def _decode_rows(cursor: sqlite3.Cursor) -> list[dict[str, Any]]:
+        columns = [column[0] for column in cursor.description or ()]
+        rows = []
+        for value in cursor.fetchall():
+            row = dict(zip(columns, value))
+            row["payload"] = json.loads(row.pop("payload_json"))
+            rows.append(row)
+        return rows
+
+    def _require_claimed(self, effect_id: str, owner: str) -> dict[str, Any]:
+        cursor = self._execute(
+            """
+            SELECT id, effect_type, status, lease_owner, attempt_count
+            FROM exit_effect_outbox
+            WHERE id=?
+            """,
+            (effect_id,),
+        )
+        value = cursor.fetchone()
+        if value is None:
+            raise ValueError("exit effect does not exist")
+        columns = [column[0] for column in cursor.description or ()]
+        row = dict(zip(columns, value))
+        if row["status"] != "IN_PROGRESS" or row["lease_owner"] != owner:
+            raise RuntimeError("exit effect requires the active lease owner")
+        return row
 
     def ensure_schema(self) -> None:
         """Create the additive outbox schema without committing caller work."""
@@ -167,6 +209,172 @@ class ExitEffectStore:
                 )
         return inserted
 
+    def claim_ready_effects(
+        self,
+        *,
+        owner: str,
+        limit: int,
+        effect_types: Iterable[str] | None = None,
+        now: datetime | None = None,
+        lease_seconds: int = 60,
+    ) -> list[dict[str, Any]]:
+        """Claim a bounded ready batch without holding a lease transaction open."""
+
+        self._require_active_transaction()
+        owner = str(owner or "").strip()
+        if not owner:
+            raise ValueError("lease owner is required")
+        if not isinstance(limit, int) or limit < 1:
+            raise ValueError("claim limit must be a positive integer")
+        if not isinstance(lease_seconds, int) or lease_seconds < 1:
+            raise ValueError("lease_seconds must be a positive integer")
+
+        selected_types = tuple(effect_types or EXIT_EFFECT_TYPES)
+        if not selected_types or any(
+            effect_type not in EXIT_EFFECT_TYPES for effect_type in selected_types
+        ):
+            raise ValueError("unsupported exit effect type")
+        selected_types = tuple(dict.fromkeys(selected_types))
+        type_enabled = tuple(
+            int(effect_type in selected_types) for effect_type in EXIT_EFFECT_TYPES
+        )
+        current = _utc_datetime(now)
+        current_iso = _utc_iso(current)
+        lease_expires_at = _utc_iso(current + timedelta(seconds=lease_seconds))
+        candidates = self._execute(
+            """
+            SELECT id
+            FROM exit_effect_outbox
+            WHERE (
+                    (? = 1 AND effect_type='JOURNAL')
+                 OR (? = 1 AND effect_type='TELEGRAM')
+                 OR (? = 1 AND effect_type='REDIS')
+                 OR (? = 1 AND effect_type='GCP')
+              )
+              AND (
+                  (status='PENDING' AND (
+                      next_attempt_at IS NULL OR next_attempt_at <= ?
+                  ))
+                  OR
+                  (status='IN_PROGRESS' AND lease_expires_at IS NOT NULL
+                   AND lease_expires_at <= ?)
+              )
+            ORDER BY created_at,
+                     CASE effect_type
+                         WHEN 'JOURNAL' THEN 1
+                         WHEN 'TELEGRAM' THEN 2
+                         WHEN 'REDIS' THEN 3
+                         WHEN 'GCP' THEN 4
+                     END,
+                     id
+            LIMIT ?
+            """,
+            (*type_enabled, current_iso, current_iso, limit),
+        ).fetchall()
+        effect_ids = [str(row[0]) for row in candidates]
+        claimed = []
+        for effect_id in effect_ids:
+            changed = self._execute(
+                """
+                UPDATE exit_effect_outbox
+                SET status='IN_PROGRESS', attempt_count=attempt_count+1,
+                    lease_owner=?, lease_expires_at=?, updated_at=?
+                WHERE id=?
+                """,
+                (owner, lease_expires_at, current_iso, effect_id),
+            ).rowcount
+            if changed != 1:
+                raise RuntimeError("exit effect claim changed unexpectedly")
+            cursor = self._execute(
+                "SELECT * FROM exit_effect_outbox WHERE id=?", (effect_id,)
+            )
+            claimed.extend(self._decode_rows(cursor))
+        return claimed
+
+    def mark_delivered(
+        self,
+        *,
+        effect_id: str,
+        owner: str,
+        remote_id: str | None = None,
+        now: datetime | None = None,
+    ) -> bool:
+        """Complete one claimed effect; publisher effects require a message id."""
+
+        self._require_active_transaction()
+        owner = str(owner or "").strip()
+        row = self._require_claimed(str(effect_id or "").strip(), owner)
+        normalized_remote_id = str(remote_id).strip() if remote_id is not None else None
+        if row["effect_type"] in REMOTE_ID_EFFECT_TYPES and not normalized_remote_id:
+            raise ValueError("publisher delivery requires a remote message id")
+        completed_at = _utc_iso(now)
+        changed = self._execute(
+            """
+            UPDATE exit_effect_outbox
+            SET status='DELIVERED', remote_id=?, last_error=NULL,
+                next_attempt_at=NULL, lease_owner=NULL, lease_expires_at=NULL,
+                updated_at=?, completed_at=?
+            WHERE id=? AND status='IN_PROGRESS' AND lease_owner=?
+            """,
+            (
+                normalized_remote_id,
+                completed_at,
+                completed_at,
+                row["id"],
+                owner,
+            ),
+        ).rowcount
+        if changed != 1:
+            raise RuntimeError("exit effect delivery changed unexpectedly")
+        return True
+
+    def record_failure(
+        self,
+        *,
+        effect_id: str,
+        owner: str,
+        error_type: str,
+        next_attempt_at: datetime,
+        max_attempts: int,
+        now: datetime | None = None,
+    ) -> str:
+        """Release a failed claim to PENDING or isolate it as DEAD."""
+
+        self._require_active_transaction()
+        owner = str(owner or "").strip()
+        error_type = str(error_type or "").strip()
+        if not _ERROR_TYPE.fullmatch(error_type):
+            raise ValueError("error_type must be a redacted exception type")
+        if not isinstance(max_attempts, int) or max_attempts < 1:
+            raise ValueError("max_attempts must be a positive integer")
+        row = self._require_claimed(str(effect_id or "").strip(), owner)
+        current_iso = _utc_iso(now)
+        terminal = int(row["attempt_count"]) >= max_attempts
+        status = "DEAD" if terminal else "PENDING"
+        retry_at = None if terminal else _utc_iso(next_attempt_at)
+        completed_at = current_iso if terminal else None
+        changed = self._execute(
+            """
+            UPDATE exit_effect_outbox
+            SET status=?, last_error=?, next_attempt_at=?,
+                lease_owner=NULL, lease_expires_at=NULL,
+                updated_at=?, completed_at=?
+            WHERE id=? AND status='IN_PROGRESS' AND lease_owner=?
+            """,
+            (
+                status,
+                error_type,
+                retry_at,
+                current_iso,
+                completed_at,
+                row["id"],
+                owner,
+            ),
+        ).rowcount
+        if changed != 1:
+            raise RuntimeError("exit effect failure changed unexpectedly")
+        return status
+
     def list_for_intent(self, intent_id: str) -> list[dict[str, Any]]:
         """Return decoded effect rows for audit and tests without mutation."""
 
@@ -174,14 +382,9 @@ class ExitEffectStore:
             "SELECT * FROM exit_effect_outbox WHERE intent_id=?",
             (str(intent_id or ""),),
         )
-        columns = [column[0] for column in cursor.description or ()]
         order = {
             effect_type: index for index, effect_type in enumerate(EXIT_EFFECT_TYPES)
         }
-        rows = []
-        for value in cursor.fetchall():
-            row = dict(zip(columns, value))
-            row["payload"] = json.loads(row.pop("payload_json"))
-            rows.append(row)
+        rows = self._decode_rows(cursor)
         rows.sort(key=lambda row: order[str(row["effect_type"])])
         return rows

--- a/tasks/issue-412/17-phase4b2b3-replay-core-plan.md
+++ b/tasks/issue-412/17-phase4b2b3-replay-core-plan.md
@@ -1,0 +1,133 @@
+# Issue #412 Phase 4-b2b-3 — exit effect replay core 계획
+
+> 기준: main `0358d004` (PR #470 atomic outbox foundation 병합)
+> 브랜치: `feature/issue-412-phase4b2b3-replay`
+> 운영 기본값: `POSITION_PENDING_KR_ENABLED=false`
+> 배포·gate ON·실제 외부 replay: 이 작업에서는 금지한다.
+
+## 1. 목적과 이번 완료 경계
+
+PR #470은 CLOSED와 같은 transaction에서 JOURNAL/TELEGRAM/REDIS/GCP 후보를 PENDING으로 남긴다.
+이번 slice는 여러 process가 같은 SQLite를 사용해도 한 effect만 claim하고, 성공은 effect별로 완료하며,
+실패·cancellation은 CLOSED를 건드리지 않고 재시도 가능 상태로 돌려놓는 **bounded replay core**를 만든다.
+
+완료 조건은 다음과 같다.
+
+1. caller-owned `BEGIN IMMEDIATE` 안에서 ready/expired effect를 제한된 개수만 claim한다.
+2. claim은 owner와 lease expiry를 기록하고 attempt count를 정확히 1 증가시킨다.
+3. 두 connection/process가 경쟁해도 같은 effect를 동시에 claim하지 않는다.
+4. Redis/GCP는 비어 있지 않은 remote message id가 있을 때만 DELIVERED가 된다.
+5. Journal/Telegram은 명시적 success 결과가 있을 때만 DELIVERED가 된다.
+6. handler exception, false/None 결과, `CancelledError`는 effect를 PENDING으로 재예약하고 CLOSED,
+   trading_history, legacy holding, position 상태를 수정하지 않는다.
+7. max-attempt에 도달한 실패는 DEAD로 격리하며 자동 무한 retry를 금지한다.
+8. 기본 dry-run/read-only audit CLI가 status/effect count와 오래된 미완료 row를 account fingerprint로만
+   JSON 보고하며 DB bytes를 변경하지 않는다.
+
+## 2. 조사 결론과 분할 이유
+
+- Redis/GCP publisher는 성공 시 message id, 실패·미설정 시 `None`을 반환한다. 따라서 message id가
+  없는 호출을 성공으로 기록하면 안 된다.
+- batch Telegram은 계좌별 exit 직후가 아니라 `run()` 끝에서 portfolio summary와 함께 queue를 한 번
+  flush한다. 현재 queue에는 exit intent linkage가 없어 개별 TELEGRAM effect를 안전하게 완료 처리할 수
+  없다.
+- hardstop/trend는 per-sell Telegram flush를 하지만 batch와 다른 완료 규칙을 먼저 넣으면 caller drift가
+  커진다.
+- trading journal에는 exit intent unique key가 없어 LLM 실행/insert 뒤 process crash가 나면 replay가
+  중복 row를 만들 수 있다.
+
+따라서 이번 slice는 transport/JournalManager adapter를 연결하지 않는다. 먼저 generic replay core와
+read-only audit를 실제 다중 connection 회귀로 잠근 뒤, 다음 adapter slice에서 journal unique linkage,
+Telegram queue linkage, Redis/GCP event id/remote id 완료 기록을 같은 계약 위에 연결한다.
+
+## 3. cleanup/구현 계획
+
+1. PR #470의 `ExitEffectStore`를 재사용하고 새 store/ORM/dependency를 만들지 않는다.
+2. schema에 이미 있는 `status`, `attempt_count`, `next_attempt_at`, `lease_owner`,
+   `lease_expires_at`, `remote_id`, `last_error`, `completed_at`만 사용한다.
+3. store는 계속 transaction-neutral하게 유지하고 commit/rollback은 replay runner가 짧게 소유한다.
+4. network/LLM handler 실행 중 SQLite transaction이나 write lock을 잡지 않는다.
+5. handler timeout은 lease보다 짧게 강제해 정상 runner가 살아 있는 동안 lease-expiry 중복 claim이
+   발생하지 않게 한다.
+6. generic async runner는 injected handler mapping만 받으며 production credential/config를 import하지 않는다.
+7. retry delay는 deterministic bounded exponential backoff로 계산하고 저장 error는 type/name 위주로 제한한다.
+8. audit CLI는 SQLite read-only URI와 parameterized query만 사용하고 account id/name/payload message를
+   출력하지 않는다.
+9. replay는 기존 DB와 outbox table이 없으면 즉시 실패하며 잘못된 경로에 새 SQLite를 만들지 않는다.
+
+## 4. 상태 전이 계약
+
+- `PENDING -> IN_PROGRESS`
+  - `next_attempt_at`이 없거나 현재 이하인 row만 claim.
+  - lease가 만료된 `IN_PROGRESS`도 재claim 가능.
+  - claim 시 attempt count +1.
+- `IN_PROGRESS -> DELIVERED`
+  - 동일 lease owner만 가능.
+  - Redis/GCP는 non-empty remote id 필수.
+  - lease/error/next-attempt를 비우고 completed timestamp 기록.
+- `IN_PROGRESS -> PENDING`
+  - 동일 owner만 가능.
+  - bounded backoff의 next-attempt와 redacted error type 기록.
+- `IN_PROGRESS -> DEAD`
+  - attempt count가 max attempts 이상인 실패만 가능.
+  - 수동 조사 전 자동 claim 금지.
+- `DELIVERED`와 `DEAD`는 generic runner가 다시 claim하지 않는다.
+
+어떤 effect 전이도 order intent, position, holdings, trading history를 변경하지 않는다.
+
+## 5. TDD slices
+
+### Slice A — store lifecycle
+
+- active transaction 밖 claim/complete/reschedule 거부.
+- limit/order/effect filter, future next-attempt 제외.
+- owner mismatch, missing Redis/GCP remote id 거부.
+- expired lease reclaim과 attempt 증가.
+- max-attempt DEAD 격리.
+
+### Slice B — bounded async runner
+
+- network handler 실행 시 DB connection이 transaction을 잡고 있지 않음.
+- success는 개별 DELIVERED, false/None/exception은 PENDING.
+- cancellation도 재예약 후 원래 `CancelledError` 재전파.
+- 두 runner 경쟁에서 effect당 handler 호출 최대 1회.
+- 한 effect 실패가 다른 effect 완료를 전체 rollback하지 않음.
+
+### Slice C — read-only audit CLI
+
+- table/status/effect count와 oldest unresolved age/order.
+- account fingerprint 외 raw account/payload/message 미노출.
+- missing/corrupt schema는 success가 아니라 unknown/exit 2.
+- audit 전후 DB bytes 및 `total_changes` 불변.
+
+## 6. 비목표와 안전선
+
+- 실제 Journal/Telegram/Redis/GCP handler를 등록하거나 호출하지 않는다.
+- 기존 batch/hardstop/trend immediate effect 순서와 message queue를 변경하지 않는다.
+- 기존 PENDING row를 실제 운영 DB에서 claim/replay하지 않는다.
+- readiness preflight 판정이나 gate 값을 변경하지 않는다.
+- 운영 server 배포, cron 등록, bot 재시작을 하지 않는다.
+- exactly-once를 주장하지 않는다. 외부 성공 후 DB DELIVERED 전 crash gap은 adapter별 idempotency가
+  추가될 때까지 남는다.
+
+## 7. 다음 adapter slice 진입 조건
+
+1. Journal `exit_intent_id` unique migration과 기존 row 호환을 검증한다.
+2. Telegram queue item에 exit effect id를 연결하고 batch run-end flush의 개별 성공/실패를 보존한다.
+3. Redis/GCP payload에 deterministic event id를 전달하고 non-empty message id만 완료 처리한다.
+4. hardstop/trend/batch가 같은 effect runner helper를 사용하도록 작은 caller별 회귀를 먼저 추가한다.
+5. 실제 multi-process integration에서 cancellation 후 재시작이 미완료 effect만 처리함을 검증한다.
+
+## 8. 검증과 롤백
+
+- 신규 store/runner/audit 테스트와 기존 KR pending entry/exit, hardstop, trend, position/intent 회귀를
+  실행한다.
+- Ruff, format check, `py_compile`, `git diff --check`, Codacy/CI를 통과한다.
+- 문제 시 runner/audit와 store lifecycle 메서드만 되돌린다. PR #470의 atomic enqueue와 기존 즉시
+  효과 경로에는 영향이 없어야 한다.
+
+구현 검증(2026-07-20): replay/outbox/audit 신규 22개를 포함해 KR pending entry·exit,
+hardstop/trend, position/intent/report 관련 **238 passed**. 신규·변경 범위 Ruff 및 format check,
+Python compile, Bandit, `git diff --check`를 통과했다. 테스트 import용 git-ignore KIS placeholder 외
+운영 설정 변경은 없으며, 실제 DB/outbox claim, Journal/Telegram/Redis/GCP 호출, 배포, cron 등록,
+gate 활성화는 수행하지 않았다.

--- a/tests/test_exit_effect_audit.py
+++ b/tests/test_exit_effect_audit.py
@@ -1,0 +1,125 @@
+import json
+import sqlite3
+
+from prism_core.exit_effects import ExitEffectStore
+from prism_core.positions import account_fingerprint
+from tools import audit_exit_effects
+
+
+ACCOUNT_ID = "vps:secret-account:01"
+INTENT_ID = "intent-audit-1"
+
+
+def _seed(path):
+    with sqlite3.connect(path) as connection:
+        store = ExitEffectStore(connection)
+        store.ensure_schema()
+        connection.commit()
+        connection.execute("BEGIN IMMEDIATE")
+        store.enqueue_exit_effects(
+            intent_id=INTENT_ID,
+            market="KR",
+            account_id=ACCOUNT_ID,
+            symbol="005930",
+            source="hardstop",
+            payload={
+                "version": 1,
+                "event_id": INTENT_ID,
+                "market": "KR",
+                "source": "hardstop",
+                "account_id": ACCOUNT_ID,
+                "symbol": "005930",
+                "message": "private sell message",
+            },
+        )
+        connection.commit()
+
+
+def test_audit_reports_unresolved_effects_without_mutating_or_leaking(tmp_path):
+    db_path = tmp_path / "audit.sqlite"
+    _seed(db_path)
+    before = db_path.read_bytes()
+
+    report = audit_exit_effects.audit_database(db_path, limit=10)
+    serialized = json.dumps(report, sort_keys=True)
+
+    assert report["status"] == "blocked"
+    assert report["status_counts"] == {"PENDING": 4}
+    assert report["effect_counts"] == {
+        "GCP": 1,
+        "JOURNAL": 1,
+        "REDIS": 1,
+        "TELEGRAM": 1,
+    }
+    assert report["unresolved"][0]["account_ref"] == account_fingerprint(ACCOUNT_ID)
+    assert ACCOUNT_ID not in serialized
+    assert "private sell message" not in serialized
+    assert before == db_path.read_bytes()
+
+
+def test_audit_redacts_non_type_error_text_and_reports_truncation(tmp_path):
+    db_path = tmp_path / "redacted.sqlite"
+    _seed(db_path)
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            "UPDATE exit_effect_outbox SET last_error='token=private-value'"
+        )
+
+    report = audit_exit_effects.audit_database(db_path, limit=1)
+    serialized = json.dumps(report, sort_keys=True)
+
+    assert report["unresolved_count"] == 4
+    assert report["returned_count"] == 1
+    assert report["truncated"] is True
+    assert report["unresolved"][0]["last_error"] == "REDACTED"
+    assert "private-value" not in serialized
+
+
+def test_missing_outbox_schema_is_unknown(tmp_path):
+    db_path = tmp_path / "missing.sqlite"
+    with sqlite3.connect(db_path):
+        pass
+
+    report = audit_exit_effects.audit_database(db_path)
+
+    assert report == {
+        "status": "unknown",
+        "error_type": "MissingExitEffectOutbox",
+    }
+
+
+def test_cli_exit_codes_follow_ready_blocked_unknown(tmp_path, capsys):
+    blocked_db = tmp_path / "blocked.sqlite"
+    _seed(blocked_db)
+    ready_db = tmp_path / "ready.sqlite"
+    _seed(ready_db)
+    with sqlite3.connect(ready_db) as connection:
+        store = ExitEffectStore(connection)
+        connection.execute("BEGIN IMMEDIATE")
+        claimed = store.claim_ready_effects(owner="test", limit=4)
+        for effect in claimed:
+            remote_id = (
+                f"{effect['effect_type'].lower()}-message-1"
+                if effect["effect_type"] in {"REDIS", "GCP"}
+                else None
+            )
+            store.mark_delivered(
+                effect_id=effect["id"], owner="test", remote_id=remote_id
+            )
+        connection.commit()
+    unknown_db = tmp_path / "unknown.sqlite"
+    with sqlite3.connect(unknown_db):
+        pass
+
+    assert audit_exit_effects.main(["--db-path", str(blocked_db)]) == 1
+    blocked = json.loads(capsys.readouterr().out)
+    assert blocked["status"] == "blocked"
+
+    assert audit_exit_effects.main(["--db-path", str(ready_db)]) == 0
+    ready = json.loads(capsys.readouterr().out)
+    assert ready["status"] == "ready"
+    assert ready["unresolved_count"] == 0
+
+    assert audit_exit_effects.main(["--db-path", str(unknown_db)]) == 2
+    unknown = json.loads(capsys.readouterr().out)
+    assert unknown["status"] == "unknown"

--- a/tests/test_exit_effect_outbox.py
+++ b/tests/test_exit_effect_outbox.py
@@ -1,4 +1,5 @@
 import sqlite3
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -110,3 +111,200 @@ def test_enqueue_rolls_back_with_caller_transaction():
         connection.close()
 
     assert rows == []
+
+
+def test_claim_requires_active_caller_transaction():
+    connection = sqlite3.connect(":memory:")
+    store = _store(connection)
+    try:
+        with pytest.raises(RuntimeError, match="active caller-owned transaction"):
+            store.claim_ready_effects(owner="worker-a", limit=1)
+    finally:
+        connection.close()
+
+
+def test_claim_filters_ready_effects_and_respects_limit():
+    connection = sqlite3.connect(":memory:")
+    store = _store(connection)
+    now = datetime(2026, 7, 20, tzinfo=timezone.utc)
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        _enqueue(store)
+        connection.execute(
+            "UPDATE exit_effect_outbox SET next_attempt_at=? WHERE effect_type='REDIS'",
+            ((now + timedelta(minutes=5)).isoformat(),),
+        )
+        connection.commit()
+
+        connection.execute("BEGIN IMMEDIATE")
+        claimed = store.claim_ready_effects(
+            owner="worker-a",
+            limit=2,
+            effect_types=("JOURNAL", "REDIS", "GCP"),
+            now=now,
+            lease_seconds=30,
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    assert [row["effect_type"] for row in claimed] == ["JOURNAL", "GCP"]
+    assert {row["status"] for row in claimed} == {"IN_PROGRESS"}
+    assert {row["attempt_count"] for row in claimed} == {1}
+    assert {row["lease_owner"] for row in claimed} == {"worker-a"}
+
+
+def test_expired_lease_can_be_reclaimed_but_live_lease_cannot():
+    connection = sqlite3.connect(":memory:")
+    store = _store(connection)
+    now = datetime(2026, 7, 20, tzinfo=timezone.utc)
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        _enqueue(store)
+        first = store.claim_ready_effects(
+            owner="worker-a",
+            limit=1,
+            effect_types=("JOURNAL",),
+            now=now,
+            lease_seconds=30,
+        )
+        connection.commit()
+
+        connection.execute("BEGIN IMMEDIATE")
+        live = store.claim_ready_effects(
+            owner="worker-b",
+            limit=1,
+            effect_types=("JOURNAL",),
+            now=now + timedelta(seconds=29),
+            lease_seconds=30,
+        )
+        connection.commit()
+
+        connection.execute("BEGIN IMMEDIATE")
+        expired = store.claim_ready_effects(
+            owner="worker-b",
+            limit=1,
+            effect_types=("JOURNAL",),
+            now=now + timedelta(seconds=31),
+            lease_seconds=30,
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    assert first[0]["attempt_count"] == 1
+    assert live == []
+    assert expired[0]["attempt_count"] == 2
+    assert expired[0]["lease_owner"] == "worker-b"
+
+
+def test_redis_and_gcp_delivery_require_remote_message_id():
+    connection = sqlite3.connect(":memory:")
+    store = _store(connection)
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        _enqueue(store)
+        claimed = store.claim_ready_effects(
+            owner="worker-a", limit=1, effect_types=("GCP",)
+        )
+        effect_id = claimed[0]["id"]
+        with pytest.raises(ValueError, match="remote message id"):
+            store.mark_delivered(effect_id=effect_id, owner="worker-a")
+        assert store.mark_delivered(
+            effect_id=effect_id,
+            owner="worker-a",
+            remote_id="gcp-message-1",
+        )
+        connection.commit()
+        row = store.list_for_intent(INTENT_ID)[3]
+    finally:
+        connection.close()
+
+    assert row["effect_type"] == "GCP"
+    assert row["status"] == "DELIVERED"
+    assert row["remote_id"] == "gcp-message-1"
+    assert row["lease_owner"] is None
+
+
+def test_only_active_lease_owner_can_finalize_effect():
+    connection = sqlite3.connect(":memory:")
+    store = _store(connection)
+    now = datetime(2026, 7, 20, tzinfo=timezone.utc)
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        _enqueue(store)
+        effect = store.claim_ready_effects(
+            owner="worker-a", limit=1, effect_types=("JOURNAL",), now=now
+        )[0]
+        connection.commit()
+
+        connection.execute("BEGIN IMMEDIATE")
+        with pytest.raises(RuntimeError, match="active lease owner"):
+            store.mark_delivered(effect_id=effect["id"], owner="worker-b")
+        with pytest.raises(RuntimeError, match="active lease owner"):
+            store.record_failure(
+                effect_id=effect["id"],
+                owner="worker-b",
+                error_type="RuntimeError",
+                next_attempt_at=now + timedelta(seconds=10),
+                max_attempts=3,
+                now=now,
+            )
+        connection.rollback()
+        row = store.list_for_intent(INTENT_ID)[0]
+    finally:
+        connection.close()
+
+    assert row["status"] == "IN_PROGRESS"
+    assert row["lease_owner"] == "worker-a"
+
+
+def test_failure_reschedules_then_dead_letters_at_max_attempts():
+    connection = sqlite3.connect(":memory:")
+    store = _store(connection)
+    now = datetime(2026, 7, 20, tzinfo=timezone.utc)
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        _enqueue(store)
+        first = store.claim_ready_effects(
+            owner="worker-a",
+            limit=1,
+            effect_types=("REDIS",),
+            now=now,
+        )[0]
+        first_status = store.record_failure(
+            effect_id=first["id"],
+            owner="worker-a",
+            error_type="DeliveryNotConfirmed",
+            next_attempt_at=now + timedelta(seconds=10),
+            max_attempts=2,
+            now=now,
+        )
+        connection.commit()
+
+        connection.execute("BEGIN IMMEDIATE")
+        second = store.claim_ready_effects(
+            owner="worker-b",
+            limit=1,
+            effect_types=("REDIS",),
+            now=now + timedelta(seconds=11),
+        )[0]
+        second_status = store.record_failure(
+            effect_id=second["id"],
+            owner="worker-b",
+            error_type="RuntimeError",
+            next_attempt_at=now + timedelta(seconds=30),
+            max_attempts=2,
+            now=now + timedelta(seconds=11),
+        )
+        connection.commit()
+        row = store.list_for_intent(INTENT_ID)[2]
+    finally:
+        connection.close()
+
+    assert first_status == "PENDING"
+    assert second["attempt_count"] == 2
+    assert second_status == "DEAD"
+    assert row["status"] == "DEAD"
+    assert row["last_error"] == "RuntimeError"
+    assert row["next_attempt_at"] is None

--- a/tests/test_exit_effect_replay.py
+++ b/tests/test_exit_effect_replay.py
@@ -1,0 +1,253 @@
+import asyncio
+import sqlite3
+from datetime import datetime, timezone
+
+import pytest
+
+from prism_core.exit_effect_replay import run_exit_effect_replay
+from prism_core.exit_effects import ExitEffectStore
+
+
+INTENT_ID = "intent-replay-1"
+NOW = datetime(2026, 7, 20, tzinfo=timezone.utc)
+
+
+def _seed(path):
+    with sqlite3.connect(path) as connection:
+        store = ExitEffectStore(connection)
+        store.ensure_schema()
+        connection.commit()
+        connection.execute("BEGIN IMMEDIATE")
+        store.enqueue_exit_effects(
+            intent_id=INTENT_ID,
+            market="KR",
+            account_id="vps:kr-primary:01",
+            symbol="005930",
+            source="kr_batch",
+            payload={
+                "version": 1,
+                "event_id": INTENT_ID,
+                "market": "KR",
+                "source": "kr_batch",
+                "account_id": "vps:kr-primary:01",
+                "symbol": "005930",
+                "message": "sold",
+            },
+        )
+        connection.commit()
+
+
+def _rows(path):
+    with sqlite3.connect(path) as connection:
+        return ExitEffectStore(connection).list_for_intent(INTENT_ID)
+
+
+@pytest.mark.asyncio
+async def test_replay_rejects_missing_database_without_creating_it(tmp_path):
+    db_path = tmp_path / "missing.sqlite"
+
+    async def journal(_payload):
+        return True
+
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        await run_exit_effect_replay(
+            db_path,
+            handlers={"JOURNAL": journal},
+            owner="runner-a",
+        )
+
+    assert not db_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_replay_rejects_database_without_outbox_schema(tmp_path):
+    db_path = tmp_path / "no-outbox.sqlite"
+    with sqlite3.connect(db_path):
+        pass
+
+    async def journal(_payload):
+        return True
+
+    with pytest.raises(RuntimeError, match="schema is missing"):
+        await run_exit_effect_replay(
+            db_path,
+            handlers={"JOURNAL": journal},
+            owner="runner-a",
+        )
+
+
+@pytest.mark.asyncio
+async def test_replay_completes_each_effect_independently(tmp_path):
+    db_path = tmp_path / "mixed.sqlite"
+    _seed(db_path)
+
+    async def journal(_payload):
+        return True
+
+    async def telegram(_payload):
+        return None
+
+    async def redis(_payload):
+        return "redis-message-1"
+
+    async def gcp(_payload):
+        raise RuntimeError("transport failed with secret detail")
+
+    summary = await run_exit_effect_replay(
+        db_path,
+        handlers={
+            "JOURNAL": journal,
+            "TELEGRAM": telegram,
+            "REDIS": redis,
+            "GCP": gcp,
+        },
+        owner="runner-a",
+        limit=4,
+        max_attempts=3,
+        base_delay_seconds=10,
+        now=lambda: NOW,
+    )
+    rows = {row["effect_type"]: row for row in _rows(db_path)}
+
+    assert summary == {
+        "claimed": 4,
+        "delivered": 2,
+        "rescheduled": 2,
+        "dead": 0,
+    }
+    assert rows["JOURNAL"]["status"] == "DELIVERED"
+    assert rows["REDIS"]["status"] == "DELIVERED"
+    assert rows["REDIS"]["remote_id"] == "redis-message-1"
+    assert rows["TELEGRAM"]["status"] == "PENDING"
+    assert rows["TELEGRAM"]["last_error"] == "DeliveryNotConfirmed"
+    assert rows["GCP"]["status"] == "PENDING"
+    assert rows["GCP"]["last_error"] == "RuntimeError"
+    assert "secret detail" not in str(rows)
+
+
+@pytest.mark.asyncio
+async def test_redis_boolean_success_is_not_a_message_id(tmp_path):
+    db_path = tmp_path / "redis-bool.sqlite"
+    _seed(db_path)
+
+    async def redis(_payload):
+        return True
+
+    summary = await run_exit_effect_replay(
+        db_path,
+        handlers={"REDIS": redis},
+        owner="runner-a",
+        limit=1,
+        now=lambda: NOW,
+    )
+    redis_row = _rows(db_path)[2]
+
+    assert summary["delivered"] == 0
+    assert summary["rescheduled"] == 1
+    assert redis_row["status"] == "PENDING"
+    assert redis_row["remote_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_cancellation_reschedules_before_propagating(tmp_path):
+    db_path = tmp_path / "cancel.sqlite"
+    _seed(db_path)
+
+    async def cancel(_payload):
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_exit_effect_replay(
+            db_path,
+            handlers={"JOURNAL": cancel},
+            owner="runner-a",
+            limit=1,
+            now=lambda: NOW,
+        )
+
+    row = _rows(db_path)[0]
+    assert row["status"] == "PENDING"
+    assert row["attempt_count"] == 1
+    assert row["last_error"] == "CancelledError"
+    assert row["lease_owner"] is None
+
+
+@pytest.mark.asyncio
+async def test_handler_timeout_reschedules_before_lease_expiry(tmp_path):
+    db_path = tmp_path / "timeout.sqlite"
+    _seed(db_path)
+
+    async def slow(_payload):
+        await asyncio.sleep(1)
+        return True
+
+    summary = await run_exit_effect_replay(
+        db_path,
+        handlers={"JOURNAL": slow},
+        owner="runner-a",
+        limit=1,
+        lease_seconds=2,
+        handler_timeout_seconds=0.01,
+        now=lambda: NOW,
+    )
+    row = _rows(db_path)[0]
+
+    assert summary["rescheduled"] == 1
+    assert row["status"] == "PENDING"
+    assert row["last_error"] == "TimeoutError"
+    assert row["lease_owner"] is None
+
+
+@pytest.mark.asyncio
+async def test_handler_runs_without_database_write_lock(tmp_path):
+    db_path = tmp_path / "unlocked.sqlite"
+    _seed(db_path)
+
+    async def journal(_payload):
+        with sqlite3.connect(db_path, timeout=0.1) as competitor:
+            competitor.execute("BEGIN IMMEDIATE")
+            competitor.rollback()
+        return True
+
+    summary = await run_exit_effect_replay(
+        db_path,
+        handlers={"JOURNAL": journal},
+        owner="runner-a",
+        limit=1,
+        now=lambda: NOW,
+    )
+
+    assert summary["delivered"] == 1
+
+
+@pytest.mark.asyncio
+async def test_two_runners_do_not_handle_same_effect_concurrently(tmp_path):
+    db_path = tmp_path / "concurrent.sqlite"
+    _seed(db_path)
+    calls = []
+
+    async def redis(_payload):
+        calls.append("redis")
+        await asyncio.sleep(0.05)
+        return "redis-message-1"
+
+    first, second = await asyncio.gather(
+        run_exit_effect_replay(
+            db_path,
+            handlers={"REDIS": redis},
+            owner="runner-a",
+            limit=1,
+            now=lambda: NOW,
+        ),
+        run_exit_effect_replay(
+            db_path,
+            handlers={"REDIS": redis},
+            owner="runner-b",
+            limit=1,
+            now=lambda: NOW,
+        ),
+    )
+
+    assert calls == ["redis"]
+    assert sorted((first["claimed"], second["claimed"])) == [0, 1]
+    assert _rows(db_path)[2]["status"] == "DELIVERED"

--- a/tools/audit_exit_effects.py
+++ b/tools/audit_exit_effects.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Read-only audit for durable exit effect delivery state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from prism_core.positions import account_fingerprint  # noqa: E402
+
+_SAFE_ERROR_TYPE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]{0,119}$")
+
+
+def _safe_error_type(value: Any) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized if _SAFE_ERROR_TYPE.fullmatch(normalized) else "REDACTED"
+
+
+def _readonly_connection(db_path: Path) -> sqlite3.Connection:
+    uri = f"{db_path.expanduser().resolve().as_uri()}?mode=ro"
+    connection = sqlite3.connect(uri, uri=True)
+    connection.row_factory = sqlite3.Row
+    return connection
+
+
+def audit_database(db_path: str | Path, *, limit: int = 50) -> dict[str, Any]:
+    """Report unresolved effects without mutating SQLite or exposing payloads."""
+
+    if not isinstance(limit, int) or limit < 1:
+        raise ValueError("audit limit must be a positive integer")
+    try:
+        with _readonly_connection(Path(db_path)) as connection:
+            table = connection.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='table' AND name='exit_effect_outbox'"
+            ).fetchone()
+            if table is None:
+                return {
+                    "status": "unknown",
+                    "error_type": "MissingExitEffectOutbox",
+                }
+            status_counts = {
+                str(row[0]): int(row[1])
+                for row in connection.execute(
+                    "SELECT status, COUNT(*) FROM exit_effect_outbox "
+                    "GROUP BY status ORDER BY status"
+                )
+            }
+            effect_counts = {
+                str(row[0]): int(row[1])
+                for row in connection.execute(
+                    "SELECT effect_type, COUNT(*) FROM exit_effect_outbox "
+                    "WHERE status != 'DELIVERED' "
+                    "GROUP BY effect_type ORDER BY effect_type"
+                )
+            }
+            rows = connection.execute(
+                """
+                SELECT id, effect_type, market, account_id, symbol, source,
+                       status, attempt_count, next_attempt_at,
+                       lease_expires_at, last_error, created_at
+                FROM exit_effect_outbox
+                WHERE status != 'DELIVERED'
+                ORDER BY created_at, id
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+            unresolved = [
+                {
+                    "effect_id": str(row["id"]),
+                    "effect_type": str(row["effect_type"]),
+                    "market": str(row["market"]),
+                    "account_ref": account_fingerprint(row["account_id"]),
+                    "symbol": str(row["symbol"]),
+                    "source": str(row["source"]),
+                    "status": str(row["status"]),
+                    "attempt_count": int(row["attempt_count"]),
+                    "next_attempt_at": row["next_attempt_at"],
+                    "lease_expires_at": row["lease_expires_at"],
+                    "last_error": _safe_error_type(row["last_error"]),
+                    "created_at": str(row["created_at"]),
+                }
+                for row in rows
+            ]
+            unresolved_count = sum(effect_counts.values())
+            return {
+                "status": "blocked" if unresolved_count else "ready",
+                "status_counts": status_counts,
+                "effect_counts": effect_counts,
+                "unresolved_count": unresolved_count,
+                "returned_count": len(unresolved),
+                "truncated": unresolved_count > len(unresolved),
+                "unresolved": unresolved,
+            }
+    except (OSError, sqlite3.Error) as error:
+        return {"status": "unknown", "error_type": type(error).__name__}
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db-path", type=Path, required=True)
+    parser.add_argument("--limit", type=int, default=50)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    report = audit_database(args.db_path, limit=args.limit)
+    print(json.dumps(report, ensure_ascii=False, sort_keys=True))
+    return {"ready": 0, "blocked": 1}.get(report["status"], 2)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add transaction-neutral claim/lease/deliver/failure transitions to the exit effect outbox
- add a bounded transport-agnostic async replay runner with timeout, backoff, cancellation release, and DEAD isolation
- add a read-only redacted audit CLI with ready/blocked/unknown exit codes

## Delivery contract
- Redis and GCP require a non-empty remote message ID before DELIVERED
- Journal and Telegram require an explicit successful handler result
- false/None, exception, timeout, or cancellation never rolls back CLOSED; the individual effect returns to PENDING or becomes DEAD at max attempts
- handlers run without an open SQLite write transaction

## Safety boundary
- no production Journal/Telegram/Redis/GCP handlers are registered or called in this PR
- no deployment, cron, production DB audit/replay, or gate activation
- existing batch/hardstop/trend immediate effect behavior is unchanged
- wrong/missing DB paths and missing outbox schema fail instead of creating a new database

## Verification
- 238 related tests passed, including 22 replay/outbox/audit tests
- Ruff and format checks passed
- py_compile, Bandit, and git diff --check passed

## Follow-up
- add journal exit-intent idempotency
- link batch Telegram queue items to exit effects
- pass deterministic event IDs and record Redis/GCP message IDs through production adapters
- add real batch/hardstop/trend multi-process restart integration tests before gate activation

Part of #412