### PR TITLE
feat(btc): swing lane v2 — exchange execution + demo-tick gating

### DIFF
--- a/prism-btc/engine/config.py
+++ b/prism-btc/engine/config.py
@@ -97,6 +97,10 @@ DB_RELATIVE_PATH: str = "state/btc_market.db"
 # 메인 레인(ENTRY_SCORE_MIN/TS_MIN)은 동결 유지 — 두 레인은 역할 분담:
 # 메인 = 성숙 추세를 크게, 스윙 = 초입/전환을 작게.
 SWING_ENABLED: bool = True
+# 스윙 레인을 구동하는 runner mode. 서버는 shadow(:01)/demo(:02) 크론 병행이라
+# 양쪽에서 돌리면 단일 커서(mode='swing')를 선착 shadow 틱이 소비해 텔레그램
+# 알림(demo/live 전용)이 영원히 안 나간다 — demo 틱 전용으로 고정.
+SWING_RUN_MODES: tuple[str, ...] = ("demo",)
 SWING_STOP_ATR_MULT: float = 2.0      # 하드스탑 = 진입가 ∓ 2.0 × ATR14(4h)
 SWING_RISK_PER_TRADE: float = 0.01    # equity 의 1% (메인 RISK_PER_TRADE 2% 의 절반)
 SWING_MAX_LEVERAGE: float = 5.0       # 명목/equity 상한 (Rocky 승인 스펙)

--- a/prism-btc/live/runner.py
+++ b/prism-btc/live/runner.py
@@ -157,14 +157,19 @@ def tick(mode: str = "shadow", market_db_path=None, root_db_path=None) -> dict:
 
     result["new_bars"] = processed
 
-    # --- 2b. 스윙 레인 (라운드6 Lane B — mode='swing' 자체 원장, 가상 집행) ---
-    # 메인 결정로직/상태와 완전 독립 (자체 메타 커서). 어떤 예외도 메인
-    # 트레이딩을 멈출 수 없다. 검증: tasks/btc_round6_swing_lane.md.
+    # --- 2b. 스윙 레인 (라운드6 Lane B — mode='swing' 자체 원장) ---
+    # SWING_RUN_MODES 틱에서만 구동 (기본 demo 전용 — shadow/demo 크론 병행 시
+    # 커서 경합 방지). 집행 백엔드는 swing 모듈이 자동 선택: 스윙 전용 키
+    # (BYBIT_SWING_API_KEY/SECRET, 메인과 별도 계정) 있으면 실주문, 없으면
+    # 가상 체결. 메인 결정로직/상태와 완전 독립 (자체 메타 커서). 어떤 예외도
+    # 메인 트레이딩을 멈출 수 없다. 검증: tasks/btc_round6_swing_lane.md.
     try:
-        from live import swing as swing_lane
-        sres = swing_lane.process(root_conn, tf_data, main_mode=mode)
-        if sres.get("events"):
-            result["swing"] = sres
+        from engine.config import SWING_RUN_MODES
+        if mode in SWING_RUN_MODES:
+            from live import swing as swing_lane
+            sres = swing_lane.process(root_conn, tf_data, main_mode=mode)
+            if sres.get("events"):
+                result["swing"] = sres
     except Exception as exc:  # noqa: BLE001 — 스윙 레인 실패는 메인과 무관
         tracking.log_event(root_conn, "error", f"swing lane: {exc}",
                            level="error", mode="swing")

--- a/prism-btc/live/swing.py
+++ b/prism-btc/live/swing.py
@@ -1,25 +1,34 @@
-# live/swing.py — 라운드6 Lane B 스윙 레인 가상 집행기 (mode='swing' 자체 원장)
+# live/swing.py — 라운드6 Lane B 스윙 레인 집행기 (mode='swing' 자체 원장)
 #
-# 왜 v1 은 가상 집행인가: 거래소 원웨이 모드에서 메인 레인과 같은 심볼의
-# 포지션이 넷팅되어 DemoAdapter 의 reconcile 불변식(거래소 포지션 == 메인
-# 포지션)이 깨진다. v1 은 스윙 레인을 tracking 의 mode='swing' 원장으로
-# 가상 체결하고 진입/청산을 텔레그램으로 즉시 알린다. 거래소 실집행
-# (헤지모드 분리)은 별도 라운드에서.
+# 결정 로직은 core/swing.py 순수함수 (백테스트 패리티 고정). 이 모듈은 집행만.
+#
+# 집행 백엔드 2종 (v2):
+#   - ExchangeBackend: 스윙 전용 Bybit 데모 키(BYBIT_SWING_API_KEY/SECRET)로
+#     실주문. ★ 메인 레인 키와 반드시 다른 계정(별도 지갑)이어야 한다 —
+#     같은 계좌를 쓰면 원웨이 넷팅으로 DemoAdapter 의 reconcile 3중 오염:
+#     ① _sync_state 가 임의 포지션을 메인 것으로 채택 ② _record_closed_trades
+#     가 모든 reduce-only 체결을 메인 트레이드로 기록 ③ 지갑 equity 공유.
+#   - VirtualBackend: 키 미설정 시 폴백 — 가상 체결 (v1 과 동일 의미론).
 #
 # 집행 의미론 (analysis/round6_swing_lane.py 백테스트 미러):
 #   - 신호: 4h 확정봉 (30m 틱마다 _get_tf_slice 로 감지 — 메인과 동일 케이던스)
-#   - 진입/룰청산 체결: 감지 시점 30m 봉 종가 (≈ 백테스트의 다음 4h 시가),
-#     비용 TAKER_FEE. 하드스탑: 30m 봉 low/high 봉내 감시, 체결 = 스탑가,
-#     비용 TAKER_FEE + SLIPPAGE_SL. (백테스트는 4h 봉내 스탑 — 30m 감시가
-#     더 정밀하며 보수적 방향의 차이만 있다.)
-#   - 포지션 최대 1개, 피라미딩/부분청산/펀딩 없음 (백테스트와 동일 스코프).
-#   - 메인 레인과 방향 충돌 시 진입 금지 (core.swing.conflicts_with_main).
+#   - 진입: 시장가 (백테스트 taker 비용 모델과 일치), 진입 직후 네이티브
+#     stop-market reduce-only SL 부착. 룰 청산: SL 취소 → 시장가 reduce.
+#   - 하드스탑: 가상=30m 봉내 감시 / 실집행=거래소 네이티브 스탑이 진실,
+#     틱마다 포지션 소멸 감지로 사후 기록.
+#   - 포지션 최대 1개, 피라미딩/부분청산/펀딩 없음. 메인 방향충돌 시 진입금지.
 #
-# 안전 원칙: process() 는 어떤 예외도 밖으로 던지지 않도록 호출측(runner)이
-# 감싼다. 여기서도 알림/신호로그 실패는 개별 흡수한다 (매매 결정 비영향).
+# 실행 모드: runner 는 SWING_RUN_MODES(기본 demo 전용) 틱에서만 호출한다 —
+# 서버는 shadow(:01)/demo(:02) 크론이 병행이라 양쪽에서 돌리면 단일 커서를
+# 선착 틱이 소비해 알림/충돌검사가 어긋난다.
+#
+# 안전 원칙: process() 밖으로 예외 비전파는 호출측(runner)이 보장, 여기서도
+# 알림/신호로그/거래소 호출 실패는 개별 흡수한다.
 from __future__ import annotations
 
 import logging
+import os
+import time
 from typing import Optional
 
 import pandas as pd
@@ -33,13 +42,224 @@ from core.swing import (
     rule_exit_due,
     stop_price,
 )
-from engine.config import SWING_ENABLED, SWING_INITIAL_EQUITY
+from engine.config import SWING_ENABLED, SWING_INITIAL_EQUITY, SWING_MAX_LEVERAGE
 from live import tracking
+from live.demo import _f, _order_id, _pstr, _qstr, _result_list
 from live.shadow import bar_index_for
 
 log = logging.getLogger("live.swing")
 
 MODE = "swing"  # tracking 원장 키 — 메인 mode(shadow/demo/live)와 완전 분리
+
+_CATEGORY = "linear"
+_SYMBOL = "BTCUSDT"
+_POSITION_IDX = 0
+_RETRY_SLEEP_SEC = 0.5
+
+
+# ---------------------------------------------------------------------------
+# 스윙 전용 세션 — 메인(BYBIT_DEMO_*)과 다른 키. 없으면 None (가상 폴백).
+# ---------------------------------------------------------------------------
+
+def _make_swing_session():
+    key = os.environ.get("BYBIT_SWING_API_KEY")
+    secret = os.environ.get("BYBIT_SWING_API_SECRET")
+    if not key or not secret:
+        try:
+            from pathlib import Path
+
+            from dotenv import load_dotenv
+            load_dotenv(Path(__file__).resolve().parent.parent.parent / ".env")
+            key = os.environ.get("BYBIT_SWING_API_KEY")
+            secret = os.environ.get("BYBIT_SWING_API_SECRET")
+        except Exception:  # noqa: BLE001
+            pass
+    if not key or not secret:
+        return None, "BYBIT_SWING_API_KEY/SECRET 미설정"
+    # 안전 가드: 메인 키와 동일하면 실집행 금지 (넷팅 오염 방지).
+    if key == os.environ.get("BYBIT_DEMO_API_KEY"):
+        return None, "SWING 키가 메인 DEMO 키와 동일 — 별도 계정 필요, 가상 폴백"
+    try:
+        from pybit.unified_trading import HTTP
+        return HTTP(demo=True, api_key=key, api_secret=secret), None
+    except Exception as exc:  # noqa: BLE001
+        return None, f"pybit HTTP(demo) init 실패: {exc}"
+
+
+# ---------------------------------------------------------------------------
+# 집행 백엔드
+# ---------------------------------------------------------------------------
+
+class VirtualBackend:
+    """가상 체결 (v1 의미론): 진입/룰청산 = 30m 종가, 스탑 = 봉내 스탑가."""
+
+    name = "virtual"
+
+    def __init__(self, conn):
+        self.conn = conn
+
+    def equity(self, fallback: float) -> float:
+        return fallback
+
+    def open(self, side: str, qty: float, sl: float,
+             hint_price: float) -> Optional[float]:
+        return hint_price
+
+    def check_stop(self, pos: tracking.PositionRow,
+                   bar: pd.Series) -> Optional[float]:
+        if pos.side == "long" and float(bar["low"]) <= pos.sl_price:
+            return pos.sl_price
+        if pos.side == "short" and float(bar["high"]) >= pos.sl_price:
+            return pos.sl_price
+        return None
+
+    def close(self, pos: tracking.PositionRow, hint_price: float) -> float:
+        return hint_price
+
+
+class ExchangeBackend:
+    """스윙 전용 데모 계정에 실주문. 거래소 지갑이 equity 의 진실."""
+
+    name = "exchange"
+
+    def __init__(self, conn, sess):
+        self.conn = conn
+        self.sess = sess
+
+    # --- 호출 헬퍼 (demo.DemoAdapter._call 미러 — 재시도 1회, 실패 흡수) ---
+    def _call(self, fn_name: str, **kwargs) -> Optional[dict]:
+        fn = getattr(self.sess, fn_name, None)
+        if fn is None:
+            return None
+        last_exc = None
+        for attempt in range(2):
+            try:
+                resp = fn(**kwargs)
+                if isinstance(resp, dict) and int(resp.get("retCode", -1)) == 0:
+                    return resp
+                last_exc = (resp.get("retMsg") if isinstance(resp, dict) else resp)
+            except Exception as exc:  # noqa: BLE001
+                last_exc = str(exc)
+            if attempt == 0:
+                time.sleep(_RETRY_SLEEP_SEC)
+        tracking.log_event(self.conn, "error", f"swing {fn_name} 실패: {last_exc}",
+                           level="error", mode=MODE)
+        return None
+
+    def equity(self, fallback: float) -> float:
+        wb = self._call("get_wallet_balance", accountType="UNIFIED")
+        rows = _result_list(wb)
+        if rows:
+            eq = _f(rows[0].get("totalEquity"))
+            if eq > 0:
+                return eq
+        return fallback
+
+    def _position_size(self) -> Optional[float]:
+        """현재 스윙 계정 BTCUSDT 포지션 크기. 조회 실패 시 None (판단 유보)."""
+        pr = self._call("get_positions", category=_CATEGORY, symbol=_SYMBOL)
+        if pr is None:
+            return None
+        for p in _result_list(pr):
+            return _f(p.get("size"))
+        return 0.0
+
+    def open(self, side: str, qty: float, sl: float,
+             hint_price: float) -> Optional[float]:
+        """시장가 진입 → 체결가 확인 → 네이티브 SL 부착. 실패 시 None (무진입)."""
+        self._call("set_leverage", category=_CATEGORY, symbol=_SYMBOL,
+                   buyLeverage=str(SWING_MAX_LEVERAGE),
+                   sellLeverage=str(SWING_MAX_LEVERAGE))
+        resp = self._call(
+            "place_order", category=_CATEGORY, symbol=_SYMBOL,
+            side="Buy" if side == "long" else "Sell",
+            orderType="Market", qty=_qstr(qty),
+            timeInForce="IOC", positionIdx=_POSITION_IDX,
+        )
+        if _order_id(resp) is None:
+            return None
+        # 체결가 확인 (최대 3회 폴링, 실패 시 힌트가로 기록).
+        fill = hint_price
+        for _ in range(3):
+            pr = self._call("get_positions", category=_CATEGORY, symbol=_SYMBOL)
+            for p in _result_list(pr or {}):
+                if _f(p.get("size")) > 0:
+                    fill = _f(p.get("avgPrice"), hint_price)
+                    break
+            else:
+                time.sleep(_RETRY_SLEEP_SEC)
+                continue
+            break
+        # 네이티브 SL (stop-market reduce-only).
+        close_side = "Sell" if side == "long" else "Buy"
+        trigger_dir = 2 if side == "long" else 1
+        sl_resp = self._call(
+            "place_order", category=_CATEGORY, symbol=_SYMBOL,
+            side=close_side, orderType="Market", qty=_qstr(qty),
+            triggerPrice=_pstr(sl), triggerDirection=trigger_dir,
+            triggerBy="LastPrice", reduceOnly=True,
+            timeInForce="GTC", positionIdx=_POSITION_IDX,
+        )
+        sl_oid = _order_id(sl_resp)
+        tracking.set_meta(self.conn, "swing_sl_order_id", sl_oid or "", MODE)
+        if sl_oid is None:
+            tracking.log_event(self.conn, "error",
+                               "swing SL 주문 실패 — 소프트 감시로만 보호됨",
+                               level="error", mode=MODE)
+        tracking.log_event(self.conn, "order",
+                           f"swing open {side} market qty={qty:.4f} fill≈{fill:.1f} "
+                           f"sl={sl:.1f} sl_oid={sl_oid}", mode=MODE)
+        return fill
+
+    def _last_close_exec_price(self) -> Optional[float]:
+        ex = self._call("get_executions", category=_CATEGORY, symbol=_SYMBOL,
+                        limit=10)
+        for r in _result_list(ex or {}):
+            if _f(r.get("closedSize")) > 0:
+                return _f(r.get("execPrice")) or None
+        return None
+
+    def check_stop(self, pos: tracking.PositionRow,
+                   bar: pd.Series) -> Optional[float]:
+        """거래소 포지션 소멸 = 스탑(또는 외부 청산) 체결. 체결가를 반환."""
+        size = self._position_size()
+        if size is None or size > 0:
+            return None
+        price = self._last_close_exec_price() or pos.sl_price
+        sl_oid = tracking.get_meta(self.conn, "swing_sl_order_id", MODE)
+        if sl_oid:
+            self._call("cancel_order", category=_CATEGORY, symbol=_SYMBOL,
+                       orderId=sl_oid)
+        tracking.set_meta(self.conn, "swing_sl_order_id", "", MODE)
+        return price
+
+    def close(self, pos: tracking.PositionRow, hint_price: float) -> float:
+        sl_oid = tracking.get_meta(self.conn, "swing_sl_order_id", MODE)
+        if sl_oid:
+            self._call("cancel_order", category=_CATEGORY, symbol=_SYMBOL,
+                       orderId=sl_oid)
+        tracking.set_meta(self.conn, "swing_sl_order_id", "", MODE)
+        close_side = "Sell" if pos.side == "long" else "Buy"
+        self._call(
+            "place_order", category=_CATEGORY, symbol=_SYMBOL,
+            side=close_side, orderType="Market", qty=_qstr(pos.qty),
+            reduceOnly=True, timeInForce="IOC", positionIdx=_POSITION_IDX,
+        )
+        return self._last_close_exec_price() or hint_price
+
+
+def _make_backend(conn, main_mode: str):
+    """demo/live 틱에서 스윙 키가 있으면 실집행, 아니면 가상 폴백."""
+    if main_mode in ("demo", "live"):
+        sess, err = _make_swing_session()
+        if sess is not None:
+            return ExchangeBackend(conn, sess)
+        if tracking.get_meta(conn, "swing_exec_fallback_notified", MODE) is None:
+            tracking.log_event(conn, "info",
+                               f"swing 실집행 불가({err}) — 가상 체결 폴백",
+                               mode=MODE)
+            tracking.set_meta(conn, "swing_exec_fallback_notified", 1, MODE)
+    return VirtualBackend(conn)
 
 
 # ---------------------------------------------------------------------------
@@ -52,7 +272,6 @@ def _notify(main_mode: str, msg: str) -> None:
         return
     try:
         import asyncio
-        import os
 
         from live.telegram_reporter import _load_env, _resolve_channel, _send
         _load_env()
@@ -75,14 +294,17 @@ def _log_signal_safe(conn, ts: str, side: str, reason: str, n_open: int) -> None
 
 
 # ---------------------------------------------------------------------------
-# 체결 — 가상 원장 (btc_positions / btc_trading_history / btc_equity_curve)
+# 원장 정산 — 백엔드 공통 (체결가만 백엔드가 결정).
 # ---------------------------------------------------------------------------
 
-def _close_position(conn, pos: tracking.PositionRow, exit_price: float,
+def _close_position(conn, backend, pos: tracking.PositionRow, exit_price: float,
                     fee_rate: float, reason: str, bar_time_str: str,
                     equity: float, trade_counter: int,
                     main_mode: str) -> tuple[float, int]:
-    """가상 청산: PnL 정산 → 트레이드 기록 → 포지션 제거 → equity 갱신 → 알림."""
+    """청산 정산: 트레이드 기록 → 포지션 제거 → equity 갱신 → 알림.
+
+    실집행 백엔드는 지갑 equity 가 진실 — 추정 net 으로 갱신 후 지갑값으로 덮는다.
+    """
     sign = 1.0 if pos.side == "long" else -1.0
     gross = sign * pos.qty * (exit_price - pos.entry_price)
     exit_fee = pos.qty * exit_price * fee_rate
@@ -113,21 +335,22 @@ def _close_position(conn, pos: tracking.PositionRow, exit_price: float,
     ))
     if pos.id is not None:
         tracking.remove_position(conn, pos.id)
-    equity += net
+    equity = backend.equity(fallback=equity + net)
     tracking.record_equity(conn, equity, MODE, bar_time_str)
     tracking.log_event(conn, "trade",
-                       f"swing close {pos.side} @ {exit_price:.1f} ({reason}) "
-                       f"net={net:+.2f} eq={equity:.2f}", mode=MODE)
+                       f"swing close[{backend.name}] {pos.side} @ {exit_price:.1f} "
+                       f"({reason}) net≈{net:+.2f} eq={equity:.2f}", mode=MODE)
     r = net / risk
     outcome = f"✅ 이익 {r:+.1f}배" if r > 0 else f"❌ 손실 {r:+.1f}배"
     why = "손절" if reason == "swing_sl" else "추세이탈 청산"
+    exec_tag = "실주문" if backend.name == "exchange" else "가상체결"
     _notify(main_mode,
-            f"🌀 [스윙레인] 포지션 정리 — {outcome} ({why})\n"
-            f"_가상자금 모의투자입니다_")
+            f"🌀 [스윙레인·{exec_tag}] 포지션 정리 — {outcome} ({why})\n"
+            f"_데모 계정 모의투자입니다_")
     return equity, trade_counter
 
 
-def _try_entry(conn, bar, bar_time_str: str, s4: pd.DataFrame,
+def _try_entry(conn, backend, bar, bar_time_str: str, s4: pd.DataFrame,
                s1: pd.DataFrame, equity: float,
                main_mode: str) -> Optional[tracking.PositionRow]:
     """4h 확정봉에서 진입 평가. 성공 시 저장된 PositionRow, 아니면 None."""
@@ -163,18 +386,24 @@ def _try_entry(conn, bar, bar_time_str: str, s4: pd.DataFrame,
                          f"swing 기각: 메인 레인 방향 충돌 (main={main_sides})", 1)
         return None
 
-    entry_price = float(bar["close"])
-    sl = stop_price(side, entry_price, float(cur["atr14"]))
-    sz = compute_swing_sizing(equity, entry_price, sl)
+    hint_price = float(bar["close"])
+    sizing_equity = backend.equity(fallback=equity)
+    sl = stop_price(side, hint_price, float(cur["atr14"]))
+    sz = compute_swing_sizing(sizing_equity, hint_price, sl)
     if sz.rejected:
         _log_signal_safe(conn, bar_time_str, side,
                          f"swing 기각: sizing ({sz.reject_reason})", 0)
         return None
 
-    entry_fee = sz.qty * entry_price * TAKER_FEE
+    fill = backend.open(side, sz.qty, sl, hint_price)
+    if fill is None:
+        _log_signal_safe(conn, bar_time_str, side, "swing 기각: 주문 실패", 0)
+        return None
+
+    entry_fee = sz.qty * fill * TAKER_FEE
     pos = tracking.PositionRow(
         side=side,
-        entry_price=entry_price,
+        entry_price=fill,
         qty=sz.qty,
         leverage=sz.leverage,
         sl_price=sl,
@@ -190,26 +419,30 @@ def _try_entry(conn, bar, bar_time_str: str, s4: pd.DataFrame,
     )
     tracking.save_position(conn, pos)
     tracking.log_event(conn, "trade",
-                       f"swing open {side} @ {entry_price:.1f} qty={sz.qty:.4f} "
-                       f"sl={sl:.1f} lev={sz.leverage:.2f}", mode=MODE)
+                       f"swing open[{backend.name}] {side} @ {fill:.1f} "
+                       f"qty={sz.qty:.4f} sl={sl:.1f} lev={sz.leverage:.2f}",
+                       mode=MODE)
     _log_signal_safe(conn, bar_time_str, side, "swing_entry", 1)
+    exec_tag = "실주문" if backend.name == "exchange" else "가상체결"
     _notify(main_mode,
-            f"🌀 [스윙레인] 새 진입 — {_side_kr(side)}\n"
-            f"진입가 {entry_price:,.0f}달러 · 손절 {sl:,.0f}달러 · "
-            f"{sz.leverage:.1f}배율\n_가상자금 모의투자입니다_")
+            f"🌀 [스윙레인·{exec_tag}] 새 진입 — {_side_kr(side)}\n"
+            f"진입가 {fill:,.0f}달러 · 손절 {sl:,.0f}달러 · "
+            f"{sz.leverage:.1f}배율\n_데모 계정 모의투자입니다_")
     return pos
 
 
 # ---------------------------------------------------------------------------
-# 핵심 진입점 — runner.tick 이 30m 틱마다 호출.
+# 핵심 진입점 — runner.tick 이 SWING_RUN_MODES 틱마다 호출.
 # ---------------------------------------------------------------------------
 
-def process(root_conn, tf_data: dict, main_mode: str = "shadow") -> dict:
+def process(root_conn, tf_data: dict, main_mode: str = "shadow",
+            backend=None) -> dict:
     """새 확정 30m 봉들을 스윙 레인 관점에서 처리. {"events": n} 반환.
 
     자체 메타 커서(mode='swing' 의 last_processed_30m_ns / last_confirmed_4h_ns)
     를 쓰므로 메인 레인 상태와 완전 독립이며 재실행에 멱등이다.
     콜드 스타트(커서 없음)는 마지막 확정봉 1개만 처리한다 (과거 재시뮬 방지).
+    backend 미지정 시 자동 선택 (스윙 키 존재+demo/live → 실집행, 아니면 가상).
     """
     result = {"events": 0}
     if not SWING_ENABLED:
@@ -218,13 +451,16 @@ def process(root_conn, tf_data: dict, main_mode: str = "shadow") -> dict:
     if bars_30m is None or bars_30m.empty:
         return result
     conn = root_conn
+    if backend is None:
+        backend = _make_backend(conn, main_mode)
 
     equity = tracking.latest_equity(conn, MODE)
     if equity is None:
-        equity = SWING_INITIAL_EQUITY
+        equity = backend.equity(fallback=SWING_INITIAL_EQUITY)
         tracking.record_equity(conn, equity, MODE)
         tracking.log_event(conn, "info",
-                           f"swing lane ledger seeded: {equity:.0f}", mode=MODE)
+                           f"swing lane ledger seeded[{backend.name}]: {equity:.0f}",
+                           mode=MODE)
 
     last_ns = tracking.get_meta(conn, "last_processed_30m_ns", MODE)
     if last_ns is None:
@@ -243,13 +479,12 @@ def process(root_conn, tf_data: dict, main_mode: str = "shadow") -> dict:
     for bar_time, bar in new_bars.iterrows():
         bar_time_str = str(bar_time)
 
-        # --- 1. 하드스탑 봉내 감시 (매 30m — 백테스트보다 정밀) ---
+        # --- 1. 하드스탑 감시 (가상=봉내 / 실집행=거래소 포지션 소멸 감지) ---
         if pos is not None:
-            hit = (pos.side == "long" and float(bar["low"]) <= pos.sl_price) or \
-                  (pos.side == "short" and float(bar["high"]) >= pos.sl_price)
-            if hit:
+            stop_fill = backend.check_stop(pos, bar)
+            if stop_fill is not None:
                 equity, trade_counter = _close_position(
-                    conn, pos, pos.sl_price, TAKER_FEE + SLIPPAGE_SL,
+                    conn, backend, pos, stop_fill, TAKER_FEE + SLIPPAGE_SL,
                     "swing_sl", bar_time_str, equity, trade_counter, main_mode)
                 pos = None
                 result["events"] += 1
@@ -268,15 +503,17 @@ def process(root_conn, tf_data: dict, main_mode: str = "shadow") -> dict:
             row = s4.iloc[-1]
             if not pd.isna(row.get("ma35")) and rule_exit_due(
                     pos.side, float(row["close"]), float(row["ma35"])):
+                fill = backend.close(pos, float(bar["close"]))
                 equity, trade_counter = _close_position(
-                    conn, pos, float(bar["close"]), TAKER_FEE,
+                    conn, backend, pos, fill, TAKER_FEE,
                     "swing_ma35_exit", bar_time_str, equity, trade_counter,
                     main_mode)
                 pos = None
                 result["events"] += 1
         else:
             s1 = _get_tf_slice(tf_data, bar_time, "1d")
-            pos = _try_entry(conn, bar, bar_time_str, s4, s1, equity, main_mode)
+            pos = _try_entry(conn, backend, bar, bar_time_str, s4, s1,
+                             equity, main_mode)
             if pos is not None:
                 result["events"] += 1
 

--- a/prism-btc/tests/test_swing.py
+++ b/prism-btc/tests/test_swing.py
@@ -263,3 +263,160 @@ class TestSwingProcess:
         monkeypatch.setattr(swing, "SWING_ENABLED", False)
         res = swing.process(conn, _make_tf_data(), main_mode="shadow")
         assert res == {"events": 0}
+
+
+# ---------------------------------------------------------------------------
+# ExchangeBackend — FakeSession 으로 실주문 경로 검증 (네트워크 없음)
+# ---------------------------------------------------------------------------
+
+class FakeSession:
+    """pybit HTTP 흉내: 호출 기록 + 프로그래머블 응답."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+        self._oid = 0
+        self.position_size = 0.0
+        self.avg_price = 0.0
+        self.total_equity = 10_000.0
+        self.close_exec_price = 0.0
+
+    def _record(self, name, kw):
+        self.calls.append((name, kw))
+
+    def set_leverage(self, **kw):
+        self._record("set_leverage", kw)
+        return {"retCode": 0, "result": {}}
+
+    def place_order(self, **kw):
+        self._record("place_order", kw)
+        self._oid += 1
+        # 시장가 진입이면 포지션이 생긴 것으로 시뮬.
+        if kw.get("orderType") == "Market" and not kw.get("reduceOnly"):
+            self.position_size = float(kw["qty"])
+        if kw.get("reduceOnly") and kw.get("orderType") == "Market" \
+                and "triggerPrice" not in kw:
+            self.position_size = 0.0
+        return {"retCode": 0, "result": {"orderId": f"oid-{self._oid}"}}
+
+    def get_positions(self, **kw):
+        self._record("get_positions", kw)
+        lst = []
+        if self.position_size > 0:
+            lst = [{"size": str(self.position_size), "side": "Buy",
+                    "avgPrice": str(self.avg_price), "leverage": "5"}]
+        return {"retCode": 0, "result": {"list": lst}}
+
+    def get_wallet_balance(self, **kw):
+        self._record("get_wallet_balance", kw)
+        return {"retCode": 0,
+                "result": {"list": [{"totalEquity": str(self.total_equity)}]}}
+
+    def get_executions(self, **kw):
+        self._record("get_executions", kw)
+        lst = []
+        if self.close_exec_price > 0:
+            lst = [{"closedSize": "0.1", "execPrice": str(self.close_exec_price)}]
+        return {"retCode": 0, "result": {"list": lst}}
+
+    def cancel_order(self, **kw):
+        self._record("cancel_order", kw)
+        return {"retCode": 0, "result": {}}
+
+    def _calls_named(self, name):
+        return [kw for n, kw in self.calls if n == name]
+
+
+def _pos_row(**over):
+    from live import tracking
+    base = dict(
+        side="long", entry_price=50_000.0, qty=0.1, leverage=1.0,
+        sl_price=49_000.0, tp1_price=0.0, tp2_price=0.0, tp3_price=0.0,
+        liq_price=0.0, entry_time="t", tranche_index=0, entry_bar_idx=0,
+        initial_risk=100.0, mode="swing")
+    base.update(over)
+    return tracking.PositionRow(**base)
+
+
+class TestExchangeBackend:
+    def test_open_places_market_then_native_sl(self, conn):
+        from live import swing, tracking
+        sess = FakeSession()
+        sess.avg_price = 50_050.0
+        be = swing.ExchangeBackend(conn, sess)
+        fill = be.open("long", 0.1, 49_000.0, 50_000.0)
+        assert fill == pytest.approx(50_050.0)  # 거래소 avgPrice 가 체결가
+        orders = sess._calls_named("place_order")
+        assert len(orders) == 2
+        entry, sl = orders
+        assert entry["side"] == "Buy" and entry["orderType"] == "Market"
+        assert not entry.get("reduceOnly")
+        assert sl["reduceOnly"] is True and sl["triggerPrice"] == "49000.0"
+        assert sl["triggerDirection"] == 2 and sl["side"] == "Sell"
+        assert tracking.get_meta(conn, "swing_sl_order_id", "swing")
+
+    def test_check_stop_detects_position_gone(self, conn):
+        from live import swing, tracking
+        sess = FakeSession()
+        sess.position_size = 0.0  # 스탑 체결로 포지션 소멸 상태
+        sess.close_exec_price = 48_990.0
+        tracking.set_meta(conn, "swing_sl_order_id", "oid-7", "swing")
+        be = swing.ExchangeBackend(conn, sess)
+        price = be.check_stop(_pos_row(), None)
+        assert price == pytest.approx(48_990.0)  # 실체결가 사용
+        assert sess._calls_named("cancel_order")  # 잔여 SL 정리
+        assert tracking.get_meta(conn, "swing_sl_order_id", "swing") == ""
+
+    def test_check_stop_holds_when_query_fails(self, conn, monkeypatch):
+        from live import swing
+
+        class DeadSession:
+            def get_positions(self, **kw):
+                raise ConnectionError("down")
+        monkeypatch.setattr(swing, "_RETRY_SLEEP_SEC", 0.0)
+        be = swing.ExchangeBackend(conn, DeadSession())
+        # 조회 실패 → None (판단 유보, 청산 기록 금지).
+        assert be.check_stop(_pos_row(), None) is None
+
+    def test_close_cancels_sl_and_market_reduces(self, conn):
+        from live import swing, tracking
+        sess = FakeSession()
+        sess.position_size = 0.1
+        sess.close_exec_price = 50_500.0
+        tracking.set_meta(conn, "swing_sl_order_id", "oid-3", "swing")
+        be = swing.ExchangeBackend(conn, sess)
+        fill = be.close(_pos_row(), 50_400.0)
+        assert fill == pytest.approx(50_500.0)
+        assert sess._calls_named("cancel_order")[0]["orderId"] == "oid-3"
+        reduces = [kw for kw in sess._calls_named("place_order")
+                   if kw.get("reduceOnly")]
+        assert reduces and reduces[0]["side"] == "Sell"
+
+    def test_process_e2e_with_exchange_backend(self, conn, monkeypatch):
+        from live import swing, tracking
+        monkeypatch.setattr(swing, "_notify", lambda *a, **k: None)  # 실발송 차단
+        sess = FakeSession()
+        sess.avg_price = 50_020.0
+        be = swing.ExchangeBackend(conn, sess)
+        res = swing.process(conn, _make_tf_data(), main_mode="demo", backend=be)
+        assert res["events"] == 1
+        pos = tracking.load_open_positions(conn, "swing")
+        assert len(pos) == 1
+        assert pos[0].entry_price == pytest.approx(50_020.0)
+        # 지갑 equity 가 원장 시드의 진실.
+        assert tracking.latest_equity(conn, "swing") == pytest.approx(10_000.0)
+
+    def test_same_key_guard_forces_virtual(self, conn, monkeypatch):
+        from live import swing
+        monkeypatch.setenv("BYBIT_SWING_API_KEY", "SAMEKEY")
+        monkeypatch.setenv("BYBIT_SWING_API_SECRET", "s")
+        monkeypatch.setenv("BYBIT_DEMO_API_KEY", "SAMEKEY")
+        sess, err = swing._make_swing_session()
+        assert sess is None
+        assert "동일" in err
+
+    def test_backend_autoselect_virtual_without_keys(self, conn, monkeypatch):
+        from live import swing
+        monkeypatch.setattr(swing, "_make_swing_session",
+                            lambda: (None, "미설정"))
+        be = swing._make_backend(conn, "demo")
+        assert be.name == "virtual"


### PR DESCRIPTION
Lane B 실집행 전환 (Rocky 승인 2026-07-22).

- 스윙 전용 데모 키(BYBIT_SWING_API_KEY/SECRET) 있으면 실주문, 없으면 가상 폴백
- 같은 계좌 사용 시 원웨이 넷팅으로 메인 reconcile 3중 오염 → 별도 계정 강제(동일키 가드)
- SWING_RUN_MODES=demo 전용: 서버 shadow/demo 크론 병행 시 커서 경합으로 알림이 영구 침묵하는 버그 수정
- 312 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)