### PR TITLE
feat(prism-btc): Phase B L-layer — BTC/ETH RS exposure multiplier

### DIFF
--- a/prism-btc/analysis/round8_spot_collector.py
+++ b/prism-btc/analysis/round8_spot_collector.py
@@ -36,8 +36,11 @@ CREATE TABLE IF NOT EXISTS spot_klines (
 
 def fetch(symbol: str, start_ms: int) -> list:
     url = f"{BASE}?symbol={symbol}&interval={INTERVAL}&startTime={start_ms}&limit=1000"
+    # 스킴을 https 로 고정 검증 (file:/ 등 예기치 않은 스킴 차단 — Bandit B310).
+    if not url.startswith("https://"):
+        raise ValueError(f"refusing non-https url: {url}")
     req = urllib.request.Request(url, headers={"User-Agent": "prism-btc-research"})
-    with urllib.request.urlopen(req, timeout=30) as r:
+    with urllib.request.urlopen(req, timeout=30) as r:  # noqa: S310  (https 검증 완료)
         return json.loads(r.read())
 
 

--- a/prism-btc/analysis/round8_spot_collector.py
+++ b/prism-btc/analysis/round8_spot_collector.py
@@ -1,0 +1,90 @@
+# analysis/round8_spot_collector.py — Phase B B-0: Binance 현물 1d 수집기
+#
+# 설계: tasks/btc_phase_b_design.md §6. 오닐 M(distribution/FTD) 번역에는
+# 파생이 아닌 '현물 거래량'이 필요하다 — Binance spot 이 소스.
+# 저장: prism-btc/state/btc_spot.db (신규 — 기존 btc_market.db 무접촉).
+# fetched_at 기록으로 point-in-time 감사 가능. 증분 갱신 지원 (idempotent upsert).
+#
+# 실행: ../.venv-bt/bin/python -m analysis.round8_spot_collector
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+import urllib.request
+from pathlib import Path
+
+BASE = "https://api.binance.com/api/v3/klines"
+SYMBOLS = ("BTCUSDT", "ETHUSDT")
+INTERVAL = "1d"
+START_MS = 1502928000000  # 2017-08-17 (Binance 상장 초기)
+DB = Path(__file__).resolve().parents[1] / "state" / "btc_spot.db"
+
+DDL = """
+CREATE TABLE IF NOT EXISTS spot_klines (
+  symbol TEXT NOT NULL,
+  timeframe TEXT NOT NULL,
+  open_time INTEGER NOT NULL,
+  open REAL, high REAL, low REAL, close REAL,
+  volume REAL, quote_volume REAL,
+  confirmed INTEGER NOT NULL DEFAULT 0,
+  fetched_at INTEGER NOT NULL,
+  PRIMARY KEY (symbol, timeframe, open_time)
+)
+"""
+
+
+def fetch(symbol: str, start_ms: int) -> list:
+    url = f"{BASE}?symbol={symbol}&interval={INTERVAL}&startTime={start_ms}&limit=1000"
+    req = urllib.request.Request(url, headers={"User-Agent": "prism-btc-research"})
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.loads(r.read())
+
+
+def main() -> None:
+    DB.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(DB)
+    conn.execute(DDL)
+    now_ms = int(time.time() * 1000)
+
+    for sym in SYMBOLS:
+        row = conn.execute(
+            "SELECT MAX(open_time) FROM spot_klines WHERE symbol=? AND timeframe=?",
+            (sym, INTERVAL)).fetchone()
+        cursor = (row[0] + 1) if row and row[0] else START_MS
+        total = 0
+        while True:
+            batch = fetch(sym, cursor)
+            if not batch:
+                break
+            for k in batch:
+                open_time, o, h, l, c, v = int(k[0]), k[1], k[2], k[3], k[4], k[5]
+                close_time, qv = int(k[6]), k[7]
+                confirmed = 1 if close_time < now_ms else 0
+                conn.execute(
+                    "INSERT INTO spot_klines VALUES (?,?,?,?,?,?,?,?,?,?,?) "
+                    "ON CONFLICT(symbol,timeframe,open_time) DO UPDATE SET "
+                    "open=excluded.open, high=excluded.high, low=excluded.low, "
+                    "close=excluded.close, volume=excluded.volume, "
+                    "quote_volume=excluded.quote_volume, confirmed=excluded.confirmed, "
+                    "fetched_at=excluded.fetched_at",
+                    (sym, INTERVAL, open_time, float(o), float(h), float(l),
+                     float(c), float(v), float(qv), confirmed, now_ms))
+            total += len(batch)
+            cursor = int(batch[-1][6]) + 1  # last close_time + 1ms
+            conn.commit()
+            if len(batch) < 1000:
+                break
+            time.sleep(0.3)  # rate-limit 예의
+        n, lo, hi = conn.execute(
+            "SELECT COUNT(*), MIN(open_time), MAX(open_time) FROM spot_klines "
+            "WHERE symbol=? AND confirmed=1", (sym,)).fetchone()
+        print(f"{sym}: fetched {total}, confirmed rows {n}, "
+              f"range {time.strftime('%Y-%m-%d', time.gmtime(lo/1000))} ~ "
+              f"{time.strftime('%Y-%m-%d', time.gmtime(hi/1000))}")
+    conn.close()
+    print(f"saved → {DB}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prism-btc/analysis/round8_spot_collector.py
+++ b/prism-btc/analysis/round8_spot_collector.py
@@ -8,11 +8,11 @@
 # 실행: ../.venv-bt/bin/python -m analysis.round8_spot_collector
 from __future__ import annotations
 
-import json
 import sqlite3
 import time
-import urllib.request
 from pathlib import Path
+
+import requests
 
 BASE = "https://api.binance.com/api/v3/klines"
 SYMBOLS = ("BTCUSDT", "ETHUSDT")
@@ -35,13 +35,12 @@ CREATE TABLE IF NOT EXISTS spot_klines (
 
 
 def fetch(symbol: str, start_ms: int) -> list:
-    url = f"{BASE}?symbol={symbol}&interval={INTERVAL}&startTime={start_ms}&limit=1000"
-    # 스킴을 https 로 고정 검증 (file:/ 등 예기치 않은 스킴 차단 — Bandit B310).
-    if not url.startswith("https://"):
-        raise ValueError(f"refusing non-https url: {url}")
-    req = urllib.request.Request(url, headers={"User-Agent": "prism-btc-research"})
-    with urllib.request.urlopen(req, timeout=30) as r:  # noqa: S310  (https 검증 완료)
-        return json.loads(r.read())
+    params = {"symbol": symbol, "interval": INTERVAL,
+              "startTime": start_ms, "limit": 1000}
+    resp = requests.get(BASE, params=params,
+                        headers={"User-Agent": "prism-btc-research"}, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
 
 
 def main() -> None:

--- a/prism-btc/core/leadership.py
+++ b/prism-btc/core/leadership.py
@@ -1,0 +1,77 @@
+# core/leadership.py — Phase B L 계층: BTC/ETH 상대강도 기반 노출 배수
+#
+# 검증 (tasks/btc_phase_b_design.md §9, 라운드8):
+#   관측: 롱 평균 R btc_leading +0.90 (n=106) vs lagging +0.28 (n=76),
+#   스프레드 +0.62R, 2022-23/2024-26 부호 일관 (round8_leadership.py).
+#   A/B: 두 독립 구간 Calmar 개선 3.36→3.57 / 3.12→3.67, full 창은 tie
+#   (round8_l_exposure_ab.py — 결과 JSON 참조).
+#
+# 원칙:
+#   - 신규 진입 리스크에만 곱한다 (보유 관리/청산/신호 불변, 하드 게이트 아님).
+#   - point-in-time: 호출 시각 이전에 "완결된" 1d 봉만 사용.
+#   - **fail-open**: 데이터 없음/부족/정체(stale)/예외 → (1.0, 1.0) = 기존 동작.
+#     L 계층 장애가 트레이딩을 절대 막지 않는다.
+#
+# 데이터: state/btc_spot.db (Binance spot 1d — analysis/round8_spot_collector.py
+# 가 백필/증분 수집; 운영은 db-server 크론이 매일 갱신).
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+from engine.config import (
+    L_LAYER_ENABLED,
+    L_MAX_STALE_DAYS,
+    L_MULT_LONG_LAGGING,
+    L_MULT_LONG_LEADING,
+    L_MULT_SHORT_LAGGING,
+    L_MULT_SHORT_LEADING,
+    L_RS_WINDOW,
+)
+
+_DAY_MS = 86_400_000
+_DEFAULT_DB = Path(__file__).resolve().parents[1] / "state" / "btc_spot.db"
+
+
+def spot_db_path() -> Path:
+    return Path(os.environ.get("PRISM_BTC_SPOT_DB", str(_DEFAULT_DB)))
+
+
+def leadership_multipliers(now_ms: int | None = None) -> tuple[float, float, str]:
+    """(long_mult, short_mult, reason) — 어떤 실패에서도 (1.0, 1.0) fail-open."""
+    if not L_LAYER_ENABLED:
+        return 1.0, 1.0, "disabled"
+    if now_ms is None:
+        now_ms = int(time.time() * 1000)
+    try:
+        path = spot_db_path()
+        if not path.exists():
+            return 1.0, 1.0, "fail-open: spot db missing"
+        conn = sqlite3.connect(path)
+        try:
+            need = L_RS_WINDOW + 1
+            q = ("SELECT close FROM spot_klines WHERE symbol=? AND timeframe='1d' "
+                 "AND confirmed=1 AND open_time + ? <= ? "
+                 "ORDER BY open_time DESC LIMIT ?")
+            btc = [r[0] for r in conn.execute(q, ("BTCUSDT", _DAY_MS, now_ms, need))]
+            eth = [r[0] for r in conn.execute(q, ("ETHUSDT", _DAY_MS, now_ms, need))]
+            row = conn.execute(
+                "SELECT MAX(open_time + ?) FROM spot_klines WHERE symbol='BTCUSDT' "
+                "AND timeframe='1d' AND confirmed=1 AND open_time + ? <= ?",
+                (_DAY_MS, _DAY_MS, now_ms)).fetchone()
+        finally:
+            conn.close()
+        if len(btc) < need or len(eth) < need:
+            return 1.0, 1.0, f"fail-open: insufficient bars ({len(btc)}/{len(eth)})"
+        last_close_ms = row[0]
+        if last_close_ms is None or now_ms - last_close_ms > L_MAX_STALE_DAYS * _DAY_MS:
+            return 1.0, 1.0, "fail-open: spot data stale"
+        # btc[0]=최신 완결봉, btc[-1]=RS_WINDOW 봉 전 → 60일 수익률 차
+        rs = (btc[0] / btc[-1]) - (eth[0] / eth[-1])
+        if rs > 0:
+            return L_MULT_LONG_LEADING, L_MULT_SHORT_LEADING, f"btc_leading rs={rs:+.4f}"
+        return L_MULT_LONG_LAGGING, L_MULT_SHORT_LAGGING, f"btc_lagging rs={rs:+.4f}"
+    except Exception as exc:  # noqa: BLE001 — fail-open 계약
+        return 1.0, 1.0, f"fail-open: {exc}"

--- a/prism-btc/core/swing.py
+++ b/prism-btc/core/swing.py
@@ -80,19 +80,21 @@ class SwingSizing:
     reject_reason: str = ""
 
 
-def compute_swing_sizing(equity: float, entry: float, stop: float) -> SwingSizing:
+def compute_swing_sizing(equity: float, entry: float, stop: float,
+                         risk_mult: float = 1.0) -> SwingSizing:
     """리스크 기반 사이징.
 
-    qty = (equity × SWING_RISK_PER_TRADE) / |entry − stop|.
+    qty = (equity × SWING_RISK_PER_TRADE × risk_mult) / |entry − stop|.
     명목/equity 가 SWING_MAX_LEVERAGE 를 넘으면 수량을 캡한다 (이때 실제
-    리스크는 1% 미만으로 줄어든다 — 스탑 가격은 불변).
+    리스크는 명목 리스크 미만으로 줄어든다 — 스탑 가격은 불변).
+    risk_mult: 라운드8 L 계층 노출 배수 (기본 1.0 = 기존과 동일).
     """
     if equity <= 0 or entry <= 0:
         return SwingSizing(0.0, 0.0, 0.0, True, "invalid equity/entry")
     sl_dist = abs(entry - stop)
     if sl_dist <= 0:
         return SwingSizing(0.0, 0.0, 0.0, True, "zero stop distance")
-    risk_amount = equity * SWING_RISK_PER_TRADE
+    risk_amount = equity * SWING_RISK_PER_TRADE * risk_mult
     qty = risk_amount / sl_dist
     leverage = qty * entry / equity
     if leverage > SWING_MAX_LEVERAGE:

--- a/prism-btc/engine/config.py
+++ b/prism-btc/engine/config.py
@@ -107,3 +107,19 @@ SWING_STOP_ATR_MULT: float = 2.0      # 하드스탑 = 진입가 ∓ 2.0 × ATR1
 SWING_RISK_PER_TRADE: float = 0.015   # equity 의 1.5% (메인 RISK_PER_TRADE 3% 의 절반)
 SWING_MAX_LEVERAGE: float = 5.0       # 명목/equity 상한 (Rocky 승인 스펙)
 SWING_INITIAL_EQUITY: float = 10_000.0  # 자체 가상 원장 시드 (shadow 와 동일)
+
+# --- 라운드8 Phase B: L 계층 (BTC/ETH 60일 상대강도 노출 배수) ---
+# 검증: analysis/round8_leadership.py — 롱 평균 R btc_leading +0.90(n=106) vs
+# lagging +0.28(n=76), 스프레드 +0.62R, 2022-23/2024-26 부호 일관.
+# A/B: analysis/round8_l_exposure_ab.py — 두 독립 구간 Calmar 3.36→3.57 /
+# 3.12→3.67 개선 (full 창은 2.84→2.83 tie — 결과 JSON·설계서 §9 기록).
+# 신규 진입 리스크에만 곱한다 (신호/청산/보유관리 불변, 하드 게이트 아님).
+# 데이터 장애 시 fail-open(1.0) — core/leadership.py. 백테스트 엔진에는
+# 미적용(사이징 전용이라 신호 파리티 유지) — 라이브/데모/섀도우 전용.
+L_LAYER_ENABLED: bool = True
+L_RS_WINDOW: int = 60          # 상대강도 창 (일)
+L_MAX_STALE_DAYS: int = 3      # spot 데이터 이보다 오래되면 fail-open
+L_MULT_LONG_LEADING: float = 1.25
+L_MULT_SHORT_LEADING: float = 0.75
+L_MULT_LONG_LAGGING: float = 0.75
+L_MULT_SHORT_LAGGING: float = 1.25

--- a/prism-btc/live/demo.py
+++ b/prism-btc/live/demo.py
@@ -62,6 +62,7 @@ from live.shadow import (
 from backtest.engine import REENTRY_COOLDOWN_BARS, SL_REENTRY_COOLDOWN_BARS
 import engine.sizing as _sizing
 from core.risk import compute_operating_risk
+from core.leadership import leadership_multipliers
 
 # 거래소 상수.
 _CATEGORY = "linear"
@@ -774,6 +775,9 @@ class DemoAdapter:
             dd_threshold=SHADOW_DD_THRESHOLD,
             reduced_risk=SHADOW_REDUCED_RISK,
         )
+        # 라운드8 L 계층: BTC/ETH 상대강도 노출 배수 (fail-open=1.0, 신규 진입만)
+        l_long, l_short, _l_reason = leadership_multipliers()
+        op_risk *= l_long if sig.side == "long" else l_short
         orig = _sizing.RISK_PER_TRADE
         _sizing.RISK_PER_TRADE = op_risk
         try:

--- a/prism-btc/live/shadow.py
+++ b/prism-btc/live/shadow.py
@@ -56,6 +56,7 @@ from core.actions import (
     OpenIntent,
 )
 from core.risk import compute_operating_risk
+from core.leadership import leadership_multipliers
 
 from live import tracking
 from live.tracking import PositionRow, TradeRow
@@ -551,6 +552,9 @@ class ShadowAdapter:
             dd_threshold=SHADOW_DD_THRESHOLD,
             reduced_risk=SHADOW_REDUCED_RISK,
         )
+        # 라운드8 L 계층: BTC/ETH 상대강도 노출 배수 (fail-open=1.0, 신규 진입만)
+        l_long, l_short, _l_reason = leadership_multipliers()
+        op_risk *= l_long if sig.side == "long" else l_short
         orig = _sizing.RISK_PER_TRADE
         _sizing.RISK_PER_TRADE = op_risk
         try:

--- a/prism-btc/live/swing.py
+++ b/prism-btc/live/swing.py
@@ -43,6 +43,7 @@ from core.swing import (
     rule_exit_due,
     stop_price,
 )
+from core.leadership import leadership_multipliers
 from engine.config import SWING_ENABLED, SWING_INITIAL_EQUITY, SWING_MAX_LEVERAGE
 from live import tracking
 from live.demo import _f, _order_id, _pstr, _qstr, _result_list
@@ -393,7 +394,10 @@ def _try_entry(conn, backend, bar, bar_time_str: str, s4: pd.DataFrame,
     hint_price = float(bar["close"])
     sizing_equity = backend.equity(fallback=equity)
     sl = stop_price(side, hint_price, float(cur["atr14"]))
-    sz = compute_swing_sizing(sizing_equity, hint_price, sl)
+    # 라운드8 L 계층: BTC/ETH 상대강도 노출 배수 (fail-open=1.0, 신규 진입만)
+    l_long, l_short, _l_reason = leadership_multipliers()
+    sz = compute_swing_sizing(sizing_equity, hint_price, sl,
+                              risk_mult=(l_long if side == "long" else l_short))
     if sz.rejected:
         _log_signal_safe(conn, bar_time_str, side,
                          f"swing 기각: sizing ({sz.reject_reason})", 0)

--- a/prism-btc/tests/test_leadership.py
+++ b/prism-btc/tests/test_leadership.py
@@ -1,0 +1,107 @@
+# tests/test_leadership.py — 라운드8 L 계층 (core/leadership.py)
+#
+# 핵심 계약: fail-open — 데이터 없음/부족/정체/예외 어떤 경우에도 (1.0, 1.0).
+# 정상 경로: BTC 60일 수익률 > ETH → leading 배수, 반대는 lagging 배수.
+from __future__ import annotations
+
+import sqlite3
+import time
+
+import pytest
+
+from core.leadership import leadership_multipliers
+from engine.config import (
+    L_MULT_LONG_LAGGING,
+    L_MULT_LONG_LEADING,
+    L_MULT_SHORT_LAGGING,
+    L_MULT_SHORT_LEADING,
+    L_RS_WINDOW,
+)
+
+_DAY_MS = 86_400_000
+
+
+def _make_db(tmp_path, btc_daily_ret: float, eth_daily_ret: float,
+             n_bars: int = 70, end_ms: int | None = None):
+    """단조 수익률 합성 시계열로 spot db 생성."""
+    path = tmp_path / "btc_spot.db"
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE spot_klines (symbol TEXT, timeframe TEXT, open_time INTEGER,"
+        " open REAL, high REAL, low REAL, close REAL, volume REAL,"
+        " quote_volume REAL, confirmed INTEGER, fetched_at INTEGER,"
+        " PRIMARY KEY (symbol, timeframe, open_time))")
+    end_ms = end_ms or int(time.time() * 1000)
+    start = end_ms - n_bars * _DAY_MS
+    for sym, ret in (("BTCUSDT", btc_daily_ret), ("ETHUSDT", eth_daily_ret)):
+        px = 100.0
+        for i in range(n_bars):
+            ot = start + i * _DAY_MS
+            px *= (1 + ret)
+            conn.execute("INSERT INTO spot_klines VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                         (sym, "1d", ot, px, px, px, px, 1.0, 1.0, 1, end_ms))
+    conn.commit()
+    conn.close()
+    return path
+
+
+def test_fail_open_when_db_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("PRISM_BTC_SPOT_DB", str(tmp_path / "nope.db"))
+    assert leadership_multipliers() == (1.0, 1.0, "fail-open: spot db missing")
+
+
+def test_fail_open_when_insufficient_bars(tmp_path, monkeypatch):
+    path = _make_db(tmp_path, 0.01, 0.0, n_bars=10)
+    monkeypatch.setenv("PRISM_BTC_SPOT_DB", str(path))
+    long_m, short_m, reason = leadership_multipliers()
+    assert (long_m, short_m) == (1.0, 1.0)
+    assert "insufficient" in reason
+
+
+def test_fail_open_when_stale(tmp_path, monkeypatch):
+    now = int(time.time() * 1000)
+    path = _make_db(tmp_path, 0.01, 0.0, end_ms=now - 10 * _DAY_MS)
+    monkeypatch.setenv("PRISM_BTC_SPOT_DB", str(path))
+    long_m, short_m, reason = leadership_multipliers(now_ms=now)
+    assert (long_m, short_m) == (1.0, 1.0)
+    assert "stale" in reason
+
+
+def test_leading_when_btc_outperforms(tmp_path, monkeypatch):
+    path = _make_db(tmp_path, 0.01, 0.0)
+    monkeypatch.setenv("PRISM_BTC_SPOT_DB", str(path))
+    long_m, short_m, reason = leadership_multipliers()
+    assert long_m == pytest.approx(L_MULT_LONG_LEADING)
+    assert short_m == pytest.approx(L_MULT_SHORT_LEADING)
+    assert "btc_leading" in reason
+
+
+def test_lagging_when_eth_outperforms(tmp_path, monkeypatch):
+    path = _make_db(tmp_path, 0.0, 0.01)
+    monkeypatch.setenv("PRISM_BTC_SPOT_DB", str(path))
+    long_m, short_m, reason = leadership_multipliers()
+    assert long_m == pytest.approx(L_MULT_LONG_LAGGING)
+    assert short_m == pytest.approx(L_MULT_SHORT_LAGGING)
+    assert "btc_lagging" in reason
+
+
+def test_swing_sizing_risk_mult():
+    from core.swing import compute_swing_sizing
+    base = compute_swing_sizing(10_000.0, 1_000.0, 990.0)
+    boosted = compute_swing_sizing(10_000.0, 1_000.0, 990.0, risk_mult=1.25)
+    assert boosted.qty == pytest.approx(base.qty * 1.25)
+    assert boosted.risk_amount == pytest.approx(base.risk_amount * 1.25)
+
+
+def test_rs_window_uses_confirmed_bars_only(tmp_path, monkeypatch):
+    # 미완결(confirmed=0) 최신 봉은 무시되어야 한다 (PIT)
+    now = int(time.time() * 1000)
+    path = _make_db(tmp_path, 0.01, 0.0, end_ms=now)
+    conn = sqlite3.connect(path)
+    conn.execute("INSERT INTO spot_klines VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                 ("BTCUSDT", "1d", now + _DAY_MS, 1, 1, 1, 0.0001, 1, 1, 0, now))
+    conn.commit(); conn.close()
+    monkeypatch.setenv("PRISM_BTC_SPOT_DB", str(path))
+    long_m, _, reason = leadership_multipliers(now_ms=now + 2 * _DAY_MS)
+    # 폭락한 미완결 봉이 무시되므로 여전히 leading
+    assert long_m == pytest.approx(L_MULT_LONG_LEADING), reason


### PR DESCRIPTION
## 배경
라운드7에서 내부 기계 조정이 전부 장세별 상반 효과로 기각 → 전략이 시장 국면을 모르는 게 근본 원인. 오닐 CAN SLIM의 L(주도성)을 BTC/ETH 60일 상대강도로 번역해 노출 배수로 도입.

## 검증 (tasks/btc_phase_b_design.md §9)
- **관측**: 롱 평균 R btc_leading +0.90 (n=106) vs lagging +0.28 (n=76), 스프레드 **+0.62R**, 2022-23/2024-26 부호 일관.
- **A/B (1.5x 통합 포트폴리오)**: 독립 2구간 Calmar 3.36→3.57 / 3.12→3.67 개선, full CAGR 39.4→43.8% (full Calmar 2.84→2.83 tie). **조건부 통과** — 데모(모의) 반영.

## 구현
- `core/leadership.py`: `leadership_multipliers()` — **fail-open(1.0)** 계약. db 없음/부족/stale(>3일)/예외 시 기존 동작. PIT(완결봉만).
- `engine/config.py`: `L_LAYER_ENABLED` + 배수 5상수 (leading 롱1.25/숏0.75, lagging 역).
- `live/{shadow,demo}.py`: 메인 레인 진입 리스크에 배수 적용.
- `core/swing.py` + `live/swing.py`: `compute_swing_sizing(risk_mult=...)` 스윙 레인.
- `analysis/round8_spot_collector.py`: Binance spot 1d 수집기 (db-server cron 필요).

## 안전
- 백테스트 엔진 **미변경** (사이징 전용 → 신호 파리티 유지).
- `L_LAYER_ENABLED=False`로 즉시 비활성.
- 배포 시 db-server에 **spot 수집 cron 추가 필수** (없으면 fail-open으로 L계층 무효).

## 검증
prism-btc **319 passed, 1 skipped** (.venv-bt). 신규 test_leadership.py 7종 (fail-open 4 + 정상 2 + 스윙배수 + PIT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)