### PR TITLE
fix: 존재하지 않는 US memory compression cron 경로 제거

### DIFF
--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -247,7 +247,7 @@ The Docker container includes **built-in cron** for automated stock analysis. Cr
 |------|-----|------|
 | 02:00 | Config backup | Daily |
 | 03:00 | Log cleanup | Daily |
-| 03:00 | Memory compression | Sunday |
+| 03:00 | KR+US memory compression | Sunday |
 | 07:00 | Stock data update | Mon-Fri |
 | 09:30 | **KR Morning batch** | Mon-Fri |
 | 15:40 | **KR Afternoon batch** | Mon-Fri |
@@ -264,7 +264,6 @@ The Docker container includes **built-in cron** for automated stock analysis. Cr
 | 07:30 | 17:30 | US Performance tracker | Tue-Sat |
 | 08:00 | 18:00 | US Dashboard refresh | Tue-Sat |
 | 03:30 | - | US log cleanup (30 days) | Daily |
-| 04:00 | - | US memory compression | Sunday |
 
 > **Note**: US market runs 3 times daily (no price limits). Tue-Sat in KST = Mon-Fri in US time.
 > Yahoo Finance data has 15-20 min delay, so schedules are adjusted accordingly.

--- a/docker/crontab
+++ b/docker/crontab
@@ -16,7 +16,8 @@ PYTHONPATH=/app/prism-insight
 # Daily config backup at 02:00 KST
 0 2 * * * cd /app/prism-insight && chmod +x utils/backup_configs.sh && ./utils/backup_configs.sh >> /app/prism-insight/logs/backup.log 2>&1
 
-# Weekly memory compression at 03:00 KST (Sunday only)
+# Weekly KR+US memory compression at 03:00 KST (Sunday only)
+# compress_trading_memory.py runs the US pass via run_us_compression().
 0 3 * * 0 cd /app/prism-insight && python3 compress_trading_memory.py >> /app/prism-insight/logs/compression.log 2>&1
 
 # Daily log cleanup at 03:00 KST
@@ -65,9 +66,6 @@ PYTHONPATH=/app/prism-insight
 
 # US log cleanup at 03:30 KST (daily) - keep 30 days
 30 3 * * * find /app/prism-insight/logs -name "us_*.log" -mtime +30 -delete
-
-# US memory compression at 04:00 KST (Sunday only)
-0 4 * * 0 cd /app/prism-insight && python3 prism-us/compress_us_trading_memory.py >> /app/prism-insight/logs/us_compression.log 2>&1 || true
 
 # =============================================================================
 # Empty line required at the end of crontab file

--- a/utils/setup_us_crontab.sh
+++ b/utils/setup_us_crontab.sh
@@ -96,7 +96,6 @@ fi
 
 # Other schedule times (KST)
 US_LOG_CLEANUP_TIME="30 3"           # 03:30 KST (daily)
-US_MEMORY_COMPRESSION_TIME="0 4"     # 04:00 KST (Sunday only)
 
 # =============================================================================
 # Functions
@@ -242,8 +241,9 @@ $US_DASHBOARD_TIME * * 2-6 cd $PROJECT_DIR && $PYTHON_PATH examples/generate_us_
 # Log cleanup for US logs (daily at 03:30 KST) - keep 30 days
 $US_LOG_CLEANUP_TIME * * * find $LOG_DIR -name "us_*.log" -mtime +30 -delete
 
-# Memory compression for US trading data (Sunday 04:00 KST)
-$US_MEMORY_COMPRESSION_TIME * * 0 cd $PROJECT_DIR && $PYTHON_PATH prism-us/compress_us_trading_memory.py >> $LOG_DIR/us_compression.log 2>&1 || true
+# US memory compression is handled by the root weekly compression job:
+#   compress_trading_memory.py -> run_us_compression()
+# Do not schedule the removed prism-us/compress_us_trading_memory.py path.
 
 # =============================================================================
 # Optional: Uncomment to enable additional features


### PR DESCRIPTION
## 요약

Docker crontab과 US crontab 생성 스크립트에서 더 이상 존재하지 않는 `prism-us/compress_us_trading_memory.py` 호출을 제거했습니다.

현재 US trading memory compression은 루트의 `compress_trading_memory.py` 안에 있는 `run_us_compression()` 경로로 통합되어 있으므로, 별도 04:00 US compression cron은 유지하지 않는 쪽이 맞습니다.

## 재현 근거

현재 main 기준으로 다음 cron 경로가 등록되어 있습니다.

- `docker/crontab`: `python3 prism-us/compress_us_trading_memory.py`
- `utils/setup_us_crontab.sh`: 같은 경로를 generated crontab에 생성

하지만 실제 저장소에는 `prism-us/compress_us_trading_memory.py` 파일이 존재하지 않습니다. 따라서 해당 cron은 실행 시 파일 없음 오류만 남기거나 `|| true` 때문에 실패가 묻힐 수 있습니다.

반면 실제 구현은 다음 경로에 있습니다.

- `compress_trading_memory.py`의 `run_us_compression()`
- `prism-us/tracking/compression.py`의 `USCompressionManager`
- `tests/test_us_compression_wiring.py`도 루트 compression 스크립트에 US compression pass가 연결되어 있음을 검증합니다.

따라서 Docker 기본 crontab에서는 03:00 weekly root compression 한 번으로 KR+US compression이 처리되도록 문서와 주석을 정리했습니다.

## 검증

- `bash -n utils/setup_us_crontab.sh`
- `git diff --check`
- Docker crontab active path audit: active python/sh 경로가 모두 존재하는지 확인
- Docker 컨테이너에서 임시 SQLite DB로 `compress_trading_memory.run_us_compression()` 직접 실행: US layer-2 샘플 3건에서 US intuition 1건 생성 확인