### PR TITLE
feat(btc): Round6 Lane B swing lane (4h cross + 1d filter, virtual ledger)

### DIFF
--- a/prism-btc/analysis/round6_swing_lane.py
+++ b/prism-btc/analysis/round6_swing_lane.py
@@ -1,0 +1,191 @@
+# analysis/round6_swing_lane.py — 라운드6: 스윙 레인 후보 백테스트
+#
+# 배경 (2026-07-21, Rocky): "너무 보수적이다. 횡보에선 스윙도 먹고, 7월 같은
+# 추세 초입에서도 먹을 수 있는 전략을 테스트해라."
+# 현행 시스템(|score|>=70 & ts_4h>=2.0)은 성숙 추세 전용 — 횡보 스윙과
+# 추세 초입은 구조적으로 미커버. 별도 소형 레인 3후보를 고정 파라미터로 검증.
+#
+#   Lane A: 횡보 평균회귀 (ts_4h<2 & ts_1d<2 에서 z=±1.5 진입, MA35 회귀 청산)
+#   Lane B: 추세 초입 (4h MA10/35 크로스 + 완결 1d봉 방향 일치, MA35 이탈 청산)
+#   Lane C: 돈치안 20/10 벤치마크
+#
+# 원칙: 파라미터 스윕 금지(각 레인 1세트 고정), 수수료+슬리피지 왕복 0.15%,
+# 신호=확정봉 / 체결=다음 봉 시가, 스탑은 봉내 촉발 시 스탑가 체결.
+# 기간 분리: 2020-21 / 2022-23 / 2024-26.
+#
+# 결과 (2020-03~2026-07, tasks/btc_round6_swing_lane.md):
+#   A: n=671, cum -88% — 전 기간 손실. 기각.
+#   B: n=186, cum +293%, maxDD -35%, 3기간 모두 양수. 채택 후보.
+#   C: n=363, cum +76%, 2024-26 음수. 기각 (B 열위).
+#
+# 실행 (prism-btc 패키지 루트에서):
+#   python -m analysis.round6_swing_lane [--db state/btc_market.db]
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import numpy as np
+import pandas as pd
+
+from engine.indicators import add_indicators
+
+COST = 0.0015  # 왕복 수수료+슬리피지 (Bybit taker 0.055%x2 + slippage)
+
+
+def load(conn: sqlite3.Connection, tf: str) -> pd.DataFrame:
+    df = pd.read_sql_query(
+        "SELECT open_time, open, high, low, close, volume, turnover FROM klines "
+        "WHERE timeframe=? AND confirmed=1 ORDER BY open_time ASC",
+        conn, params=(tf,))
+    df = add_indicators(df)
+    # 환경 가드 (라운드5와 동일): pandas rolling 버그 조기 실패
+    if len(df) >= 35 and df["ma10"].isna().all():
+        raise RuntimeError(
+            f"indicator computation broken in this environment ({tf}) — "
+            f"pandas rolling bug. Run on .venv-bt / db-server.")
+    df["dt"] = pd.to_datetime(df["open_time"], unit="ms", utc=True)
+    return df.dropna(subset=["ma10", "ma35", "atr14"]).reset_index(drop=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db", default="state/btc_market.db")
+    parser.add_argument("--csv-dir", default=None, help="트레이드 CSV 저장 경로")
+    args = parser.parse_args()
+
+    conn = sqlite3.connect(args.db)
+    d4 = load(conn, "4h")
+    d1 = load(conn, "1d")
+    conn.close()
+
+    d4["ts4"] = (d4["ma10"] - d4["ma35"]).abs() / d4["atr14"]
+    d4["z"] = (d4["close"] - d4["ma35"]) / d4["atr14"]
+    d4["cross_up"] = (d4["ma10"] > d4["ma35"]) & (d4["ma10"].shift(1) <= d4["ma35"].shift(1))
+    d4["cross_dn"] = (d4["ma10"] < d4["ma35"]) & (d4["ma10"].shift(1) >= d4["ma35"].shift(1))
+    d4["hh20"] = d4["high"].rolling(20).max().shift(1)
+    d4["ll20"] = d4["low"].rolling(20).min().shift(1)
+    d4["hh10"] = d4["high"].rolling(10).max().shift(1)
+    d4["ll10"] = d4["low"].rolling(10).min().shift(1)
+
+    # 각 4h 확정봉 시점의 "완결된" 1d 봉 매핑 (미래정보 차단)
+    d1_close_time = d1["open_time"].values + 86_400_000
+    d4["t_close"] = d4["open_time"] + 4 * 3_600_000
+    i1 = np.searchsorted(d1_close_time, d4["t_close"].values, side="right") - 1
+    d1_up = (d1["ma10"] > d1["ma35"]).values
+    d1_ts = ((d1["ma10"] - d1["ma35"]).abs() / d1["atr14"]).values
+
+    o = d4["open"].values; h = d4["high"].values; l = d4["low"].values; c = d4["close"].values
+    atr = d4["atr14"].values; ma35 = d4["ma35"].values
+    ts4 = d4["ts4"].values; z = d4["z"].values
+    xup = d4["cross_up"].values; xdn = d4["cross_dn"].values
+    hh20 = d4["hh20"].values; ll20 = d4["ll20"].values
+    hh10 = d4["hh10"].values; ll10 = d4["ll10"].values
+    dts = d4["dt"].values
+    n = len(d4)
+
+    def run_lane(entry_fn, exit_fn, stop_mult, label, time_stop=None):
+        trades = []
+        pos = 0
+        ep = st = 0.0
+        ei = -1
+        for i in range(40, n - 1):
+            if pos == 0:
+                sig = entry_fn(i)
+                if sig != 0:
+                    pos = sig
+                    ep = o[i + 1]
+                    st = ep - sig * stop_mult * atr[i]
+                    ei = i + 1
+            else:
+                j = i
+                if j >= ei:
+                    if pos == 1 and l[j] <= st:
+                        trades.append((ei, j, pos, ep, st)); pos = 0; continue
+                    if pos == -1 and h[j] >= st:
+                        trades.append((ei, j, pos, ep, st)); pos = 0; continue
+                    if exit_fn(j, pos) or (time_stop and j - ei >= time_stop):
+                        if j + 1 < n:
+                            trades.append((ei, j + 1, pos, ep, o[j + 1])); pos = 0
+        rows = []
+        for (a, b, p, e, x) in trades:
+            rows.append({"lane": label, "entry_dt": dts[a], "exit_dt": dts[b],
+                         "side": "L" if p == 1 else "S", "entry": e, "exit": x,
+                         "ret": p * (x - e) / e - COST, "bars": b - a})
+        return pd.DataFrame(rows)
+
+    # Lane A: 횡보 평균회귀
+    def entryA(i):
+        k = i1[i]
+        if k < 35 or ts4[i] >= 2.0 or d1_ts[k] >= 2.0:
+            return 0
+        if z[i] <= -1.5:
+            return 1
+        if z[i] >= 1.5:
+            return -1
+        return 0
+
+    def exitA(j, pos):
+        return (pos == 1 and c[j] >= ma35[j]) or (pos == -1 and c[j] <= ma35[j])
+
+    # Lane B: 추세 초입
+    def entryB(i):
+        k = i1[i]
+        if k < 35:
+            return 0
+        if xup[i] and d1_up[k] and c[i] > ma35[i]:
+            return 1
+        if xdn[i] and (not d1_up[k]) and c[i] < ma35[i]:
+            return -1
+        return 0
+
+    def exitB(j, pos):
+        return (pos == 1 and c[j] < ma35[j]) or (pos == -1 and c[j] > ma35[j])
+
+    # Lane C: 돈치안 20/10
+    def entryC(i):
+        if c[i] > hh20[i]:
+            return 1
+        if c[i] < ll20[i]:
+            return -1
+        return 0
+
+    def exitC(j, pos):
+        return (pos == 1 and c[j] < ll10[j]) or (pos == -1 and c[j] > hh10[j])
+
+    lanes = [
+        (run_lane(entryA, exitA, 1.5, "A_chop_swing", time_stop=30), "Lane A 횡보스윙"),
+        (run_lane(entryB, exitB, 2.0, "B_early_trend"), "Lane B 추세초입"),
+        (run_lane(entryC, exitC, 2.0, "C_donchian"), "Lane C 돈치안"),
+    ]
+
+    def stats(t, label):
+        if len(t) == 0:
+            print(f"{label:20s} n=0")
+            return
+        r = t["ret"]
+        eq = (1 + r).cumprod()
+        dd = (eq / eq.cummax() - 1).min()
+        yrs = (t["exit_dt"].iloc[-1] - t["entry_dt"].iloc[0]).days / 365.25
+        print(f"{label:20s} n={len(t):4d}  win={100 * (r > 0).mean():4.1f}%  "
+              f"avg={100 * r.mean():+5.2f}%  sum={100 * r.sum():+7.1f}%  "
+              f"cum={100 * (eq.iloc[-1] - 1):+8.1f}%  maxDD={100 * dd:5.1f}%  "
+              f"trades/yr={len(t) / max(yrs, 0.1):.0f}")
+
+    for t, lab in lanes:
+        print(f"\n[{lab}]")
+        stats(t, "전체")
+        for lo, hi in [("2020", "2022"), ("2022", "2024"), ("2024", "2027")]:
+            stats(t[(t["entry_dt"] >= lo) & (t["entry_dt"] < hi)], f"  {lo}~")
+        for side in ["L", "S"]:
+            stats(t[t["side"] == side], f"  side={side}")
+        if args.csv_dir:
+            t.to_csv(Path(args.csv_dir) / f"round6_{t['lane'].iloc[0]}.csv", index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/prism-btc/core/swing.py
+++ b/prism-btc/core/swing.py
@@ -1,0 +1,105 @@
+# core/swing.py — 라운드6 Lane B: 추세 초입 스윙 레인의 순수 결정 로직
+#
+# 검증: analysis/round6_swing_lane.py (2020-03~2026-07 n=186, cum +293%,
+# maxDD -35%, 3분리기간 모두 양수) + tasks/btc_round6_swing_lane.md.
+# TF 전수검증(§4b/4c): 12h/1w 추가는 초입 상실, 30m/1h 추가는 무개선/유해,
+# 메인 6-TF 다이어트(M2)는 한계 코호트 무엣지 — 4h 트리거 + 1d 필터로 고정.
+#
+# 순수함수 원칙 (core/entries.py 와 동일): pandas/DB/네트워크 금지, 스칼라
+# 입출력만. 어댑터(live/swing.py)가 DataFrame 을 소유하고 스칼라를 잘라 넣는다.
+# 룰 정의는 백테스트 스크립트의 entryB/exitB 와 문자 그대로 동일해야 한다
+# (라이브=백테스트 패리티 — tests/test_swing.py 가 고정).
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+from engine.config import (
+    SWING_MAX_LEVERAGE,
+    SWING_RISK_PER_TRADE,
+    SWING_STOP_ATR_MULT,
+)
+
+Side = Literal["long", "short"]
+
+
+def detect_cross(ma10_prev: float, ma35_prev: float,
+                 ma10: float, ma35: float) -> int:
+    """4h MA10/MA35 크로스 감지: +1 골든, -1 데드, 0 없음.
+
+    백테스트 정의 미러: cross_up = (ma10>ma35) & (ma10_prev<=ma35_prev).
+    """
+    if ma10 > ma35 and ma10_prev <= ma35_prev:
+        return 1
+    if ma10 < ma35 and ma10_prev >= ma35_prev:
+        return -1
+    return 0
+
+
+def entry_side(cross: int, d1_ma10: float, d1_ma35: float,
+               close: float, ma35_4h: float) -> Optional[Side]:
+    """진입 방향: 크로스 + 완결 1d 봉 방향 일치 + 4h 종가 MA35 순방향.
+
+    백테스트 entryB 미러 — 숏의 1d 조건은 not(ma10>ma35), 즉 ma10<=ma35.
+    """
+    if cross > 0 and d1_ma10 > d1_ma35 and close > ma35_4h:
+        return "long"
+    if cross < 0 and d1_ma10 <= d1_ma35 and close < ma35_4h:
+        return "short"
+    return None
+
+
+def stop_price(side: Side, entry: float, atr_4h: float) -> float:
+    """하드스탑 = 진입가 ∓ SWING_STOP_ATR_MULT × ATR14(4h)."""
+    if side == "long":
+        return entry - SWING_STOP_ATR_MULT * atr_4h
+    return entry + SWING_STOP_ATR_MULT * atr_4h
+
+
+def rule_exit_due(side: Side, close_4h: float, ma35_4h: float) -> bool:
+    """룰 청산: 4h 확정 종가가 MA35 를 역방향 이탈 (백테스트 exitB 미러)."""
+    if side == "long":
+        return close_4h < ma35_4h
+    return close_4h > ma35_4h
+
+
+def conflicts_with_main(swing_side: Side, main_sides: list[str]) -> bool:
+    """메인 레인 보유 포지션과 방향 충돌이면 True (스윙 진입 금지).
+
+    같은 방향 보유는 허용 — 두 레인의 논리적 노출 합산은 사이징 캡이 제한한다.
+    """
+    return any(s != swing_side for s in main_sides)
+
+
+@dataclass(frozen=True)
+class SwingSizing:
+    qty: float
+    leverage: float
+    risk_amount: float
+    rejected: bool
+    reject_reason: str = ""
+
+
+def compute_swing_sizing(equity: float, entry: float, stop: float) -> SwingSizing:
+    """리스크 기반 사이징.
+
+    qty = (equity × SWING_RISK_PER_TRADE) / |entry − stop|.
+    명목/equity 가 SWING_MAX_LEVERAGE 를 넘으면 수량을 캡한다 (이때 실제
+    리스크는 1% 미만으로 줄어든다 — 스탑 가격은 불변).
+    """
+    if equity <= 0 or entry <= 0:
+        return SwingSizing(0.0, 0.0, 0.0, True, "invalid equity/entry")
+    sl_dist = abs(entry - stop)
+    if sl_dist <= 0:
+        return SwingSizing(0.0, 0.0, 0.0, True, "zero stop distance")
+    risk_amount = equity * SWING_RISK_PER_TRADE
+    qty = risk_amount / sl_dist
+    leverage = qty * entry / equity
+    if leverage > SWING_MAX_LEVERAGE:
+        qty = equity * SWING_MAX_LEVERAGE / entry
+        leverage = SWING_MAX_LEVERAGE
+        risk_amount = qty * sl_dist
+    if qty <= 0:
+        return SwingSizing(0.0, 0.0, 0.0, True, "qty<=0")
+    return SwingSizing(qty=qty, leverage=leverage,
+                       risk_amount=risk_amount, rejected=False)

--- a/prism-btc/engine/config.py
+++ b/prism-btc/engine/config.py
@@ -87,3 +87,17 @@ BACKFILL_START_MS: int = 1577836800000  # 2020-01-01 00:00:00 UTC
 # SQLite path (relative to prism-btc/ package root)
 # 비트코인 시세 원본 DB (거래/일지 장부인 루트 stock_tracking_db.sqlite 와 구분).
 DB_RELATIVE_PATH: str = "state/btc_market.db"
+
+# --- 라운드6: Lane B 스윙 레인 (추세 초입, 자체 원장 가상 집행) ---
+# 검증: analysis/round6_swing_lane.py + tasks/btc_round6_swing_lane.md.
+# 2020-03~2026-07 백테스트 n=186, cum +293%, maxDD -35%, 3분리기간 모두 양수.
+# TF 전수검증(라운드6 §4b/4c): 12h/1w 추가는 추세 초입 상실(+95→+61/+20%),
+# 30m/1h 방향필터는 무개선, 30m/1h 캔들위치(메인식)는 유해(+293→+111%, 5월말
+# 숏 상실) — 4h 크로스 트리거 + 완결 1d 방향 필터로 고정. 파라미터 스윕 없음.
+# 메인 레인(ENTRY_SCORE_MIN/TS_MIN)은 동결 유지 — 두 레인은 역할 분담:
+# 메인 = 성숙 추세를 크게, 스윙 = 초입/전환을 작게.
+SWING_ENABLED: bool = True
+SWING_STOP_ATR_MULT: float = 2.0      # 하드스탑 = 진입가 ∓ 2.0 × ATR14(4h)
+SWING_RISK_PER_TRADE: float = 0.01    # equity 의 1% (메인 RISK_PER_TRADE 2% 의 절반)
+SWING_MAX_LEVERAGE: float = 5.0       # 명목/equity 상한 (Rocky 승인 스펙)
+SWING_INITIAL_EQUITY: float = 10_000.0  # 자체 가상 원장 시드 (shadow 와 동일)

--- a/prism-btc/live/runner.py
+++ b/prism-btc/live/runner.py
@@ -157,6 +157,18 @@ def tick(mode: str = "shadow", market_db_path=None, root_db_path=None) -> dict:
 
     result["new_bars"] = processed
 
+    # --- 2b. 스윙 레인 (라운드6 Lane B — mode='swing' 자체 원장, 가상 집행) ---
+    # 메인 결정로직/상태와 완전 독립 (자체 메타 커서). 어떤 예외도 메인
+    # 트레이딩을 멈출 수 없다. 검증: tasks/btc_round6_swing_lane.md.
+    try:
+        from live import swing as swing_lane
+        sres = swing_lane.process(root_conn, tf_data, main_mode=mode)
+        if sres.get("events"):
+            result["swing"] = sres
+    except Exception as exc:  # noqa: BLE001 — 스윙 레인 실패는 메인과 무관
+        tracking.log_event(root_conn, "error", f"swing lane: {exc}",
+                           level="error", mode="swing")
+
     # --- 3. 매매일지/부검 (학습 기어 — 트레이딩 처리 완료 후에만, 실패 절대 비전파) ---
     # LLM 은 주문 경로 밖: 종결 트레이드의 facts 추출 + 부검만 수행한다.
     # 어떤 예외도 데몬을 멈출 수 없다 (이벤트 로그로 흡수, 다음 틱 재시도).

--- a/prism-btc/live/swing.py
+++ b/prism-btc/live/swing.py
@@ -1,0 +1,288 @@
+# live/swing.py — 라운드6 Lane B 스윙 레인 가상 집행기 (mode='swing' 자체 원장)
+#
+# 왜 v1 은 가상 집행인가: 거래소 원웨이 모드에서 메인 레인과 같은 심볼의
+# 포지션이 넷팅되어 DemoAdapter 의 reconcile 불변식(거래소 포지션 == 메인
+# 포지션)이 깨진다. v1 은 스윙 레인을 tracking 의 mode='swing' 원장으로
+# 가상 체결하고 진입/청산을 텔레그램으로 즉시 알린다. 거래소 실집행
+# (헤지모드 분리)은 별도 라운드에서.
+#
+# 집행 의미론 (analysis/round6_swing_lane.py 백테스트 미러):
+#   - 신호: 4h 확정봉 (30m 틱마다 _get_tf_slice 로 감지 — 메인과 동일 케이던스)
+#   - 진입/룰청산 체결: 감지 시점 30m 봉 종가 (≈ 백테스트의 다음 4h 시가),
+#     비용 TAKER_FEE. 하드스탑: 30m 봉 low/high 봉내 감시, 체결 = 스탑가,
+#     비용 TAKER_FEE + SLIPPAGE_SL. (백테스트는 4h 봉내 스탑 — 30m 감시가
+#     더 정밀하며 보수적 방향의 차이만 있다.)
+#   - 포지션 최대 1개, 피라미딩/부분청산/펀딩 없음 (백테스트와 동일 스코프).
+#   - 메인 레인과 방향 충돌 시 진입 금지 (core.swing.conflicts_with_main).
+#
+# 안전 원칙: process() 는 어떤 예외도 밖으로 던지지 않도록 호출측(runner)이
+# 감싼다. 여기서도 알림/신호로그 실패는 개별 흡수한다 (매매 결정 비영향).
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import pandas as pd
+
+from backtest.engine import SLIPPAGE_SL, TAKER_FEE, _get_tf_slice
+from core.swing import (
+    compute_swing_sizing,
+    conflicts_with_main,
+    detect_cross,
+    entry_side,
+    rule_exit_due,
+    stop_price,
+)
+from engine.config import SWING_ENABLED, SWING_INITIAL_EQUITY
+from live import tracking
+from live.shadow import bar_index_for
+
+log = logging.getLogger("live.swing")
+
+MODE = "swing"  # tracking 원장 키 — 메인 mode(shadow/demo/live)와 완전 분리
+
+
+# ---------------------------------------------------------------------------
+# 텔레그램 알림 — notifier 와 동일한 재사용 패턴, [스윙레인] 태그로 구분.
+# ---------------------------------------------------------------------------
+
+def _notify(main_mode: str, msg: str) -> None:
+    """메인이 demo/live 로 돌 때만 발송 (shadow 로컬 테스트 스팸 방지). 실패 흡수."""
+    if main_mode not in ("demo", "live"):
+        return
+    try:
+        import asyncio
+        import os
+
+        from live.telegram_reporter import _load_env, _resolve_channel, _send
+        _load_env()
+        token = os.environ.get("TELEGRAM_BOT_TOKEN")
+        asyncio.run(_send(token, _resolve_channel(None), msg))
+    except Exception as exc:  # noqa: BLE001 — 알림 실패는 매매와 무관
+        log.warning("swing notify 실패 (흡수): %s", exc)
+
+
+def _side_kr(side: str) -> str:
+    return "롱 (상승 베팅)" if side == "long" else "숏 (하락 베팅)"
+
+
+def _log_signal_safe(conn, ts: str, side: str, reason: str, n_open: int) -> None:
+    try:
+        tracking.log_signal(conn, ts, score=None, ts_4h=None, ts_1d=None,
+                            side=side, reason=reason, n_open=n_open, mode=MODE)
+    except Exception as exc:  # noqa: BLE001 — 관측 실패는 매매와 무관
+        log.warning("swing log_signal 실패 (흡수): %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# 체결 — 가상 원장 (btc_positions / btc_trading_history / btc_equity_curve)
+# ---------------------------------------------------------------------------
+
+def _close_position(conn, pos: tracking.PositionRow, exit_price: float,
+                    fee_rate: float, reason: str, bar_time_str: str,
+                    equity: float, trade_counter: int,
+                    main_mode: str) -> tuple[float, int]:
+    """가상 청산: PnL 정산 → 트레이드 기록 → 포지션 제거 → equity 갱신 → 알림."""
+    sign = 1.0 if pos.side == "long" else -1.0
+    gross = sign * pos.qty * (exit_price - pos.entry_price)
+    exit_fee = pos.qty * exit_price * fee_rate
+    net = gross - pos.entry_fee - exit_fee
+    risk = pos.initial_risk if pos.initial_risk > 0 else 1.0
+    trade_counter += 1
+    tracking.record_trade(conn, tracking.TradeRow(
+        trade_id=trade_counter,
+        side=pos.side,
+        entry_time=pos.entry_time,
+        entry_price=pos.entry_price,
+        exit_time=bar_time_str,
+        exit_price=exit_price,
+        qty=pos.qty,
+        leverage=pos.leverage,
+        sl_price=pos.sl_price,
+        exit_reason=reason,
+        r_multiple=net / risk,
+        fee_paid=pos.entry_fee + exit_fee,
+        funding_paid=0.0,
+        tranche_index=0,
+        liq_price=0.0,
+        net_pnl=net,
+        gross_pnl=gross,
+        gross_r_multiple=gross / risk,
+        num_legs=1,
+        mode=MODE,
+    ))
+    if pos.id is not None:
+        tracking.remove_position(conn, pos.id)
+    equity += net
+    tracking.record_equity(conn, equity, MODE, bar_time_str)
+    tracking.log_event(conn, "trade",
+                       f"swing close {pos.side} @ {exit_price:.1f} ({reason}) "
+                       f"net={net:+.2f} eq={equity:.2f}", mode=MODE)
+    r = net / risk
+    outcome = f"✅ 이익 {r:+.1f}배" if r > 0 else f"❌ 손실 {r:+.1f}배"
+    why = "손절" if reason == "swing_sl" else "추세이탈 청산"
+    _notify(main_mode,
+            f"🌀 [스윙레인] 포지션 정리 — {outcome} ({why})\n"
+            f"_가상자금 모의투자입니다_")
+    return equity, trade_counter
+
+
+def _try_entry(conn, bar, bar_time_str: str, s4: pd.DataFrame,
+               s1: pd.DataFrame, equity: float,
+               main_mode: str) -> Optional[tracking.PositionRow]:
+    """4h 확정봉에서 진입 평가. 성공 시 저장된 PositionRow, 아니면 None."""
+    if len(s4) < 36 or s1.empty:
+        return None
+    cur = s4.iloc[-1]
+    prev = s4.iloc[-2]
+    d1 = s1.iloc[-1]
+    needed = [cur.get("ma10"), cur.get("ma35"), cur.get("atr14"),
+              prev.get("ma10"), prev.get("ma35"), d1.get("ma10"), d1.get("ma35")]
+    if any(v is None or pd.isna(v) for v in needed):
+        return None
+
+    cross = detect_cross(float(prev["ma10"]), float(prev["ma35"]),
+                         float(cur["ma10"]), float(cur["ma35"]))
+    if cross == 0:
+        return None
+
+    side = entry_side(cross, float(d1["ma10"]), float(d1["ma35"]),
+                      float(cur["close"]), float(cur["ma35"]))
+    if side is None:
+        _log_signal_safe(conn, bar_time_str, "none",
+                         f"swing cross={cross:+d} 기각: 1d 불일치 또는 MA35 역방향", 0)
+        return None
+
+    # 메인 레인과 방향 충돌 금지 (같은 runner 프로세스의 메인 mode 포지션 조회).
+    try:
+        main_sides = [p.side for p in tracking.load_open_positions(conn, main_mode)]
+    except Exception:  # noqa: BLE001 — 조회 실패 시 보수적으로 진입 보류
+        main_sides = ["__unknown__"]
+    if conflicts_with_main(side, main_sides):
+        _log_signal_safe(conn, bar_time_str, side,
+                         f"swing 기각: 메인 레인 방향 충돌 (main={main_sides})", 1)
+        return None
+
+    entry_price = float(bar["close"])
+    sl = stop_price(side, entry_price, float(cur["atr14"]))
+    sz = compute_swing_sizing(equity, entry_price, sl)
+    if sz.rejected:
+        _log_signal_safe(conn, bar_time_str, side,
+                         f"swing 기각: sizing ({sz.reject_reason})", 0)
+        return None
+
+    entry_fee = sz.qty * entry_price * TAKER_FEE
+    pos = tracking.PositionRow(
+        side=side,
+        entry_price=entry_price,
+        qty=sz.qty,
+        leverage=sz.leverage,
+        sl_price=sl,
+        tp1_price=0.0, tp2_price=0.0, tp3_price=0.0,
+        liq_price=0.0,
+        entry_time=bar_time_str,
+        tranche_index=0,
+        entry_bar_idx=bar_index_for(int(pd.Timestamp(bar_time_str).value) // 1_000_000),
+        initial_risk=sz.risk_amount,
+        entry_fee=entry_fee,
+        initial_qty=sz.qty,
+        mode=MODE,
+    )
+    tracking.save_position(conn, pos)
+    tracking.log_event(conn, "trade",
+                       f"swing open {side} @ {entry_price:.1f} qty={sz.qty:.4f} "
+                       f"sl={sl:.1f} lev={sz.leverage:.2f}", mode=MODE)
+    _log_signal_safe(conn, bar_time_str, side, "swing_entry", 1)
+    _notify(main_mode,
+            f"🌀 [스윙레인] 새 진입 — {_side_kr(side)}\n"
+            f"진입가 {entry_price:,.0f}달러 · 손절 {sl:,.0f}달러 · "
+            f"{sz.leverage:.1f}배율\n_가상자금 모의투자입니다_")
+    return pos
+
+
+# ---------------------------------------------------------------------------
+# 핵심 진입점 — runner.tick 이 30m 틱마다 호출.
+# ---------------------------------------------------------------------------
+
+def process(root_conn, tf_data: dict, main_mode: str = "shadow") -> dict:
+    """새 확정 30m 봉들을 스윙 레인 관점에서 처리. {"events": n} 반환.
+
+    자체 메타 커서(mode='swing' 의 last_processed_30m_ns / last_confirmed_4h_ns)
+    를 쓰므로 메인 레인 상태와 완전 독립이며 재실행에 멱등이다.
+    콜드 스타트(커서 없음)는 마지막 확정봉 1개만 처리한다 (과거 재시뮬 방지).
+    """
+    result = {"events": 0}
+    if not SWING_ENABLED:
+        return result
+    bars_30m = tf_data.get("30m")
+    if bars_30m is None or bars_30m.empty:
+        return result
+    conn = root_conn
+
+    equity = tracking.latest_equity(conn, MODE)
+    if equity is None:
+        equity = SWING_INITIAL_EQUITY
+        tracking.record_equity(conn, equity, MODE)
+        tracking.log_event(conn, "info",
+                           f"swing lane ledger seeded: {equity:.0f}", mode=MODE)
+
+    last_ns = tracking.get_meta(conn, "last_processed_30m_ns", MODE)
+    if last_ns is None:
+        new_bars = bars_30m.iloc[[-1]]
+    else:
+        new_bars = bars_30m[bars_30m.index.map(
+            lambda t: int(t.value) > int(last_ns))]
+    if new_bars.empty:
+        return result
+
+    last_4h_ns = tracking.get_meta(conn, "last_confirmed_4h_ns", MODE)
+    trade_counter = int(tracking.get_meta(conn, "trade_id_counter", MODE) or 0)
+    positions = tracking.load_open_positions(conn, MODE)
+    pos = positions[0] if positions else None
+
+    for bar_time, bar in new_bars.iterrows():
+        bar_time_str = str(bar_time)
+
+        # --- 1. 하드스탑 봉내 감시 (매 30m — 백테스트보다 정밀) ---
+        if pos is not None:
+            hit = (pos.side == "long" and float(bar["low"]) <= pos.sl_price) or \
+                  (pos.side == "short" and float(bar["high"]) >= pos.sl_price)
+            if hit:
+                equity, trade_counter = _close_position(
+                    conn, pos, pos.sl_price, TAKER_FEE + SLIPPAGE_SL,
+                    "swing_sl", bar_time_str, equity, trade_counter, main_mode)
+                pos = None
+                result["events"] += 1
+
+        # --- 2. 새 4h 확정 감지 → 룰 청산(보유 시) / 진입 평가(무포지션 시) ---
+        # 백테스트 run_lane 미러: 같은 4h 에서 청산과 진입을 겸하지 않는다.
+        s4 = _get_tf_slice(tf_data, bar_time, "4h")
+        if s4.empty:
+            continue
+        cur_4h_ns = int(s4.index[-1].value)
+        if last_4h_ns is not None and cur_4h_ns == int(last_4h_ns):
+            continue
+        last_4h_ns = cur_4h_ns
+
+        if pos is not None:
+            row = s4.iloc[-1]
+            if not pd.isna(row.get("ma35")) and rule_exit_due(
+                    pos.side, float(row["close"]), float(row["ma35"])):
+                equity, trade_counter = _close_position(
+                    conn, pos, float(bar["close"]), TAKER_FEE,
+                    "swing_ma35_exit", bar_time_str, equity, trade_counter,
+                    main_mode)
+                pos = None
+                result["events"] += 1
+        else:
+            s1 = _get_tf_slice(tf_data, bar_time, "1d")
+            pos = _try_entry(conn, bar, bar_time_str, s4, s1, equity, main_mode)
+            if pos is not None:
+                result["events"] += 1
+
+    tracking.set_meta(conn, "last_processed_30m_ns",
+                      int(new_bars.index[-1].value), MODE)
+    if last_4h_ns is not None:
+        tracking.set_meta(conn, "last_confirmed_4h_ns", int(last_4h_ns), MODE)
+    tracking.set_meta(conn, "trade_id_counter", trade_counter, MODE)
+    return result

--- a/prism-btc/tests/test_swing.py
+++ b/prism-btc/tests/test_swing.py
@@ -1,0 +1,265 @@
+# tests/test_swing.py — 라운드6 Lane B 스윙 레인 (core/swing + live/swing)
+#
+# 오프라인 전용 (네트워크/실DB 불필요): 순수함수 단위 테스트 + 인메모리
+# sqlite/합성 tf_data 로 진입→손절 전체 사이클 검증.
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.swing import (  # noqa: E402
+    SwingSizing,
+    compute_swing_sizing,
+    conflicts_with_main,
+    detect_cross,
+    entry_side,
+    rule_exit_due,
+    stop_price,
+)
+from engine.config import (  # noqa: E402
+    SWING_INITIAL_EQUITY,
+    SWING_MAX_LEVERAGE,
+    SWING_RISK_PER_TRADE,
+    SWING_STOP_ATR_MULT,
+)
+
+
+# ---------------------------------------------------------------------------
+# core/swing — 순수함수 (백테스트 entryB/exitB 정의 고정)
+# ---------------------------------------------------------------------------
+
+class TestDetectCross:
+    def test_golden_cross(self):
+        assert detect_cross(99.0, 100.0, 101.0, 100.0) == 1
+
+    def test_dead_cross(self):
+        assert detect_cross(101.0, 100.0, 99.0, 100.0) == -1
+
+    def test_no_cross_above(self):
+        assert detect_cross(101.0, 100.0, 102.0, 100.0) == 0
+
+    def test_no_cross_below(self):
+        assert detect_cross(99.0, 100.0, 98.0, 100.0) == 0
+
+    def test_touch_then_cross_up(self):
+        # 이전 봉 ma10 == ma35 (경계) 후 상향 — 백테스트 정의상 크로스다.
+        assert detect_cross(100.0, 100.0, 101.0, 100.0) == 1
+
+
+class TestEntrySide:
+    def test_long(self):
+        assert entry_side(1, 105.0, 100.0, 110.0, 100.0) == "long"
+
+    def test_long_blocked_by_1d(self):
+        # 1d 하락 정렬이면 골든크로스여도 롱 금지.
+        assert entry_side(1, 95.0, 100.0, 110.0, 100.0) is None
+
+    def test_long_blocked_below_ma35(self):
+        assert entry_side(1, 105.0, 100.0, 99.0, 100.0) is None
+
+    def test_short(self):
+        assert entry_side(-1, 95.0, 100.0, 90.0, 100.0) == "short"
+
+    def test_short_allows_1d_equal(self):
+        # 백테스트 정의: 숏의 1d 조건은 not(ma10>ma35) → 같아도 허용.
+        assert entry_side(-1, 100.0, 100.0, 90.0, 100.0) == "short"
+
+    def test_no_cross_no_entry(self):
+        assert entry_side(0, 105.0, 100.0, 110.0, 100.0) is None
+
+
+class TestStopAndExit:
+    def test_stop_long(self):
+        assert stop_price("long", 100.0, 2.0) == 100.0 - SWING_STOP_ATR_MULT * 2.0
+
+    def test_stop_short(self):
+        assert stop_price("short", 100.0, 2.0) == 100.0 + SWING_STOP_ATR_MULT * 2.0
+
+    def test_exit_long_on_break(self):
+        assert rule_exit_due("long", 99.0, 100.0) is True
+        assert rule_exit_due("long", 101.0, 100.0) is False
+
+    def test_exit_short_on_break(self):
+        assert rule_exit_due("short", 101.0, 100.0) is True
+        assert rule_exit_due("short", 99.0, 100.0) is False
+
+
+class TestConflict:
+    def test_opposite_blocks(self):
+        assert conflicts_with_main("long", ["short"]) is True
+
+    def test_same_side_allowed(self):
+        assert conflicts_with_main("long", ["long"]) is False
+
+    def test_no_main_positions(self):
+        assert conflicts_with_main("short", []) is False
+
+
+class TestSizing:
+    def test_risk_based_qty(self):
+        sz = compute_swing_sizing(10_000.0, 50_000.0, 49_000.0)
+        assert not sz.rejected
+        # risk = 10000 * 1% = 100; sl_dist = 1000 → qty = 0.1
+        assert sz.qty == pytest.approx(10_000.0 * SWING_RISK_PER_TRADE / 1_000.0)
+        assert sz.leverage == pytest.approx(sz.qty * 50_000.0 / 10_000.0)
+        assert sz.leverage < SWING_MAX_LEVERAGE
+
+    def test_leverage_cap(self):
+        # 스탑이 극단적으로 좁으면 명목이 커진다 → 5x 캡, 리스크 축소.
+        sz = compute_swing_sizing(10_000.0, 100.0, 99.9)
+        assert not sz.rejected
+        assert sz.leverage == pytest.approx(SWING_MAX_LEVERAGE)
+        assert sz.qty == pytest.approx(10_000.0 * SWING_MAX_LEVERAGE / 100.0)
+        assert sz.risk_amount < 10_000.0 * SWING_RISK_PER_TRADE
+
+    def test_rejects_zero_stop_distance(self):
+        assert compute_swing_sizing(10_000.0, 100.0, 100.0).rejected
+
+    def test_rejects_bad_equity(self):
+        assert compute_swing_sizing(0.0, 100.0, 99.0).rejected
+
+    def test_frozen_dataclass(self):
+        sz = SwingSizing(1.0, 1.0, 1.0, False)
+        with pytest.raises(Exception):
+            sz.qty = 2.0  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# live/swing.process — 합성 시나리오 E2E (인메모리 sqlite, 가상 체결)
+# ---------------------------------------------------------------------------
+
+def _dt(s: str) -> pd.Timestamp:
+    return pd.Timestamp(s, tz="UTC")
+
+
+def _make_tf_data(with_stop_bar: bool = False) -> dict:
+    """골든크로스 직후 상태의 합성 tf_data.
+
+    4h: 40봉, 마지막 봉(12:00 open, 16:00 close)에서 ma10 이 ma35 상향 돌파.
+    1d: 완결 봉 ma10>ma35 (상승 정렬).
+    30m: 16:00 봉(진입 트리거) + 선행 더미, with_stop_bar 면 16:30 봉(low 가
+         스탑 관통) 추가.
+    """
+    idx4 = pd.date_range(_dt("2026-01-01 00:00"), periods=40, freq="4h")
+    d4 = pd.DataFrame({
+        "open": 49_500.0, "high": 50_200.0, "low": 49_300.0,
+        "close": 50_000.0, "volume": 1.0, "turnover": 1.0,
+        "ma10": 48_900.0, "ma35": 49_000.0, "atr14": 500.0,
+    }, index=idx4)
+    # 마지막 봉에서 골든크로스 (prev: 48,900 <= 49,000 / cur: 49,100 > 49,000).
+    d4.iloc[-1, d4.columns.get_loc("ma10")] = 49_100.0
+
+    idx1 = pd.date_range(_dt("2025-12-20 00:00"), periods=18, freq="1D")
+    d1 = pd.DataFrame({
+        "open": 48_000.0, "high": 49_000.0, "low": 47_000.0,
+        "close": 48_500.0, "volume": 1.0, "turnover": 1.0,
+        "ma10": 48_000.0, "ma35": 47_000.0, "atr14": 800.0,
+    }, index=idx1)
+
+    rows_30m = [
+        (_dt("2026-01-07 15:30"), 49_950.0, 50_050.0, 49_900.0, 49_990.0),
+        (_dt("2026-01-07 16:00"), 49_990.0, 50_100.0, 49_900.0, 50_000.0),
+    ]
+    if with_stop_bar:
+        rows_30m.append(
+            (_dt("2026-01-07 16:30"), 50_000.0, 50_050.0, 48_900.0, 48_950.0))
+    d30 = pd.DataFrame(
+        [{"open": o, "high": h, "low": lo, "close": c,
+          "volume": 1.0, "turnover": 1.0}
+         for _, o, h, lo, c in rows_30m],
+        index=pd.DatetimeIndex([t for t, *_ in rows_30m]))
+    return {"30m": d30, "4h": d4, "1d": d1}
+
+
+@pytest.fixture()
+def conn():
+    from live import tracking
+    c = tracking.get_connection(":memory:")
+    tracking.ensure_schema(c)
+    yield c
+    c.close()
+
+
+class TestSwingProcess:
+    def test_cold_start_entry_on_golden_cross(self, conn):
+        from live import swing, tracking
+        tf_data = _make_tf_data()
+        res = swing.process(conn, tf_data, main_mode="shadow")
+        assert res["events"] == 1
+        pos = tracking.load_open_positions(conn, "swing")
+        assert len(pos) == 1
+        p = pos[0]
+        assert p.side == "long"
+        assert p.entry_price == pytest.approx(50_000.0)
+        # stop = entry - 2*ATR(500) = 49,000
+        assert p.sl_price == pytest.approx(49_000.0)
+        assert p.leverage < SWING_MAX_LEVERAGE
+        assert tracking.latest_equity(conn, "swing") == pytest.approx(
+            SWING_INITIAL_EQUITY)
+
+    def test_idempotent_no_new_bars(self, conn):
+        from live import swing, tracking
+        tf_data = _make_tf_data()
+        swing.process(conn, tf_data, main_mode="shadow")
+        res2 = swing.process(conn, tf_data, main_mode="shadow")  # 같은 봉 재호출
+        assert res2["events"] == 0
+        assert len(tracking.load_open_positions(conn, "swing")) == 1
+
+    def test_stop_hit_closes_and_records(self, conn):
+        from live import swing, tracking
+        swing.process(conn, _make_tf_data(), main_mode="shadow")
+        res = swing.process(conn, _make_tf_data(with_stop_bar=True),
+                            main_mode="shadow")
+        assert res["events"] == 1
+        assert tracking.load_open_positions(conn, "swing") == []
+        trades = conn.execute(
+            "SELECT * FROM btc_trading_history WHERE mode='swing'").fetchall()
+        assert len(trades) == 1
+        t = trades[0]
+        assert t["exit_reason"] == "swing_sl"
+        assert t["exit_price"] == pytest.approx(49_000.0)
+        # 손실 ≈ -1R (수수료 포함 -1.0 ~ -1.2R 범위).
+        assert -1.2 < t["r_multiple"] < -0.95
+        eq = tracking.latest_equity(conn, "swing")
+        assert eq < SWING_INITIAL_EQUITY
+
+    def test_conflict_with_main_blocks_entry(self, conn):
+        from live import swing, tracking
+        # 메인(demo) 레인이 숏 보유 중 → 스윙 롱 진입 금지.
+        tracking.save_position(conn, tracking.PositionRow(
+            side="short", entry_price=50_000.0, qty=0.1, leverage=10.0,
+            sl_price=51_000.0, tp1_price=0.0, tp2_price=0.0, tp3_price=0.0,
+            liq_price=0.0, entry_time="2026-01-07 00:00:00+00:00",
+            tranche_index=0, entry_bar_idx=0, initial_risk=100.0,
+            mode="demo"))
+        res = swing.process(conn, _make_tf_data(), main_mode="demo")
+        assert res["events"] == 0
+        assert tracking.load_open_positions(conn, "swing") == []
+
+    def test_no_entry_without_cross(self, conn):
+        from live import swing, tracking
+        tf_data = _make_tf_data()
+        # 크로스 제거: 마지막 4h ma10 도 ma35 아래로.
+        tf_data["4h"].iloc[-1, tf_data["4h"].columns.get_loc("ma10")] = 48_950.0
+        res = swing.process(conn, tf_data, main_mode="shadow")
+        assert res["events"] == 0
+        assert tracking.load_open_positions(conn, "swing") == []
+
+    def test_1d_disagreement_blocks_long(self, conn):
+        from live import swing, tracking
+        tf_data = _make_tf_data()
+        tf_data["1d"]["ma10"] = 46_000.0  # 1d 하락 정렬
+        res = swing.process(conn, tf_data, main_mode="shadow")
+        assert res["events"] == 0
+        assert tracking.load_open_positions(conn, "swing") == []
+
+    def test_disabled_flag(self, conn, monkeypatch):
+        from live import swing
+        monkeypatch.setattr(swing, "SWING_ENABLED", False)
+        res = swing.process(conn, _make_tf_data(), main_mode="shadow")
+        assert res == {"events": 0}


### PR DESCRIPTION
## 요약
- 라운드6 연구로 채택된 Lane B(추세 초입 스윙)를 라이브 파이프라인에 통합
- 백테스트 2020-03~2026-07: n=186, cum +293%, maxDD −35%, 3분리기간 모두 양수
- TF 전수검증 완료: 12h/1w(초입 상실)·30m/1h(무개선/유해)·메인 2-TF 다이어트(한계코호트 무엣지) 모두 기각 → 4h+1d 고정

## 구현
- `core/swing.py`: 순수 결정 로직 (백테스트 entryB/exitB 문자 그대로, 스윕 없음)
- `live/swing.py`: mode='swing' 자체 가상 원장 집행기 — 원웨이 넷팅 충돌 회피(v1), 메인과 방향충돌 시 진입금지, 리스크 1%/스탑 2ATR/레버리지 캡 5x, 텔레그램 즉시 알림
- `live/runner.py`: 격리 훅 (스윙 예외는 메인 트레이딩 비전파, 자체 메타 커서, 콜드스타트 안전)
- 메인 레인 상수(ENTRY_SCORE_MIN/TS_MIN)는 동결 유지

## 검증
- 305 tests pass (신규 30)
- 전 이력 패리티: core/swing 재구동 = 원본 백테스트 186 트레이드 진입 시퀀스·누적수익(+293.20%) 완전 일치
- 로컬 shadow 스모크: 원장 시드·커서 정상, 콜드스타트 재시뮬 없음

Rocky 구두 승인 (2026-07-22, 섀도우 검증기간 생략·데모 직행).

🤖 Generated with [Claude Code](https://claude.com/claude-code)