### PR TITLE
fix(us): resolve root cores when loading report_generation under prism-us shadow

### DIFF
--- a/prism-us/cores/us_analysis.py
+++ b/prism-us/cores/us_analysis.py
@@ -29,8 +29,71 @@ def _import_from_project_root(module_name: str, file_path: Path):
     spec.loader.exec_module(module)
     return module
 
-# Import report_generation from main project's cores
-_report_gen_module = _import_from_project_root(
+
+def _import_root_module_with_root_cores(module_name: str, file_path: Path):
+    """Import a ROOT-project module by file path while temporarily making the
+    ROOT ``cores`` package authoritative for the duration of ``exec_module``.
+
+    Why this is needed:
+    prism-us runs as ``python prism-us/us_stock_analysis_orchestrator.py``, so
+    ``sys.path[0]`` is the ``prism-us/`` dir and ``import cores`` binds to
+    ``prism-us/cores`` — which SHADOWS the root ``cores`` package. Modules like
+    ``cores/report_generation.py`` contain TOP-LEVEL absolute imports
+    (``from cores.agents.report_agent import ReportAgent``, ``from cores.llm...``,
+    ``from cores.openai_error_logging import ...``) that must resolve against the
+    ROOT ``cores`` package. ``prism-us/cores/agents/`` has no ``report_agent``, so
+    a plain file-path exec raises
+    ``ModuleNotFoundError: No module named 'cores.agents.report_agent'``.
+
+    Fix: for the exec only, (a) put the project root at the front of ``sys.path``
+    and (b) evict the prism-us ``cores``/``cores.*`` entries from ``sys.modules``
+    so the exec re-imports ``cores`` and its submodules from ROOT. Everything is
+    restored in ``finally`` so the rest of the prism-us process keeps seeing
+    ``cores`` == ``prism-us/cores``. report_generation performs its ``cores.*``
+    imports only at module top level, so the swap only needs to be active while
+    exec_module runs; the returned module keeps its ROOT-backed bindings.
+    """
+    root_str = str(_project_root)
+
+    # Snapshot & evict the prism-us `cores` (and submodules) so the exec below
+    # re-imports `cores`/`cores.agents`/`cores.llm`/... from ROOT.
+    saved_modules = {
+        name: mod
+        for name, mod in list(sys.modules.items())
+        if name == "cores" or name.startswith("cores.")
+    }
+    for name in saved_modules:
+        del sys.modules[name]
+
+    path_inserted = False
+    if not sys.path or sys.path[0] != root_str:
+        sys.path.insert(0, root_str)
+        path_inserted = True
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, file_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if path_inserted:
+            try:
+                sys.path.remove(root_str)
+            except ValueError:
+                pass
+        # Drop any ROOT `cores.*` entries created during the exec, then restore
+        # the original prism-us `cores` view so downstream prism-us imports keep
+        # resolving against prism-us/cores.
+        for name in [
+            n for n in list(sys.modules) if n == "cores" or n.startswith("cores.")
+        ]:
+            del sys.modules[name]
+        sys.modules.update(saved_modules)
+
+
+# Import report_generation from main project's cores.
+# report_generation.py has top-level `from cores.X import ...` statements that
+# must bind to the ROOT cores package, so use the cores-swapping loader.
+_report_gen_module = _import_root_module_with_root_cores(
     "main_report_generation",
     _project_root / "cores" / "report_generation.py"
 )

--- a/prism-us/tests/test_us_analysis_cores_shadow.py
+++ b/prism-us/tests/test_us_analysis_cores_shadow.py
@@ -1,0 +1,123 @@
+"""Regression tests for the prism-us `cores` shadow import bug.
+
+Background
+----------
+prism-us runs as ``python prism-us/us_stock_analysis_orchestrator.py``, so
+``sys.path[0]`` is the ``prism-us/`` directory and ``import cores`` binds to
+``prism-us/cores`` — which shadows the ROOT ``cores`` package. The US
+orchestrator loads ROOT ``cores/report_generation.py`` by file path via
+``prism-us/cores/us_analysis.py``. report_generation.py has TOP-LEVEL absolute
+imports (``from cores.agents.report_agent import ReportAgent``, ``from
+cores.llm...``, ``from cores.openai_error_logging import ...``) which, under the
+shadow, resolve against ``prism-us/cores`` and fail with::
+
+    ModuleNotFoundError: No module named 'cores.agents.report_agent'
+
+This broke US morning/afternoon report generation in production
+(us_morning.log 2026-07-20 23:22, reports 0/3).
+
+These tests run in fresh subprocesses (the shadow manipulation is global and
+must not corrupt the pytest interpreter's sys.modules) and assert:
+
+1. Without the cores-swap, loading report_generation under the shadow raises the
+   exact production ModuleNotFoundError (documents pre-fix behavior).
+2. With the fix, importing ``cores.us_analysis`` under the shadow succeeds, the
+   ReportAgent-backed callables are present, and ``sys.modules['cores']`` is
+   restored to the prism-us package afterwards (no global corruption).
+"""
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+PRISM_US_DIR = Path(__file__).resolve().parent.parent          # .../prism-us
+PROJECT_ROOT = PRISM_US_DIR.parent                              # repo root
+
+
+def _run_in_shadow_subprocess(body: str) -> subprocess.CompletedProcess:
+    """Run ``body`` in a fresh interpreter with the prism-us `cores` shadow.
+
+    Mirrors production: prism-us/ precedes the project root on sys.path, so
+    ``import cores`` binds to prism-us/cores.
+    """
+    preamble = textwrap.dedent(
+        f"""
+        import sys
+        # Mirror `python prism-us/...`: prism-us dir is sys.path[0], root after it.
+        sys.path.insert(0, {str(PROJECT_ROOT)!r})
+        sys.path.insert(0, {str(PRISM_US_DIR)!r})
+        import cores  # binds to prism-us/cores (the shadow)
+        assert cores.__file__.replace("\\\\", "/").endswith("prism-us/cores/__init__.py"), (
+            "test setup failed: cores is not the prism-us shadow: " + cores.__file__
+        )
+        """
+    )
+    script = preamble + textwrap.dedent(body)
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        cwd=str(PRISM_US_DIR),
+    )
+
+
+def test_shadow_reproduces_module_not_found_without_swap():
+    """Pre-fix behavior: a plain file-path exec of report_generation under the
+    shadow raises the exact production ModuleNotFoundError."""
+    body = f"""
+        import importlib.util
+        from pathlib import Path
+        rg = Path({str(PROJECT_ROOT)!r}) / "cores" / "report_generation.py"
+        spec = importlib.util.spec_from_file_location("main_report_generation", rg)
+        mod = importlib.util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(mod)
+        except ModuleNotFoundError as e:
+            print("REPRO:" + str(e))
+        else:
+            print("NO_REPRO")
+    """
+    result = _run_in_shadow_subprocess(body)
+    assert result.returncode == 0, (
+        "subprocess crashed unexpectedly:\n" + result.stdout + result.stderr
+    )
+    assert "REPRO:No module named 'cores.agents.report_agent'" in result.stdout, (
+        "Expected the production ModuleNotFoundError but got:\n"
+        + result.stdout + result.stderr
+    )
+
+
+def test_us_analysis_loader_resolves_root_cores_under_shadow():
+    """Post-fix behavior: importing cores.us_analysis under the shadow succeeds,
+    exposes the ReportAgent-backed callables, and restores sys.modules['cores']
+    to the prism-us package (no global corruption)."""
+    body = """
+        import cores.us_analysis as ua
+
+        required = [
+            "generate_report",
+            "generate_summary",
+            "generate_investment_strategy",
+            "get_disclaimer",
+            "generate_market_report",
+        ]
+        missing = [name for name in required if not callable(getattr(ua, name, None))]
+        assert not missing, "us_analysis missing callables: " + repr(missing)
+
+        # After the swap, `cores` must be restored to the prism-us shadow so the
+        # rest of the prism-us process is unaffected.
+        import sys
+        restored = sys.modules["cores"].__file__.replace("\\\\", "/")
+        assert restored.endswith("prism-us/cores/__init__.py"), (
+            "cores not restored to prism-us after load: " + restored
+        )
+        print("FIX_OK")
+    """
+    result = _run_in_shadow_subprocess(body)
+    assert result.returncode == 0, (
+        "Importing cores.us_analysis under the shadow failed (the bug):\n"
+        + result.stdout + result.stderr
+    )
+    assert "FIX_OK" in result.stdout, (
+        "Post-fix assertions did not pass:\n" + result.stdout + result.stderr
+    )


### PR DESCRIPTION
## Incident
US morning/afternoon orchestrator sent the screening trigger alert, then **report generation failed 0/3** and terminated ("No US reports generated"). So users got the screening message but no follow-up reports. Broken since commit 826a2e96 (report pipeline refactor).

## Root cause
`cores/report_generation.py` has top-level absolute imports (`from cores.agents.report_agent import ReportAgent`, `from cores.llm.*`, `cores.openai_error_logging`). `prism-us/cores/` **shadows** the root `cores/` package (the US orchestrator runs as `python prism-us/…`, so `sys.modules['cores']` = `prism-us/cores`). When `us_analysis.py` loads root `report_generation.py` by file path, those imports resolved to `prism-us/cores` — which has no `agents.report_agent` / `llm` — raising `ModuleNotFoundError: No module named 'cores.agents.report_agent'`. KR is unaffected (imports report_generation directly with root cores on path).

## Fix (US boundary only — root `cores/**` untouched, KR behavior identical)
`prism-us/cores/us_analysis.py`: new `_import_root_module_with_root_cores()` that, for the `exec_module` of a root module, temporarily prepends the project root to `sys.path` and evicts the prism-us `cores`/`cores.*` entries from `sys.modules` so the module's top-level `from cores.X` bind to **root** cores, then restores the prism-us cores view in `finally`. report_generation's `cores.*` imports are all top-level, so the swap only spans the exec.

## Verification
- New `prism-us/tests/test_us_analysis_cores_shadow.py`: simulates the shadow. **Fails pre-fix** with the exact `ModuleNotFoundError`, **passes post-fix** (2 passed). Also asserts `sys.modules['cores']` is restored to prism-us afterward (no global corruption).
- KR safety: `python -c "import cores.report_generation"` → OK.
- ruff 0 new errors (us_analysis 3→3; new test clean), py_compile OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)