### PR TITLE
feat: wire durable exit effect adapters

### DIFF
--- a/messaging/gcp_pubsub_signal_publisher.py
+++ b/messaging/gcp_pubsub_signal_publisher.py
@@ -250,7 +250,8 @@ class SignalPublisher:
         buy_price: float,
         profit_rate: float,
         sell_reason: str,
-        trade_result: Optional[Dict[str, Any]] = None
+        trade_result: Optional[Dict[str, Any]] = None,
+        event_id: Optional[str] = None,
     ) -> Optional[str]:
         """
         Publish sell signal
@@ -276,6 +277,8 @@ class SignalPublisher:
         if trade_result:
             extra_data["trade_success"] = trade_result.get("success", False)
             extra_data["trade_message"] = trade_result.get("message", "")
+        if event_id:
+            extra_data["event_id"] = event_id
 
         return await self.publish_signal(
             signal_type="SELL",
@@ -372,7 +375,8 @@ async def publish_sell_signal(
     profit_rate: float,
     sell_reason: str,
     trade_result: Optional[Dict[str, Any]] = None,
-    market: str = "KR"
+    market: str = "KR",
+    event_id: Optional[str] = None,
 ) -> Optional[str]:
     """Publish sell signal via global publisher (convenience function)
 
@@ -391,6 +395,8 @@ async def publish_sell_signal(
     if trade_result:
         extra_data["trade_success"] = trade_result.get("success", False)
         extra_data["trade_message"] = trade_result.get("message", "")
+    if event_id:
+        extra_data["event_id"] = event_id
 
     return await publisher.publish_signal(
         signal_type="SELL",

--- a/messaging/redis_signal_publisher.py
+++ b/messaging/redis_signal_publisher.py
@@ -239,7 +239,8 @@ class SignalPublisher:
         buy_price: float,
         profit_rate: float,
         sell_reason: str,
-        trade_result: Optional[Dict[str, Any]] = None
+        trade_result: Optional[Dict[str, Any]] = None,
+        event_id: Optional[str] = None,
     ) -> Optional[str]:
         """
         Publish sell signal
@@ -265,6 +266,8 @@ class SignalPublisher:
         if trade_result:
             extra_data["trade_success"] = trade_result.get("success", False)
             extra_data["trade_message"] = trade_result.get("message", "")
+        if event_id:
+            extra_data["event_id"] = event_id
 
         return await self.publish_signal(
             signal_type="SELL",
@@ -361,7 +364,8 @@ async def publish_sell_signal(
     profit_rate: float,
     sell_reason: str,
     trade_result: Optional[Dict[str, Any]] = None,
-    market: str = "KR"
+    market: str = "KR",
+    event_id: Optional[str] = None,
 ) -> Optional[str]:
     """Publish sell signal via global publisher (convenience function)
 
@@ -381,6 +385,8 @@ async def publish_sell_signal(
     if trade_result:
         extra_data["trade_success"] = trade_result.get("success", False)
         extra_data["trade_message"] = trade_result.get("message", "")
+    if event_id:
+        extra_data["event_id"] = event_id
 
     return await publisher.publish_signal(
         signal_type="SELL",

--- a/prism_core/exit_effect_replay.py
+++ b/prism_core/exit_effect_replay.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import sqlite3
 from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -17,6 +18,14 @@ from prism_core.exit_effects import (
 
 
 EffectHandler = Callable[[dict[str, Any]], Awaitable[str | bool | None]]
+
+
+@dataclass(frozen=True)
+class ExitEffectDeliveryOutcome:
+    """Result of attempting one exact durable effect."""
+
+    status: str
+    remote_id: str | None = None
 
 
 def _utc_now() -> datetime:
@@ -46,6 +55,177 @@ def _retry_delay(
         if delay == max_delay_seconds:
             break
     return delay
+
+
+def _open_replay_database(db_path: str | Path) -> sqlite3.Connection:
+    resolved_db_path = Path(db_path).expanduser().resolve()
+    if not resolved_db_path.is_file():
+        raise FileNotFoundError("exit effect replay database does not exist")
+    connection = sqlite3.connect(resolved_db_path, timeout=30)
+    connection.row_factory = sqlite3.Row
+    table = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='exit_effect_outbox'"
+    ).fetchone()
+    if table is None:
+        connection.close()
+        raise RuntimeError("exit effect outbox schema is missing")
+    return connection
+
+
+async def _process_claimed_effect(
+    connection: sqlite3.Connection,
+    store: ExitEffectStore,
+    effect: dict[str, Any],
+    *,
+    handler: EffectHandler,
+    owner: str,
+    handler_timeout_seconds: float,
+    max_attempts: int,
+    base_delay_seconds: int,
+    max_delay_seconds: int,
+    now: Callable[[], datetime],
+) -> ExitEffectDeliveryOutcome:
+    if connection.in_transaction:
+        raise RuntimeError("replay handler cannot run inside a DB transaction")
+    effect_type = str(effect["effect_type"])
+    error_type = None
+    try:
+        result = await asyncio.wait_for(
+            handler(effect["payload"]), timeout=handler_timeout_seconds
+        )
+        delivered, remote_id = _delivery_result(effect_type, result)
+        if not delivered:
+            error_type = "DeliveryNotConfirmed"
+    except asyncio.CancelledError:
+        try:
+            current = now()
+            delay = _retry_delay(
+                effect["attempt_count"],
+                base_delay_seconds=base_delay_seconds,
+                max_delay_seconds=max_delay_seconds,
+            )
+            connection.execute("BEGIN IMMEDIATE")
+            store.record_failure(
+                effect_id=effect["id"],
+                owner=owner,
+                error_type="CancelledError",
+                next_attempt_at=current + timedelta(seconds=delay),
+                max_attempts=max_attempts,
+                now=current,
+            )
+            connection.commit()
+        except BaseException:
+            if connection.in_transaction:
+                connection.rollback()
+        raise
+    except Exception as error:
+        delivered = False
+        remote_id = None
+        error_type = type(error).__name__
+
+    current = now()
+    connection.execute("BEGIN IMMEDIATE")
+    try:
+        if delivered:
+            store.mark_delivered(
+                effect_id=effect["id"],
+                owner=owner,
+                remote_id=remote_id,
+                now=current,
+            )
+            connection.commit()
+            return ExitEffectDeliveryOutcome("delivered", remote_id)
+
+        delay = _retry_delay(
+            effect["attempt_count"],
+            base_delay_seconds=base_delay_seconds,
+            max_delay_seconds=max_delay_seconds,
+        )
+        status = store.record_failure(
+            effect_id=effect["id"],
+            owner=owner,
+            error_type=error_type or "DeliveryNotConfirmed",
+            next_attempt_at=current + timedelta(seconds=delay),
+            max_attempts=max_attempts,
+            now=current,
+        )
+        connection.commit()
+        return ExitEffectDeliveryOutcome("dead" if status == "DEAD" else "rescheduled")
+    except BaseException:
+        if connection.in_transaction:
+            connection.rollback()
+        raise
+
+
+async def deliver_exit_effect_once(
+    db_path: str | Path,
+    *,
+    effect_id: str,
+    effect_type: str,
+    handler: EffectHandler,
+    owner: str,
+    lease_seconds: int = 60,
+    handler_timeout_seconds: float = 30,
+    max_attempts: int = 5,
+    base_delay_seconds: int = 30,
+    max_delay_seconds: int = 3600,
+    now: Callable[[], datetime] = _utc_now,
+) -> ExitEffectDeliveryOutcome:
+    """Claim and deliver one exact effect, never unrelated ready work."""
+
+    if effect_type not in EXIT_EFFECT_TYPES:
+        raise ValueError("unsupported exit effect type")
+    if not callable(handler):
+        raise TypeError("exit effect handler must be callable")
+    if handler_timeout_seconds <= 0 or handler_timeout_seconds >= lease_seconds:
+        raise ValueError("handler timeout must be positive and shorter than the lease")
+    if base_delay_seconds < 1 or max_delay_seconds < base_delay_seconds:
+        raise ValueError("invalid replay delay bounds")
+    if not isinstance(max_attempts, int) or max_attempts < 1:
+        raise ValueError("max_attempts must be a positive integer")
+
+    connection = _open_replay_database(db_path)
+    store = ExitEffectStore(connection)
+    try:
+        existing = store.get_effect(effect_id)
+        if existing is None:
+            raise ValueError("exit effect does not exist")
+        if existing["effect_type"] != effect_type:
+            raise ValueError("exit effect type does not match requested handler")
+        if existing["status"] == "DELIVERED":
+            return ExitEffectDeliveryOutcome(
+                "already_delivered", existing.get("remote_id")
+            )
+
+        connection.execute("BEGIN IMMEDIATE")
+        claimed = store.claim_effect(
+            effect_id=effect_id,
+            owner=owner,
+            now=now(),
+            lease_seconds=lease_seconds,
+        )
+        connection.commit()
+        if claimed is None:
+            latest = store.get_effect(effect_id)
+            if latest is not None and latest["status"] == "DELIVERED":
+                return ExitEffectDeliveryOutcome(
+                    "already_delivered", latest.get("remote_id")
+                )
+            return ExitEffectDeliveryOutcome("not_ready")
+        return await _process_claimed_effect(
+            connection,
+            store,
+            claimed,
+            handler=handler,
+            owner=owner,
+            handler_timeout_seconds=handler_timeout_seconds,
+            max_attempts=max_attempts,
+            base_delay_seconds=base_delay_seconds,
+            max_delay_seconds=max_delay_seconds,
+            now=now,
+        )
+    finally:
+        connection.close()
 
 
 async def run_exit_effect_replay(
@@ -81,19 +261,9 @@ async def run_exit_effect_replay(
     if not isinstance(max_attempts, int) or max_attempts < 1:
         raise ValueError("max_attempts must be a positive integer")
 
-    resolved_db_path = Path(db_path).expanduser().resolve()
-    if not resolved_db_path.is_file():
-        raise FileNotFoundError("exit effect replay database does not exist")
-    connection = sqlite3.connect(resolved_db_path, timeout=30)
-    connection.row_factory = sqlite3.Row
+    connection = _open_replay_database(db_path)
     store = ExitEffectStore(connection)
     try:
-        table = connection.execute(
-            "SELECT 1 FROM sqlite_master "
-            "WHERE type='table' AND name='exit_effect_outbox'"
-        ).fetchone()
-        if table is None:
-            raise RuntimeError("exit effect outbox schema is missing")
         connection.execute("BEGIN IMMEDIATE")
         claimed = store.claim_ready_effects(
             owner=owner,
@@ -106,76 +276,21 @@ async def run_exit_effect_replay(
         summary["claimed"] = len(claimed)
 
         for effect in claimed:
-            if connection.in_transaction:
-                raise RuntimeError("replay handler cannot run inside a DB transaction")
             effect_type = str(effect["effect_type"])
             handler = handlers[effect_type]
-            error_type = None
-            try:
-                result = await asyncio.wait_for(
-                    handler(effect["payload"]), timeout=handler_timeout_seconds
-                )
-                delivered, remote_id = _delivery_result(effect_type, result)
-                if not delivered:
-                    error_type = "DeliveryNotConfirmed"
-            except asyncio.CancelledError:
-                try:
-                    current = now()
-                    delay = _retry_delay(
-                        effect["attempt_count"],
-                        base_delay_seconds=base_delay_seconds,
-                        max_delay_seconds=max_delay_seconds,
-                    )
-                    connection.execute("BEGIN IMMEDIATE")
-                    store.record_failure(
-                        effect_id=effect["id"],
-                        owner=owner,
-                        error_type="CancelledError",
-                        next_attempt_at=current + timedelta(seconds=delay),
-                        max_attempts=max_attempts,
-                        now=current,
-                    )
-                    connection.commit()
-                except BaseException:
-                    if connection.in_transaction:
-                        connection.rollback()
-                raise
-            except Exception as error:
-                delivered = False
-                remote_id = None
-                error_type = type(error).__name__
-
-            current = now()
-            connection.execute("BEGIN IMMEDIATE")
-            try:
-                if delivered:
-                    store.mark_delivered(
-                        effect_id=effect["id"],
-                        owner=owner,
-                        remote_id=remote_id,
-                        now=current,
-                    )
-                    summary["delivered"] += 1
-                else:
-                    delay = _retry_delay(
-                        effect["attempt_count"],
-                        base_delay_seconds=base_delay_seconds,
-                        max_delay_seconds=max_delay_seconds,
-                    )
-                    status = store.record_failure(
-                        effect_id=effect["id"],
-                        owner=owner,
-                        error_type=error_type or "DeliveryNotConfirmed",
-                        next_attempt_at=current + timedelta(seconds=delay),
-                        max_attempts=max_attempts,
-                        now=current,
-                    )
-                    summary["dead" if status == "DEAD" else "rescheduled"] += 1
-                connection.commit()
-            except BaseException:
-                if connection.in_transaction:
-                    connection.rollback()
-                raise
+            outcome = await _process_claimed_effect(
+                connection,
+                store,
+                effect,
+                handler=handler,
+                owner=owner,
+                handler_timeout_seconds=handler_timeout_seconds,
+                max_attempts=max_attempts,
+                base_delay_seconds=base_delay_seconds,
+                max_delay_seconds=max_delay_seconds,
+                now=now,
+            )
+            summary[outcome.status] += 1
     finally:
         connection.close()
     return summary

--- a/prism_core/exit_effects.py
+++ b/prism_core/exit_effects.py
@@ -291,6 +291,69 @@ class ExitEffectStore:
             claimed.extend(self._decode_rows(cursor))
         return claimed
 
+    def get_effect(self, effect_id: str) -> dict[str, Any] | None:
+        """Return one decoded effect without changing its lease or status."""
+
+        cursor = self._execute(
+            "SELECT * FROM exit_effect_outbox WHERE id=?",
+            (str(effect_id or "").strip(),),
+        )
+        rows = self._decode_rows(cursor)
+        return rows[0] if rows else None
+
+    def claim_effect(
+        self,
+        *,
+        effect_id: str,
+        owner: str,
+        now: datetime | None = None,
+        lease_seconds: int = 60,
+    ) -> dict[str, Any] | None:
+        """Claim one exact ready effect without selecting unrelated backlog."""
+
+        self._require_active_transaction()
+        effect_id = str(effect_id or "").strip()
+        owner = str(owner or "").strip()
+        if not effect_id:
+            raise ValueError("effect id is required")
+        if not owner:
+            raise ValueError("lease owner is required")
+        if not isinstance(lease_seconds, int) or lease_seconds < 1:
+            raise ValueError("lease_seconds must be a positive integer")
+
+        current = _utc_datetime(now)
+        current_iso = _utc_iso(current)
+        lease_expires_at = _utc_iso(current + timedelta(seconds=lease_seconds))
+        changed = self._execute(
+            """
+            UPDATE exit_effect_outbox
+            SET status='IN_PROGRESS', attempt_count=attempt_count+1,
+                lease_owner=?, lease_expires_at=?, updated_at=?
+            WHERE id=?
+              AND (
+                  (status='PENDING' AND (
+                      next_attempt_at IS NULL OR next_attempt_at <= ?
+                  ))
+                  OR
+                  (status='IN_PROGRESS' AND lease_expires_at IS NOT NULL
+                   AND lease_expires_at <= ?)
+              )
+            """,
+            (
+                owner,
+                lease_expires_at,
+                current_iso,
+                effect_id,
+                current_iso,
+                current_iso,
+            ),
+        ).rowcount
+        if changed == 0:
+            return None
+        if changed != 1:
+            raise RuntimeError("exit effect claim changed unexpectedly")
+        return self.get_effect(effect_id)
+
     def mark_delivered(
         self,
         *,

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -55,6 +55,7 @@ from prism_core.execution_service import (
     normalize_checked_holding,
 )
 from prism_core.exit_effects import ExitEffectStore
+from prism_core.exit_effect_replay import deliver_exit_effect_once
 from prism_core.order_intents import IntentStore, OrderIntent
 from prism_core.positions import (
     LegacyPositionWriteResult,
@@ -178,6 +179,7 @@ class StockTrackingAgent:
         self.max_slots = self.MAX_SLOTS
         self.message_queue = []  # For storing Telegram messages
         self._msg_types = []  # msg_type for each message in queue
+        self._msg_effect_ids = []  # durable effect id for each queued message
         self._broadcast_task = None  # Track broadcast translation task
         self.trading_agent = None
         self.db_path = db_path
@@ -1512,6 +1514,37 @@ class StockTrackingAgent:
                 reservation=prepared.reservation,
             )
 
+    def _queue_message(
+        self,
+        message: str,
+        msg_type: str | None,
+        *,
+        effect_id: str | None = None,
+    ) -> None:
+        """Append a message while preserving optional durable-effect linkage."""
+
+        self.message_queue.append(message)
+        self._msg_types.append(msg_type)
+        effect_ids = getattr(self, "_msg_effect_ids", None)
+        if not isinstance(effect_ids, list):
+            effect_ids = []
+            self._msg_effect_ids = effect_ids
+        while len(effect_ids) < len(self.message_queue) - 1:
+            effect_ids.append(None)
+        effect_ids.append(effect_id)
+
+    def _message_effect_id(self, index: int) -> str | None:
+        effect_ids = getattr(self, "_msg_effect_ids", None)
+        if isinstance(effect_ids, list) and index < len(effect_ids):
+            value = effect_ids[index]
+            return str(value) if value else None
+        return None
+
+    def _clear_message_queue(self) -> None:
+        self.message_queue = []
+        self._msg_types = []
+        self._msg_effect_ids = []
+
     def _complete_pending_kr_entry(self, prepared: _PreparedKrEntry) -> None:
         """Commit OPEN before making the prebuilt message externally visible."""
 
@@ -1529,8 +1562,7 @@ class StockTrackingAgent:
             if self.conn.in_transaction:
                 self.conn.rollback()
             raise
-        self._msg_types.append("analysis")
-        self.message_queue.append(prepared.message)
+        self._queue_message(prepared.message, "analysis")
 
     def _fail_pending_kr_entry(self, prepared: _PreparedKrEntry) -> None:
         """Atomically remove the legacy holding and tombstone a rejected entry."""
@@ -1878,8 +1910,11 @@ class StockTrackingAgent:
                 self.conn.rollback()
             raise
 
-        self._msg_types.append("analysis")
-        self.message_queue.append(prepared.message)
+        self._queue_message(
+            prepared.message,
+            "analysis",
+            effect_id=f"{prepared.intent.id}:telegram",
+        )
         logger.info(
             "%s(%s) pending exit complete (return: %.2f%%)",
             prepared.symbol,
@@ -1944,19 +1979,97 @@ class StockTrackingAgent:
             or str(row[1]) != prepared.intent.id
         ):
             raise RuntimeError("KR pending exit post-commit requires durable CLOSED")
-        try:
-            await self._create_journal_entry(
+        async def deliver_journal(_payload: dict[str, Any]):
+            if getattr(self, "enable_journal", True) is False:
+                return "disabled-by-config"
+            return await self._create_journal_entry(
                 stock_data=prepared.journal_stock_data,
                 sell_price=prepared.sell_price,
                 profit_rate=prepared.profit_rate,
                 holding_days=prepared.holding_days,
                 sell_reason=prepared.sell_reason,
+                exit_intent_id=prepared.intent.id,
             )
+
+        try:
+            outcome = await deliver_exit_effect_once(
+                self.db_path,
+                effect_id=f"{prepared.intent.id}:journal",
+                effect_type="JOURNAL",
+                handler=deliver_journal,
+                owner=(
+                    f"stock-agent:{os.getpid()}:journal:"
+                    f"{prepared.intent.id[:12]}"
+                ),
+            )
+            if outcome.status not in {"delivered", "already_delivered"}:
+                logger.warning(
+                    "Journal effect remains unresolved: intent=%s status=%s",
+                    prepared.intent.id,
+                    outcome.status,
+                )
+        except asyncio.CancelledError:
+            raise
         except Exception as journal_err:
             logger.warning(
-                "Journal entry creation failed (non-critical): %s", journal_err
+                "Journal effect delivery failed (non-critical): %s",
+                type(journal_err).__name__,
             )
         await self._after_pending_kr_exit_closed(prepared)
+
+    async def _deliver_pending_kr_exit_publish_effects(
+        self,
+        prepared: _PreparedKrExit,
+        trade_result: Dict[str, Any] | None = None,
+    ) -> dict[str, str]:
+        """Deliver Redis/GCP independently after the exit is durably CLOSED."""
+
+        publish_kwargs = {
+            "ticker": prepared.symbol,
+            "company_name": prepared.company_name,
+            "price": prepared.sell_price,
+            "buy_price": prepared.buy_price,
+            "profit_rate": prepared.profit_rate,
+            "sell_reason": prepared.sell_reason,
+            "trade_result": trade_result,
+            "market": "KR",
+            "event_id": prepared.intent.id,
+        }
+
+        async def deliver_redis(_payload: dict[str, Any]):
+            from messaging.redis_signal_publisher import publish_sell_signal
+
+            return await publish_sell_signal(**publish_kwargs)
+
+        async def deliver_gcp(_payload: dict[str, Any]):
+            from messaging.gcp_pubsub_signal_publisher import publish_sell_signal
+
+            return await publish_sell_signal(**publish_kwargs)
+
+        outcomes = {}
+        for effect_type, handler in (
+            ("REDIS", deliver_redis),
+            ("GCP", deliver_gcp),
+        ):
+            outcome = await deliver_exit_effect_once(
+                self.db_path,
+                effect_id=f"{prepared.intent.id}:{effect_type.lower()}",
+                effect_type=effect_type,
+                handler=handler,
+                owner=(
+                    f"stock-agent:{os.getpid()}:{effect_type.lower()}:"
+                    f"{prepared.intent.id[:12]}"
+                ),
+            )
+            outcomes[effect_type] = outcome.status
+            if outcome.status not in {"delivered", "already_delivered"}:
+                logger.warning(
+                    "%s effect remains unresolved: intent=%s status=%s",
+                    effect_type,
+                    prepared.intent.id,
+                    outcome.status,
+                )
+        return outcomes
 
     async def buy_stock(self, ticker: str, company_name: str, current_price: float, scenario: Dict[str, Any], rank_change_msg: str = "", is_add: bool = False) -> bool:
         """Preserve the public bool contract while exposing an internal typed result."""
@@ -2182,8 +2295,7 @@ class StockTrackingAgent:
                 if portfolio_context:
                     message += f"💼 포트폴리오 관점:\n  {portfolio_context}\n"
 
-            self._msg_types.append("analysis")
-            self.message_queue.append(message)
+            self._queue_message(message, "analysis")
             logger.info(f"{ticker}({company_name}) purchase complete")
 
             return LegacyPositionWriteResult(True, int(legacy_holding_id))
@@ -2499,6 +2611,8 @@ class StockTrackingAgent:
             if trigger_win_rate:
                 message += f"\n{trigger_win_rate}"
 
+            # Keep legacy sell_stock dependency-light: concurrency regression
+            # tests and downstream consumers execute this method in isolation.
             self._msg_types.append("analysis")
             self.message_queue.append(message)
             logger.info(f"{ticker}({company_name}) sell complete (return: {profit_rate:.2f}%)")
@@ -2531,11 +2645,18 @@ class StockTrackingAgent:
         sell_price: float,
         profit_rate: float,
         holding_days: int,
-        sell_reason: str
+        sell_reason: str,
+        *,
+        exit_intent_id: str | None = None,
     ) -> bool:
         """Create trading journal entry (delegates to tracking.journal.JournalManager)"""
         return await self.journal_manager.create_entry(
-            stock_data, sell_price, profit_rate, holding_days, sell_reason
+            stock_data,
+            sell_price,
+            profit_rate,
+            holding_days,
+            sell_reason,
+            exit_intent_id=exit_intent_id,
         )
 
     def _extract_principles_from_lessons(
@@ -2834,38 +2955,15 @@ class StockTrackingAgent:
             trade_result.get("message", "submitted"),
         )
         try:
-            from messaging.redis_signal_publisher import publish_sell_signal
-
-            await publish_sell_signal(
-                ticker=ticker,
-                company_name=company_name,
-                price=prepared.sell_price,
-                buy_price=stock.get("buy_price", 0),
-                profit_rate=prepared.profit_rate,
-                sell_reason=sell_reason,
-                trade_result=trade_result,
+            await self._deliver_pending_kr_exit_publish_effects(
+                prepared, trade_result
             )
-        except Exception as signal_err:
+        except asyncio.CancelledError:
+            raise
+        except Exception as signal_error:
             logger.warning(
-                "Sell signal publish failed (non-critical): %s", signal_err
-            )
-        try:
-            from messaging.gcp_pubsub_signal_publisher import (
-                publish_sell_signal as gcp_publish_sell_signal,
-            )
-
-            await gcp_publish_sell_signal(
-                ticker=ticker,
-                company_name=company_name,
-                price=prepared.sell_price,
-                buy_price=stock.get("buy_price", 0),
-                profit_rate=prepared.profit_rate,
-                sell_reason=sell_reason,
-                trade_result=trade_result,
-            )
-        except Exception as signal_err:
-            logger.warning(
-                "GCP sell signal publish failed (non-critical): %s", signal_err
+                "Durable sell effects failed after CLOSED (non-critical): %s",
+                type(signal_error).__name__,
             )
         return True
 
@@ -3758,8 +3856,7 @@ class StockTrackingAgent:
                     logger.info(f"[Message (not sent)] {message[:100]}...")
 
                 # Initialize message queue
-                self.message_queue = []
-                self._msg_types = []
+                self._clear_message_queue()
                 return True  # Consider intentional skip as success
 
             # If Telegram bot not initialized, only output logs
@@ -3771,8 +3868,7 @@ class StockTrackingAgent:
                     logger.info(f"[Telegram message (bot not initialized)] {message[:100]}...")
 
                 # Initialize message queue
-                self.message_queue = []
-                self._msg_types = []
+                self._clear_message_queue()
                 return False
 
             # Generate summary report — de-duplicated so near-simultaneous run-ends
@@ -3786,8 +3882,7 @@ class StockTrackingAgent:
                 _emit_portfolio = True  # fail-open
             if _emit_portfolio:
                 summary = await self.generate_report_summary()
-                self._msg_types.append("portfolio")
-                self.message_queue.append(summary)
+                self._queue_message(summary, "portfolio")
             else:
                 logger.info("[portfolio-dedup] KR portfolio summary skipped (sent within debounce window)")
 
@@ -3811,21 +3906,32 @@ class StockTrackingAgent:
             firebase_tasks = []
             for idx, message in enumerate(self.message_queue):
                 msg_type = self._msg_types[idx] if idx < len(self._msg_types) else None
+                effect_id = self._message_effect_id(idx)
                 logger.info(f"Sending Telegram message: {chat_id}")
-                try:
+
+                async def send_primary_message(payload=None):
                     # Telegram message length limit (4096 characters)
                     MAX_MESSAGE_LENGTH = 4096
+                    outbound_message = message
+                    event_id = str((payload or {}).get("event_id") or "").strip()
+                    if event_id:
+                        outbound_message = (
+                            f"{message}\n\n[exit-event: {event_id}]"
+                        )
 
-                    if len(message) <= MAX_MESSAGE_LENGTH:
+                    if len(outbound_message) <= MAX_MESSAGE_LENGTH:
                         # Send in one message if short
-                        result = await self._send_with_retry(chat_id=chat_id, text=message)
+                        result = await self._send_with_retry(
+                            chat_id=chat_id, text=outbound_message
+                        )
                         firebase_tasks.append(self._schedule_firebase(message, chat_id, result.message_id, msg_type=msg_type))
+                        first_msg_id = result.message_id
                     else:
                         # Split and send if long
                         parts = []
                         current_part = ""
 
-                        for line in message.split('\n'):
+                        for line in outbound_message.split('\n'):
                             if len(current_part) + len(line) + 1 <= MAX_MESSAGE_LENGTH:
                                 current_part += line + '\n'
                             else:
@@ -3847,9 +3953,45 @@ class StockTrackingAgent:
                         # Notify with full original message, link to first part
                         firebase_tasks.append(self._schedule_firebase(message, chat_id, first_msg_id, msg_type=msg_type))
 
-                    logger.info(f"Telegram message sent: {chat_id}")
+                    return str(first_msg_id)
+
+                try:
+                    if effect_id:
+                        outcome = await deliver_exit_effect_once(
+                            self.db_path,
+                            effect_id=effect_id,
+                            effect_type="TELEGRAM",
+                            handler=send_primary_message,
+                            owner=(
+                                f"stock-agent:{os.getpid()}:telegram:"
+                                f"{effect_id[:12]}"
+                            ),
+                        )
+                        if outcome.status not in {
+                            "delivered",
+                            "already_delivered",
+                        }:
+                            logger.warning(
+                                "Telegram effect remains unresolved: effect=%s "
+                                "status=%s",
+                                effect_id,
+                                outcome.status,
+                            )
+                            success = False
+                    else:
+                        await send_primary_message()
+                    if not effect_id or outcome.status in {
+                        "delivered",
+                        "already_delivered",
+                    }:
+                        logger.info(f"Telegram message sent: {chat_id}")
                 except TelegramError as e:
                     logger.error(f"Telegram message send failed: {e}")
+                    success = False
+                except Exception as e:
+                    logger.error(
+                        "Telegram effect handling failed: %s", type(e).__name__
+                    )
                     success = False
 
                 # Delay to prevent API rate limiting
@@ -3874,8 +4016,7 @@ class StockTrackingAgent:
                         self._broadcast_task = None
 
             # Clear message queue
-            self.message_queue = []
-            self._msg_types = []
+            self._clear_message_queue()
 
             return success
 

--- a/tasks/issue-412/18-phase4b2b3-production-adapters-plan.md
+++ b/tasks/issue-412/18-phase4b2b3-production-adapters-plan.md
@@ -1,0 +1,124 @@
+# Issue #412 Phase 4-b2b-3 — production effect adapters 계획
+
+> 기준: main `f9d2c958` (PR #471 bounded replay core 병합)
+> 브랜치: `feature/issue-412-phase4b2b3-adapters`
+> 운영 기본값: `POSITION_PENDING_KR_ENABLED=false`
+> 배포·gate ON·운영 DB replay: 별도 승인 전까지 금지한다.
+
+## 1. 목적과 완료 경계
+
+PR #470은 KR pending exit의 CLOSED 전이와 JOURNAL/TELEGRAM/REDIS/GCP effect 생성을 같은
+transaction에 묶었고, PR #471은 각 effect를 독립적으로 claim/retry/complete하는 bounded replay core를
+추가했다. 이번 slice는 production adapter를 그 계약에 연결한다.
+
+완료 조건은 다음과 같다.
+
+1. Journal row는 `exit_intent_id`로 멱등 생성되며 process 재시작에도 중복 LLM 실행/insert를 피한다.
+2. Telegram queue의 pending exit 항목은 대응하는 effect id를 보존하고 실제 전송 성공 뒤에만 완료된다.
+3. Redis/GCP payload에는 deterministic exit event id가 포함되고 non-empty remote message id가 있을 때만
+   해당 effect가 DELIVERED가 된다.
+4. batch, hardstop, trend pending exit가 동일한 delivery helper와 성공 판정을 사용한다.
+5. Journal/Telegram/Redis/GCP 중 하나의 실패는 이미 커밋된 CLOSED나 다른 effect 성공을 되돌리지 않는다.
+   즉 **외부 서비스 실패는 거래 전체 실패가 아니라 해당 effect만 PENDING/DEAD인 부분 실패**다.
+6. 실제 별도 OS process 경쟁과 lease 만료 후 재시작에서 effect당 단일 claim과 미완료 effect만 재처리됨을
+   검증한다.
+7. readiness preflight는 미해결 outbox를 read-only로 탐지하며 gate ON blocker로 판정한다.
+8. replay CLI는 기본 dry-run이고 명시적 실행 옵션 없이는 외부 호출이나 DB 상태 변경을 하지 않는다.
+
+## 2. cleanup/구현 원칙
+
+1. 기존 `ExitEffectStore`와 replay core를 확장하고 새 queue/store/dependency를 만들지 않는다.
+2. exact effect claim helper를 추가해 즉시 전송 경로가 unrelated backlog를 claim하지 않게 한다.
+3. SQLite transaction은 claim/finalize 때만 짧게 잡고 network/LLM 실행 중에는 lock을 보유하지 않는다.
+4. batch/hardstop/trend의 중복 Redis/GCP 호출을 공통 `StockTrackingAgent` helper로 모은다.
+5. Telegram의 기존 문자열 queue API는 유지하고 parallel effect-id metadata를 lazy-init해 `__new__` 기반
+   legacy test double도 깨뜨리지 않는다.
+6. 기존 non-pending/US/legacy gate-OFF 경로는 기존 publisher와 queue 동작을 유지한다.
+7. 새 dependency와 새 credential key를 추가하지 않는다.
+8. 외부 성공 뒤 SQLite finalize 전 crash 가능성 때문에 exactly-once는 주장하지 않는다. Journal은 unique key,
+   Redis/GCP는 event id, Telegram은 remote message id와 event reference로 중복 조사 가능성을 높인다.
+
+## 3. 상태 및 실패 계약
+
+- CLOSED commit 이후 adapter 실패는 order intent, position, holdings, trading history를 변경하지 않는다.
+- 성공한 effect는 다른 effect 실패와 무관하게 DELIVERED로 남는다.
+- timeout, exception, false/None, 빈 remote id는 해당 effect만 bounded backoff로 PENDING에 재예약한다.
+- max-attempt 도달 effect만 DEAD가 되며 다른 effect와 거래 자체는 성공 상태를 유지한다.
+- 명시적으로 비활성화된 optional Journal은 외부 재시도 대상이 아니므로 adapter가
+  `disabled-by-config` 결과로 종결하고 audit에서 식별 가능하게 한다.
+- Telegram token/chat id, Redis, GCP 설정이 없으면 성공으로 가장하지 않고 해당 effect를 미해결로 둔다.
+- readiness에서는 PENDING, IN_PROGRESS, DEAD를 모두 gate ON blocker로 본다.
+
+## 4. TDD slices
+
+### Slice A — exact delivery core
+
+- exact effect id/type/owner claim, 이미 DELIVERED인 row skip, active lease 충돌 skip.
+- success/failure/cancellation 전이와 Redis/GCP remote id 필수 계약.
+- handler 실행 중 DB transaction 미보유.
+
+### Slice B — Journal 멱등성
+
+- nullable `exit_intent_id` migration과 partial unique index의 기존 DB 호환.
+- 같은 exit intent 재호출은 LLM/principle extraction과 INSERT를 반복하지 않음.
+- unique 경쟁 시 기존 row를 성공으로 인정.
+- 기존 caller가 id 없이 만드는 journal 동작 보존.
+
+### Slice C — Telegram queue linkage
+
+- pending exit queue item만 effect id를 보존하고 다른 message와 metadata 정렬 유지.
+- bot/chat id 없음, 전송 exception, split message 일부 실패는 DELIVERED 처리하지 않음.
+- 실제 primary-channel send 성공 뒤 remote Telegram message id 기록.
+- batch run-end flush에서 여러 exit의 성공/실패를 effect별로 독립 기록.
+
+### Slice D — Redis/GCP와 caller 통합
+
+- publisher payload에 `event_id`를 optional로 추가해 기존 caller payload를 보존.
+- batch/hardstop/trend pending 경로가 공통 helper를 사용.
+- Redis 실패/GCP 성공 및 반대 조합에서 성공 effect만 DELIVERED.
+- gate-OFF/legacy path는 기존 broadcast 동작 유지.
+
+### Slice E — restart/readiness/CLI
+
+- `multiprocessing` spawn 기반 두 process 경쟁에서 effect당 한 claim.
+- 첫 process가 finalize 전 종료한 뒤 lease 만료 시 두 번째 process가 미완료 effect만 전달.
+- readiness는 outbox table 누락을 unknown, 미해결 effect를 blocker, 전부 DELIVERED를 clean으로 판정.
+- audit/replay 출력은 raw account, token, credential, message body를 노출하지 않음.
+- replay CLI는 default dry-run이며 execute mode도 bounded limit/effect filter를 요구.
+
+## 5. `.env` 계약
+
+PR #470과 PR #471의 `.env*` diff는 비어 있으며 새 key는 없다. 이번 adapter slice도 새 key를 추가하지 않고
+기존 설정을 재사용한다.
+
+- `TELEGRAM_BOT_TOKEN`: Telegram Bot 인증 토큰. 값이 없으면 TELEGRAM effect는 성공 처리하지 않는다.
+- `TELEGRAM_CHANNEL_ID`: 기본 전송 대상 chat/channel id. hardstop/trend의 기존 `CHAT_ID` override가 있으면
+  그것을 우선하고, 없으면 이 값을 사용한다.
+- `TELEGRAM_CHANNEL_ID_EN`, `TELEGRAM_CHANNEL_ID_JA`, `TELEGRAM_CHANNEL_ID_ZH`,
+  `TELEGRAM_CHANNEL_ID_ES`: 기존 번역 채널용 optional id. primary TELEGRAM effect의 성공 기준은 기본 채널이다.
+- `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`: Redis REST publisher 접속 정보. 둘 중 필요한 값이
+  없거나 publisher가 message id를 반환하지 않으면 REDIS effect는 미완료다.
+- `GCP_PROJECT_ID`, `GCP_PUBSUB_TOPIC_ID`, `GCP_CREDENTIALS_PATH`: GCP Pub/Sub 대상과 credential 경로.
+  publish 성공으로 non-empty message id를 받아야 GCP effect가 완료된다.
+- `ENABLE_TRADING_JOURNAL`: 기존 Journal 기능 스위치. false이면 거래 CLOSED는 유지되고 JOURNAL effect는
+  `disabled-by-config`로 종결한다.
+- `POSITION_PENDING_KR_ENABLED`: KR pending 주문/exit gate. 이번 PR은 기본값 false를 바꾸거나 운영에서
+  활성화하지 않는다.
+
+토큰, credential JSON, 실제 channel/account 값은 commit·로그·audit에 기록하지 않는다.
+
+## 6. 비목표와 안전선
+
+- 운영 서버 배포, bot restart, cron 등록, 운영 DB replay, gate ON을 하지 않는다.
+- 미국/legacy 즉시 매매 경로를 pending state machine으로 전환하지 않는다.
+- 외부 provider가 지원하지 않는 exactly-once를 보장한다고 주장하지 않는다.
+- 미해결 DEAD effect를 자동으로 무한 재시도하거나 자동 삭제하지 않는다.
+- readiness blocker가 하나라도 있으면 gate ON을 권장하지 않는다.
+
+## 7. 검증과 PR 완료 조건
+
+1. 신규 exact delivery, journal, Telegram, publisher, caller, multiprocessing, readiness/CLI 테스트.
+2. 기존 KR pending entry/exit, batch, hardstop, trend, journal, publisher, readiness 회귀.
+3. Ruff, format check, Python compile, Bandit, `git diff --check`.
+4. GitHub Actions와 repository check를 확인하고 실패를 해소한 뒤 병합.
+5. `tasks/handoff.md`에 PR/commit/검증/운영 미실행/환경변수 무변경을 기록.

--- a/tasks/issue-412/README.md
+++ b/tasks/issue-412/README.md
@@ -2,7 +2,7 @@
 
 > 이슈: [#412 매수/매도 Agent 분리와 KIS 실제 주문 실행 구조 이식 설계](https://github.com/dragon1086/prism-insight/issues/412)
 > 브랜치: `feature/issue-412-execution-architecture`
-> 상태: Phase 4-b2b-2 KR EXIT 게이트 OFF 배포 완료, Phase 4-b2b-3 alert-only preflight 로컬 구현·검증 완료
+> 상태: Phase 4-b2b-2 KR EXIT 게이트 OFF 배포 완료, Phase 4-b2b-3 outbox/replay/production adapter 로컬 구현·검증 완료
 > (2026-07-06 시작, 2026-07-13 main #432 기준 전면 재검토,
 > **2026-07-19 Phase 4-b2b-2 PR #467, main `693c8838` 게이트 OFF 배포 완료**)
 
@@ -34,6 +34,9 @@ greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 
 | [13-phase4b2b1-kr-entry-plan.md](13-phase4b2b1-kr-entry-plan.md) | Phase 4-b2b-1 KR ENTRY 구현 계획 — no-auto-retry guard, private lifecycle, 결과별 TDD |
 | [14-phase4b2b2-kr-exit-plan.md](14-phase4b2b2-kr-exit-plan.md) | Phase 4-b2b-2 KR EXIT 구현 계획 — write-ahead claim, legacy finalize, loop 상태 행렬 |
 | [15-phase4b2b3-readiness-plan.md](15-phase4b2b3-readiness-plan.md) | Phase 4-b2b-3 활성화 전 alert-only KR preflight — gate/원장/KIS open SELL 검증 |
+| [16-phase4b2b3-outbox-plan.md](16-phase4b2b3-outbox-plan.md) | CLOSED와 Journal/Telegram/Redis/GCP 후보를 묶는 atomic outbox 계획 |
+| [17-phase4b2b3-replay-core-plan.md](17-phase4b2b3-replay-core-plan.md) | bounded claim/lease/retry/DEAD와 read-only audit 계획 |
+| [18-phase4b2b3-production-adapters-plan.md](18-phase4b2b3-production-adapters-plan.md) | Journal 멱등성, Telegram linkage, Redis/GCP remote id, multi-process restart, readiness 계획 |
 
 ## 진행 체크리스트
 
@@ -50,8 +53,9 @@ greenfield 이식이 아니라 **라이브 시스템의 strangler 방식 단계 
 - [x] Phase 4-b2b-0: KR 전환 안전 기반 — originating store, exit quarantine, 3상태 holding 조회 (PR #464, main `449e4750`)
 - [x] Phase 4-b2b-1: KR ENTRY 전체 경로 PENDING write-ahead (PR #465, flag OFF 배포)
 - [x] Phase 4-b2b-2: KR EXIT 전체 경로 PENDING write-ahead + 실패 보상 (PR #467, flag OFF 배포)
-- [ ] Phase 4-b2b-3: alert-only preflight 로컬 구현 완료. outbox/replay·다중 프로세스 검증과
-  별도 승인·무거래 창 검증 후에만 KR 시장 gate 일괄 활성화
+- [x] Phase 4-b2b-3 code: alert-only preflight, atomic outbox, bounded replay core, production adapter,
+  실제 다중 프로세스 claim/restart 회귀 로컬 구현·검증 완료
+- [ ] Phase 4-b2b-3 operation: 별도 승인·무거래 창·운영 preflight 후에만 KR 시장 gate 일괄 활성화
 - [ ] Phase 4-b2c: US queued-intent 연속성 + US 전체 경로 전환 (시장 단위 gate)
 - [ ] Phase 4 read switch: 충분한 운영 대조 후 별도 승인
 - [ ] Phase 5: BrokerAdapter 추출 (체결/미체결/정정 포함) + lock 일반화 + reconciliation (alert-only)

--- a/tests/test_exit_effect_multiprocess.py
+++ b/tests/test_exit_effect_multiprocess.py
@@ -1,0 +1,152 @@
+import multiprocessing
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+from prism_core.exit_effects import ExitEffectStore
+
+
+INTENT_ID = "intent-multiprocess-1"
+NOW = datetime(2026, 7, 20, tzinfo=timezone.utc)
+
+
+def _seed(path):
+    with sqlite3.connect(path) as connection:
+        store = ExitEffectStore(connection)
+        store.ensure_schema()
+        connection.commit()
+        connection.execute("BEGIN IMMEDIATE")
+        store.enqueue_exit_effects(
+            intent_id=INTENT_ID,
+            market="KR",
+            account_id="vps:kr-primary:01",
+            symbol="005930",
+            source="kr_batch",
+            payload={"event_id": INTENT_ID, "message": "sold"},
+        )
+        connection.commit()
+
+
+def _claim_in_process(
+    db_path,
+    owner,
+    now_iso,
+    start_event,
+    result_queue,
+    finalize,
+):
+    now = datetime.fromisoformat(now_iso)
+    start_event.wait(timeout=10)
+    connection = sqlite3.connect(db_path, timeout=10)
+    store = ExitEffectStore(connection)
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        effect = store.claim_effect(
+            effect_id=f"{INTENT_ID}:redis",
+            owner=owner,
+            now=now,
+            lease_seconds=1,
+        )
+        connection.commit()
+        result_queue.put((owner, effect is not None))
+        if effect is not None and finalize:
+            connection.execute("BEGIN IMMEDIATE")
+            store.mark_delivered(
+                effect_id=effect["id"],
+                owner=owner,
+                remote_id=f"remote-{owner}",
+                now=now,
+            )
+            connection.commit()
+    finally:
+        connection.close()
+
+
+def _run_process(context, path, owner, now, start_event, result_queue, finalize):
+    process = context.Process(
+        target=_claim_in_process,
+        args=(
+            str(path),
+            owner,
+            now.isoformat(),
+            start_event,
+            result_queue,
+            finalize,
+        ),
+    )
+    process.start()
+    return process
+
+
+def test_two_os_processes_claim_exact_effect_once(tmp_path):
+    db_path = tmp_path / "process-race.sqlite"
+    _seed(db_path)
+    context = multiprocessing.get_context("spawn")
+    start_event = context.Event()
+    result_queue = context.Queue()
+    processes = [
+        _run_process(
+            context,
+            db_path,
+            owner,
+            NOW,
+            start_event,
+            result_queue,
+            True,
+        )
+        for owner in ("process-a", "process-b")
+    ]
+
+    start_event.set()
+    for process in processes:
+        process.join(timeout=15)
+        assert process.exitcode == 0
+    results = sorted(result_queue.get(timeout=2)[1] for _ in processes)
+
+    with sqlite3.connect(db_path) as connection:
+        row = ExitEffectStore(connection).get_effect(f"{INTENT_ID}:redis")
+    assert results == [False, True]
+    assert row["status"] == "DELIVERED"
+    assert row["attempt_count"] == 1
+
+
+def test_expired_lease_is_completed_by_restarted_process(tmp_path):
+    db_path = tmp_path / "process-restart.sqlite"
+    _seed(db_path)
+    context = multiprocessing.get_context("spawn")
+    result_queue = context.Queue()
+
+    first_start = context.Event()
+    first = _run_process(
+        context,
+        db_path,
+        "crashed-process",
+        NOW,
+        first_start,
+        result_queue,
+        False,
+    )
+    first_start.set()
+    first.join(timeout=15)
+    assert first.exitcode == 0
+    assert result_queue.get(timeout=2) == ("crashed-process", True)
+
+    second_start = context.Event()
+    second = _run_process(
+        context,
+        db_path,
+        "restarted-process",
+        NOW + timedelta(seconds=2),
+        second_start,
+        result_queue,
+        True,
+    )
+    second_start.set()
+    second.join(timeout=15)
+    assert second.exitcode == 0
+    assert result_queue.get(timeout=2) == ("restarted-process", True)
+
+    with sqlite3.connect(db_path) as connection:
+        row = ExitEffectStore(connection).get_effect(f"{INTENT_ID}:redis")
+    assert row["status"] == "DELIVERED"
+    assert row["attempt_count"] == 2
+    assert row["remote_id"] == "remote-restarted-process"

--- a/tests/test_exit_effect_replay.py
+++ b/tests/test_exit_effect_replay.py
@@ -4,7 +4,10 @@ from datetime import datetime, timezone
 
 import pytest
 
-from prism_core.exit_effect_replay import run_exit_effect_replay
+from prism_core.exit_effect_replay import (
+    deliver_exit_effect_once,
+    run_exit_effect_replay,
+)
 from prism_core.exit_effects import ExitEffectStore
 
 
@@ -251,3 +254,85 @@ async def test_two_runners_do_not_handle_same_effect_concurrently(tmp_path):
     assert calls == ["redis"]
     assert sorted((first["claimed"], second["claimed"])) == [0, 1]
     assert _rows(db_path)[2]["status"] == "DELIVERED"
+
+
+@pytest.mark.asyncio
+async def test_exact_delivery_claims_only_requested_effect(tmp_path):
+    db_path = tmp_path / "exact.sqlite"
+    _seed(db_path)
+    calls = []
+
+    async def redis(payload):
+        calls.append(payload["event_id"])
+        return "redis-message-exact"
+
+    outcome = await deliver_exit_effect_once(
+        db_path,
+        effect_id=f"{INTENT_ID}:redis",
+        effect_type="REDIS",
+        handler=redis,
+        owner="immediate-a",
+        now=lambda: NOW,
+    )
+    rows = {row["effect_type"]: row for row in _rows(db_path)}
+
+    assert outcome.status == "delivered"
+    assert outcome.remote_id == "redis-message-exact"
+    assert calls == [INTENT_ID]
+    assert rows["REDIS"]["status"] == "DELIVERED"
+    assert rows["JOURNAL"]["status"] == "PENDING"
+    assert rows["TELEGRAM"]["status"] == "PENDING"
+    assert rows["GCP"]["status"] == "PENDING"
+
+
+@pytest.mark.asyncio
+async def test_exact_delivery_skips_already_delivered_without_handler_call(tmp_path):
+    db_path = tmp_path / "exact-delivered.sqlite"
+    _seed(db_path)
+    calls = 0
+
+    async def redis(_payload):
+        nonlocal calls
+        calls += 1
+        return "redis-message-first"
+
+    first = await deliver_exit_effect_once(
+        db_path,
+        effect_id=f"{INTENT_ID}:redis",
+        effect_type="REDIS",
+        handler=redis,
+        owner="immediate-a",
+        now=lambda: NOW,
+    )
+    second = await deliver_exit_effect_once(
+        db_path,
+        effect_id=f"{INTENT_ID}:redis",
+        effect_type="REDIS",
+        handler=redis,
+        owner="immediate-b",
+        now=lambda: NOW,
+    )
+
+    assert first.status == "delivered"
+    assert second.status == "already_delivered"
+    assert second.remote_id == "redis-message-first"
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_exact_delivery_rejects_effect_type_mismatch(tmp_path):
+    db_path = tmp_path / "exact-type.sqlite"
+    _seed(db_path)
+
+    async def telegram(_payload):
+        return "telegram-message"
+
+    with pytest.raises(ValueError, match="effect type does not match"):
+        await deliver_exit_effect_once(
+            db_path,
+            effect_id=f"{INTENT_ID}:redis",
+            effect_type="TELEGRAM",
+            handler=telegram,
+            owner="immediate-a",
+            now=lambda: NOW,
+        )

--- a/tests/test_exit_effect_replay_cli.py
+++ b/tests/test_exit_effect_replay_cli.py
@@ -1,0 +1,110 @@
+import json
+import sqlite3
+
+import pytest
+
+from prism_core.exit_effects import ExitEffectStore
+from tools import replay_exit_effects
+
+
+INTENT_ID = "intent-cli-1"
+
+
+def _seed(path):
+    with sqlite3.connect(path) as connection:
+        store = ExitEffectStore(connection)
+        store.ensure_schema()
+        connection.commit()
+        connection.execute("BEGIN IMMEDIATE")
+        store.enqueue_exit_effects(
+            intent_id=INTENT_ID,
+            market="KR",
+            account_id="vps:kr-primary:01",
+            symbol="005930",
+            source="kr_batch",
+            payload={
+                "event_id": INTENT_ID,
+                "market": "KR",
+                "symbol": "005930",
+                "company_name": "Samsung",
+                "sell_price": 75000,
+                "buy_price": 70000,
+                "profit_rate": 7.1,
+                "holding_days": 10,
+                "sell_reason": "target",
+                "message": "private sold message",
+                "journal_stock_data": {"ticker": "005930"},
+            },
+        )
+        connection.commit()
+
+
+def test_replay_cli_defaults_to_read_only_audit(tmp_path, monkeypatch, capsys):
+    db_path = tmp_path / "dry.sqlite"
+    _seed(db_path)
+    before = db_path.read_bytes()
+
+    def unexpected_handlers(*_args, **_kwargs):
+        raise AssertionError("dry-run must not build production handlers")
+
+    monkeypatch.setattr(
+        replay_exit_effects, "build_exit_effect_handlers", unexpected_handlers
+    )
+
+    result = replay_exit_effects.main(["--db-path", str(db_path)])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert result == 1
+    assert payload["mode"] == "dry-run"
+    assert payload["audit"]["unresolved_count"] == 4
+    assert before == db_path.read_bytes()
+    assert "private sold message" not in json.dumps(payload)
+
+
+def test_execute_requires_explicit_effect_filter(tmp_path):
+    db_path = tmp_path / "filter.sqlite"
+    _seed(db_path)
+
+    with pytest.raises(SystemExit) as error:
+        replay_exit_effects.main(["--db-path", str(db_path), "--execute"])
+
+    assert error.value.code == 2
+
+
+def test_execute_runs_bounded_selected_handler(tmp_path, monkeypatch, capsys):
+    db_path = tmp_path / "execute.sqlite"
+    _seed(db_path)
+    calls = []
+
+    async def redis(payload):
+        calls.append(payload["event_id"])
+        return "redis-cli-message-1"
+
+    monkeypatch.setattr(
+        replay_exit_effects,
+        "build_exit_effect_handlers",
+        lambda *_args, **_kwargs: {"REDIS": redis},
+    )
+
+    result = replay_exit_effects.main(
+        [
+            "--db-path",
+            str(db_path),
+            "--execute",
+            "--effect",
+            "REDIS",
+            "--limit",
+            "1",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    with sqlite3.connect(db_path) as connection:
+        row = ExitEffectStore(connection).get_effect(f"{INTENT_ID}:redis")
+
+    assert result == 0
+    assert payload["mode"] == "execute"
+    assert payload["summary"]["claimed"] == 1
+    assert payload["summary"]["delivered"] == 1
+    assert calls == [INTENT_ID]
+    assert row["status"] == "DELIVERED"
+    assert row["remote_id"] == "redis-cli-message-1"

--- a/tests/test_exit_effect_telegram_queue.py
+++ b/tests/test_exit_effect_telegram_queue.py
@@ -1,0 +1,134 @@
+import asyncio
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+from telegram.error import TelegramError
+
+from prism_core.exit_effects import ExitEffectStore
+from stock_tracking_agent import StockTrackingAgent
+
+
+INTENT_ID = "intent-telegram-1"
+
+
+def _seed(path):
+    with sqlite3.connect(path) as connection:
+        store = ExitEffectStore(connection)
+        store.ensure_schema()
+        connection.commit()
+        connection.execute("BEGIN IMMEDIATE")
+        store.enqueue_exit_effects(
+            intent_id=INTENT_ID,
+            market="KR",
+            account_id="vps:kr-primary:01",
+            symbol="005930",
+            source="kr_batch",
+            payload={"event_id": INTENT_ID, "message": "sold"},
+        )
+        connection.commit()
+
+
+def _telegram_row(path):
+    with sqlite3.connect(path) as connection:
+        return ExitEffectStore(connection).list_for_intent(INTENT_ID)[1]
+
+
+def _agent(path):
+    agent = StockTrackingAgent.__new__(StockTrackingAgent)
+    agent.db_path = str(path)
+    agent.message_queue = []
+    agent._msg_types = []
+    agent._msg_effect_ids = []
+    agent._broadcast_task = None
+    agent.telegram_bot = object()
+
+    async def summary():
+        return "portfolio"
+
+    agent.generate_report_summary = summary
+    agent._schedule_firebase = lambda *_args, **_kwargs: asyncio.create_task(
+        asyncio.sleep(0)
+    )
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_pending_exit_telegram_effect_completes_after_real_send(
+    monkeypatch, tmp_path
+):
+    db_path = tmp_path / "telegram.sqlite"
+    _seed(db_path)
+    agent = _agent(db_path)
+    sent = []
+
+    async def send(chat_id, text):
+        sent.append((chat_id, text))
+        return SimpleNamespace(message_id=731)
+
+    agent._send_with_retry = send
+    agent._queue_message(
+        "sold",
+        "analysis",
+        effect_id=f"{INTENT_ID}:telegram",
+    )
+    monkeypatch.setattr(
+        "portfolio_broadcast.should_send_portfolio", lambda *_a, **_k: False
+    )
+
+    result = await agent.send_telegram_message("channel-1")
+    row = _telegram_row(db_path)
+
+    assert result is True
+    assert sent == [("channel-1", f"sold\n\n[exit-event: {INTENT_ID}]")]
+    assert row["status"] == "DELIVERED"
+    assert row["remote_id"] == "731"
+    assert agent.message_queue == []
+    assert agent._msg_effect_ids == []
+
+
+@pytest.mark.asyncio
+async def test_missing_chat_id_does_not_complete_telegram_effect(tmp_path):
+    db_path = tmp_path / "telegram-no-chat.sqlite"
+    _seed(db_path)
+    agent = _agent(db_path)
+    agent._queue_message(
+        "sold",
+        "analysis",
+        effect_id=f"{INTENT_ID}:telegram",
+    )
+
+    result = await agent.send_telegram_message(None)
+
+    assert result is True
+    assert _telegram_row(db_path)["status"] == "PENDING"
+    assert agent._msg_effect_ids == []
+
+
+@pytest.mark.asyncio
+async def test_telegram_error_reschedules_only_telegram_effect(monkeypatch, tmp_path):
+    db_path = tmp_path / "telegram-fail.sqlite"
+    _seed(db_path)
+    agent = _agent(db_path)
+
+    async def fail(**_kwargs):
+        raise TelegramError("transport detail")
+
+    agent._send_with_retry = fail
+    agent._queue_message(
+        "sold",
+        "analysis",
+        effect_id=f"{INTENT_ID}:telegram",
+    )
+    monkeypatch.setattr(
+        "portfolio_broadcast.should_send_portfolio", lambda *_a, **_k: False
+    )
+
+    result = await agent.send_telegram_message("channel-1")
+    with sqlite3.connect(db_path) as connection:
+        rows = ExitEffectStore(connection).list_for_intent(INTENT_ID)
+
+    assert result is False
+    assert rows[1]["status"] == "PENDING"
+    assert rows[1]["last_error"] == "TelegramError"
+    assert all(row["status"] == "PENDING" for row in (rows[0], rows[2], rows[3]))

--- a/tests/test_gcp_pubsub_signal.py
+++ b/tests/test_gcp_pubsub_signal.py
@@ -241,6 +241,24 @@ class TestPublishSellSignal:
         assert signal_data["profit_rate"] == 9.76
         assert signal_data["sell_reason"] == "Target price reached"
 
+    @pytest.mark.asyncio
+    async def test_publish_sell_signal_includes_optional_exit_event_id(
+        self, publisher_with_mock, mock_publisher_client
+    ):
+        await publisher_with_mock.publish_sell_signal(
+            ticker="005930",
+            company_name="Samsung Electronics",
+            price=90000,
+            buy_price=82000,
+            profit_rate=9.76,
+            sell_reason="Target price reached",
+            event_id="intent-publisher-1",
+        )
+
+        message_bytes = mock_publisher_client.publish.call_args[0][1]
+        signal_data = json.loads(message_bytes.decode("utf-8"))
+        assert signal_data["event_id"] == "intent-publisher-1"
+
 
 class TestPublishEventSignal:
     """이벤트 시그널 발행 테스트"""

--- a/tests/test_hardstop_seller.py
+++ b/tests/test_hardstop_seller.py
@@ -159,6 +159,12 @@ class PendingFakeAgent(FakeAgent):
     async def _run_pending_kr_exit_post_commit(self, prepared):
         self.calls.append("postcommit")
 
+    async def _deliver_pending_kr_exit_publish_effects(
+        self, prepared, trade_result
+    ):
+        self.calls.append("effects")
+        return {"REDIS": "delivered", "GCP": "delivered"}
+
 
 @pytest.fixture
 def tmp_db(tmp_path, monkeypatch):
@@ -347,7 +353,7 @@ def test_pending_kr_gate_does_not_change_us_legacy_path(tmp_db, monkeypatch):
                 "complete",
                 "postcommit",
                 "tg",
-                "publish",
+                "effects",
                 "tg",
             ],
             "FILLED",
@@ -435,7 +441,7 @@ def test_pending_kr_live_local_flat_closes_without_broker(tmp_db, monkeypatch):
         "complete",
         "postcommit",
         "tg",
-        "publish",
+        "effects",
         "tg",
     ]
     assert "broker" not in calls

--- a/tests/test_journal_exit_intent_idempotency.py
+++ b/tests/test_journal_exit_intent_idempotency.py
@@ -1,0 +1,117 @@
+import sqlite3
+
+import pytest
+
+from tracking.db_schema import (
+    TABLE_TRADING_JOURNAL,
+    migrate_trading_journal_exit_intent,
+)
+from tracking.journal import JournalManager
+
+
+def _connection():
+    connection = sqlite3.connect(":memory:")
+    connection.execute(TABLE_TRADING_JOURNAL)
+    migrate_trading_journal_exit_intent(connection.cursor(), connection)
+    return connection
+
+
+def test_journal_exit_intent_migration_upgrades_legacy_table():
+    connection = sqlite3.connect(":memory:")
+    connection.execute(
+        """
+        CREATE TABLE trading_journal (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ticker TEXT NOT NULL,
+            company_name TEXT NOT NULL,
+            trade_date TEXT NOT NULL,
+            trade_type TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        )
+        """
+    )
+
+    migrate_trading_journal_exit_intent(connection.cursor(), connection)
+
+    columns = {
+        row[1] for row in connection.execute("PRAGMA table_info(trading_journal)")
+    }
+    indexes = {
+        row[1] for row in connection.execute("PRAGMA index_list(trading_journal)")
+    }
+    assert "exit_intent_id" in columns
+    assert "idx_trading_journal_exit_intent" in indexes
+
+
+@pytest.mark.asyncio
+async def test_existing_exit_intent_skips_llm_and_returns_success():
+    connection = _connection()
+    connection.execute(
+        """
+        INSERT INTO trading_journal (
+            ticker, company_name, trade_date, trade_type, created_at,
+            exit_intent_id
+        ) VALUES ('005930', 'Samsung', '2026-07-20', 'sell',
+                  '2026-07-20', 'intent-journal-1')
+        """
+    )
+    connection.commit()
+    manager = JournalManager(
+        cursor=connection.cursor(),
+        conn=connection,
+        enable_journal=True,
+    )
+
+    result = await manager.create_entry(
+        stock_data={"ticker": "005930", "company_name": "Samsung"},
+        sell_price=75000,
+        profit_rate=7.1,
+        holding_days=10,
+        sell_reason="target",
+        exit_intent_id="intent-journal-1",
+    )
+
+    assert result is True
+    assert connection.execute("SELECT COUNT(*) FROM trading_journal").fetchone()[0] == 1
+
+
+def test_journal_save_reports_duplicate_exit_intent_without_second_row():
+    connection = _connection()
+    manager = JournalManager(
+        cursor=connection.cursor(),
+        conn=connection,
+        enable_journal=True,
+    )
+    journal_data = {
+        "situation_analysis": {},
+        "judgment_evaluation": {},
+        "lessons": [],
+        "pattern_tags": [],
+        "one_line_summary": "done",
+        "confidence_score": 0.8,
+    }
+    args = (
+        "005930",
+        "Samsung",
+        70000,
+        "2026-07-01",
+        "{}",
+        {},
+        75000,
+        "target",
+        7.1,
+        10,
+        journal_data,
+    )
+
+    first_id, first_created = manager._save_to_database(
+        *args, exit_intent_id="intent-journal-race"
+    )
+    second_id, second_created = manager._save_to_database(
+        *args, exit_intent_id="intent-journal-race"
+    )
+
+    assert first_created is True
+    assert second_created is False
+    assert second_id == first_id
+    assert connection.execute("SELECT COUNT(*) FROM trading_journal").fetchone()[0] == 1

--- a/tests/test_kr_pending_exit.py
+++ b/tests/test_kr_pending_exit.py
@@ -478,6 +478,57 @@ async def test_post_commit_effects_reject_pending_position_before_journal(tmp_pa
     assert journal_calls == []
 
 
+@pytest.mark.asyncio
+async def test_publish_effects_complete_independently_from_remote_message_ids(
+    monkeypatch, tmp_path
+):
+    db_path = tmp_path / "publish-effects.sqlite"
+    agent, connection = _pending_exit_agent(db_path)
+    stock = _insert_open_holding(connection)
+    prepared = _prepare(agent, stock)
+    _set_intent_status(db_path, prepared.intent.id, "SUBMITTED")
+    calls = []
+
+    async def redis_publish(**kwargs):
+        calls.append(("REDIS", kwargs))
+        return "redis-message-1"
+
+    async def gcp_publish(**kwargs):
+        calls.append(("GCP", kwargs))
+        return None
+
+    monkeypatch.setattr(
+        "messaging.redis_signal_publisher.publish_sell_signal", redis_publish
+    )
+    monkeypatch.setattr(
+        "messaging.gcp_pubsub_signal_publisher.publish_sell_signal", gcp_publish
+    )
+    try:
+        agent._complete_pending_kr_exit(prepared)
+        outcomes = await agent._deliver_pending_kr_exit_publish_effects(
+            prepared,
+            {"success": True, "message": "submitted"},
+        )
+        rows = {
+            row["effect_type"]: row
+            for row in ExitEffectStore(connection).list_for_intent(
+                prepared.intent.id
+            )
+        }
+    finally:
+        connection.close()
+
+    assert outcomes == {"REDIS": "delivered", "GCP": "rescheduled"}
+    assert rows["REDIS"]["status"] == "DELIVERED"
+    assert rows["REDIS"]["remote_id"] == "redis-message-1"
+    assert rows["GCP"]["status"] == "PENDING"
+    assert rows["GCP"]["last_error"] == "DeliveryNotConfirmed"
+    assert [effect for effect, _kwargs in calls] == ["REDIS", "GCP"]
+    assert all(
+        kwargs["event_id"] == prepared.intent.id for _effect, kwargs in calls
+    )
+
+
 def _batch_agent(db_path: Path, *, rows: int = 1):
     connection = sqlite3.connect(db_path)
     connection.row_factory = sqlite3.Row
@@ -636,6 +687,12 @@ def _install_batch_runtime(
 
     redis_module.publish_sell_signal = publish_redis
     gcp_module.publish_sell_signal = publish_gcp
+
+    async def publish_effects(_prepared, _trade_result):
+        await publish_redis()
+        await publish_gcp()
+
+    agent._deliver_pending_kr_exit_publish_effects = publish_effects
     monkeypatch.setitem(sys.modules, "messaging.redis_signal_publisher", redis_module)
     monkeypatch.setitem(
         sys.modules, "messaging.gcp_pubsub_signal_publisher", gcp_module
@@ -667,6 +724,33 @@ async def test_batch_pending_exit_submitted_completes_before_publish(
         "post-commit",
         "redis",
         "gcp",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_batch_publish_effect_failure_does_not_change_closed_trade_result(
+    monkeypatch, tmp_path
+):
+    agent, connection = _batch_agent(tmp_path / "batch-effect-failure.sqlite")
+    events, _, _, _ = _install_batch_runtime(monkeypatch, agent=agent)
+
+    async def fail_effects(_prepared, _trade_result):
+        events.append("effects-failed")
+        raise RuntimeError("transport setup failed")
+
+    agent._deliver_pending_kr_exit_publish_effects = fail_effects
+    try:
+        sold = await agent.update_holdings()
+    finally:
+        connection.close()
+
+    assert [item["ticker"] for item in sold] == [TICKER]
+    assert events == [
+        "prepare",
+        "execute",
+        "complete",
+        "post-commit",
+        "effects-failed",
     ]
 
 

--- a/tests/test_kr_pending_readiness.py
+++ b/tests/test_kr_pending_readiness.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from prism_core.order_intents import IntentStore, OrderIntent
+from prism_core.exit_effects import ExitEffectStore
 from prism_core.positions import PositionStore, account_fingerprint
 from tools import check_kr_pending_readiness as readiness
 from tracking.db_schema import TABLE_STOCK_HOLDINGS
@@ -23,6 +24,7 @@ def _seed_clean_db(path: Path, *, rows: int = 1) -> None:
         connection.execute(TABLE_STOCK_HOLDINGS)
         position_store = PositionStore(connection)
         position_store.ensure_schema()
+        ExitEffectStore(connection).ensure_schema()
         for index in range(rows):
             holding_id = connection.execute(
                 """INSERT INTO stock_holdings (
@@ -94,6 +96,12 @@ def test_clean_readiness_is_ready_and_does_not_mutate_database(tmp_path):
     }
     assert report["comparator"]["matches"] is True
     assert report["pyramided_holdings"] == []
+    assert report["exit_effect_outbox"] == {
+        "status_counts": {},
+        "effect_counts": {},
+        "unresolved_count": 0,
+        "unresolved": [],
+    }
     assert report["kis_inquiries"] == [
         {
             "account_ref": account_fingerprint(ACCOUNT),
@@ -103,6 +111,62 @@ def test_clean_readiness_is_ready_and_does_not_mutate_database(tmp_path):
         }
     ]
     assert before == db_path.read_bytes()
+
+
+def test_missing_exit_effect_outbox_schema_is_unknown(tmp_path):
+    db_path = tmp_path / "missing-outbox.sqlite"
+    _seed_clean_db(db_path)
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("DROP TABLE exit_effect_outbox")
+
+    report = readiness.audit_database(db_path, _kis_ok())
+
+    assert report["status"] == "unknown"
+    assert report["exit_effect_outbox"] is None
+    assert "exit_effect_outbox_schema" in report["unknowns"]
+
+
+@pytest.mark.parametrize("status", ["PENDING", "IN_PROGRESS", "DEAD"])
+def test_each_unresolved_exit_effect_status_blocks_with_redacted_account(
+    tmp_path, status
+):
+    db_path = tmp_path / f"outbox-{status.lower()}.sqlite"
+    _seed_clean_db(db_path)
+    intent_id = f"intent-outbox-{status.lower()}"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        ExitEffectStore(connection).enqueue_exit_effects(
+            intent_id=intent_id,
+            market="KR",
+            account_id=ACCOUNT,
+            symbol="005930",
+            source="test",
+            payload={
+                "event_id": intent_id,
+                "message": "sensitive sell detail",
+            },
+        )
+        connection.execute(
+            "UPDATE exit_effect_outbox SET status=? WHERE effect_type='REDIS'",
+            (status,),
+        )
+        connection.execute(
+            "UPDATE exit_effect_outbox SET status='DELIVERED' "
+            "WHERE effect_type!='REDIS'"
+        )
+        connection.commit()
+
+    report = readiness.audit_database(db_path, _kis_ok())
+    serialized = json.dumps(report, sort_keys=True)
+
+    assert report["status"] == "blocked"
+    assert "unresolved_exit_effects" in report["blockers"]
+    assert report["exit_effect_outbox"]["unresolved_count"] == 1
+    assert report["exit_effect_outbox"]["unresolved"][0]["account_ref"] == (
+        account_fingerprint(ACCOUNT)
+    )
+    assert ACCOUNT not in serialized
+    assert "sensitive sell detail" not in serialized
 
 
 @pytest.mark.parametrize(

--- a/tests/test_redis_signal_pubsub.py
+++ b/tests/test_redis_signal_pubsub.py
@@ -259,6 +259,23 @@ class TestPublishSellSignal:
         assert signal_data["profit_rate"] == 9.76
         assert signal_data["sell_reason"] == "Target price reached"
 
+    @pytest.mark.asyncio
+    async def test_publish_sell_signal_includes_optional_exit_event_id(
+        self, publisher_with_mock_redis, mock_redis
+    ):
+        await publisher_with_mock_redis.publish_sell_signal(
+            ticker="005930",
+            company_name="Samsung Electronics",
+            price=90000,
+            buy_price=82000,
+            profit_rate=9.76,
+            sell_reason="Target price reached",
+            event_id="intent-publisher-1",
+        )
+
+        signal_data = json.loads(mock_redis.xadd.call_args[0][2]["data"])
+        assert signal_data["event_id"] == "intent-publisher-1"
+
 
 class TestPublishEventSignal:
     """이벤트 시그널 발행 테스트"""

--- a/tests/test_trend_exit_seller.py
+++ b/tests/test_trend_exit_seller.py
@@ -142,6 +142,12 @@ class FakeAgent:
     async def _run_pending_kr_exit_post_commit(self, _prepared):
         self.calls.append("postcommit")
 
+    async def _deliver_pending_kr_exit_publish_effects(
+        self, prepared, trade_result
+    ):
+        self.calls.append("effects")
+        return {"REDIS": "delivered", "GCP": "delivered"}
+
     async def send_telegram_message(self, chat_id, language="ko", **kwargs):
         self.calls.append("tg")
         return True
@@ -506,7 +512,7 @@ def test_pending_kr_submitted_closes_before_telegram_and_publish(tmp_db, monkeyp
         "complete",
         "postcommit",
         "tg",
-        "publish",
+        "effects",
         "tg",
     ]
     assert agent.prepare_kwargs["source"] == "trend_exit"
@@ -634,7 +640,7 @@ def test_pending_kr_local_flat_is_audited_without_broker_call(tmp_db, monkeypatc
         "complete",
         "postcommit",
         "tg",
-        "publish",
+        "effects",
         "tg",
     ]
     assert not any(call.startswith("kis:") for call in calls)

--- a/tools/check_kr_pending_readiness.py
+++ b/tools/check_kr_pending_readiness.py
@@ -166,6 +166,70 @@ def _pyramided_holdings(connection: sqlite3.Connection) -> list[dict[str, Any]]:
     ]
 
 
+def _exit_effect_outbox_audit(
+    connection: sqlite3.Connection,
+) -> dict[str, Any] | None:
+    table = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='exit_effect_outbox'"
+    ).fetchone()
+    if table is None:
+        return None
+
+    status_counts = {
+        str(status): int(count)
+        for status, count in connection.execute(
+            "SELECT status, COUNT(*) FROM exit_effect_outbox "
+            "WHERE market='KR' GROUP BY status ORDER BY status"
+        )
+    }
+    effect_counts = {
+        str(effect_type): int(count)
+        for effect_type, count in connection.execute(
+            "SELECT effect_type, COUNT(*) FROM exit_effect_outbox "
+            "WHERE market='KR' GROUP BY effect_type ORDER BY effect_type"
+        )
+    }
+    unresolved_rows = connection.execute(
+        """
+        SELECT effect_type, status, account_id, symbol, attempt_count,
+               last_error, created_at
+        FROM exit_effect_outbox
+        WHERE market='KR' AND status IN ('PENDING', 'IN_PROGRESS', 'DEAD')
+        ORDER BY created_at, effect_type, id
+        LIMIT 50
+        """
+    ).fetchall()
+    unresolved = [
+        {
+            "effect_type": str(effect_type),
+            "status": str(status),
+            "account_ref": account_fingerprint(account_id),
+            "symbol": str(symbol).upper(),
+            "attempt_count": int(attempt_count),
+            "last_error": str(last_error) if last_error is not None else None,
+            "created_at": str(created_at),
+        }
+        for (
+            effect_type,
+            status,
+            account_id,
+            symbol,
+            attempt_count,
+            last_error,
+            created_at,
+        ) in unresolved_rows
+    ]
+    unresolved_count = sum(
+        status_counts.get(status, 0) for status in ("PENDING", "IN_PROGRESS", "DEAD")
+    )
+    return {
+        "status_counts": status_counts,
+        "effect_counts": effect_counts,
+        "unresolved_count": unresolved_count,
+        "unresolved": unresolved,
+    }
+
+
 def _accepted_kr_sells(connection: sqlite3.Connection) -> list[dict[str, Any]]:
     rows = connection.execute(
         """SELECT bo.id, bo.broker_order_id, oi.id, oi.account_id, oi.symbol
@@ -287,6 +351,7 @@ def audit_database(
         position_counts = _position_status_counts(connection)
         comparator = PositionStore(connection).compare_legacy_positions("KR")
         pyramids = _pyramided_holdings(connection)
+        exit_effect_outbox = _exit_effect_outbox_audit(connection)
         accepted = _accepted_kr_sells(connection)
         broker_audit = None
         if not unknown_kis:
@@ -304,6 +369,8 @@ def audit_database(
         blockers.append("failed_exit_linked_open_positions")
     if pyramids:
         blockers.append("pyramided_kr_holdings")
+    if exit_effect_outbox is not None and exit_effect_outbox["unresolved_count"] > 0:
+        blockers.append("unresolved_exit_effects")
     if broker_audit is not None:
         if broker_audit["accepted_without_broker_order_id"]:
             blockers.append("accepted_sell_missing_broker_order_id")
@@ -315,6 +382,8 @@ def audit_database(
             blockers.append("current_open_sell_orders")
 
     unknowns = ["kis_open_orders"] if unknown_kis else []
+    if exit_effect_outbox is None:
+        unknowns.append("exit_effect_outbox_schema")
     status = "unknown" if unknowns else "blocked" if blockers else "ready"
     return {
         "status": status,
@@ -323,6 +392,7 @@ def audit_database(
         "position_status_counts": position_counts,
         "comparator": comparator,
         "pyramided_holdings": pyramids,
+        "exit_effect_outbox": exit_effect_outbox,
         "broker_order_audit": broker_audit,
         "blockers": blockers,
         "unknowns": unknowns,

--- a/tools/hardstop_seller.py
+++ b/tools/hardstop_seller.py
@@ -527,20 +527,12 @@ async def _act_on_pending_kr_trigger(
                     "[KR] %s telegram flush failed: %s", ticker, telegram_error
                 )
             try:
-                from sell_broadcast import publish_loop_sell
-
-                await publish_loop_sell(
-                    market="KR",
-                    ticker=ticker,
-                    company_name=stock_data.get("company_name", ticker),
-                    price=float(stock_data.get("current_price", 0) or 0),
-                    buy_price=float(stock_data.get("buy_price", 0) or 0),
-                    sell_reason=reason,
-                    trade_result=result,
+                await ag._deliver_pending_kr_exit_publish_effects(
+                    prepared, result
                 )
             except Exception as publish_error:
                 logger.warning(
-                    "[KR] %s sell signal publish failed (non-critical): %s",
+                    "[KR] %s durable sell effects failed (non-critical): %s",
                     ticker,
                     publish_error,
                 )

--- a/tools/replay_exit_effects.py
+++ b/tools/replay_exit_effects.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Audit or explicitly replay a bounded set of durable exit effects."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import socket
+import sqlite3
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from dotenv import load_dotenv  # noqa: E402
+
+from prism_core.exit_effect_replay import (  # noqa: E402
+    EffectHandler,
+    run_exit_effect_replay,
+)
+from prism_core.exit_effects import EXIT_EFFECT_TYPES  # noqa: E402
+from tools.audit_exit_effects import audit_database  # noqa: E402
+from tracking.db_schema import migrate_trading_journal_exit_intent  # noqa: E402
+from tracking.journal import JournalManager  # noqa: E402
+
+
+load_dotenv(PROJECT_ROOT / ".env")
+
+
+async def _send_telegram_message(bot, chat_id: str, message: str, event_id: str):
+    event_ref = f"[exit-event: {event_id}]"
+    text = f"{message}\n\n{event_ref}" if message else event_ref
+    chunks = [text[index : index + 4000] for index in range(0, len(text), 4000)]
+    first_message_id = None
+    for chunk in chunks:
+        result = await bot.send_message(chat_id=chat_id, text=chunk)
+        if first_message_id is None:
+            first_message_id = result.message_id
+    return str(first_message_id) if first_message_id is not None else None
+
+
+def build_exit_effect_handlers(
+    db_path: str | Path,
+    effect_types: Sequence[str],
+    *,
+    environment: Mapping[str, str] | None = None,
+) -> dict[str, EffectHandler]:
+    """Build production handlers from existing configuration only."""
+
+    selected = tuple(dict.fromkeys(effect_types))
+    if not selected or any(value not in EXIT_EFFECT_TYPES for value in selected):
+        raise ValueError("unsupported or empty exit effect selection")
+    env = dict(os.environ if environment is None else environment)
+    resolved_db_path = Path(db_path).expanduser().resolve()
+    handlers: dict[str, EffectHandler] = {}
+
+    if "JOURNAL" in selected:
+        journal_enabled = env.get("ENABLE_TRADING_JOURNAL", "false").lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+
+        async def journal(payload: dict[str, Any]):
+            if not journal_enabled:
+                return "disabled-by-config"
+            connection = sqlite3.connect(resolved_db_path, timeout=30)
+            try:
+                cursor = connection.cursor()
+                migrate_trading_journal_exit_intent(cursor, connection)
+                manager = JournalManager(
+                    cursor,
+                    connection,
+                    enable_journal=True,
+                )
+                return await manager.create_entry(
+                    stock_data=dict(payload.get("journal_stock_data") or {}),
+                    sell_price=float(payload.get("sell_price") or 0),
+                    profit_rate=float(payload.get("profit_rate") or 0),
+                    holding_days=int(payload.get("holding_days") or 0),
+                    sell_reason=str(payload.get("sell_reason") or ""),
+                    exit_intent_id=str(payload.get("event_id") or ""),
+                )
+            finally:
+                connection.close()
+
+        handlers["JOURNAL"] = journal
+
+    if "TELEGRAM" in selected:
+        token = str(env.get("TELEGRAM_BOT_TOKEN") or "").strip()
+        chat_id = str(env.get("TELEGRAM_CHANNEL_ID") or "").strip()
+        bot = None
+        if token and chat_id:
+            from telegram import Bot
+
+            bot = Bot(token=token)
+
+        async def telegram(payload: dict[str, Any]):
+            if bot is None:
+                return None
+            return await _send_telegram_message(
+                bot,
+                chat_id,
+                str(payload.get("message") or ""),
+                str(payload.get("event_id") or ""),
+            )
+
+        handlers["TELEGRAM"] = telegram
+
+    def publish_kwargs(payload: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "ticker": str(payload.get("symbol") or ""),
+            "company_name": str(payload.get("company_name") or ""),
+            "price": float(payload.get("sell_price") or 0),
+            "buy_price": float(payload.get("buy_price") or 0),
+            "profit_rate": float(payload.get("profit_rate") or 0),
+            "sell_reason": str(payload.get("sell_reason") or ""),
+            "market": str(payload.get("market") or "KR"),
+            "event_id": str(payload.get("event_id") or ""),
+        }
+
+    if "REDIS" in selected:
+
+        async def redis(payload: dict[str, Any]):
+            from messaging.redis_signal_publisher import publish_sell_signal
+
+            return await publish_sell_signal(**publish_kwargs(payload))
+
+        handlers["REDIS"] = redis
+
+    if "GCP" in selected:
+
+        async def gcp(payload: dict[str, Any]):
+            from messaging.gcp_pubsub_signal_publisher import publish_sell_signal
+
+            return await publish_sell_signal(**publish_kwargs(payload))
+
+        handlers["GCP"] = gcp
+
+    return handlers
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db-path", type=Path, required=True)
+    parser.add_argument("--limit", type=int, default=10)
+    parser.add_argument(
+        "--effect",
+        action="append",
+        choices=EXIT_EFFECT_TYPES,
+        dest="effects",
+        default=[],
+        help="Effect type to execute; repeat for multiple types.",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Perform bounded external delivery. Default is read-only audit.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _parser()
+    args = parser.parse_args(argv)
+    if args.limit < 1:
+        parser.error("--limit must be a positive integer")
+    if not args.execute:
+        report = audit_database(args.db_path, limit=args.limit)
+        print(
+            json.dumps(
+                {"mode": "dry-run", "audit": report},
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+        )
+        return {"ready": 0, "blocked": 1}.get(report["status"], 2)
+    if not args.effects:
+        parser.error("--execute requires at least one explicit --effect")
+
+    handlers = build_exit_effect_handlers(args.db_path, args.effects)
+    owner = f"replay:{socket.gethostname()}:{os.getpid()}"
+    summary = asyncio.run(
+        run_exit_effect_replay(
+            args.db_path,
+            handlers=handlers,
+            owner=owner,
+            limit=args.limit,
+        )
+    )
+    report = audit_database(args.db_path, limit=args.limit)
+    print(
+        json.dumps(
+            {"mode": "execute", "summary": summary, "audit": report},
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/trend_exit_seller.py
+++ b/tools/trend_exit_seller.py
@@ -718,20 +718,12 @@ async def _act_on_pending_kr_trigger(
                     "[KR] %s telegram flush failed: %s", ticker, telegram_error
                 )
             try:
-                from sell_broadcast import publish_loop_sell
-
-                await publish_loop_sell(
-                    market="KR",
-                    ticker=ticker,
-                    company_name=stock_data.get("company_name", ticker),
-                    price=float(stock_data.get("current_price", 0) or 0),
-                    buy_price=float(stock_data.get("buy_price", 0) or 0),
-                    sell_reason=reason,
-                    trade_result=result,
+                await ag._deliver_pending_kr_exit_publish_effects(
+                    prepared, result
                 )
             except Exception as publish_error:
                 logger.warning(
-                    "[KR] %s sell signal publish failed (non-critical): %s",
+                    "[KR] %s durable sell effects failed (non-critical): %s",
                     ticker, publish_error,
                 )
             return

--- a/tracking/db_schema.py
+++ b/tracking/db_schema.py
@@ -152,6 +152,7 @@ CREATE TABLE IF NOT EXISTS trading_journal (
     compressed_summary TEXT,
 
     -- Metadata
+    exit_intent_id TEXT,
     created_at TEXT NOT NULL,
     last_compressed_at TEXT
 )
@@ -761,6 +762,21 @@ def migrate_trading_history_columns(cursor, conn):
                 logger.warning(f"Migration warning for {table_name}: {exc}")
 
 
+def migrate_trading_journal_exit_intent(cursor, conn):
+    """Add the nullable exit-intent idempotency key and partial unique index."""
+
+    columns = {
+        str(row[1]) for row in cursor.execute("PRAGMA table_info(trading_journal)")
+    }
+    if "exit_intent_id" not in columns:
+        cursor.execute("ALTER TABLE trading_journal ADD COLUMN exit_intent_id TEXT")
+    cursor.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_trading_journal_exit_intent "
+        "ON trading_journal(exit_intent_id) WHERE exit_intent_id IS NOT NULL"
+    )
+    conn.commit()
+
+
 def create_all_tables(cursor, conn):
     """
     Create all database tables.
@@ -790,6 +806,7 @@ def create_all_tables(cursor, conn):
     migrate_watchlist_history_columns(cursor, conn)
     migrate_analysis_performance_tracker_columns(cursor, conn)
     migrate_trading_history_columns(cursor, conn)
+    migrate_trading_journal_exit_intent(cursor, conn)
     conn.commit()
     logger.info("Database tables created")
 

--- a/tracking/journal.py
+++ b/tracking/journal.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import re
+import sqlite3
 import sys
 import traceback
 from datetime import datetime
@@ -49,7 +50,9 @@ class JournalManager:
         sell_price: float,
         profit_rate: float,
         holding_days: int,
-        sell_reason: str
+        sell_reason: str,
+        *,
+        exit_intent_id: str | None = None,
     ) -> bool:
         """
         Create trading journal entry with retrospective analysis.
@@ -67,6 +70,19 @@ class JournalManager:
         if not self.enable_journal:
             logger.debug("Trading journal is disabled")
             return False
+
+        normalized_exit_intent_id = str(exit_intent_id or "").strip() or None
+        if normalized_exit_intent_id:
+            existing = self.cursor.execute(
+                "SELECT id FROM trading_journal WHERE exit_intent_id=?",
+                (normalized_exit_intent_id,),
+            ).fetchone()
+            if existing is not None:
+                logger.info(
+                    "Journal entry already exists for exit intent %s",
+                    normalized_exit_intent_id,
+                )
+                return True
 
         try:
             from cores.agents.trading_journal_agent import create_trading_journal_agent
@@ -128,17 +144,18 @@ class JournalManager:
 
             # Parse and save
             journal_data = self._parse_response(response)
-            journal_id = self._save_to_database(
+            journal_id, created = self._save_to_database(
                 ticker, company_name, buy_price, buy_date, scenario_json,
                 scenario_data, sell_price, sell_reason, profit_rate,
-                holding_days, journal_data
+                holding_days, journal_data,
+                exit_intent_id=normalized_exit_intent_id,
             )
 
             logger.info(f"Journal entry created for {ticker}: {journal_data.get('one_line_summary', '')}")
 
             # Extract principles
             lessons = journal_data.get('lessons', [])
-            if lessons and journal_id > 0:
+            if created and lessons and journal_id > 0:
                 extracted_count = self.extract_principles(lessons, journal_id)
                 logger.info(f"Extracted {extracted_count} principles from journal {journal_id}")
 
@@ -233,36 +250,51 @@ Please review the following completed trade:
     def _save_to_database(
         self, ticker: str, company_name: str, buy_price: float, buy_date: str,
         scenario_json: str, scenario_data: Dict, sell_price: float, sell_reason: str,
-        profit_rate: float, holding_days: int, journal_data: Dict
-    ) -> int:
+        profit_rate: float, holding_days: int, journal_data: Dict,
+        *, exit_intent_id: str | None = None,
+    ) -> tuple[int, bool]:
         """Save journal entry to database."""
         now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        self.cursor.execute(
-            """
-            INSERT INTO trading_journal
-            (ticker, company_name, trade_date, trade_type,
-             buy_price, buy_date, buy_scenario, buy_market_context,
-             sell_price, sell_reason, profit_rate, holding_days,
-             situation_analysis, judgment_evaluation, lessons, pattern_tags,
-             one_line_summary, confidence_score, compression_layer, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                ticker, company_name, now, 'sell',
-                buy_price, buy_date, scenario_json,
-                json.dumps(scenario_data.get('market_condition', ''), ensure_ascii=False),
-                sell_price, sell_reason, profit_rate, holding_days,
-                json.dumps(journal_data.get('situation_analysis', {}), ensure_ascii=False),
-                json.dumps(journal_data.get('judgment_evaluation', {}), ensure_ascii=False),
-                json.dumps(journal_data.get('lessons', []), ensure_ascii=False),
-                json.dumps(journal_data.get('pattern_tags', []), ensure_ascii=False),
-                journal_data.get('one_line_summary', ''),
-                journal_data.get('confidence_score', 0.5),
-                1, now
+        normalized_exit_intent_id = str(exit_intent_id or "").strip() or None
+        try:
+            self.cursor.execute(
+                """
+                INSERT INTO trading_journal
+                (ticker, company_name, trade_date, trade_type,
+                 buy_price, buy_date, buy_scenario, buy_market_context,
+                 sell_price, sell_reason, profit_rate, holding_days,
+                 situation_analysis, judgment_evaluation, lessons, pattern_tags,
+                 one_line_summary, confidence_score, compression_layer,
+                 exit_intent_id, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    ticker, company_name, now, 'sell',
+                    buy_price, buy_date, scenario_json,
+                    json.dumps(scenario_data.get('market_condition', ''), ensure_ascii=False),
+                    sell_price, sell_reason, profit_rate, holding_days,
+                    json.dumps(journal_data.get('situation_analysis', {}), ensure_ascii=False),
+                    json.dumps(journal_data.get('judgment_evaluation', {}), ensure_ascii=False),
+                    json.dumps(journal_data.get('lessons', []), ensure_ascii=False),
+                    json.dumps(journal_data.get('pattern_tags', []), ensure_ascii=False),
+                    journal_data.get('one_line_summary', ''),
+                    journal_data.get('confidence_score', 0.5),
+                    1, normalized_exit_intent_id, now,
+                )
             )
-        )
+        except sqlite3.IntegrityError:
+            if not normalized_exit_intent_id:
+                raise
+            self.conn.rollback()
+            existing = self.cursor.execute(
+                "SELECT id FROM trading_journal WHERE exit_intent_id=?",
+                (normalized_exit_intent_id,),
+            ).fetchone()
+            if existing is None:
+                raise
+            return int(existing[0]), False
         self.conn.commit()
-        return self.cursor.lastrowid
+        return int(self.cursor.lastrowid), True
 
     def extract_principles(self, lessons: List[Dict[str, Any]], source_journal_id: int) -> int:
         """Extract universal principles from lessons."""


### PR DESCRIPTION
## Summary
- add exact outbox delivery shared by immediate and bounded replay paths
- make trading journals idempotent by exit intent and link Telegram queue items to durable effects
- propagate deterministic event IDs to Redis/GCP and require remote message IDs per effect
- route batch, hardstop, and trend pending exits through the same independent delivery contract
- add read-only outbox readiness blockers and an explicit bounded replay CLI
- verify real OS-process claim competition and lease-expiry restart

## Failure contract
- CLOSED trading state is not rolled back when Journal, Telegram, Redis, or GCP fails
- only the failed effect remains PENDING or becomes DEAD after bounded retries
- unresolved effects block gate activation in readiness

## Environment
- no `.env` or `.env.example` keys were added or changed
- existing Telegram, Upstash Redis, GCP Pub/Sub, journal, and KR gate keys are reused

## Verification
- 374 passed, 16 skipped across effect, pending KR, journal, publisher, loop, intent, position, concurrency, and report regressions
- Ruff scoped checks and format checks passed
- Python compile passed
- Bandit: no findings in new replay/readiness code; no Medium/High findings in the changed journal scope
- `git diff --check` passed

## Safety
- no production DB replay or external delivery was executed
- no deployment, cron change, bot restart, or gate activation was performed
- `POSITION_PENDING_KR_ENABLED` remains default OFF