### PR TITLE
fix(trading): inject distribution_days count into KR/US buy prompt (#448)

### DIFF
--- a/cores/regime_policy.py
+++ b/cores/regime_policy.py
@@ -81,6 +81,24 @@ _STATE_CACHE: dict = {}
 # the ~400d index replay runs at most once per market per process. Fail-open False.
 _PILOT_CACHE: dict = {}
 
+# Item 5: Market Pulse detail cache — state + distribution_days + window, per-process.
+_DETAIL_CACHE: dict = {}
+
+
+@dataclass(frozen=True)
+class MarketPulseDetail:
+    """Snapshot of the Market Pulse state machine after the latest replay.
+
+    Attributes:
+        state:             Final state string (UPTREND / UNDER_PRESSURE / CORRECTION).
+        distribution_days: Live distribution-day count from the rolling window.
+        window:            Rolling-window length in sessions (mirrors DISTRIBUTION_WINDOW).
+    """
+
+    state: str
+    distribution_days: int
+    window: int
+
 
 @dataclass(frozen=True)
 class BatchPolicy:
@@ -257,8 +275,18 @@ def _load_root_cores(name: str):
     except Exception:  # noqa: BLE001 - shadowed/missing => fall through to by-path
         pass
 
+    import sys
+
     spec = importlib.util.spec_from_file_location(f"prism_root_cores_{name}", target)
     mod = importlib.util.module_from_spec(spec)
+    # Register before exec_module so a top-level frozen @dataclass in the loaded
+    # module (e.g. market_pulse.DailyBar) can resolve sys.modules[cls.__module__]
+    # .__dict__ during class creation. Without this, the by-path fallback — hit
+    # whenever cores/ is shadowed (e.g. the prism-us runtime) — raises
+    # AttributeError('NoneType' object has no attribute '__dict__') and
+    # get_market_pulse_state/detail silently fail-open to None. Mirrors the same
+    # fix in us_stock_tracking_agent._import_from_main_cores.
+    sys.modules[spec.name] = mod
     spec.loader.exec_module(mod)  # type: ignore[union-attr]
     return mod
 
@@ -387,9 +415,68 @@ def get_market_pulse_state(market: str, use_cache: bool = True) -> Optional[str]
 
 
 def _reset_state_cache() -> None:
-    """Test/utility hook: clear the memoized pulse-state + pilot caches."""
+    """Test/utility hook: clear the memoized pulse-state + pilot + detail caches."""
     _STATE_CACHE.clear()
     _PILOT_CACHE.clear()
+    _DETAIL_CACHE.clear()
+
+
+def get_market_pulse_detail(market: str, use_cache: bool = True) -> Optional[MarketPulseDetail]:
+    """Compute Market Pulse state AND distribution-day count for ``market``.
+
+    Replays :class:`cores.market_pulse.MarketPulse` over ~400 calendar days of
+    index bars and returns a :class:`MarketPulseDetail` with ``state``,
+    ``distribution_days``, and ``window``.  Per-process memoized (:data:`_DETAIL_CACHE`).
+
+    Fail-open: ANY exception (network, auth, missing data, import) is logged as a
+    warning and returns ``None``, so this never raises into the buy path.
+    The existing :func:`get_market_pulse_state` signature/return contract is unchanged.
+    """
+    m = (market or "").strip().lower()
+    if use_cache and m in _DETAIL_CACHE:
+        return _DETAIL_CACHE[m]
+
+    try:
+        mp_mod = _load_root_cores("market_pulse")
+        MarketPulse = mp_mod.MarketPulse
+        DailyBar = mp_mod.DailyBar
+        dd_window = getattr(mp_mod, "DISTRIBUTION_WINDOW", 25)
+
+        if m == "kr":
+            bars = _fetch_kr_bars(DailyBar)
+        elif m == "us":
+            bars = _fetch_us_bars(DailyBar)
+        else:
+            logger.warning("[MARKET_PULSE_DETAIL] unknown market %r -> None", market)
+            _DETAIL_CACHE[m] = None
+            return None
+
+        if not bars or len(bars) < 30:
+            raise RuntimeError(f"insufficient index bars: {len(bars) if bars else 0}")
+
+        mp = MarketPulse()
+        state: Optional[str] = None
+        for bar in bars:
+            state = mp.feed(bar)
+
+        if state is None:
+            _DETAIL_CACHE[m] = None
+            return None
+
+        detail = MarketPulseDetail(
+            state=state,
+            distribution_days=int(mp.distribution_days),
+            window=int(dd_window),
+        )
+        _DETAIL_CACHE[m] = detail
+        return detail
+    except Exception as e:  # noqa: BLE001 - fail-open, never raise
+        logger.warning(
+            "[MARKET_PULSE_DETAIL] detail compute failed for %s, fail-open None: %s",
+            m or "?", e,
+        )
+        _DETAIL_CACHE[m] = None
+        return None
 
 
 # --------------------------------------------------------------------------- #

--- a/prism-us/tests/test_issue_448_distribution_days_prompt.py
+++ b/prism-us/tests/test_issue_448_distribution_days_prompt.py
@@ -1,0 +1,306 @@
+"""Regression tests for issue #448: distribution_days count in US buy-decision prompt.
+
+Mirror of tests/test_issue_448_distribution_days_prompt.py for the US agent.
+TDD protocol: written BEFORE the fix. Pre-fix: all tests fail.
+Post-fix: all tests pass.
+
+prism-us shadowing note
+-----------------------
+``prism-us/cores/`` shadows the main project's ``cores/`` on sys.path, so a plain
+``import cores.regime_policy`` resolves to the prism-us copy (which has no
+regime_policy). Production loads the ROOT module by file path via
+``us_stock_tracking_agent._import_from_main_cores`` under the module name
+``prism_root_regime_policy`` and re-execs it fresh on every call. These tests
+therefore (a) load the root module by file path once at module-import time for
+direct-function assertions (Part A), and (b) patch ``_import_from_main_cores``
+itself for the agent-output tests (Part B) — the only reliable seam, since the
+module is re-loaded inside the method under test.
+
+Import isolation
+----------------
+``us_stock_tracking_agent`` loads ``openai_responses_llm.py`` from the ROOT
+``cores/llm/`` dir by file path at import time.  That real file in turn does::
+
+    from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
+
+so ``mcp_agent.workflows.llm.augmented_llm_openai`` must be stubbed before the
+first ``import us_stock_tracking_agent`` is executed.  The stub block below
+handles this (and mirrors the KR test's stub block).
+
+Run with:
+    cd prism-us && python -m pytest tests/test_issue_448_distribution_days_prompt.py -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pandas as pd
+
+PRISM_US_DIR = Path(__file__).resolve().parent.parent
+PROJECT_ROOT = PRISM_US_DIR.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+sys.path.insert(0, str(PRISM_US_DIR))
+
+# ---------------------------------------------------------------------------
+# Stub heavy/unavailable modules so us_stock_tracking_agent imports in CI/local.
+# (mcp_agent, KIS auth, Crypto, seaborn, US data client are not needed to
+# exercise _get_trend_facts, which is what Part B tests assert on).
+# Mirrors the KR test's stub block.
+# ---------------------------------------------------------------------------
+for _n in [
+    "mcp_agent",
+    "mcp_agent.app",
+    "mcp_agent.agents",
+    "mcp_agent.agents.agent",               # telegram_translator_agent.py imports this
+    "mcp_agent.workflows",
+    "mcp_agent.workflows.llm",
+    "mcp_agent.workflows.llm.augmented_llm",
+    "mcp_agent.workflows.llm.augmented_llm_openai",  # openai_responses_llm.py loads this at exec time
+    "cores.llm",
+    "cores.llm.openai_responses_llm",
+    "cores.agents.trading_agents",
+    "Crypto",
+    "Crypto.Cipher",
+    "Crypto.Cipher.AES",
+    "Crypto.Util",
+    "Crypto.Util.Padding",
+    "trading.kis_auth",
+    "seaborn",
+    "cores.us_data_client",  # provides get_us_data_client(); configured per-test in Part B
+    "cores.openai_error_logging",   # telegram_translator_agent.py imports this at exec time
+    "telegram",                     # us_stock_tracking_agent top-level imports
+    "telegram.error",
+]:
+    sys.modules.setdefault(_n, MagicMock())
+
+# ---------------------------------------------------------------------------
+# Prevent trading/kis_auth.py from executing at us_stock_tracking_agent import
+# time.  The agent loads it by file path:
+#   spec_from_file_location("kis_auth", PROJECT_ROOT / "trading/kis_auth.py")
+#   exec_module(ka)   ← opens a YAML config absent from this worktree → FileNotFoundError
+# Patching spec_from_file_location to return a no-op spec for that path stops
+# exec_module from running the real file.  All other calls pass through.
+# ---------------------------------------------------------------------------
+_real_spec_from_file_location = importlib.util.spec_from_file_location
+
+
+def _kis_auth_safe_spec(name, location=None, *args, **kwargs):
+    if location is not None and "kis_auth" in str(location):
+        stub = MagicMock()
+        stub.name = name
+        stub.loader.exec_module = lambda m: None  # no-op: skip YAML config read
+        return stub
+    return _real_spec_from_file_location(name, location, *args, **kwargs)
+
+
+importlib.util.spec_from_file_location = _kis_auth_safe_spec
+
+
+def _load_root_regime(module_name: str = "prism_root_regime_policy_test"):
+    """Load ROOT cores/regime_policy.py by file path (bypasses prism-us/cores).
+
+    The module MUST be registered in sys.modules BEFORE exec_module so the
+    frozen @dataclass resolves sys.modules[cls.__module__].__dict__ during
+    class creation (Python 3.12+ dataclass impl).  Mirrors the same guard in
+    us_stock_tracking_agent._import_from_main_cores.
+
+    Called ONCE at module-import time via ``_RP`` below; do not re-call per
+    test — re-execing the module rebinds the frozen MarketPulseDetail dataclass
+    and can break the sys.modules[cls.__module__] reference.
+    """
+    spec = importlib.util.spec_from_file_location(
+        module_name, PROJECT_ROOT / "cores" / "regime_policy.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Load the root regime_policy module exactly once for the whole test module.
+_RP = _load_root_regime()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_bars(n_flat: int, n_dd: int):
+    """Synthetic bars: n_flat flat sessions then n_dd distribution days.
+
+    MarketPulse.feed duck-types each bar (.date/.close/.volume), so a plain
+    SimpleNamespace works without depending on the (shadowed) cores.market_pulse
+    DailyBar class.
+    """
+    bars = []
+    close = 100.0
+    vol = 1_000.0
+    for i in range(n_flat):
+        bars.append(types.SimpleNamespace(
+            date=f"2023-{(i // 28) + 1:02d}-{(i % 28) + 1:02d}", close=close, volume=vol))
+    for j in range(n_dd):
+        close = round(close * 0.99, 6)
+        vol += 100.0
+        bars.append(types.SimpleNamespace(
+            date=f"2024-{(j // 28) + 1:02d}-{(j % 28) + 1:02d}", close=close, volume=vol))
+    return bars
+
+
+def _fake_ohlcv_us(n: int = 70) -> pd.DataFrame:
+    """Minimal OHLCV DataFrame for patching cores.us_data_client.get_us_data_client."""
+    dates = pd.date_range("2026-01-01", periods=n)
+    return pd.DataFrame({
+        "Close":  [150.0 + i * 0.5 for i in range(n)],
+        "Open":   [149.0 + i * 0.5 for i in range(n)],
+        "High":   [151.0 + i * 0.5 for i in range(n)],
+        "Low":    [148.0 + i * 0.5 for i in range(n)],
+        "Volume": [5_000_000] * n,
+        "close":  [150.0 + i * 0.5 for i in range(n)],
+    }, index=dates)
+
+
+# ---------------------------------------------------------------------------
+# Part A: get_market_pulse_detail on the ROOT cores/regime_policy.py
+# ---------------------------------------------------------------------------
+
+def test_get_market_pulse_detail_exists_in_root_regime_policy():
+    """FAILS pre-fix: get_market_pulse_detail / MarketPulseDetail don't exist yet."""
+    rp = _RP
+    assert hasattr(rp, "get_market_pulse_detail"), (
+        "get_market_pulse_detail not found in root cores/regime_policy.py"
+    )
+    assert hasattr(rp, "MarketPulseDetail"), (
+        "MarketPulseDetail not found in root cores/regime_policy.py"
+    )
+
+
+def test_get_market_pulse_detail_returns_state_and_dd_us():
+    """Post-fix: US index branch returns MarketPulseDetail(state/distribution_days/window)."""
+    rp = _RP
+    rp._reset_state_cache()
+    bars = _make_bars(n_flat=60, n_dd=2)
+
+    with patch.object(rp, "_fetch_us_bars", return_value=bars):
+        detail = rp.get_market_pulse_detail("us", use_cache=False)
+
+    assert detail is not None, "get_market_pulse_detail returned None for valid US bars"
+    assert isinstance(detail.state, str), f"state should be str, got {type(detail.state)}"
+    assert isinstance(detail.distribution_days, int), (
+        f"distribution_days should be int, got {type(detail.distribution_days)}"
+    )
+    assert detail.distribution_days >= 0
+    assert isinstance(detail.window, int), (
+        f"window should be int, got {type(detail.window)}"
+    )
+    assert detail.window > 0
+
+
+def test_get_market_pulse_detail_fail_open_returns_none_us():
+    """Post-fix: exception in the US branch -> fail-open None (never raises)."""
+    rp = _RP
+    rp._reset_state_cache()
+
+    with patch.object(rp, "_fetch_us_bars", side_effect=RuntimeError("simulated network failure")):
+        detail = rp.get_market_pulse_detail("us", use_cache=False)
+
+    assert detail is None, "fail-open: should return None on exception, not raise"
+
+
+# ---------------------------------------------------------------------------
+# Part B: US _get_trend_facts — distribution_days number in prompt output
+#
+# _get_trend_facts calls _import_from_main_cores("prism_root_regime_policy", ...)
+# to load regime_policy fresh. We intercept that call via a side_effect and
+# return a controlled fake module, delegating all other module loads to the
+# real _import_from_main_cores so us_stock_tracking_agent initialises normally.
+# ---------------------------------------------------------------------------
+
+def _make_regime_patcher(us_mod, get_detail_return):
+    """Build a side_effect for patching us_mod._import_from_main_cores.
+
+    Returns a controlled fake module when called with ``"prism_root_regime_policy"``;
+    delegates every other module load to the real implementation.
+    Uses ``_RP.MarketPulseDetail`` (the once-loaded class) so the frozen dataclass
+    sys.modules reference is always valid.
+    """
+    real_import = us_mod._import_from_main_cores  # capture before patch
+
+    def _side_effect(module_name, relative_path):
+        if module_name == "prism_root_regime_policy":
+            fake_rp = MagicMock()
+            fake_rp.MarketPulseDetail = _RP.MarketPulseDetail
+            fake_rp.get_market_pulse_detail.return_value = get_detail_return
+            return fake_rp
+        return real_import(module_name, relative_path)
+
+    return _side_effect
+
+
+def test_us_trend_facts_contains_distribution_days_number(tmp_path):
+    """Post-fix: US _get_trend_facts output includes the numeric dd count.
+
+    FAILS pre-fix: the Market Pulse injection block is absent, so neither "5"
+    nor the "分散日"/"distribution days" label appear in the output.
+    """
+    fake_detail = _RP.MarketPulseDetail(state="UPTREND", distribution_days=5, window=25)
+    fake_ohlcv = _fake_ohlcv_us(70)
+
+    import us_stock_tracking_agent as us_mod
+    from us_stock_tracking_agent import USStockTrackingAgent
+
+    mock_client = MagicMock()
+    mock_client.get_ohlcv.return_value = fake_ohlcv
+    mock_client.get_index_data.return_value = None
+
+    db_path = str(tmp_path / "test_us_trend.sqlite")
+    agent = USStockTrackingAgent(db_path=db_path)
+
+    with patch.object(sys.modules["cores.us_data_client"], "get_us_data_client",
+                      return_value=mock_client), \
+         patch.object(us_mod, "_import_from_main_cores",
+                      side_effect=_make_regime_patcher(us_mod, fake_detail)):
+        result = agent._get_trend_facts("AAPL")
+
+    assert result, "US trend_facts should not be empty"
+    assert "5" in result, (
+        f"distribution_days count (5) not found in US trend_facts output.\n"
+        f"Output:\n{result}"
+    )
+    assert "분산일" in result or "distribution days" in result, (
+        f"distribution_days label not found in US trend_facts output.\n"
+        f"Output:\n{result}"
+    )
+
+
+def test_us_trend_facts_omits_market_pulse_line_when_detail_none(tmp_path):
+    """Post-fix: when get_market_pulse_detail returns None, Market Pulse line is omitted.
+
+    FAILS pre-fix (function doesn't exist, so any patch attempt raises AttributeError).
+    Post-fix: fail-open — the Market Pulse line is silently skipped.
+    """
+    fake_ohlcv = _fake_ohlcv_us(70)
+
+    import us_stock_tracking_agent as us_mod
+    from us_stock_tracking_agent import USStockTrackingAgent
+
+    mock_client = MagicMock()
+    mock_client.get_ohlcv.return_value = fake_ohlcv
+    mock_client.get_index_data.return_value = None
+
+    db_path = str(tmp_path / "test_us_trend_none.sqlite")
+    agent = USStockTrackingAgent(db_path=db_path)
+
+    with patch.object(sys.modules["cores.us_data_client"], "get_us_data_client",
+                      return_value=mock_client), \
+         patch.object(us_mod, "_import_from_main_cores",
+                      side_effect=_make_regime_patcher(us_mod, None)):
+        result = agent._get_trend_facts("AAPL")
+
+    assert result, "US trend_facts should not be empty (fail-open on None detail)"
+    assert "Market Pulse:" not in result, (
+        f"Market Pulse line should be omitted when detail=None.\nOutput:\n{result}"
+    )

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -1008,16 +1008,18 @@ class USStockTrackingAgent:
                 f"- T1_hit(종가<{ma_mid_label}, 오닐 10주선 이탈): {t1_hit} / "
                 f"T2_hit(MA20 하락 and 종가 MA20 대비 -5%↓): {t2_hit}",
             ]
-            # Market Pulse (O'Neil M) 상태를 프롬프트 정보로 주입 (distribution_days 동급).
+            # Market Pulse (O'Neil M) 상태 + 분산일 카운트를 프롬프트 정보로 주입.
             # prism-us/cores 섀도잉을 피해 root cores/ 파일경로로 로드; 프로세스당 1회 캐시; fail-open.
             try:
                 _rp = _import_from_main_cores(
                     "prism_root_regime_policy", "cores/regime_policy.py"
                 )
-                _mp_state = _rp.get_market_pulse_state("us")
-                if _mp_state:
+                _mp_detail = _rp.get_market_pulse_detail("us")
+                if _mp_detail:
+                    _dd = _mp_detail.distribution_days
                     lines.append(
-                        f"- Market Pulse: {_mp_state} "
+                        f"- Market Pulse: {_mp_detail.state} "
+                        f"| 분산일(distribution days, 최근 {_mp_detail.window}세션): {_dd} "
                         "(오닐 M 상태; CORRECTION=신중, 반등대박도 이 구간에서 나옴)"
                     )
             except Exception as _mpe:

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -670,14 +670,16 @@ class StockTrackingAgent:
                 f"- T1_hit(종가<{ma_mid_label}, 오닐 10주선 이탈): {t1_hit} / "
                 f"T2_hit(MA20 하락 and 종가 MA20 대비 -5%↓): {t2_hit}",
             ]
-            # Market Pulse (O'Neil M) 상태를 프롬프트 정보로 주입 (distribution_days 동급).
+            # Market Pulse (O'Neil M) 상태 + 분산일 카운트를 프롬프트 정보로 주입.
             # 프로세스당 1회 계산(regime_policy 모듈 캐시); fail-open.
             try:
-                from cores.regime_policy import get_market_pulse_state
-                _mp_state = get_market_pulse_state("kr")
-                if _mp_state:
+                from cores.regime_policy import get_market_pulse_detail
+                _mp_detail = get_market_pulse_detail("kr")
+                if _mp_detail:
+                    _dd = _mp_detail.distribution_days
                     lines.append(
-                        f"- Market Pulse: {_mp_state} "
+                        f"- Market Pulse: {_mp_detail.state} "
+                        f"| 분산일(distribution days, 최근 {_mp_detail.window}세션): {_dd} "
                         "(오닐 M 상태; CORRECTION=신중, 반등대박도 이 구간에서 나옴)"
                     )
             except Exception as _mpe:

--- a/tests/test_issue_448_distribution_days_prompt.py
+++ b/tests/test_issue_448_distribution_days_prompt.py
@@ -1,0 +1,223 @@
+"""Regression tests for issue #448: distribution_days count in KR buy-decision prompt.
+
+TDD protocol: written BEFORE the fix. Pre-fix: all tests fail.
+Post-fix: all tests pass.
+
+Run with:
+    python3 -m pytest tests/test_issue_448_distribution_days_prompt.py -v
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pandas as pd
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+# ---------------------------------------------------------------------------
+# Stub unavailable modules so stock_tracking_agent can be imported in CI/local
+# (mcp_agent, Crypto/pycryptodome, etc. are not installed in dev/test environments).
+# ---------------------------------------------------------------------------
+for _n in [
+    "mcp_agent",
+    "mcp_agent.app",
+    "mcp_agent.workflows",
+    "mcp_agent.workflows.llm",
+    "mcp_agent.workflows.llm.augmented_llm",
+    "cores.llm",
+    "cores.llm.openai_responses_llm",
+    "cores.agents.trading_agents",
+    "Crypto",
+    "Crypto.Cipher",
+    "Crypto.Cipher.AES",
+    "Crypto.Util",
+    "Crypto.Util.Padding",
+    "trading.kis_auth",  # reads YAML config at import time
+    "seaborn",           # required by cores.stock_chart
+    "cores.stock_chart", # requires seaborn; imported lazily inside _get_trend_facts
+]:
+    sys.modules.setdefault(_n, MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_bars(n_flat: int, n_dd: int, DailyBar):
+    """Synthetic bars: n_flat flat sessions then n_dd distribution days.
+
+    Distribution day = close -1% on rising volume (meets -0.2% threshold).
+    """
+    bars = []
+    close = 100.0
+    vol = 1_000.0
+    for i in range(n_flat):
+        bars.append(DailyBar(date=f"2023-{(i // 28) + 1:02d}-{(i % 28) + 1:02d}",
+                             close=close, volume=vol))
+    for j in range(n_dd):
+        close = round(close * 0.99, 6)  # -1% -> distribution day
+        vol += 100.0
+        bars.append(DailyBar(date=f"2024-{(j // 28) + 1:02d}-{(j % 28) + 1:02d}",
+                             close=close, volume=vol))
+    return bars
+
+
+def _fake_ohlcv(n: int = 70) -> pd.DataFrame:
+    """Minimal DataFrame mimicking get_market_ohlcv_by_date output."""
+    dates = pd.date_range("2026-01-01", periods=n)
+    return pd.DataFrame({
+        "Close": [100.0 + i * 0.5 for i in range(n)],
+        "Open":  [99.0  + i * 0.5 for i in range(n)],
+        "High":  [101.0 + i * 0.5 for i in range(n)],
+        "Low":   [98.0  + i * 0.5 for i in range(n)],
+        "Volume": [1_000_000] * n,
+    }, index=dates)
+
+
+# ---------------------------------------------------------------------------
+# Part A: get_market_pulse_detail — new function contract
+# ---------------------------------------------------------------------------
+
+def test_get_market_pulse_detail_exists():
+    """FAILS pre-fix: get_market_pulse_detail does not exist yet."""
+    import cores.regime_policy as rp
+    assert hasattr(rp, "get_market_pulse_detail"), (
+        "get_market_pulse_detail not found in cores.regime_policy"
+    )
+
+
+def test_market_pulse_detail_dataclass_exists():
+    """FAILS pre-fix: MarketPulseDetail dataclass does not exist yet."""
+    import cores.regime_policy as rp
+    assert hasattr(rp, "MarketPulseDetail"), (
+        "MarketPulseDetail not found in cores.regime_policy"
+    )
+
+
+def test_get_market_pulse_detail_returns_state_and_dd_and_window():
+    """FAILS pre-fix: function doesn't exist.
+    Post-fix: returns MarketPulseDetail with state/distribution_days/window.
+    """
+    from cores.market_pulse import DailyBar
+    import cores.regime_policy as rp
+
+    rp._reset_state_cache()
+    bars = _make_bars(n_flat=60, n_dd=3, DailyBar=DailyBar)
+
+    with patch.object(rp, "_fetch_kr_bars", return_value=bars):
+        detail = rp.get_market_pulse_detail("kr", use_cache=False)
+
+    assert detail is not None, "get_market_pulse_detail returned None for valid bars"
+    assert isinstance(detail.state, str), f"state should be str, got {type(detail.state)}"
+    assert isinstance(detail.distribution_days, int), (
+        f"distribution_days should be int, got {type(detail.distribution_days)}"
+    )
+    assert detail.distribution_days >= 0
+    assert isinstance(detail.window, int), (
+        f"window should be int, got {type(detail.window)}"
+    )
+    assert detail.window > 0
+
+
+def test_get_market_pulse_detail_fail_open_returns_none():
+    """FAILS pre-fix (fn doesn't exist). Post-fix: exception -> None, never raises."""
+    import cores.regime_policy as rp
+
+    rp._reset_state_cache()
+
+    with patch.object(rp, "_fetch_kr_bars", side_effect=RuntimeError("simulated network failure")):
+        detail = rp.get_market_pulse_detail("kr", use_cache=False)
+
+    assert detail is None, "fail-open: should return None on exception, not raise"
+
+
+def test_get_market_pulse_state_contract_unchanged():
+    """Pre-fix: passes (fn exists). Post-fix: still passes (contract unchanged)."""
+    from cores.market_pulse import DailyBar
+    import cores.regime_policy as rp
+
+    rp._reset_state_cache()
+    bars = _make_bars(n_flat=60, n_dd=0, DailyBar=DailyBar)
+
+    with patch.object(rp, "_fetch_kr_bars", return_value=bars):
+        state = rp.get_market_pulse_state("kr", use_cache=False)
+
+    # State is str or None — contract unchanged
+    assert state is None or isinstance(state, str), (
+        f"get_market_pulse_state contract broken: got {type(state)}"
+    )
+
+
+def test_reset_state_cache_clears_detail_cache():
+    """FAILS pre-fix if _DETAIL_CACHE doesn't exist or isn't cleared."""
+    import cores.regime_policy as rp
+    assert hasattr(rp, "_DETAIL_CACHE"), "_DETAIL_CACHE module-level dict missing"
+    # Verify reset clears it (should not raise)
+    rp._reset_state_cache()
+    assert rp._DETAIL_CACHE == {}, "_DETAIL_CACHE not cleared by _reset_state_cache()"
+
+
+# ---------------------------------------------------------------------------
+# Part B: _get_trend_facts — distribution_days number in prompt output
+# ---------------------------------------------------------------------------
+
+def _configure_stock_chart_mock(fake_ohlcv):
+    """Configure the cores.stock_chart MagicMock stub with realistic return values."""
+    sc = sys.modules["cores.stock_chart"]
+    sc.get_market_ohlcv_by_date.return_value = fake_ohlcv
+    sc.get_index_ohlcv_by_date.return_value = None
+    sc._detect_index_ticker.return_value = "^KS11"
+    return sc
+
+
+def test_trend_facts_contains_distribution_days_number(tmp_path):
+    """FAILS pre-fix: _get_trend_facts output lacks distribution_days count.
+    Post-fix: output includes the numeric dd count.
+    """
+    import cores.regime_policy as rp
+    if not hasattr(rp, "MarketPulseDetail"):
+        pytest.fail("MarketPulseDetail missing from cores.regime_policy (pre-fix)")
+
+    fake_detail = rp.MarketPulseDetail(state="UPTREND", distribution_days=3, window=25)
+    fake_ohlcv = _fake_ohlcv(70)
+    _configure_stock_chart_mock(fake_ohlcv)
+
+    from stock_tracking_agent import StockTrackingAgent
+    db_path = str(tmp_path / "test_trend_kr.sqlite")
+    agent = StockTrackingAgent(db_path=db_path)
+
+    with patch("cores.regime_policy.get_market_pulse_detail", return_value=fake_detail):
+        result = agent._get_trend_facts("005930")
+
+    assert result, "trend_facts should not be empty"
+    assert "3" in result, (
+        f"distribution_days count (3) not found in trend_facts output.\n"
+        f"Output:\n{result}"
+    )
+    assert "분산일" in result or "distribution days" in result, (
+        f"distribution_days label not found in trend_facts.\nOutput:\n{result}"
+    )
+
+
+def test_trend_facts_omits_market_pulse_line_when_detail_none(tmp_path):
+    """FAILS pre-fix (get_market_pulse_detail doesn't exist, so AttributeError on patch).
+    Post-fix: when detail=None, Market Pulse line is omitted (fail-open).
+    """
+    fake_ohlcv = _fake_ohlcv(70)
+    _configure_stock_chart_mock(fake_ohlcv)
+
+    from stock_tracking_agent import StockTrackingAgent
+    db_path = str(tmp_path / "test_trend_kr_none.sqlite")
+    agent = StockTrackingAgent(db_path=db_path)
+
+    with patch("cores.regime_policy.get_market_pulse_detail", return_value=None):
+        result = agent._get_trend_facts("005930")
+
+    assert result, "trend_facts should not be empty (fail-open on None detail)"
+    assert "Market Pulse:" not in result, (
+        f"Market Pulse line should be omitted when detail=None.\nOutput:\n{result}"
+    )


### PR DESCRIPTION
## Problem (#448)
The KR/US buy-decision LLM prompt received only the Market Pulse regime STATE string (UPTREND/UNDER_PRESSURE/CORRECTION). The numeric **distribution-day count** is computed by `MarketPulse` but `get_market_pulse_state()` discarded it, so the buy LLM reported *"distribution_days 값은 별도 제공되지 않았으나"* (e.g. the SK하이닉스 000660 Skip case in the issue).

## Fix (display-only, fail-open, ZERO order-execution impact)
- `cores/regime_policy.py`: add `MarketPulseDetail` (state / distribution_days / window) + `get_market_pulse_detail()`. Existing `get_market_pulse_state()` signature/return **unchanged**; same replay, per-process cache, fail-open (None on any error).
- `stock_tracking_agent.py` (KR) & `prism-us/us_stock_tracking_agent.py` (US): render `분산일(distribution days, 최근 25세션): N` in the trend-facts block. Fail-open omits the line when detail is None.

## Verification
- New regression tests: **KR 8 passed / US 5 passed** (run separately — root `cores/` and `prism-us/cores/` shadow each other in one process).
- TDD: proven fail on pre-fix source → pass after.
- Related suites: **KR 85 passed / US 55 passed**. py_compile OK, `git diff --check` clean.
- Ruff: new test files clean; source changes add **0** new lint errors (regime_policy 0→0, stock_tracking 40→33, us 19→19).

Does NOT touch order execution, gates, or `POSITION_PENDING_KR_ENABLED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)