### PR TITLE
fix: add Naver fallback for KR market snapshot

### DIFF
--- a/cores/naver_market_snapshot.py
+++ b/cores/naver_market_snapshot.py
@@ -1,0 +1,422 @@
+"""Emergency Naver-backed market snapshot for the KR screening batch.
+
+The normal source remains KRX.  This module is deliberately narrow and is
+called only after the complete KRX snapshot bundle has failed.  Naver's bulk
+market list supplies close/volume/amount/market-cap; the same XML endpoint used
+by pykrx supplies regular-session OHLCV for stocks liquid enough to reach the
+screening triggers.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import math
+import re
+import time
+import xml.etree.ElementTree as ET
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import Callable
+
+import pandas as pd
+import requests
+
+
+logger = logging.getLogger(__name__)
+
+_BULK_URL = "https://m.stock.naver.com/api/stocks/marketValue/{market}"
+_DAILY_URL = "https://fchart.stock.naver.com/sise.nhn"
+_MARKETS = ("KOSPI", "KOSDAQ")
+_PAGE_SIZE = 100  # Naver rejects larger page sizes.
+_HEADERS = {
+    "User-Agent": "Mozilla/5.0",
+    "Referer": "https://finance.naver.com/",
+}
+_REQUIRED_COLUMNS = ["Open", "High", "Low", "Close", "Volume", "Amount"]
+
+
+class NaverSnapshotError(RuntimeError):
+    """The Naver fallback could not produce a safe screening snapshot."""
+
+
+@dataclass(frozen=True)
+class MarketSnapshotBundle:
+    """All market-wide inputs consumed by ``trigger_batch.run_batch``."""
+
+    snapshot: pd.DataFrame
+    prev_snapshot: pd.DataFrame
+    cap_df: pd.DataFrame
+    prev_date: str
+    source: str
+
+
+def _as_int(value) -> int:
+    if value in (None, "", "N/A"):
+        return 0
+    return int(str(value).replace(",", ""))
+
+
+def _request_json(
+    request_get: Callable,
+    url: str,
+    *,
+    params: dict,
+    timeout: float,
+    max_attempts: int,
+    retry_wait_sec: float,
+) -> dict:
+    last_exc: Exception | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            response = request_get(
+                url,
+                params=params,
+                headers=_HEADERS,
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, dict):
+                raise ValueError("response is not a JSON object")
+            return payload
+        except Exception as exc:  # network, status, decode, or schema failure
+            last_exc = exc
+            if attempt < max_attempts and retry_wait_sec > 0:
+                time.sleep(retry_wait_sec * attempt)
+    raise NaverSnapshotError(f"Naver request failed after {max_attempts} attempts: {last_exc}")
+
+
+def _fetch_bulk_rows(
+    request_get: Callable,
+    *,
+    timeout: float,
+    max_attempts: int,
+    retry_wait_sec: float,
+    max_workers: int,
+) -> list[dict]:
+    pages: list[tuple[str, int, dict | None]] = []
+    expected_counts: dict[str, int] = {}
+
+    for market in _MARKETS:
+        url = _BULK_URL.format(market=market)
+        first = _request_json(
+            request_get,
+            url,
+            params={"page": 1, "pageSize": _PAGE_SIZE},
+            timeout=timeout,
+            max_attempts=max_attempts,
+            retry_wait_sec=retry_wait_sec,
+        )
+        total_count = _as_int(first.get("totalCount"))
+        first_rows = first.get("stocks")
+        if total_count <= 0 or not isinstance(first_rows, list):
+            raise NaverSnapshotError(f"Naver bulk schema invalid for {market}")
+        expected_counts[market] = total_count
+        pages.append((market, 1, first))
+        for page in range(2, math.ceil(total_count / _PAGE_SIZE) + 1):
+            pages.append((market, page, None))
+
+    fetched: dict[tuple[str, int], dict] = {
+        (market, page): payload
+        for market, page, payload in pages
+        if payload is not None
+    }
+    pending = [(market, page) for market, page, payload in pages if payload is None]
+
+    if pending:
+        with ThreadPoolExecutor(max_workers=max(1, min(max_workers, len(pending)))) as pool:
+            futures = {
+                pool.submit(
+                    _request_json,
+                    request_get,
+                    _BULK_URL.format(market=market),
+                    params={"page": page, "pageSize": _PAGE_SIZE},
+                    timeout=timeout,
+                    max_attempts=max_attempts,
+                    retry_wait_sec=retry_wait_sec,
+                ): (market, page)
+                for market, page in pending
+            }
+            for future in as_completed(futures):
+                fetched[futures[future]] = future.result()
+
+    all_rows: list[dict] = []
+    for market in _MARKETS:
+        market_rows: list[dict] = []
+        page_numbers = sorted(page for mkt, page in fetched if mkt == market)
+        for page in page_numbers:
+            rows = fetched[(market, page)].get("stocks")
+            if not isinstance(rows, list):
+                raise NaverSnapshotError(
+                    f"Naver bulk schema invalid for {market} page {page}"
+                )
+            market_rows.extend(rows)
+
+        expected = expected_counts[market]
+        if len(market_rows) < expected * 0.98:
+            raise NaverSnapshotError(
+                f"Naver bulk coverage too low for {market}: {len(market_rows)}/{expected}"
+            )
+        all_rows.extend(market_rows)
+
+    return all_rows
+
+
+def _parse_daily_xml(content: bytes, trade_date: str) -> tuple[dict, dict]:
+    # Naver declares EUC-KR, which Python's bundled expat parser rejects as a
+    # multi-byte encoding.  Decode explicitly, then parse the Unicode XML body.
+    text = content.decode("euc-kr", errors="replace")
+    text = re.sub(r"^\s*<\?xml[^?]*\?>", "", text, count=1)
+    root = ET.fromstring(text)
+    rows: dict[str, dict[str, int]] = {}
+    for node in root.iter("item"):
+        raw = node.get("data", "")
+        fields = raw.split("|")
+        if len(fields) != 6 or not re.fullmatch(r"\d{8}", fields[0]):
+            continue
+        date, open_, high, low, close, volume = fields
+        rows[date] = {
+            "Open": _as_int(open_),
+            "High": _as_int(high),
+            "Low": _as_int(low),
+            "Close": _as_int(close),
+            "Volume": _as_int(volume),
+        }
+
+    current = rows.get(trade_date)
+    previous_dates = sorted(date for date in rows if date < trade_date)
+    if current is None or not previous_dates:
+        raise ValueError(f"missing current/previous rows for {trade_date}")
+
+    previous = rows[previous_dates[-1]].copy()
+    previous["Date"] = previous_dates[-1]
+
+    if min(current["Open"], current["High"], current["Low"], current["Close"]) <= 0:
+        raise ValueError("non-positive OHLC")
+    if current["High"] < max(current["Open"], current["Close"]):
+        raise ValueError("high price invariant failed")
+    if current["Low"] > min(current["Open"], current["Close"]):
+        raise ValueError("low price invariant failed")
+    if current["Volume"] < 0 or previous["Volume"] < 0:
+        raise ValueError("negative volume")
+
+    return current, previous
+
+
+def _fetch_daily_pair(
+    request_get: Callable,
+    ticker: str,
+    trade_date: str,
+    *,
+    timeout: float,
+    max_attempts: int,
+    retry_wait_sec: float,
+) -> tuple[dict, dict]:
+    last_exc: Exception | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            response = request_get(
+                _DAILY_URL,
+                params={
+                    "symbol": ticker,
+                    "timeframe": "day",
+                    "count": 10,
+                    "requestType": "0",
+                },
+                headers=_HEADERS,
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            return _parse_daily_xml(response.content, trade_date)
+        except Exception as exc:  # transport, parse, or data invariant
+            last_exc = exc
+            if attempt < max_attempts and retry_wait_sec > 0:
+                time.sleep(retry_wait_sec * attempt)
+    raise NaverSnapshotError(f"{ticker} detail failed: {last_exc}")
+
+
+def fetch_naver_snapshot_bundle(
+    trade_date: str,
+    *,
+    request_get: Callable = requests.get,
+    min_stock_count: int = 2500,
+    detail_min_amount: int = 10_000_000_000,
+    min_detail_coverage: float = 0.98,
+    max_workers: int = 5,
+    timeout: float = 10.0,
+    max_attempts: int = 3,
+    retry_wait_sec: float = 0.5,
+) -> MarketSnapshotBundle:
+    """Build a KRX-compatible current/previous/cap bundle from Naver.
+
+    Detailed OHLCV is fetched only for rows that can pass the screening
+    pipeline's 10B KRW minimum amount gate.  All rows remain in the base frames
+    so market-average volume calculations preserve their original universe.
+    """
+    if not re.fullmatch(r"\d{8}", trade_date):
+        raise ValueError("trade_date must be YYYYMMDD")
+    if not 0 < min_detail_coverage <= 1:
+        raise ValueError("min_detail_coverage must be in (0, 1]")
+
+    bulk_rows = _fetch_bulk_rows(
+        request_get,
+        timeout=timeout,
+        max_attempts=max_attempts,
+        retry_wait_sec=retry_wait_sec,
+        max_workers=max_workers,
+    )
+
+    normalized: dict[str, dict] = {}
+    bulk_dates: list[str] = []
+    for row in bulk_rows:
+        code = str(row.get("itemCode", ""))
+        if row.get("stockEndType") != "stock" or not re.fullmatch(r"\d{6}", code):
+            continue
+
+        # Display fields use mixed units (notably trading value/market cap are
+        # shown in KRW millions).  Never guess units when the raw fields drift.
+        required_raw = (
+            "closePriceRaw",
+            "compareToPreviousClosePriceRaw",
+            "accumulatedTradingVolumeRaw",
+            "accumulatedTradingValueRaw",
+            "marketValueRaw",
+        )
+        if any(row.get(field) in (None, "") for field in required_raw):
+            continue
+
+        close = _as_int(row["closePriceRaw"])
+        volume = _as_int(row["accumulatedTradingVolumeRaw"])
+        amount = _as_int(row["accumulatedTradingValueRaw"])
+        market_cap = _as_int(row["marketValueRaw"])
+        change = _as_int(row["compareToPreviousClosePriceRaw"])
+        traded_at = str(row.get("localTradedAt", ""))
+        if len(traded_at) >= 10:
+            bulk_dates.append(traded_at[:10].replace("-", ""))
+        if close <= 0:
+            continue
+
+        normalized[code] = {
+            "Close": close,
+            "Volume": max(volume, 0),
+            "Amount": max(amount, 0),
+            "MarketCap": max(market_cap, 0),
+            "PrevClose": close - change,
+        }
+
+    if len(normalized) < min_stock_count:
+        raise NaverSnapshotError(
+            f"Naver stock coverage too low: {len(normalized)}/{min_stock_count}"
+        )
+    if len(bulk_dates) < min_stock_count * 0.95:
+        raise NaverSnapshotError(
+            f"Naver timestamp coverage too low: {len(bulk_dates)}/{min_stock_count}"
+        )
+    if bulk_dates.count(trade_date) / len(bulk_dates) < 0.95:
+        observed = Counter(bulk_dates).most_common(1)
+        raise NaverSnapshotError(
+            f"Naver bulk data is stale for {trade_date}; observed={observed}"
+        )
+
+    index = sorted(normalized)
+    snapshot = pd.DataFrame(index=index, columns=_REQUIRED_COLUMNS, dtype=float)
+    prev_snapshot = pd.DataFrame(index=index, columns=_REQUIRED_COLUMNS, dtype=float)
+    cap_df = pd.DataFrame(index=index, columns=["시가총액"], dtype=float)
+
+    for code in index:
+        row = normalized[code]
+        snapshot.loc[code, ["Close", "Volume", "Amount"]] = [
+            row["Close"],
+            row["Volume"],
+            row["Amount"],
+        ]
+        prev_snapshot.loc[code, "Close"] = row["PrevClose"]
+        cap_df.loc[code, "시가총액"] = row["MarketCap"]
+
+    detail_codes = [
+        code for code in index if normalized[code]["Amount"] >= detail_min_amount
+    ]
+    detail_results: dict[str, tuple[dict, dict]] = {}
+    detail_failures: dict[str, str] = {}
+
+    if detail_codes:
+        with ThreadPoolExecutor(
+            max_workers=max(1, min(max_workers, len(detail_codes)))
+        ) as pool:
+            futures = {
+                pool.submit(
+                    _fetch_daily_pair,
+                    request_get,
+                    code,
+                    trade_date,
+                    timeout=timeout,
+                    max_attempts=max_attempts,
+                    retry_wait_sec=retry_wait_sec,
+                ): code
+                for code in detail_codes
+            }
+            for future in as_completed(futures):
+                code = futures[future]
+                try:
+                    detail_results[code] = future.result()
+                except Exception as exc:
+                    detail_failures[code] = str(exc)
+
+    coverage = len(detail_results) / len(detail_codes) if detail_codes else 1.0
+    if coverage < min_detail_coverage:
+        raise NaverSnapshotError(
+            "Naver detail coverage too low: "
+            f"{len(detail_results)}/{len(detail_codes)} ({coverage:.1%}); "
+            f"failures={list(detail_failures)[:10]}"
+        )
+
+    previous_dates: list[str] = []
+    for code, (current, previous) in detail_results.items():
+        snapshot.loc[code, ["Open", "High", "Low", "Close", "Volume"]] = [
+            current["Open"],
+            current["High"],
+            current["Low"],
+            current["Close"],
+            current["Volume"],
+        ]
+        prev_snapshot.loc[code, ["Open", "High", "Low", "Close", "Volume"]] = [
+            previous["Open"],
+            previous["High"],
+            previous["Low"],
+            previous["Close"],
+            previous["Volume"],
+        ]
+        previous_dates.append(previous["Date"])
+
+    # A failed detail row must never leak through the amount gate with NaN OHLC.
+    for code in detail_failures:
+        snapshot.loc[code, "Amount"] = 0
+
+    if previous_dates:
+        prev_date, prev_count = Counter(previous_dates).most_common(1)[0]
+        if prev_count / len(previous_dates) < min_detail_coverage:
+            raise NaverSnapshotError(
+                f"Naver previous-date coverage too low: {prev_count}/{len(previous_dates)}"
+            )
+    else:
+        prev_date = (dt.datetime.strptime(trade_date, "%Y%m%d") - dt.timedelta(days=1)).strftime(
+            "%Y%m%d"
+        )
+
+    logger.warning(
+        "[NAVER-SNAPSHOT-FALLBACK] stocks=%d detail=%d/%d prev_date=%s failures=%d",
+        len(snapshot),
+        len(detail_results),
+        len(detail_codes),
+        prev_date,
+        len(detail_failures),
+    )
+    return MarketSnapshotBundle(
+        snapshot=snapshot,
+        prev_snapshot=prev_snapshot,
+        cap_df=cap_df,
+        prev_date=prev_date,
+        source="naver",
+    )

--- a/cores/naver_market_snapshot.py
+++ b/cores/naver_market_snapshot.py
@@ -14,7 +14,6 @@ import logging
 import math
 import re
 import time
-import xml.etree.ElementTree as ET
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
@@ -166,13 +165,13 @@ def _fetch_bulk_rows(
 
 def _parse_daily_xml(content: bytes, trade_date: str) -> tuple[dict, dict]:
     # Naver declares EUC-KR, which Python's bundled expat parser rejects as a
-    # multi-byte encoding.  Decode explicitly, then parse the Unicode XML body.
+    # multi-byte encoding. Decode explicitly and extract only the inert data
+    # attribute. Do not invoke an XML parser on this untrusted network input;
+    # the endpoint's external entities and declarations must never be resolved.
     text = content.decode("euc-kr", errors="replace")
-    text = re.sub(r"^\s*<\?xml[^?]*\?>", "", text, count=1)
-    root = ET.fromstring(text)
     rows: dict[str, dict[str, int]] = {}
-    for node in root.iter("item"):
-        raw = node.get("data", "")
+    for match in re.finditer(r'<item\s+data="([^"]*)"\s*/?>', text):
+        raw = match.group(1)
         fields = raw.split("|")
         if len(fields) != 6 or not re.fullmatch(r"\d{8}", fields[0]):
             continue

--- a/stock_analysis_orchestrator.py
+++ b/stock_analysis_orchestrator.py
@@ -428,9 +428,11 @@ class StockAnalysisOrchestrator:
             list: List of selected stock codes
         """
         logger.info(f"Starting trigger batch execution: {mode}")
+        market_data_error_type = None
         try:
             # Direct import instead of subprocess to share KRX session
-            from trigger_batch import run_batch
+            from trigger_batch import MarketSnapshotUnavailableError, run_batch
+            market_data_error_type = MarketSnapshotUnavailableError
 
             # Results file path
             results_file = f"trigger_results_{mode}_{datetime.now().strftime('%Y%m%d')}.json"
@@ -504,6 +506,9 @@ class StockAnalysisOrchestrator:
             logger.error(f"Error during trigger batch execution: {str(e)}")
             import traceback
             logger.error(traceback.format_exc())
+            if market_data_error_type and isinstance(e, market_data_error_type):
+                from telegram_config import send_market_data_failure_alert
+                await send_market_data_failure_alert(self.telegram_config, mode=mode)
             return []
 
     async def convert_to_pdf(self, report_paths):

--- a/telegram_config.py
+++ b/telegram_config.py
@@ -249,6 +249,39 @@ async def send_buy_analysis_failure_alert(telegram_config: "TelegramConfig", fai
         logger.error(f"[{market}] Failed to send buy-analysis failure alert: {e}")
 
 
+async def send_market_data_failure_alert(
+    telegram_config: "TelegramConfig",
+    mode: str,
+    market: str = "KR",
+):
+    """Alert operators when both primary and fallback market data fail."""
+    if not telegram_config or not telegram_config.use_telegram:
+        return
+
+    try:
+        from telegram import Bot
+        from telegram.request import HTTPXRequest
+
+        request = HTTPXRequest(connect_timeout=10.0, read_timeout=10.0)
+        bot = Bot(token=telegram_config.bot_token, request=request)
+        batch_label = "오전" if mode == "morning" else "오후"
+        alert_message = (
+            f"🚨 [{market}] {batch_label} 종목 선정 중단\n\n"
+            "KRX 전종목 시세 조회와 네이버 비상 폴백이 모두 실패해 "
+            "이번 배치를 안전하게 중단했습니다.\n\n"
+            "• 조치: 서버 로그의 [MARKET-DATA] 및 "
+            "[NAVER-SNAPSHOT-FALLBACK] 항목 확인"
+        )
+
+        await bot.send_message(
+            chat_id=telegram_config.channel_id,
+            text=alert_message,
+        )
+        logger.info(f"[{market}] Market-data failure alert sent ({mode})")
+    except Exception as e:
+        logger.error(f"[{market}] Failed to send market-data failure alert: {e}")
+
+
 # --- Market Pulse "batch resting" subscriber notice (static, no LLM) -----------
 # When the Market Pulse hook rests a LIVE batch, subscribers would otherwise see
 # silence. These pre-translated notices explain the pause. Deterministic /

--- a/tests/test_naver_market_snapshot.py
+++ b/tests/test_naver_market_snapshot.py
@@ -1,0 +1,311 @@
+"""Tests for the emergency Naver market snapshot fallback.
+
+All HTTP responses are fixtures.  CI must never depend on live Naver/KRX data.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections import Counter
+from unittest.mock import AsyncMock
+
+import pandas as pd
+import pytest
+
+from cores.naver_market_snapshot import (
+    MarketSnapshotBundle,
+    NaverSnapshotError,
+    fetch_naver_snapshot_bundle,
+)
+
+
+TRADE_DATE = "20260722"
+
+
+class _Response:
+    def __init__(self, *, payload=None, text="", status_code=200):
+        self._payload = payload
+        self.text = text
+        self.content = text.encode("utf-8")
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        if self._payload is None:
+            return json.loads(self.text)
+        return self._payload
+
+
+def _stock(
+    code: str,
+    *,
+    close: int,
+    change: int,
+    volume: int,
+    amount: int,
+    market_cap: int,
+    market: str,
+    traded_at: str = "2026-07-22T14:46:10+09:00",
+):
+    return {
+        "stockType": "domestic",
+        "stockEndType": "stock",
+        "itemCode": code,
+        "stockName": f"stock-{code}",
+        "closePriceRaw": str(close),
+        "compareToPreviousClosePriceRaw": str(change),
+        "accumulatedTradingVolumeRaw": str(volume),
+        "accumulatedTradingValueRaw": str(amount),
+        "marketValueRaw": str(market_cap),
+        "localTradedAt": traded_at,
+        "stockExchangeType": {"name": market},
+    }
+
+
+def _daily_xml(code: str) -> str:
+    rows = {
+        "005930": [
+            "20260721|69000|71000|68000|69000|900000",
+            "20260722|70000|73000|69500|70000|1000000",
+        ],
+        "035720": [
+            "20260721|51000|52000|50000|51000|1500000",
+            "20260722|50500|51500|49500|50000|2000000",
+        ],
+    }[code]
+    items = "".join(f'<item data="{row}" />' for row in rows)
+    return f"<?xml version='1.0'?><protocol><chartdata>{items}</chartdata></protocol>"
+
+
+class _FixtureGet:
+    def __init__(self, *, stale=False, fail_detail_code=None):
+        self.calls = Counter()
+        traded_at = (
+            "2026-07-21T14:46:10+09:00"
+            if stale
+            else "2026-07-22T14:46:10+09:00"
+        )
+        self.market_rows = {
+            "KOSPI": [
+                _stock(
+                    "005930",
+                    close=70000,
+                    change=1000,
+                    volume=1000000,
+                    amount=20_000_000_000,
+                    market_cap=500_000_000_000,
+                    market="KOSPI",
+                    traded_at=traded_at,
+                ),
+                _stock(
+                    "000660",
+                    close=50000,
+                    change=1000,
+                    volume=100000,
+                    amount=5_000_000_000,
+                    market_cap=400_000_000_000,
+                    market="KOSPI",
+                    traded_at=traded_at,
+                ),
+            ],
+            "KOSDAQ": [
+                _stock(
+                    "035720",
+                    close=50000,
+                    change=-1000,
+                    volume=2000000,
+                    amount=15_000_000_000,
+                    market_cap=600_000_000_000,
+                    market="KOSDAQ",
+                    traded_at=traded_at,
+                )
+            ],
+        }
+        self.fail_detail_code = fail_detail_code
+
+    def __call__(self, url, *, params, headers, timeout):
+        if "marketValue" in url:
+            market = url.rsplit("/", 1)[-1]
+            self.calls[f"bulk:{market}"] += 1
+            rows = self.market_rows[market]
+            return _Response(
+                payload={
+                    "stocks": rows,
+                    "totalCount": len(rows),
+                    "page": 1,
+                    "pageSize": 100,
+                }
+            )
+
+        code = params["symbol"]
+        self.calls[f"detail:{code}"] += 1
+        if code == self.fail_detail_code:
+            return _Response(text="not xml")
+        return _Response(text=_daily_xml(code))
+
+
+def _fetch(fake_get, **kwargs):
+    return fetch_naver_snapshot_bundle(
+        TRADE_DATE,
+        request_get=fake_get,
+        min_stock_count=3,
+        detail_min_amount=10_000_000_000,
+        min_detail_coverage=0.98,
+        max_workers=2,
+        max_attempts=1,
+        retry_wait_sec=0,
+        **kwargs,
+    )
+
+
+def test_fetch_builds_current_previous_and_cap_contract():
+    fake_get = _FixtureGet()
+
+    bundle = _fetch(fake_get)
+
+    assert isinstance(bundle, MarketSnapshotBundle)
+    assert bundle.source == "naver"
+    assert bundle.prev_date == "20260721"
+    assert list(bundle.snapshot.columns) == [
+        "Open",
+        "High",
+        "Low",
+        "Close",
+        "Volume",
+        "Amount",
+    ]
+    assert bundle.snapshot.loc["005930", "High"] == 73000
+    assert bundle.snapshot.loc["035720", "Low"] == 49500
+    assert pd.isna(bundle.snapshot.loc["000660", "Open"])
+    assert bundle.prev_snapshot.loc["005930", "Volume"] == 900000
+    assert bundle.prev_snapshot.loc["000660", "Close"] == 49000
+    assert bundle.cap_df.loc["035720", "시가총액"] == 600_000_000_000
+    assert fake_get.calls["detail:005930"] == 1
+    assert fake_get.calls["detail:035720"] == 1
+    assert fake_get.calls["detail:000660"] == 0
+
+
+def test_fetch_rejects_stale_bulk_trade_date():
+    with pytest.raises(NaverSnapshotError, match="stale"):
+        _fetch(_FixtureGet(stale=True))
+
+
+def test_fetch_fails_closed_when_detail_coverage_is_too_low():
+    with pytest.raises(NaverSnapshotError, match="coverage"):
+        _fetch(_FixtureGet(fail_detail_code="035720"))
+
+
+def test_fetch_rejects_bulk_rows_without_raw_unit_fields():
+    fake_get = _FixtureGet()
+    del fake_get.market_rows["KOSPI"][0]["accumulatedTradingValueRaw"]
+    fake_get.market_rows["KOSPI"][0]["accumulatedTradingValue"] = "20,000"
+
+    with pytest.raises(NaverSnapshotError, match="coverage"):
+        _fetch(fake_get)
+
+
+def test_trigger_batch_uses_naver_bundle_after_krx_failure(monkeypatch):
+    import trigger_batch
+
+    fake_get = _FixtureGet()
+    naver_bundle = _fetch(fake_get)
+    monkeypatch.setattr(
+        trigger_batch,
+        "get_snapshot",
+        lambda _date: (_ for _ in ()).throw(RuntimeError("KRX down")),
+    )
+    monkeypatch.setattr(
+        trigger_batch,
+        "fetch_naver_snapshot_bundle",
+        lambda _date, **_kwargs: naver_bundle,
+    )
+
+    result = trigger_batch.load_market_snapshot_bundle(TRADE_DATE)
+
+    assert result is naver_bundle
+    assert result.source == "naver"
+
+
+def test_trigger_batch_keeps_krx_as_primary(monkeypatch):
+    import trigger_batch
+
+    snapshot = pd.DataFrame(
+        {
+            "Open": [10],
+            "High": [12],
+            "Low": [9],
+            "Close": [11],
+            "Volume": [100],
+            "Amount": [1100],
+        },
+        index=["005930"],
+    )
+    previous = snapshot.copy()
+    cap = pd.DataFrame({"시가총액": [1_000_000]}, index=["005930"])
+    monkeypatch.setattr(trigger_batch, "get_snapshot", lambda _date: snapshot)
+    monkeypatch.setattr(
+        trigger_batch,
+        "get_previous_snapshot",
+        lambda _date: (previous, "20260721"),
+    )
+    monkeypatch.setattr(trigger_batch, "get_market_cap_df", lambda _date: cap)
+    monkeypatch.setattr(
+        trigger_batch,
+        "fetch_naver_snapshot_bundle",
+        lambda _date, **_kwargs: (_ for _ in ()).throw(AssertionError("fallback called")),
+    )
+
+    result = trigger_batch.load_market_snapshot_bundle(TRADE_DATE)
+
+    assert result.source == "krx"
+    assert result.snapshot is snapshot
+    assert result.prev_snapshot is previous
+    assert result.cap_df is cap
+
+
+def test_trigger_batch_raises_typed_error_when_both_sources_fail(monkeypatch):
+    import trigger_batch
+
+    monkeypatch.setattr(
+        trigger_batch,
+        "get_snapshot",
+        lambda _date: (_ for _ in ()).throw(RuntimeError("KRX down")),
+    )
+    monkeypatch.setattr(
+        trigger_batch,
+        "fetch_naver_snapshot_bundle",
+        lambda _date, **_kwargs: (_ for _ in ()).throw(RuntimeError("Naver down")),
+    )
+
+    with pytest.raises(trigger_batch.MarketSnapshotUnavailableError):
+        trigger_batch.load_market_snapshot_bundle(TRADE_DATE)
+
+
+def test_orchestrator_alerts_when_both_market_sources_fail(monkeypatch):
+    import stock_analysis_orchestrator
+    import telegram_config
+    import trigger_batch
+
+    monkeypatch.setattr(
+        trigger_batch,
+        "run_batch",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            trigger_batch.MarketSnapshotUnavailableError("both sources down")
+        ),
+    )
+    send_alert = AsyncMock()
+    monkeypatch.setattr(telegram_config, "send_market_data_failure_alert", send_alert)
+
+    orchestrator = stock_analysis_orchestrator.StockAnalysisOrchestrator.__new__(
+        stock_analysis_orchestrator.StockAnalysisOrchestrator
+    )
+    orchestrator.telegram_config = object()
+
+    result = asyncio.run(orchestrator.run_trigger_batch("afternoon"))
+
+    assert result == []
+    send_alert.assert_awaited_once_with(orchestrator.telegram_config, mode="afternoon")

--- a/tests/test_naver_market_snapshot.py
+++ b/tests/test_naver_market_snapshot.py
@@ -16,6 +16,7 @@ import pytest
 from cores.naver_market_snapshot import (
     MarketSnapshotBundle,
     NaverSnapshotError,
+    _parse_daily_xml,
     fetch_naver_snapshot_bundle,
 )
 
@@ -206,6 +207,18 @@ def test_fetch_rejects_bulk_rows_without_raw_unit_fields():
 
     with pytest.raises(NaverSnapshotError, match="coverage"):
         _fetch(fake_get)
+
+
+def test_daily_parser_never_resolves_external_xml_entities():
+    malicious = b'''<?xml version="1.0"?>
+<!DOCTYPE protocol [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+<protocol><chartdata>
+<item data="20260721|69000|71000|68000|69000|900000" />
+<item data="20260722|&xxe;|73000|69500|70000|1000000" />
+</chartdata></protocol>'''
+
+    with pytest.raises(ValueError, match="invalid literal"):
+        _parse_daily_xml(malicious, TRADE_DATE)
 
 
 def test_trigger_batch_uses_naver_bundle_after_krx_failure(monkeypatch):

--- a/trigger_batch.py
+++ b/trigger_batch.py
@@ -10,6 +10,10 @@ import logging
 import os
 import time
 from typing import Optional
+from cores.naver_market_snapshot import (
+    MarketSnapshotBundle,
+    fetch_naver_snapshot_bundle,
+)
 from cores.rs_rating import oneil_weighted_return, percentile_ratings
 from krx_data_client import (
     _get_client,
@@ -36,6 +40,11 @@ logger.addHandler(ch)
 
 
 _TICKER_NAME_CACHE: Optional[dict[str, str]] = None
+SCREENING_MIN_TRADE_VALUE = 10_000_000_000
+
+
+class MarketSnapshotUnavailableError(RuntimeError):
+    """Raised when neither KRX nor the emergency Naver source is usable."""
 
 
 def _normalize_ticker_code(ticker) -> str:
@@ -235,6 +244,60 @@ def get_market_cap_df(trade_date: str, market: str = "ALL") -> pd.DataFrame:
         logger.error(f"No market cap data for {trade_date}.")
         raise ValueError(f"No market cap data for {trade_date}.")
     return cap_df
+
+
+def load_market_snapshot_bundle(trade_date: str) -> MarketSnapshotBundle:
+    """Load current, previous, and market-cap data from one coherent source.
+
+    KRX is always primary.  If any market-wide KRX input fails, rebuild the
+    complete bundle from Naver rather than mixing sources with different
+    timestamps or universes.
+    """
+    try:
+        snapshot = get_snapshot(trade_date)
+        prev_snapshot, prev_date = get_previous_snapshot(trade_date)
+        cap_df = get_market_cap_df(trade_date)
+        logger.info(
+            "[MARKET-DATA] source=KRX stocks=%d prev_date=%s cap_rows=%d",
+            len(snapshot),
+            prev_date,
+            len(cap_df),
+        )
+        return MarketSnapshotBundle(
+            snapshot=snapshot,
+            prev_snapshot=prev_snapshot,
+            cap_df=cap_df,
+            prev_date=prev_date,
+            source="krx",
+        )
+    except Exception as krx_exc:
+        logger.warning(
+            "[MARKET-DATA] KRX bundle failed; switching to Naver fallback: %s",
+            krx_exc,
+        )
+        try:
+            bundle = fetch_naver_snapshot_bundle(
+                trade_date,
+                detail_min_amount=SCREENING_MIN_TRADE_VALUE,
+            )
+        except Exception as naver_exc:
+            logger.error(
+                "[MARKET-DATA] both KRX and Naver snapshot sources failed: "
+                "krx=%s naver=%s",
+                krx_exc,
+                naver_exc,
+            )
+            raise MarketSnapshotUnavailableError(
+                f"Market snapshot unavailable from KRX and Naver: {naver_exc}"
+            ) from naver_exc
+
+        logger.warning(
+            "[MARKET-DATA] source=NAVER_FALLBACK stocks=%d prev_date=%s cap_rows=%d",
+            len(bundle.snapshot),
+            bundle.prev_date,
+            len(bundle.cap_df),
+        )
+        return bundle
 
 def filter_low_liquidity(df: pd.DataFrame, threshold: float = 0.2) -> pd.DataFrame:
     """
@@ -622,7 +685,7 @@ def trigger_morning_volume_surge(trade_date: str, snapshot: pd.DataFrame, prev_s
     logger.debug(f"Current day close data sample: {snap['Close'].head()}")
 
     # Apply absolute criteria (raised to 10B KRW trade value)
-    snap = apply_absolute_filters(snap, min_value=10000000000)
+    snap = apply_absolute_filters(snap, min_value=SCREENING_MIN_TRADE_VALUE)
 
     # Calculate volume ratio
     snap["volume_ratio"] = snap["Volume"] / prev["Volume"].replace(0, np.nan)
@@ -695,7 +758,7 @@ def trigger_morning_gap_up_momentum(trade_date: str, snapshot: pd.DataFrame, pre
             return pd.DataFrame()
 
     # Apply absolute criteria (raised to 10B KRW trade value)
-    snap = apply_absolute_filters(snap, min_value=10000000000)
+    snap = apply_absolute_filters(snap, min_value=SCREENING_MIN_TRADE_VALUE)
 
     # Calculate gap rate
     snap["gap_up_rate"] = (snap["Open"] / prev["Close"] - 1) * 100
@@ -796,7 +859,7 @@ def trigger_morning_value_to_cap_ratio(trade_date: str, snapshot: pd.DataFrame, 
 
         # Apply absolute criteria (raised to 10B KRW trade value)
         logger.debug("Starting absolute criteria filtering")
-        merged = apply_absolute_filters(merged, min_value=10000000000)
+        merged = apply_absolute_filters(merged, min_value=SCREENING_MIN_TRADE_VALUE)
         if merged.empty:
             logger.warning("No stocks after absolute criteria filtering")
             return pd.DataFrame()
@@ -897,7 +960,7 @@ def trigger_afternoon_daily_rise_top(trade_date: str, snapshot: pd.DataFrame, pr
             return pd.DataFrame()
 
     # Apply absolute criteria (raised to 10B KRW trade value)
-    snap = apply_absolute_filters(snap.copy(), min_value=10000000000)
+    snap = apply_absolute_filters(snap.copy(), min_value=SCREENING_MIN_TRADE_VALUE)
 
     # Calculate two types of change rates
     snap["intraday_change_rate"] = (snap["Close"] / snap["Open"] - 1) * 100  # Current vs opening price
@@ -943,7 +1006,7 @@ def trigger_afternoon_closing_strength(trade_date: str, snapshot: pd.DataFrame, 
             return pd.DataFrame()
 
     # Apply absolute criteria (raised to 10B KRW trade value)
-    snap = apply_absolute_filters(snap, min_value=10000000000)
+    snap = apply_absolute_filters(snap, min_value=SCREENING_MIN_TRADE_VALUE)
 
     # Calculate closing strength (closer to high = closer to 1)
     snap["closing_strength"] = 0.0  # Set default value
@@ -1022,7 +1085,7 @@ def trigger_afternoon_volume_surge_flat(trade_date: str, snapshot: pd.DataFrame,
             return pd.DataFrame()
 
     # Apply absolute criteria (raised to 10B KRW trade value)
-    snap = apply_absolute_filters(snap, min_value=10000000000)
+    snap = apply_absolute_filters(snap, min_value=SCREENING_MIN_TRADE_VALUE)
 
     # Calculate volume increase rate
     snap["volume_increase_rate"] = (snap["Volume"] / prev["Volume"].replace(0, np.nan) - 1) * 100
@@ -1111,7 +1174,7 @@ def trigger_macro_sector_leader(trade_date: str, snapshot: pd.DataFrame,
     prev = prev_snapshot.loc[common].copy()
 
     # Absolute filters (100억원)
-    snap = apply_absolute_filters(snap, min_value=10000000000)
+    snap = apply_absolute_filters(snap, min_value=SCREENING_MIN_TRADE_VALUE)
 
     if snap.empty:
         logger.debug("trigger_macro_sector_leader: No stocks pass absolute filters")
@@ -1220,7 +1283,7 @@ def trigger_contrarian_value(trade_date: str, snapshot: pd.DataFrame,
     prev = prev_snapshot.loc[common].copy()
 
     # Absolute filters (100억원)
-    snap = apply_absolute_filters(snap, min_value=10000000000)
+    snap = apply_absolute_filters(snap, min_value=SCREENING_MIN_TRADE_VALUE)
 
     # Filter rising stocks today (Close > Open) — positive recovery signal
     snap["DailyChange"] = ((snap["Close"] - prev["Close"]) / prev["Close"]) * 100
@@ -1632,18 +1695,12 @@ def run_batch(trigger_time: str, log_level: str = "INFO", output_file: str = Non
     trade_date = stock_api.get_nearest_business_day_in_a_week(today_str, prev=True)
     logger.info(f"Batch reference trading date: {trade_date}")
 
-    try:
-        snapshot = get_snapshot(trade_date)
-    except ValueError as e:
-        logger.error(f"Snapshot query failed: {e}")
-        trade_date = stock_api.get_nearest_business_day_in_a_week(trade_date, prev=True)
-        logger.info(f"Retry batch reference trading date: {trade_date}")
-        snapshot = get_snapshot(trade_date)
-
-    prev_snapshot, prev_date = get_previous_snapshot(trade_date)
+    market_data = load_market_snapshot_bundle(trade_date)
+    snapshot = market_data.snapshot
+    prev_snapshot = market_data.prev_snapshot
+    prev_date = market_data.prev_date
+    cap_df = market_data.cap_df
     logger.debug(f"Previous trading date: {prev_date}")
-
-    cap_df = get_market_cap_df(trade_date, market="ALL")
     logger.debug(f"Market cap data stock count: {len(cap_df)}")
 
     if trigger_time == "morning":


### PR DESCRIPTION
## Summary
- keep the coherent KRX current/previous/cap bundle as the primary screening source
- fall back to Naver bulk market data plus regular-session OHLCV when KRX snapshot loading fails
- fail closed on stale dates, low stock/detail coverage, schema drift, or invalid OHLCV
- alert Telegram only when both KRX and Naver sources fail

## Design notes
- uses raw KRW fields from Naver to avoid display-unit ambiguity
- fetches detailed OHLCV only for stocks above the existing KRW 10B screening gate
- preserves the full bulk universe for market-relative volume calculations
- explicit timeouts, bounded retries, concurrency limit, and source-labelled logs

## Verification
- `python -m pytest -q tests/test_naver_market_snapshot.py tests/test_screening_fetch.py tests/test_screening_change_rate.py tests/test_trigger_batch_enhance_dataframe.py` (27 passed)
- `python tests/test_issue_289_screening.py` (59 passed)
- `python -m py_compile ...`
- `ruff check cores/naver_market_snapshot.py tests/test_naver_market_snapshot.py`
- live Naver bundle smoke: 2,689 stocks, 245/245 eligible detail rows, ~3.6s
- live afternoon trigger smoke: 10 / 10 / 1 candidates with no required-field nulls

## Operational risk
Naver endpoints are undocumented and remain an emergency-only dependency. The adapter fails closed and leaves KRX as the default path.