### PR TITLE
fix(trading): unify KR regime floor source

### DIFF
--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -480,14 +480,15 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                 # 레짐 적응 하한선(env-gated REGIME_MIN_SCORE_FLOOR, 기본 off). 플래그 ON 시
                 # 약세장 하한(strong_bear 9 / bear·sideways 8)을 강제해 min_score 를 끌어올린다.
                 # 아래 진입 게이트(buy_score < min_score → Skip)가 그대로 차단을 수행한다.
-                # 레짐은 시나리오의 market_condition 라벨(strong_bear 등) 선두 토큰을 사용.
+                # 레짐은 레거시 경로와 동일한 결정론적 현재 시장 레짐을 사용한다.
+                # 종목별 LLM market_condition은 설명용이며 안전 게이트 입력으로 쓰지 않는다.
                 try:
                     from cores.regime_policy import (
                         effective_min_score,
                         regime_min_score_floor_enabled,
                     )
                     if regime_min_score_floor_enabled():
-                        _fr = scenario.get("market_condition") or ""
+                        _fr = self._buy_floor_regime()
                         _eff = effective_min_score(min_score, _fr)
                         if _eff > min_score:
                             logger.info(

--- a/tests/test_parallel_trading_batch.py
+++ b/tests/test_parallel_trading_batch.py
@@ -141,6 +141,36 @@ async def test_prepass_respects_semaphore_cap(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Regime floor source parity
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_enhanced_floor_uses_deterministic_live_regime(monkeypatch):
+    """Enhanced path must use the same programmatic regime as the legacy path."""
+    monkeypatch.setenv("REGIME_MIN_SCORE_FLOOR", "true")
+    agent = _make_agent()
+    agent._analyze_report_core = AsyncMock(
+        return_value=_core_ok("005930", "Samsung", decision="Skip")
+    )
+    result = _core_ok(
+        "005930",
+        "Samsung",
+        decision="Skip",
+        buy_score=2,
+        min_score=6,
+    )
+    result["scenario"]["market_condition"] = "strong_bear"
+    agent.analyze_report = AsyncMock(return_value=result)
+    agent._buy_floor_regime = MagicMock(return_value="moderate_bull")
+
+    await agent.process_reports(
+        ["reports/005930_Samsung_20260101_morning.pdf"]
+    )
+
+    agent._buy_floor_regime.assert_called_once_with()
+    assert agent._save_watchlist_item.await_args.kwargs["min_score"] == 6
+
+
+# ---------------------------------------------------------------------------
 # 2. Order-sensitive gates stay in the sequential phase
 # ---------------------------------------------------------------------------
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- make the enhanced KR buy path use the deterministic cached live regime already used by the legacy path
- keep per-stock LLM `market_condition` for explanation only, not as the hard floor input
- add a regression test covering a conflicting LLM vs deterministic regime

## Evidence
- `tests/test_parallel_trading_batch.py`: 9 passed
- `tests/test_regime_min_score_floor.py` + focused regression: 29 passed
- `py_compile stock_tracking_enhanced_agent.py`
- production history audit since feature activation: 9 floor raises, 0 causal incremental blocks (all 9 already rejected by AI)

## Risk
- changes the active KR enhanced trading gate source, but aligns it with the original feature design and existing legacy implementation
- floor values and order flow are unchanged