### PR TITLE
fix(subscriber): mirror partial (pyramiding) exits instead of full-liquidating

### DIFF
--- a/examples/messaging/gcp_pubsub_subscriber_example.py
+++ b/examples/messaging/gcp_pubsub_subscriber_example.py
@@ -502,7 +502,7 @@ async def execute_buy_trade(ticker: str, company_name: str, logger: logging.Logg
         return {"success": False, "message": str(e)}
 
 
-async def execute_sell_trade(ticker: str, company_name: str, logger: logging.Logger, limit_price: Optional[int] = None) -> Dict[str, Any]:
+async def execute_sell_trade(ticker: str, company_name: str, logger: logging.Logger, limit_price: Optional[int] = None, sell_denominator: int = 1) -> Dict[str, Any]:
     """Execute actual sell order (async)
 
     Args:
@@ -510,6 +510,12 @@ async def execute_sell_trade(ticker: str, company_name: str, logger: logging.Log
         company_name: Company name for logging
         logger: Logger instance
         limit_price: Limit price for reserved orders (required for off-hours trading)
+        sell_denominator: Portion of the position to sell so a partial
+            (pyramiding) exit on the source account is mirrored here. We sell
+            floor(our_holding / sell_denominator); 1 (default) sells the whole
+            position (unchanged behavior). A larger denominator means the source
+            trimmed one lot of several, so we trim the same fraction instead of
+            full-liquidating.
     """
     try:
         from trading.domestic_stock_trading import AsyncTradingContext
@@ -522,7 +528,26 @@ async def execute_sell_trade(ticker: str, company_name: str, logger: logging.Log
                 if price_info:
                     effective_limit_price = int(price_info['current_price'])
 
-            trade_result = await trading.async_sell_stock(stock_code=ticker, limit_price=effective_limit_price)
+            # Mirror a partial (pyramiding) exit: sell only our proportional share.
+            sell_quantity = None  # None => full-position sell (unchanged behavior)
+            if sell_denominator and sell_denominator > 1:
+                holding = await asyncio.to_thread(trading.get_holding_quantity, ticker)
+                sell_quantity = holding // sell_denominator
+                if sell_quantity < 1:
+                    # Our position is too small for this fraction to round to a
+                    # share. Keep it — the source's final full sweep (denominator
+                    # 1) will close the remainder. Not a failure.
+                    logger.info(
+                        f"⏭️ Partial sell skipped: {company_name}({ticker}) "
+                        f"holding {holding} / denom {sell_denominator} < 1 share; keeping for final sweep"
+                    )
+                    return {"success": True, "message": f"partial sell skipped (holding {holding}/{sell_denominator} < 1 share)"}
+                logger.info(
+                    f"➗ Partial (pyramiding) sell: {company_name}({ticker}) "
+                    f"{sell_quantity} of {holding} shares (denom {sell_denominator})"
+                )
+
+            trade_result = await trading.async_sell_stock(stock_code=ticker, limit_price=effective_limit_price, quantity=sell_quantity)
 
         if trade_result['success']:
             logger.info(f"✅ Actual sell successful: {company_name}({ticker}) - {trade_result['message']}")
@@ -577,7 +602,7 @@ async def execute_us_buy_trade(ticker: str, company_name: str, logger: logging.L
         return {"success": False, "message": str(e)}
 
 
-async def execute_us_sell_trade(ticker: str, company_name: str, logger: logging.Logger, limit_price: Optional[float] = None) -> Dict[str, Any]:
+async def execute_us_sell_trade(ticker: str, company_name: str, logger: logging.Logger, limit_price: Optional[float] = None, sell_denominator: int = 1) -> Dict[str, Any]:
     """Execute actual US stock sell order (async)
 
     Args:
@@ -585,6 +610,10 @@ async def execute_us_sell_trade(ticker: str, company_name: str, logger: logging.
         company_name: Company name for logging
         logger: Logger instance
         limit_price: Limit price in USD for reserved orders (required for off-hours trading)
+        sell_denominator: Portion of the position to sell so a partial
+            (pyramiding) exit on the source account is mirrored here. We sell
+            floor(our_holding / sell_denominator); 1 (default) sells the whole
+            position (unchanged behavior).
     """
     try:
         USStockTrading = load_us_stock_trading_class()
@@ -598,7 +627,25 @@ async def execute_us_sell_trade(ticker: str, company_name: str, logger: logging.
             if price_info:
                 effective_limit_price = price_info['current_price']
 
-        trade_result = await trading.async_sell_stock(ticker=ticker, limit_price=effective_limit_price)
+        # Mirror a partial (pyramiding) exit: sell only our proportional share.
+        sell_quantity = None  # None => full-position sell (unchanged behavior)
+        if sell_denominator and sell_denominator > 1:
+            holding = await asyncio.to_thread(trading.get_holding_quantity, ticker)
+            sell_quantity = holding // sell_denominator
+            if sell_quantity < 1:
+                # Position too small for this fraction to round to a share; keep
+                # it for the source's final full sweep (denominator 1). Not a failure.
+                logger.info(
+                    f"⏭️ 🇺🇸 Partial sell skipped: {company_name}({ticker}) "
+                    f"holding {holding} / denom {sell_denominator} < 1 share; keeping for final sweep"
+                )
+                return {"success": True, "message": f"partial sell skipped (holding {holding}/{sell_denominator} < 1 share)"}
+            logger.info(
+                f"➗ 🇺🇸 Partial (pyramiding) sell: {company_name}({ticker}) "
+                f"{sell_quantity} of {holding} shares (denom {sell_denominator})"
+            )
+
+        trade_result = await trading.async_sell_stock(ticker=ticker, limit_price=effective_limit_price, quantity=sell_quantity)
 
         if trade_result['success']:
             logger.info(f"✅ 🇺🇸 US sell successful: {company_name}({ticker}) - {trade_result['message']}")
@@ -687,19 +734,27 @@ def main():
             company_name = signal.get("company_name", "")
             # Get price from signal for limit orders (signal may contain price info)
             price = signal.get("price", 0)
+            # Preserve the source's partial-exit fraction across the demo-mode
+            # off-hours queue (the whole signal was stored, so it survives here).
+            try:
+                sell_denominator = int(signal.get("sell_denominator", 1) or 1)
+            except (TypeError, ValueError):
+                sell_denominator = 1
+            if sell_denominator < 1:
+                sell_denominator = 1
 
             # Call different trading functions based on market
             # Pass price as limit_price for reserved orders
             if market == "US":
                 limit_price = float(price) if price else None
                 if signal_type == "SELL":
-                    return asyncio.run(execute_us_sell_trade(ticker, company_name, logger, limit_price=limit_price))
+                    return asyncio.run(execute_us_sell_trade(ticker, company_name, logger, limit_price=limit_price, sell_denominator=sell_denominator))
                 else:  # BUY
                     return asyncio.run(execute_us_buy_trade(ticker, company_name, logger, limit_price=limit_price))
             else:  # KR (default)
                 limit_price = int(price) if price else None
                 if signal_type == "SELL":
-                    return asyncio.run(execute_sell_trade(ticker, company_name, logger, limit_price=limit_price))
+                    return asyncio.run(execute_sell_trade(ticker, company_name, logger, limit_price=limit_price, sell_denominator=sell_denominator))
                 else:  # BUY
                     return asyncio.run(execute_buy_trade(ticker, company_name, logger, limit_price=limit_price))
 
@@ -812,6 +867,14 @@ def main():
             profit_rate = signal.get("profit_rate", 0)
             sell_reason = signal.get("sell_reason", "")
             buy_price = signal.get("buy_price", 0)
+            # Portion of the position the source sold (pyramiding partial exit).
+            # Default 1 (full sell) keeps backward compatibility with old signals.
+            try:
+                sell_denominator = int(signal.get("sell_denominator", 1) or 1)
+            except (TypeError, ValueError):
+                sell_denominator = 1
+            if sell_denominator < 1:
+                sell_denominator = 1
 
             details = []
             if buy_price:
@@ -838,9 +901,9 @@ def main():
                     # Live trading or market hours: execute immediately
                     logger.info(f"🚀 Executing sell order: {market_label} {company_name}({ticker})")
                     if market == "US":
-                        asyncio.run(execute_us_sell_trade(ticker, company_name, logger, limit_price=float(price) if price else None))
+                        asyncio.run(execute_us_sell_trade(ticker, company_name, logger, limit_price=float(price) if price else None, sell_denominator=sell_denominator))
                     else:
-                        asyncio.run(execute_sell_trade(ticker, company_name, logger, limit_price=int(price) if price else None))
+                        asyncio.run(execute_sell_trade(ticker, company_name, logger, limit_price=int(price) if price else None, sell_denominator=sell_denominator))
             else:
                 logger.info(f"🔸 [DRY-RUN] Sell skipped: {market_label} {company_name}({ticker})")
 

--- a/messaging/gcp_pubsub_signal_publisher.py
+++ b/messaging/gcp_pubsub_signal_publisher.py
@@ -252,6 +252,7 @@ class SignalPublisher:
         sell_reason: str,
         trade_result: Optional[Dict[str, Any]] = None,
         event_id: Optional[str] = None,
+        sell_denominator: int = 1,
     ) -> Optional[str]:
         """
         Publish sell signal
@@ -264,6 +265,10 @@ class SignalPublisher:
             profit_rate: Profit rate
             sell_reason: Sell reason
             trade_result: Actual trade result
+            sell_denominator: Portion of the position this sell represents so
+                mirroring subscribers can match a partial (pyramiding) exit.
+                Subscribers sell floor(their_holding / sell_denominator);
+                1 (default) means a full-position sell (unchanged behavior).
 
         Returns:
             str: Message ID
@@ -272,6 +277,7 @@ class SignalPublisher:
             "buy_price": buy_price,
             "profit_rate": profit_rate,
             "sell_reason": sell_reason,
+            "sell_denominator": sell_denominator,
         }
 
         if trade_result:
@@ -377,11 +383,16 @@ async def publish_sell_signal(
     trade_result: Optional[Dict[str, Any]] = None,
     market: str = "KR",
     event_id: Optional[str] = None,
+    sell_denominator: int = 1,
 ) -> Optional[str]:
     """Publish sell signal via global publisher (convenience function)
 
     Args:
         market: Market identifier ("KR" for Korea, "US" for US stocks)
+        sell_denominator: Portion of the position this sell represents so
+            mirroring subscribers can match a partial (pyramiding) exit.
+            Subscribers sell floor(their_holding / sell_denominator);
+            1 (default) means a full-position sell (unchanged behavior).
     """
     publisher = await get_signal_publisher()
     # Include market in extra_data by passing through the publish_signal method
@@ -390,6 +401,7 @@ async def publish_sell_signal(
         "profit_rate": profit_rate,
         "sell_reason": sell_reason,
         "market": market,
+        "sell_denominator": sell_denominator,
     }
 
     if trade_result:

--- a/messaging/redis_signal_publisher.py
+++ b/messaging/redis_signal_publisher.py
@@ -241,6 +241,7 @@ class SignalPublisher:
         sell_reason: str,
         trade_result: Optional[Dict[str, Any]] = None,
         event_id: Optional[str] = None,
+        sell_denominator: int = 1,
     ) -> Optional[str]:
         """
         Publish sell signal
@@ -253,6 +254,10 @@ class SignalPublisher:
             profit_rate: Profit rate
             sell_reason: Sell reason
             trade_result: Actual trade result
+            sell_denominator: Portion of the position this sell represents so
+                mirroring subscribers can match a partial (pyramiding) exit.
+                Subscribers sell floor(their_holding / sell_denominator);
+                1 (default) means a full-position sell (unchanged behavior).
 
         Returns:
             str: Message ID
@@ -261,6 +266,7 @@ class SignalPublisher:
             "buy_price": buy_price,
             "profit_rate": profit_rate,
             "sell_reason": sell_reason,
+            "sell_denominator": sell_denominator,
         }
 
         if trade_result:
@@ -366,11 +372,16 @@ async def publish_sell_signal(
     trade_result: Optional[Dict[str, Any]] = None,
     market: str = "KR",
     event_id: Optional[str] = None,
+    sell_denominator: int = 1,
 ) -> Optional[str]:
     """Publish sell signal via global publisher (convenience function)
 
     Args:
         market: Market identifier ("KR" for Korea, "US" for US stocks)
+        sell_denominator: Portion of the position this sell represents so
+            mirroring subscribers can match a partial (pyramiding) exit.
+            Subscribers sell floor(their_holding / sell_denominator);
+            1 (default) means a full-position sell (unchanged behavior).
     """
     publisher = await get_signal_publisher()
     # Include market in extra_data by passing through the publish_signal method
@@ -380,6 +391,7 @@ async def publish_sell_signal(
         "profit_rate": profit_rate,
         "sell_reason": sell_reason,
         "market": market,
+        "sell_denominator": sell_denominator,
     }
 
     if trade_result:

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -2735,6 +2735,15 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     plan = decide_us_sell_plan(remaining_rows, will_queue)
                     logger.info(f"{ticker} sell plan: {plan} (remaining_rows={remaining_rows}, will_queue={will_queue})")
 
+                    # Portion of this position that this sell represents, so
+                    # mirroring subscribers replicate a partial (pyramiding) exit
+                    # instead of full-liquidating. Only a "fractional" plan sells
+                    # part of the position; full_exit / single_full sell the whole
+                    # (remaining) position → denominator 1 (unchanged behavior).
+                    # Computed from plan/remaining_rows (always in scope here);
+                    # sell_quantity is not defined on the current_price<=0 path.
+                    sell_denominator = remaining_rows if plan == "fractional" else 1
+
                     # Delete from holding_decisions when selling
                     await self._delete_holding_decision(ticker)
 
@@ -2877,7 +2886,8 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                                 profit_rate=profit_rate,
                                 sell_reason=sell_reason,
                                 trade_result=trade_result,
-                                market="US"
+                                market="US",
+                                sell_denominator=sell_denominator
                             )
                         except Exception as signal_err:
                             logger.warning(f"Sell signal publish failed (non-critical): {signal_err}")
@@ -2895,7 +2905,8 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                                 profit_rate=profit_rate,
                                 sell_reason=sell_reason,
                                 trade_result=trade_result,
-                                market="US"
+                                market="US",
+                                sell_denominator=sell_denominator
                             )
                         except Exception as signal_err:
                             logger.warning(f"GCP sell signal publish failed (non-critical): {signal_err}")

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -3193,6 +3193,13 @@ class StockTrackingAgent:
                         else:
                             logger.error(f"Actual sell failed: {trade_result['message']}")
 
+                        # Portion of this position that was actually sold, so
+                        # mirroring subscribers replicate a partial (pyramiding)
+                        # exit instead of full-liquidating. sell_quantity is only
+                        # set for fractional multi-row sells; a genuine full sell
+                        # leaves it None → denominator 1 (unchanged behavior).
+                        sell_denominator = remaining_rows if sell_quantity is not None else 1
+
                         # [Optional] Publish sell signal via Redis Streams
                         # Auto-skipped if Redis not configured (requires UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN)
                         try:
@@ -3204,7 +3211,8 @@ class StockTrackingAgent:
                                 buy_price=stock.get('buy_price', 0),
                                 profit_rate=((current_price - stock.get('buy_price', 0)) / stock.get('buy_price', 0) * 100),
                                 sell_reason=sell_reason,
-                                trade_result=trade_result
+                                trade_result=trade_result,
+                                sell_denominator=sell_denominator
                             )
                         except Exception as signal_err:
                             logger.warning(f"Sell signal publish failed (non-critical): {signal_err}")
@@ -3220,7 +3228,8 @@ class StockTrackingAgent:
                                 buy_price=stock.get('buy_price', 0),
                                 profit_rate=((current_price - stock.get('buy_price', 0)) / stock.get('buy_price', 0) * 100),
                                 sell_reason=sell_reason,
-                                trade_result=trade_result
+                                trade_result=trade_result,
+                                sell_denominator=sell_denominator
                             )
                         except Exception as signal_err:
                             logger.warning(f"GCP sell signal publish failed (non-critical): {signal_err}")

--- a/tests/test_sell_denominator_sync.py
+++ b/tests/test_sell_denominator_sync.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Regression tests: partial (pyramiding) sells must stay in sync with mirroring
+subscribers.
+
+Root cause: the main tracking agents sell a *fraction* of a multi-lot
+(pyramided) position — e.g. buy SK Hynix twice, then loss-cut only the second
+lot → the source sells floor(total / remaining_rows) and keeps the rest. The
+published sell signal, however, carried no size hint, so the example subscriber
+always called ``async_sell_stock`` with no quantity → a full liquidation of the
+subscriber's whole position.
+
+Fix (Approach A): the publishers now attach ``sell_denominator`` (default 1 =
+full sell, unchanged) to every SELL payload, and the subscriber sells
+``floor(its_holding / sell_denominator)`` — the same 1/N fraction the source
+used — so a partial exit is mirrored as a partial exit. A too-small position
+(fraction < 1 share) is kept for the source's final full sweep.
+
+Run (root suite):
+    .venv/bin/python -m pytest tests/test_sell_denominator_sync.py -q
+"""
+import importlib
+import json
+import logging
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+SUB_MOD = "examples.messaging.gcp_pubsub_subscriber_example"
+_LOG = logging.getLogger("test_sell_denominator_sync")
+
+
+# --------------------------------------------------------------------------- #
+# Publisher side: SELL payload must carry sell_denominator (default 1)
+# --------------------------------------------------------------------------- #
+def _make_gcp_publisher():
+    from messaging.gcp_pubsub_signal_publisher import SignalPublisher
+
+    pub = SignalPublisher(project_id="test-project", topic_id="test-topic")
+    mock_client = MagicMock()
+    future = MagicMock()
+    future.result = MagicMock(return_value="msg-id")
+    mock_client.publish = MagicMock(return_value=future)
+    pub._publisher = mock_client
+    pub._topic_path = "projects/test/topics/test"
+    return pub, mock_client
+
+
+def _gcp_payload(mock_client) -> dict:
+    message_bytes = mock_client.publish.call_args[0][1]
+    return json.loads(message_bytes.decode("utf-8"))
+
+
+def _make_redis_publisher():
+    from messaging.redis_signal_publisher import SignalPublisher as RedisSignalPublisher
+
+    pub = RedisSignalPublisher.__new__(RedisSignalPublisher)
+    pub.STREAM_NAME = "prism-trading-signals"
+    mock_redis = MagicMock()
+    mock_redis.xadd = MagicMock(return_value="1-0")
+    pub._redis = mock_redis
+    pub._is_connected = lambda: True
+    return pub, mock_redis
+
+
+def _redis_payload(mock_redis) -> dict:
+    fields = mock_redis.xadd.call_args[0][2]
+    return json.loads(fields["data"])
+
+
+@pytest.mark.asyncio
+async def test_gcp_sell_carries_denominator():
+    pub, mc = _make_gcp_publisher()
+    await pub.publish_sell_signal(
+        ticker="000660", company_name="SK hynix", price=170000,
+        buy_price=200000, profit_rate=-15.0, sell_reason="stop-loss",
+        sell_denominator=2,
+    )
+    assert _gcp_payload(mc)["sell_denominator"] == 2
+
+
+@pytest.mark.asyncio
+async def test_gcp_sell_denominator_defaults_to_full():
+    pub, mc = _make_gcp_publisher()
+    await pub.publish_sell_signal(
+        ticker="000660", company_name="SK hynix", price=170000,
+        buy_price=200000, profit_rate=-15.0, sell_reason="stop-loss",
+    )
+    assert _gcp_payload(mc)["sell_denominator"] == 1
+
+
+@pytest.mark.asyncio
+async def test_redis_sell_carries_denominator():
+    pub, mr = _make_redis_publisher()
+    await pub.publish_sell_signal(
+        ticker="000660", company_name="SK hynix", price=170000,
+        buy_price=200000, profit_rate=-15.0, sell_reason="stop-loss",
+        sell_denominator=3,
+    )
+    assert _redis_payload(mr)["sell_denominator"] == 3
+
+
+@pytest.mark.asyncio
+async def test_redis_sell_denominator_defaults_to_full():
+    pub, mr = _make_redis_publisher()
+    await pub.publish_sell_signal(
+        ticker="000660", company_name="SK hynix", price=170000,
+        buy_price=200000, profit_rate=-15.0, sell_reason="stop-loss",
+    )
+    assert _redis_payload(mr)["sell_denominator"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# Subscriber side: mirror the source's 1/N fraction against our own holding
+# --------------------------------------------------------------------------- #
+class _FakeTrader:
+    """Stand-in for the KIS trading client (KR context / US instance)."""
+
+    def __init__(self, holding: int):
+        self._holding = holding
+        self.sell_calls = []  # captured quantity= per async_sell_stock call
+
+    def get_current_price(self, ticker):
+        return {"current_price": 100}
+
+    def get_holding_quantity(self, ticker):
+        return self._holding
+
+    async def async_sell_stock(self, stock_code=None, ticker=None,
+                               limit_price=None, quantity=None):
+        self.sell_calls.append(quantity)
+        return {"success": True, "message": f"sold quantity={quantity}"}
+
+
+class _FakeCtx:
+    def __init__(self, trader):
+        self._trader = trader
+
+    async def __aenter__(self):
+        return self._trader
+
+    async def __aexit__(self, *a):
+        return False
+
+
+@pytest.fixture
+def sub():
+    return importlib.import_module(SUB_MOD)
+
+
+def _install_kr_stub(monkeypatch, trader):
+    # The subscriber does `from trading.domestic_stock_trading import
+    # AsyncTradingContext` inside the function; a stub module in sys.modules
+    # keeps this test free of the heavy KIS import chain.
+    if "trading" not in sys.modules:
+        pkg = types.ModuleType("trading")
+        pkg.__path__ = []
+        monkeypatch.setitem(sys.modules, "trading", pkg)
+    mod = types.ModuleType("trading.domestic_stock_trading")
+    mod.AsyncTradingContext = lambda *a, **k: _FakeCtx(trader)
+    monkeypatch.setitem(sys.modules, "trading.domestic_stock_trading", mod)
+
+
+@pytest.mark.asyncio
+async def test_kr_partial_sell_mirrors_fraction(sub, monkeypatch):
+    trader = _FakeTrader(holding=10)
+    _install_kr_stub(monkeypatch, trader)
+    res = await sub.execute_sell_trade("000660", "SK hynix", _LOG,
+                                       limit_price=170000, sell_denominator=2)
+    assert res["success"] is True
+    assert trader.sell_calls == [5]  # floor(10 / 2)
+
+
+@pytest.mark.asyncio
+async def test_kr_full_sell_when_denominator_one(sub, monkeypatch):
+    trader = _FakeTrader(holding=10)
+    _install_kr_stub(monkeypatch, trader)
+    await sub.execute_sell_trade("000660", "SK hynix", _LOG,
+                                 limit_price=170000, sell_denominator=1)
+    assert trader.sell_calls == [None]  # None => sell whole position
+
+
+@pytest.mark.asyncio
+async def test_kr_partial_skips_when_fraction_below_one_share(sub, monkeypatch):
+    trader = _FakeTrader(holding=1)
+    _install_kr_stub(monkeypatch, trader)
+    res = await sub.execute_sell_trade("000660", "SK hynix", _LOG,
+                                       limit_price=170000, sell_denominator=2)
+    assert res["success"] is True          # not a failure
+    assert trader.sell_calls == []         # no order placed; kept for final sweep
+
+
+@pytest.mark.asyncio
+async def test_us_partial_sell_mirrors_fraction(sub, monkeypatch):
+    trader = _FakeTrader(holding=9)
+    monkeypatch.setattr(sub, "load_us_stock_trading_class", lambda: (lambda: trader))
+    res = await sub.execute_us_sell_trade("NVDA", "NVIDIA", _LOG,
+                                          limit_price=120.0, sell_denominator=3)
+    assert res["success"] is True
+    assert trader.sell_calls == [3]  # floor(9 / 3)
+
+
+@pytest.mark.asyncio
+async def test_us_full_sell_when_denominator_one(sub, monkeypatch):
+    trader = _FakeTrader(holding=9)
+    monkeypatch.setattr(sub, "load_us_stock_trading_class", lambda: (lambda: trader))
+    await sub.execute_us_sell_trade("NVDA", "NVIDIA", _LOG,
+                                    limit_price=120.0, sell_denominator=1)
+    assert trader.sell_calls == [None]


### PR DESCRIPTION
## 문제
본로직(KR/US 트래킹 에이전트)은 피라미딩(#288)으로 한 티커에 여러 lot이 있을 때 **부분매도**한다 — 예: SK하이닉스를 두 번 매수 → 어제 산 lot만 손절 시 `floor(total / remaining_rows)`만 팔고 나머지는 보유. 그런데 발행되는 SELL 시그널에는 수량 힌트가 전혀 없어, 예제 subscriber가 `async_sell_stock()`을 수량 없이 호출 → **전량청산**. 소스의 부분매도가 하위에서 전량매도로 변질됐다.

## 해결 (Approach A — 가산적, 하위호환)
- **발행부**(redis + gcp, 클래스 메서드 + 모듈 함수): 모든 SELL payload에 `sell_denominator`(기본 1 = 전량, 기존 동작) 추가.
- **KR 호출부**: `sell_quantity is not None`(실제 부분매도)이면 `remaining_rows`, 아니면 1.
- **US 호출부**: `plan == "fractional"`이면 `remaining_rows`, 아니면 1(full_exit/single_full은 전량). publish 시점에 항상 스코프에 있는 `plan`/`remaining_rows`로 계산(현재가<=0 경로에서 `sell_quantity` 미정의 문제 회피).
- **subscriber**: `floor(보유 / sell_denominator)` 매도 — 소스와 동일한 1/N 비율. denominator 1이면 `quantity=None`(전량). 비율이 1주 미만으로 떨어지면 매도하지 않고 소스의 마지막 전량 스윕(denominator 1)까지 보유. 즉시 경로 + demo 장외 예약 경로 모두 반영.

hardstop/trend loop 매도(`sell_broadcast.publish_loop_sell`)는 인자 미전달 → 기본 1 → 전량(의도된 동작).

## 테스트
`tests/test_sell_denominator_sync.py` 신규 9개 — 양 transport payload 전파 + 기본값, subscriber KR/US 부분/전량/스킵 동작. 신규 9 passed, #288 피라미딩 + 발행/마켓전파 스위트 그린(64 passed, 16 skipped). 변경 5파일 compile OK.

## 실주문 영향
서버측(발행) 주문 실행 동작은 불변 — payload에 필드 1개만 추가. 실질 동작 변화는 로컬 미러링 subscriber에 국한. gate와 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)