### PR TITLE
feat(prism-btc): scale risk 1.5x — main 2%→3%, swing 1%→1.5%

### DIFF
--- a/prism-btc/engine/config.py
+++ b/prism-btc/engine/config.py
@@ -102,6 +102,8 @@ SWING_ENABLED: bool = True
 # 알림(demo/live 전용)이 영원히 안 나간다 — demo 틱 전용으로 고정.
 SWING_RUN_MODES: tuple[str, ...] = ("demo",)
 SWING_STOP_ATR_MULT: float = 2.0      # 하드스탑 = 진입가 ∓ 2.0 × ATR14(4h)
-SWING_RISK_PER_TRADE: float = 0.01    # equity 의 1% (메인 RISK_PER_TRADE 2% 의 절반)
+# 라운드7 G-1 (2026-07-24, Rocky 1.5x 승인): 1% → 1.5% (메인 3% 의 절반 유지).
+# 공동 시뮬에서 5x 명목 캡 바인딩 0회 확인 — 실효 리스크 그대로 스케일됨.
+SWING_RISK_PER_TRADE: float = 0.015   # equity 의 1.5% (메인 RISK_PER_TRADE 3% 의 절반)
 SWING_MAX_LEVERAGE: float = 5.0       # 명목/equity 상한 (Rocky 승인 스펙)
 SWING_INITIAL_EQUITY: float = 10_000.0  # 자체 가상 원장 시드 (shadow 와 동일)

--- a/prism-btc/engine/sizing.py
+++ b/prism-btc/engine/sizing.py
@@ -8,7 +8,11 @@ from typing import Literal
 # Constants (all tuneable here without touching logic)
 # ---------------------------------------------------------------------------
 
-RISK_PER_TRADE: float = 0.02          # 2% of equity per trade
+# 라운드7 G-1 (2026-07-24, Rocky 1.5x 승인): 2% → 3%. 통합(메인+스윙) 공동
+# 시뮬 실측 — 결합 CAGR 24.7→37.5%, intra-trade MDD -14.8→-20.7%(각오치 이내),
+# liq_approach 0 유지. 검증: analysis/round7_g1_joint_sim.py,
+# tasks/btc_round7_results.md §G-1 본실험. 레버리지 밴드/청산버퍼는 불변.
+RISK_PER_TRADE: float = 0.03          # 3% of equity per trade
 MMR: float = 0.005                    # Bybit isolated MMR approximation (0.5%)
 
 # Leverage bands (라운드4: 12~18x 폐기, 라운드2 수준 8~12x 복원 — 라운드3 문서

--- a/prism-btc/live/shadow.py
+++ b/prism-btc/live/shadow.py
@@ -66,8 +66,10 @@ from live.tracking import PositionRow, TradeRow
 # 내고 MDD 1%p 를 사는 손해 보는 보험. 추세전략의 큰 승리가 손실 직후에
 # 오는 구조라, DD 트리거가 정확히 회복 트레이드의 사이즈를 반토막낸다.
 # compute_operating_risk 배관은 유지 (가변 리스크 재검토 시 값만 변경).
-SHADOW_BASE_RISK: float = 0.02
-SHADOW_REDUCED_RISK: float = 0.02  # == base → E4 비활성
+# 라운드7 G-1 (2026-07-24, Rocky 1.5x 승인): 2% → 3% (engine/sizing.py 참조).
+# E4 중립화(reduced == base)는 유지 — 위 재시뮬 근거 그대로.
+SHADOW_BASE_RISK: float = 0.03
+SHADOW_REDUCED_RISK: float = 0.03  # == base → E4 비활성
 SHADOW_DD_THRESHOLD: float = 0.05
 
 INITIAL_EQUITY: float = 10_000.0


### PR DESCRIPTION
## 배경

라운드7 G-1: 통합(메인+스윙) 성과가 위험조정 기준으로 외부 비교 전략과 대등(Calmar 2.69 vs 2.54)하며, 격차는 엣지가 아니라 노출량임을 확인. Rocky가 1.5x 배수를 승인.

## 검증 (analysis/round7_g1_joint_sim.py, 2022-01~2026-07 바 단위 MTM 실측)

- 1.0x: 결합 CAGR 24.7%, intra-trade MDD −14.8%
- **1.5x: 결합 CAGR 37.5%, intra-trade MDD −20.7% (각오치 −20% 안팎 이내), Calmar 1.81**
- liq_approach 0 유지 (수량만 확대 — 레버리지 밴드/청산버퍼 불변), 스윙 5x 캡 바인딩 0회

## 변경 (상수 3곳)

- `engine/sizing.py` RISK_PER_TRADE 0.02 → 0.03
- `live/shadow.py` SHADOW_BASE_RISK/SHADOW_REDUCED_RISK 0.02 → 0.03 (demo/shadow 실운영 리스크 소스, E4 중립화 유지)
- `engine/config.py` SWING_RISK_PER_TRADE 0.01 → 0.015

## 배포

머지 후 db-server `git pull --ff-only origin main`. cron이 매 틱 새 프로세스를 띄우므로 재시작 불필요.

검증: prism-btc 테스트 312 passed, 1 skipped (.venv-bt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)