### PR TITLE
fix(kr-trading): capture KIS order number from uppercase ODNO key

### DIFF
--- a/tests/test_multi_account_domestic.py
+++ b/tests/test_multi_account_domestic.py
@@ -191,6 +191,64 @@ def _trader_with_revisable_orders_response(response):
     return trader
 
 
+class _OrderCashResponse:
+    """Mock KIS order-cash placement response.
+
+    KIS returns the placed order number under the UPPERCASE key ``ODNO``
+    (the revisable-order *inquiry* returns lowercase ``odno``, which is a
+    different endpoint and must stay lowercase).
+    """
+
+    def __init__(self, *, ok=True, output=None):
+        self._ok = ok
+        self._body = SimpleNamespace(output={} if output is None else output)
+
+    def isOK(self):
+        return self._ok
+
+    def getBody(self):
+        return self._body
+
+    def getErrorCode(self):
+        return "E-ORDER"
+
+    def getErrorMessage(self):
+        return "order placement failed"
+
+
+def _trader_for_order_placement(response):
+    trader = dst.DomesticStockTrading.__new__(dst.DomesticStockTrading)
+    trader.mode = "demo"
+    trader.auto_trading = True
+    trader.trenv = SimpleNamespace(my_acct="12345678", my_prod="01")
+    trader._request = lambda *_args, **_kwargs: response
+    return trader
+
+
+# KIS order-cash success output carries the order number as uppercase ``ODNO``.
+_ODNO_ORDER_OUTPUT = {
+    "KRX_FWDG_ORD_ORGNO": "00950",
+    "ODNO": "0000123456",
+    "ORD_TMD": "090012",
+}
+
+
+def test_buy_market_price_captures_uppercase_odno():
+    trader = _trader_for_order_placement(_OrderCashResponse(output=_ODNO_ORDER_OUTPUT))
+    trader.calculate_buy_quantity = lambda *_a, **_k: 3
+    result = trader.buy_market_price("005930")
+    assert result["success"] is True
+    assert result["order_no"] == "0000123456"
+
+
+def test_sell_all_market_price_captures_uppercase_odno():
+    trader = _trader_for_order_placement(_OrderCashResponse(output=_ODNO_ORDER_OUTPUT))
+    trader.get_holding_quantity = lambda *_a, **_k: 10
+    result = trader.sell_all_market_price("005930")
+    assert result["success"] is True
+    assert result["order_no"] == "0000123456"
+
+
 def test_checked_revisable_orders_preserves_authoritative_empty_and_rows():
     raw = {
         "odno": "000123",

--- a/trading/domestic_stock_trading.py
+++ b/trading/domestic_stock_trading.py
@@ -397,7 +397,9 @@ class DomesticStockTrading:
 
             if res.isOK():
                 output = res.getBody().output
-                order_no = output.get('odno', '')
+                # KIS order placement responses return the order number as the
+                # UPPERCASE key ``ODNO``; keep a lowercase fallback for safety.
+                order_no = output.get('ODNO') or output.get('odno') or ''
 
                 logger.info(f"[{stock_code}] Market buy order successful: {buy_quantity} shares, order no: {order_no}")
 
@@ -532,7 +534,9 @@ class DomesticStockTrading:
 
             if res.isOK():
                 output = res.getBody().output
-                order_no = output.get('odno', '')
+                # KIS order placement responses return the order number as the
+                # UPPERCASE key ``ODNO``; keep a lowercase fallback for safety.
+                order_no = output.get('ODNO') or output.get('odno') or ''
 
                 logger.info(f"[{stock_code}] Limit buy order successful: {buy_quantity} shares x {limit_price:,} KRW, order no: {order_no}")
 
@@ -682,7 +686,9 @@ class DomesticStockTrading:
 
             if res.isOK():
                 output = res.getBody().output
-                order_no = output.get('odno', '')
+                # KIS order placement responses return the order number as the
+                # UPPERCASE key ``ODNO``; keep a lowercase fallback for safety.
+                order_no = output.get('ODNO') or output.get('odno') or ''
 
                 logger.info(f"[{stock_code}] After-hours closing price buy order successful: {buy_quantity} shares, order no: {order_no}")
 
@@ -915,7 +921,9 @@ class DomesticStockTrading:
 
             if res.isOK():
                 output = res.getBody().output
-                order_no = output.get('odno', '')
+                # KIS order placement responses return the order number as the
+                # UPPERCASE key ``ODNO``; keep a lowercase fallback for safety.
+                order_no = output.get('ODNO') or output.get('odno') or ''
 
                 logger.info(f"[{stock_code}] Market sell all order successful: {buy_quantity} shares, order no: {order_no}")
 
@@ -1070,7 +1078,9 @@ class DomesticStockTrading:
 
             if res.isOK():
                 output = res.getBody().output
-                order_no = output.get('odno', '')
+                # KIS order placement responses return the order number as the
+                # UPPERCASE key ``ODNO``; keep a lowercase fallback for safety.
+                order_no = output.get('ODNO') or output.get('odno') or ''
 
                 logger.info(f"[{stock_code}] After-hours closing price sell order successful: {buy_quantity} shares, order no: {order_no}")
 
@@ -1885,7 +1895,9 @@ class DomesticStockTrading:
 
             if res.isOK():
                 output = res.getBody().output
-                order_no = output.get('odno', '')
+                # KIS order placement responses return the order number as the
+                # UPPERCASE key ``ODNO``; keep a lowercase fallback for safety.
+                order_no = output.get('ODNO') or output.get('odno') or ''
                 logger.info(
                     f"[{stock_code}] {action} order success: orgn={orgn_odno}, "
                     f"new_no={order_no}, price={limit_price}"


### PR DESCRIPTION
## 배경 (#412)
KR pending gate ON 준비 중 `check_kr_pending_readiness.py`가 `accepted_sell_missing_broker_order_id`를 blocker로 보고. 조사 결과 오늘 정상 체결·CLOSED된 KR 매도 3건의 `broker_order_id`가 비어 있었고, 원인은 **KR 주문 배치 wrapper가 order 번호를 소문자 `odno`로 읽는 것**이었다. KIS는 이를 대문자 `ODNO`로 반환한다(이미 `prism-us` 모듈은 `ODNO` 사용). 그 결과 모든 KR buy/sell/amend 주문이 빈 order_no를 기록.

로그 증거: `Market sell all order successful: N shares, order no: `(빈 값)이 07-07/07-13/07-20 매도마다 반복.

## 변경
- `trading/domestic_stock_trading.py`의 order-cash/order-rvsecncl 배치 6곳: `output.get('odno','')` → `output.get('ODNO') or output.get('odno') or ''` (대문자 우선 + 소문자 fallback).
- **의도적으로 건드리지 않음**: 정정취소가능주문 *조회*(`row.get('odno')`, KIS 조회는 소문자), 예약주문(`RSVN_ORD_SEQ`).
- 회귀 테스트 추가: `buy_market_price`/`sell_all_market_price`가 대문자 `ODNO`를 캡처하는지.

## 검증
- 신규 2 테스트 fix 전 red → 후 green.
- 관련 274 passed (domestic/order_intents/positions/kr_pending/exit_effect/execution/fill/journal). compile OK.

## 영향
- 이후 KR 주문이 `broker_order_id`를 채워 readiness `accepted_sell_missing_broker_order_id` blocker 해소 경로 확보. gate ON 선결과제.
- 기존 3건(이미 CLOSED)은 소급되지 않음(선택적 backfill 별도).

🤖 Generated with [Claude Code](https://claude.com/claude-code)