### PR TITLE
fix: openai-agents 0.7.0 호환을 위해 OpenAI SDK 상한 고정

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,9 @@ aiohttp~=3.11.13
 python-dateutil~=2.9.0.post0
 email-validator
 # openai bumped from <2.0.0: openai-agents requires >=2.9; verified mcp-agent 0.2.6
-# runs on openai 2.x (2026-06-19 coexistence test). See tasks/mcp_agent_removal_prd.md.
-openai>=2.9,<3
+# Keep below 2.45 while openai-agents==0.7.0 constructs InputTokensDetails
+# without the newer required cache_write_tokens field.
+openai>=2.9,<2.45
 openai-agents==0.7.0
 anthropic~=0.64.0
 markdown>=3.3.0


### PR DESCRIPTION
## 요약

`openai-agents==0.7.0`과 최신 `openai` SDK 조합에서 Responses 호출이 모델 요청 전에 실패하는 문제를 방지하기 위해 `openai` 의존성 범위를 `>=2.9,<2.45`로 좁혔습니다.

## 재현 근거

현재 `requirements.txt`의 `openai>=2.9,<3` 범위로 Docker를 새로 빌드하면 최신 `openai 2.48.0`이 설치됩니다. 이 상태에서 openai-agents 기반 Responses 호출을 실행하면 아래처럼 실패합니다.

```bash
python3 tools/verify_openai_agents_live.py \
  --auth proxy \
  --model gpt-5.6-terra \
  --reasoning medium
```

실패 에러는 다음과 같습니다.

```text
ValidationError: 1 validation error for InputTokensDetails
cache_write_tokens
  Field required [type=missing, input_value={'cached_tokens': 0}, input_type=dict]
```

확인 결과 `openai 2.45.0`부터 `InputTokensDetails`의 필수 필드에 `cache_write_tokens`가 추가되었고, `openai-agents==0.7.0` 내부에서는 아직 `InputTokensDetails(cached_tokens=0)` 형태로 기본 usage 객체를 생성하고 있어 충돌이 발생합니다.

## 검증

`openai==2.44.0` + `openai-agents==0.7.0` 조합에서 같은 OAuth Responses smoke test가 통과하는 것을 확인했습니다.

```text
[PASS] openai-agents (proxy) -> Responses roundtrip OK
```

추가로 같은 환경에서 아래 모델들의 짧은 OAuth 호출도 정상 동작했습니다.

```text
gpt-5.6-terra / medium: OK
gpt-5.6-sol / high: OK
gpt-5.4-mini / none: OK
gpt-5.6-luna / none: OK
```

## 비고

이 변경은 `openai-agents` 쪽 usage 기본값 생성이 최신 `openai` SDK와 호환되기 전까지의 방어적 pin입니다. 추후 `openai-agents`가 `cache_write_tokens` 필드를 포함하도록 수정되거나 호환 버전으로 올라가면 `openai<3` 범위로 다시 넓힐 수 있습니다.
