### PR TITLE
fix(llm): disable tracing for OAuth proxy

### DIFF
--- a/cores/llm/backends/openai_agents_backend.py
+++ b/cores/llm/backends/openai_agents_backend.py
@@ -17,7 +17,12 @@ from cores.llm.ports import AgentSpec, LLMBackend, LLMParams, LLMResult
 # --- SDK import guard ---------------------------------------------------
 try:
     from agents import Agent, ModelSettings, Runner
-    from agents import set_default_openai_api, set_default_openai_client, set_default_openai_key
+    from agents import (
+        set_default_openai_api,
+        set_default_openai_client,
+        set_default_openai_key,
+        set_tracing_disabled,
+    )
     from agents.mcp import MCPServerStdio, MCPServerStdioParams
     from openai import AsyncOpenAI
     from openai.types.shared import Reasoning
@@ -33,6 +38,7 @@ except ImportError:
     set_default_openai_api = None  # type: ignore[assignment]
     set_default_openai_client = None  # type: ignore[assignment]
     set_default_openai_key = None  # type: ignore[assignment]
+    set_tracing_disabled = None  # type: ignore[assignment]
     AsyncOpenAI = None  # type: ignore[assignment]
     _sdk_available = False
 # ------------------------------------------------------------------------
@@ -70,6 +76,9 @@ def configure_openai_agents_for_proxy(
     set_default_openai_client(client)
     set_default_openai_api("responses")
     set_default_openai_key(api_key)
+    # The OAuth proxy supports Responses requests but not OpenAI trace export.
+    # The placeholder proxy key would otherwise produce one non-fatal 401 per span.
+    set_tracing_disabled(True)
 
 
 def build_model_settings(params: LLMParams) -> "ModelSettings":

--- a/cores/llm/tests/test_openai_agents_backend.py
+++ b/cores/llm/tests/test_openai_agents_backend.py
@@ -22,6 +22,53 @@ from cores.llm.ports import AgentSpec, LLMParams
 
 
 # ---------------------------------------------------------------------------
+# Proxy configuration tests
+# ---------------------------------------------------------------------------
+
+
+def test_configure_proxy_disables_unsupported_tracing(monkeypatch):
+    """The OAuth proxy handles Responses calls, not OpenAI trace export."""
+    import cores.llm.backends.openai_agents_backend as mod
+
+    calls = []
+    fake_client = object()
+
+    monkeypatch.setattr(
+        mod,
+        "AsyncOpenAI",
+        lambda **kwargs: calls.append(("client", kwargs)) or fake_client,
+    )
+    monkeypatch.setattr(
+        mod,
+        "set_default_openai_client",
+        lambda client: calls.append(("default_client", client)),
+    )
+    monkeypatch.setattr(
+        mod,
+        "set_default_openai_api",
+        lambda api: calls.append(("default_api", api)),
+    )
+    monkeypatch.setattr(
+        mod,
+        "set_default_openai_key",
+        lambda key: calls.append(("default_key", key)),
+    )
+    monkeypatch.setattr(
+        mod,
+        "set_tracing_disabled",
+        lambda disabled: calls.append(("tracing_disabled", disabled)),
+        raising=False,
+    )
+
+    mod.configure_openai_agents_for_proxy(
+        "http://localhost:18741/v1",
+        "placeholder",
+    )
+
+    assert ("tracing_disabled", True) in calls
+
+
+# ---------------------------------------------------------------------------
 # Helpers / shared fixtures
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- disable OpenAI Agents SDK trace export only when using the ChatGPT OAuth Responses proxy
- prevent placeholder proxy credentials from generating one non-fatal tracing 401 per span
- preserve tracing behavior for direct OpenAI API mode
- add a network-free regression test

## Verification
- `cores/llm/tests/test_openai_agents_backend.py`: 28 passed
- proxy-related `test_agent_bridge.py`: 2 passed
- py_compile and diff check passed

## Operational impact
- removes noisy telemetry errors only; model requests, analysis output, and trading logic are unchanged