### PR TITLE
fix(btc): rearm swing fallback alert after recovery

### DIFF
--- a/prism-btc/live/swing.py
+++ b/prism-btc/live/swing.py
@@ -254,8 +254,11 @@ def _make_backend(conn, main_mode: str):
     if main_mode in ("demo", "live"):
         sess, err = _make_swing_session()
         if sess is not None:
+            # 연결이 회복되면 다음 장애 때 폴백 경고가 다시 발송되도록 재무장.
+            if tracking.get_meta(conn, "swing_exec_fallback_notified", MODE):
+                tracking.set_meta(conn, "swing_exec_fallback_notified", 0, MODE)
             return ExchangeBackend(conn, sess)
-        if tracking.get_meta(conn, "swing_exec_fallback_notified", MODE) is None:
+        if not tracking.get_meta(conn, "swing_exec_fallback_notified", MODE):
             tracking.log_event(conn, "info",
                                f"swing 실집행 불가({err}) — 가상 체결 폴백",
                                mode=MODE)

--- a/prism-btc/tests/test_swing.py
+++ b/prism-btc/tests/test_swing.py
@@ -420,3 +420,14 @@ class TestExchangeBackend:
                             lambda: (None, "미설정"))
         be = swing._make_backend(conn, "demo")
         assert be.name == "virtual"
+
+    def test_backend_rearms_fallback_notice_after_exchange_recovers(
+            self, conn, monkeypatch):
+        from live import swing, tracking
+        tracking.set_meta(conn, "swing_exec_fallback_notified", 1, "swing")
+        monkeypatch.setattr(swing, "_make_swing_session",
+                            lambda: (FakeSession(), None))
+        be = swing._make_backend(conn, "demo")
+        assert be.name == "exchange"
+        assert tracking.get_meta(
+            conn, "swing_exec_fallback_notified", "swing") == 0


### PR DESCRIPTION
## Summary
- clear the one-shot swing fallback marker after Demo API recovery
- allow a later credential/API outage to emit a new fallback event
- keep order execution behavior unchanged

## Verification
- `38 passed` in `prism-btc/tests/test_swing.py`
- `313 passed` in `prism-btc/tests`
- regression test fails before the fix and passes after it