### PR TITLE
fix(btc): make swing demo credential names explicit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,6 +123,9 @@ TELEGRAM_CHANNEL_ID=your_channel_id
 # Bybit DEMO trading credentials (prism-btc/live/demo.py)
 # BYBIT_DEMO_API_KEY=your_bybit_demo_api_key
 # BYBIT_DEMO_API_SECRET=your_bybit_demo_api_secret
+# Separate Bybit DEMO subaccount credentials for the BTC swing lane
+# BYBIT_SWING_DEMO_API_KEY=your_bybit_swing_demo_api_key
+# BYBIT_SWING_DEMO_API_SECRET=your_bybit_swing_demo_api_secret
 # Telegram channel for BTC ops/healthcheck alerts (prism-btc/live/healthcheck.py)
 # BTC_OPS_CHANNEL_ID=your_btc_ops_channel_id
 

--- a/prism-btc/live/runner.py
+++ b/prism-btc/live/runner.py
@@ -160,7 +160,7 @@ def tick(mode: str = "shadow", market_db_path=None, root_db_path=None) -> dict:
     # --- 2b. 스윙 레인 (라운드6 Lane B — mode='swing' 자체 원장) ---
     # SWING_RUN_MODES 틱에서만 구동 (기본 demo 전용 — shadow/demo 크론 병행 시
     # 커서 경합 방지). 집행 백엔드는 swing 모듈이 자동 선택: 스윙 전용 키
-    # (BYBIT_SWING_API_KEY/SECRET, 메인과 별도 계정) 있으면 실주문, 없으면
+    # (BYBIT_SWING_DEMO_API_KEY/SECRET, 메인과 별도 계정) 있으면 실주문, 없으면
     # 가상 체결. 메인 결정로직/상태와 완전 독립 (자체 메타 커서). 어떤 예외도
     # 메인 트레이딩을 멈출 수 없다. 검증: tasks/btc_round6_swing_lane.md.
     try:

--- a/prism-btc/live/swing.py
+++ b/prism-btc/live/swing.py
@@ -3,7 +3,8 @@
 # 결정 로직은 core/swing.py 순수함수 (백테스트 패리티 고정). 이 모듈은 집행만.
 #
 # 집행 백엔드 2종 (v2):
-#   - ExchangeBackend: 스윙 전용 Bybit 데모 키(BYBIT_SWING_API_KEY/SECRET)로
+#   - ExchangeBackend: 스윙 전용 Bybit 데모 키
+#     (BYBIT_SWING_DEMO_API_KEY/SECRET)로
 #     실주문. ★ 메인 레인 키와 반드시 다른 계정(별도 지갑)이어야 한다 —
 #     같은 계좌를 쓰면 원웨이 넷팅으로 DemoAdapter 의 reconcile 3중 오염:
 #     ① _sync_state 가 임의 포지션을 메인 것으로 채택 ② _record_closed_trades
@@ -62,20 +63,20 @@ _RETRY_SLEEP_SEC = 0.5
 # ---------------------------------------------------------------------------
 
 def _make_swing_session():
-    key = os.environ.get("BYBIT_SWING_API_KEY")
-    secret = os.environ.get("BYBIT_SWING_API_SECRET")
+    key = os.environ.get("BYBIT_SWING_DEMO_API_KEY")
+    secret = os.environ.get("BYBIT_SWING_DEMO_API_SECRET")
     if not key or not secret:
         try:
             from pathlib import Path
 
             from dotenv import load_dotenv
             load_dotenv(Path(__file__).resolve().parent.parent.parent / ".env")
-            key = os.environ.get("BYBIT_SWING_API_KEY")
-            secret = os.environ.get("BYBIT_SWING_API_SECRET")
+            key = os.environ.get("BYBIT_SWING_DEMO_API_KEY")
+            secret = os.environ.get("BYBIT_SWING_DEMO_API_SECRET")
         except Exception:  # noqa: BLE001
             pass
     if not key or not secret:
-        return None, "BYBIT_SWING_API_KEY/SECRET 미설정"
+        return None, "BYBIT_SWING_DEMO_API_KEY/SECRET 미설정"
     # 안전 가드: 메인 키와 동일하면 실집행 금지 (넷팅 오염 방지).
     if key == os.environ.get("BYBIT_DEMO_API_KEY"):
         return None, "SWING 키가 메인 DEMO 키와 동일 — 별도 계정 필요, 가상 폴백"

--- a/prism-btc/tests/test_swing.py
+++ b/prism-btc/tests/test_swing.py
@@ -407,8 +407,8 @@ class TestExchangeBackend:
 
     def test_same_key_guard_forces_virtual(self, conn, monkeypatch):
         from live import swing
-        monkeypatch.setenv("BYBIT_SWING_API_KEY", "SAMEKEY")
-        monkeypatch.setenv("BYBIT_SWING_API_SECRET", "s")
+        monkeypatch.setenv("BYBIT_SWING_DEMO_API_KEY", "SAMEKEY")
+        monkeypatch.setenv("BYBIT_SWING_DEMO_API_SECRET", "s")
         monkeypatch.setenv("BYBIT_DEMO_API_KEY", "SAMEKEY")
         sess, err = swing._make_swing_session()
         assert sess is None


### PR DESCRIPTION
## Summary
- rename swing credentials to `BYBIT_SWING_DEMO_API_KEY/SECRET`
- keep `HTTP(demo=True)` behavior unchanged
- document the separate swing demo subaccount in `.env.example`
- update same-key safety test

## Verification
- `37 passed` in `prism-btc/tests/test_swing.py`
- `312 passed` in `prism-btc/tests`
- `git diff --check` clean