### PR TITLE
fix(us): stop Market Pulse hook import fail-open

### DIFF
--- a/prism-us/tests/test_phase7_orchestrator.py
+++ b/prism-us/tests/test_phase7_orchestrator.py
@@ -47,6 +47,24 @@ class TestDirectoryStructure:
         assert telegram_dir.exists() or True
 
 
+class TestMainCoresImport:
+    """Regression coverage for root cores modules loaded from prism-us."""
+
+    def test_registers_module_before_frozen_dataclass_exec(self):
+        from us_stock_analysis_orchestrator import _import_from_main_cores
+
+        module_name = "prism_root_regime_policy_orchestrator_test"
+        sys.modules.pop(module_name, None)
+        try:
+            module = _import_from_main_cores(
+                module_name, "cores/regime_policy.py"
+            )
+            assert sys.modules[module_name] is module
+            assert module.MarketPulseDetail is not None
+        finally:
+            sys.modules.pop(module_name, None)
+
+
 # =============================================================================
 # Test: USStockAnalysisOrchestrator Class
 # =============================================================================

--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -81,7 +81,16 @@ def _import_from_main_cores(module_name: str, relative_path: str):
     file_path = PROJECT_ROOT / relative_path
     spec = importlib.util.spec_from_file_location(module_name, file_path)
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    previous = sys.modules.get(module_name)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        if previous is None:
+            sys.modules.pop(module_name, None)
+        else:
+            sys.modules[module_name] = previous
+        raise
     return module
 
 


### PR DESCRIPTION
## Summary
- register root `cores` modules in `sys.modules` before file-path execution
- restore the previous module entry if execution fails
- prevent Python 3.12 frozen-dataclass `NoneType.__dict__` failures in the US Market Pulse hook

## Verification
- regression reproduces the production exception before the fix
- `6 passed` for the import regression and #448 regime-detail tests
- `py_compile` and `git diff --check` clean

## Local environment note
The broader legacy Phase 7 file has 10 unrelated failures because the local mcp-agent package lacks the retired `evaluator_optimizer` module; GitHub CI remains the authoritative full-suite environment.