### PR TITLE
fix(firecrawl): 주간 인텔리전스 최신성·정확성 개선

### DIFF
--- a/firecrawl_client.py
+++ b/firecrawl_client.py
@@ -49,7 +49,17 @@ def get_firecrawl_app():
     return _firecrawl_app
 
 
-def firecrawl_search(query: str, limit: int = 10, with_content: bool = False):
+def firecrawl_search(
+    query: str,
+    limit: int = 10,
+    with_content: bool = False,
+    *,
+    tbs: Optional[str] = None,
+    sources: Optional[list] = None,
+    location: Optional[str] = None,
+    include_domains: Optional[list] = None,
+    exclude_domains: Optional[list] = None,
+):
     """
     Search the web via Firecrawl.
 
@@ -59,28 +69,136 @@ def firecrawl_search(query: str, limit: int = 10, with_content: bool = False):
         with_content: When True, scrape full markdown content for each result.
                       Each result item will have a .markdown attribute with the
                       article body (more credits used, but much richer data).
+        tbs: Recency filter passed to the search backend. "qdr:w" = past week,
+             "qdr:d" = past day, "qdr:m" = past month. Without this the engine
+             happily returns years-old articles, which is the single biggest
+             cause of stale market reports.
+        sources: Result channels, e.g. ["news"], ["web", "news"]. News results
+                 carry a published date, which lets us drop off-window articles.
+        location: Country bias for the search backend, e.g. "KR" / "US".
+        include_domains: Allowlist of domains. Use to pin results to primary
+                         outlets instead of blog/community aggregators.
+        exclude_domains: Blocklist of domains.
 
     Returns:
-        SearchData object with .web list of results, or None on error
+        SearchData object with .web / .news lists of results, or None on error
     """
+    extra = {
+        "tbs": tbs,
+        "sources": sources,
+        "location": location,
+        "include_domains": include_domains,
+        "exclude_domains": exclude_domains,
+    }
+    extra = {k: v for k, v in extra.items() if v}
+
     try:
         app = get_firecrawl_app()
         if with_content:
             try:
                 from firecrawl import ScrapeOptions  # available in firecrawl-py >= 1.0
-                scrape_opts = ScrapeOptions(formats=["markdown"])
-                result = app.search(query, limit=limit, scrape_options=scrape_opts)
+                # only_main_content strips nav/menu/footer boilerplate — without it
+                # the first 2000 chars of an article are usually junk.
+                scrape_opts = ScrapeOptions(formats=["markdown"], only_main_content=True)
+                result = app.search(query, limit=limit, scrape_options=scrape_opts, **extra)
             except (ImportError, TypeError) as ie:
                 # Fallback: SDK version doesn't support ScrapeOptions — use plain search
                 logger.warning(f"ScrapeOptions not available ({ie}), falling back to plain search")
-                result = app.search(query, limit=limit)
+                result = app.search(query, limit=limit, **extra)
         else:
-            result = app.search(query, limit=limit)
-        logger.info(f"Firecrawl search: query='{query[:50]}', results={len(result.web) if result and result.web else 0}, with_content={with_content}")
+            result = app.search(query, limit=limit, **extra)
+
+        n_web = len(result.web) if result and getattr(result, "web", None) else 0
+        n_news = len(result.news) if result and getattr(result, "news", None) else 0
+        logger.info(
+            f"Firecrawl search: query='{query[:60]}', web={n_web}, news={n_news}, "
+            f"with_content={with_content}, opts={extra}"
+        )
         return result
+    except TypeError as e:
+        # SDK too old for one of the extra kwargs — retry without them rather than
+        # silently returning nothing.
+        if extra:
+            logger.warning(f"Firecrawl search rejected extra opts ({e}); retrying without {list(extra)}")
+            return firecrawl_search(query, limit=limit, with_content=with_content)
+        logger.error(f"Firecrawl search failed: {e}")
+        return None
     except Exception as e:
         logger.error(f"Firecrawl search failed: {e}")
         return None
+
+
+# Sources whose numbers must never be trusted for factual claims.
+_LOW_TRUST_HOSTS = (
+    "blog.naver.com", "m.blog.naver.com", "cafe.naver.com", "post.naver.com",
+    "tistory.com", "brunch.co.kr", "velog.io", "medium.com",
+    "namu.wiki", "dcinside.com", "fmkorea.com", "clien.net",
+)
+
+
+def normalize_search_items(result) -> list[dict]:
+    """
+    Flatten a Firecrawl SearchData into plain dicts.
+
+    Handles both bare search results (title/url/description|snippet/date) and
+    scraped Documents (markdown + metadata), which the SDK returns
+    interchangeably depending on whether scrape_options was set.
+    """
+    items: list[dict] = []
+    if not result:
+        return items
+
+    for channel in ("news", "web"):
+        for raw in (getattr(result, channel, None) or []):
+            meta = getattr(raw, "metadata", None) or {}
+
+            def pick(*names):
+                for n in names:
+                    val = getattr(raw, n, None)
+                    if val:
+                        return val
+                for n in names:
+                    val = meta.get(n) if isinstance(meta, dict) else None
+                    if val:
+                        return val
+                return ""
+
+            url = pick("url", "sourceURL", "source_url")
+            if not url:
+                continue
+
+            items.append({
+                "title": pick("title", "og_title", "ogTitle"),
+                "url": url,
+                "date": pick("date", "publishedTime", "published_time", "modifiedTime"),
+                "body": (getattr(raw, "markdown", "") or ""),
+                "snippet": pick("snippet", "description"),
+                "channel": channel,
+                "low_trust": any(h in url for h in _LOW_TRUST_HOSTS),
+            })
+    return items
+
+
+def firecrawl_search_multi(queries: list[str], **kwargs) -> list[dict]:
+    """
+    Fan out several queries and merge results, de-duplicated by URL.
+
+    A single query can only surface one slice of a week. Market recaps need
+    index moves, flows, themes and the forward calendar — those are different
+    searches, not different paragraphs of one search.
+    """
+    seen: set[str] = set()
+    merged: list[dict] = []
+    for q in queries:
+        for item in normalize_search_items(firecrawl_search(q, **kwargs)):
+            url = item["url"].split("?")[0].rstrip("/")
+            if url in seen:
+                continue
+            seen.add(url)
+            item["query"] = q
+            merged.append(item)
+    logger.info(f"firecrawl_search_multi: {len(queries)} queries -> {len(merged)} unique results")
+    return merged
 
 
 def _extract_agent_text(result) -> Optional[str]:

--- a/firecrawl_client.py
+++ b/firecrawl_client.py
@@ -136,6 +136,20 @@ _LOW_TRUST_HOSTS = (
 )
 
 
+def _pick(raw, meta, *names) -> str:
+    """First non-empty value among `names`, checked on the object then its metadata."""
+    for name in names:
+        val = getattr(raw, name, None)
+        if val:
+            return val
+    if isinstance(meta, dict):
+        for name in names:
+            val = meta.get(name)
+            if val:
+                return val
+    return ""
+
+
 def normalize_search_items(result) -> list[dict]:
     """
     Flatten a Firecrawl SearchData into plain dicts.
@@ -152,27 +166,16 @@ def normalize_search_items(result) -> list[dict]:
         for raw in (getattr(result, channel, None) or []):
             meta = getattr(raw, "metadata", None) or {}
 
-            def pick(*names):
-                for n in names:
-                    val = getattr(raw, n, None)
-                    if val:
-                        return val
-                for n in names:
-                    val = meta.get(n) if isinstance(meta, dict) else None
-                    if val:
-                        return val
-                return ""
-
-            url = pick("url", "sourceURL", "source_url")
+            url = _pick(raw, meta, "url", "sourceURL", "source_url")
             if not url:
                 continue
 
             items.append({
-                "title": pick("title", "og_title", "ogTitle"),
+                "title": _pick(raw, meta, "title", "og_title", "ogTitle"),
                 "url": url,
-                "date": pick("date", "publishedTime", "published_time", "modifiedTime"),
+                "date": _pick(raw, meta, "date", "publishedTime", "published_time", "modifiedTime"),
                 "body": (getattr(raw, "markdown", "") or ""),
-                "snippet": pick("snippet", "description"),
+                "snippet": _pick(raw, meta, "snippet", "description"),
                 "channel": channel,
                 "low_trust": any(h in url for h in _LOW_TRUST_HOSTS),
             })

--- a/report_generator.py
+++ b/report_generator.py
@@ -1259,64 +1259,138 @@ async def generate_journal_conversation_response(
 # Firecrawl Search + shared LLM analysis
 # =============================================================================
 
-async def generate_firecrawl_search_response(search_query: str, analysis_prompt: str, limit: int = 5) -> Optional[str]:
+MAX_ARTICLE_CHARS = 3000
+MAX_CONTEXT_CHARS = 60000
+
+
+def _build_search_context(items: list) -> str:
     """
-    Cost-efficient Firecrawl /search (2 credits) plus shared LLM analysis.
+    Render normalized search results into LLM context.
+
+    Every article carries its published date and a trust marker. Without the
+    date the model cannot tell a week-old recap from a two-year-old one; without
+    the trust marker it quotes hard numbers straight out of blog posts.
+    """
+    chunks: list[str] = []
+    total = 0
+    for item in items:
+        body = (item.get("body") or "").strip() or (item.get("snippet") or "").strip()
+        if not body:
+            continue
+        body = body[:MAX_ARTICLE_CHARS]
+        tag = "블로그·커뮤니티(수치 인용 금지)" if item.get("low_trust") else item.get("channel", "web")
+        published = item.get("date") or "발행일 미상"
+        chunk = (
+            f"[{item.get('title') or '제목 없음'}]\n"
+            f"발행일: {published} | 출처유형: {tag}\n"
+            f"URL: {item.get('url')}\n{body}\n\n"
+        )
+        if total + len(chunk) > MAX_CONTEXT_CHARS:
+            break
+        chunks.append(chunk)
+        total += len(chunk)
+
+    logger.info(f"Search context built: {len(chunks)} articles, {total} chars")
+    return "".join(chunks)
+
+
+async def generate_firecrawl_search_response(
+    search_query,
+    analysis_prompt: str,
+    limit: int = 5,
+    *,
+    tbs: Optional[str] = None,
+    sources: Optional[list] = None,
+    location: Optional[str] = None,
+    include_domains: Optional[list] = None,
+    exclude_domains: Optional[list] = None,
+    grounded_facts: str = "",
+    period_label: str = "",
+) -> Optional[str]:
+    """
+    Firecrawl /search plus shared LLM analysis.
 
     Args:
-        search_query: Web search query for Firecrawl
+        search_query: A query string, or a list of queries to fan out and merge.
         analysis_prompt: Prompt used to analyze the search results
-        limit: Number of search results (default 5)
+        limit: Number of search results per query
+        tbs: Recency filter, e.g. "qdr:w" for the past week
+        sources: Search channels, e.g. ["news", "web"]
+        location: Country bias, e.g. "KR" / "US"
+        include_domains / exclude_domains: Domain allow/block lists
+        grounded_facts: Authoritative numbers fetched from a primary data source.
+                        These override anything found on the web.
+        period_label: Explicit period the report covers, e.g. "2026-07-20 ~ 2026-07-24"
 
     Returns:
         str: Generated analysis, or None on error
     """
     try:
-        from firecrawl_client import firecrawl_search
+        from firecrawl_client import firecrawl_search_multi
 
-        # Step 1: Firecrawl search with full article content
-        # with_content=True fetches markdown body per result — much richer than meta descriptions.
+        queries = [search_query] if isinstance(search_query, str) else list(search_query)
+
         loop = asyncio.get_running_loop()
-        result = await loop.run_in_executor(
-            None, lambda: firecrawl_search(search_query, limit=limit, with_content=True)
+        items = await loop.run_in_executor(
+            None,
+            lambda: firecrawl_search_multi(
+                queries,
+                limit=limit,
+                with_content=True,
+                tbs=tbs,
+                sources=sources,
+                location=location,
+                include_domains=include_domains,
+                exclude_domains=exclude_domains,
+            ),
         )
-        items = result.web if result and result.web else []
 
-        if not items:
-            logger.warning(f"No search results for: {search_query[:50]}, falling back to model-only analysis")
-            context = "(최신 웹 검색 결과를 찾지 못했습니다. 알려진 시장 지식을 바탕으로 분석합니다.)\n\n"
-        else:
-            # Step 2: Build context — prefer full markdown, fall back to description snippet
-            context = ""
-            for item in items:
-                title = getattr(item, 'title', '') or ''
-                url = getattr(item, 'url', '') or ''
-                desc = getattr(item, 'description', '') or ''
-                # markdown is populated when with_content=True; truncate to 2000 chars per article
-                markdown = getattr(item, 'markdown', '') or ''
-                body = markdown[:2000] if markdown else desc
-                context += f"[{title}]\nURL: {url}\n{body}\n\n"
+        # Prefer dated results, newest first; undated ones sink to the bottom.
+        items.sort(key=lambda it: (bool(it.get("date")), it.get("date") or ""), reverse=True)
 
-            logger.info(f"Search context built: {len(items)} results, {len(context)} chars")
+        context = _build_search_context(items)
+        if not context:
+            logger.warning(f"No usable search results for: {queries[0][:60]}")
+            if not grounded_facts:
+                return None
+            context = "(웹 검색 결과 없음 — 아래 검증 데이터만으로 작성)\n\n"
 
-        # Step 3: analyze the gathered content with the shared LLM backend.
         current_date = datetime.now().strftime("%Y년 %m월 %d일")
+        period_line = f"이 리포트가 다루는 기간은 {period_label} 입니다.\n" if period_label else ""
+
         agent = Agent(
             name="firecrawl_search_analyst",
             instruction=(
                 f"당신은 웹 검색 결과를 분석하여 투자자에게 유용한 인사이트를 제공하는 전문가입니다.\n"
-                f"오늘은 {current_date}입니다. '최근'·'올해'·'현재' 등은 이 날짜 기준으로 해석하고, "
-                f"모델 학습 시점의 연도로 착각하지 마세요.\n"
-                "텔레그램 메시지 형태로, 이모지를 포함하여 자연스럽게 작성하세요.\n"
-                "마크다운 형식 대신 텔레그램에 적합한 플레인 텍스트로 작성하세요.\n"
-                "검색 결과에 없는 내용을 지어내지 마세요."
+                f"오늘은 {current_date}입니다. {period_line}"
+                f"'최근'·'올해'·'현재' 등은 이 날짜 기준으로 해석하고, "
+                f"모델 학습 시점의 연도로 착각하지 마세요.\n\n"
+                "[사실 검증 규칙]\n"
+                "1. '검증된 시장 데이터' 블록이 주어지면 지수 레벨·등락률·수급 금액은 "
+                "반드시 그 값만 사용한다. 검색 결과의 숫자와 충돌하면 검증 데이터가 항상 우선한다.\n"
+                "2. 출처유형이 '블로그·커뮤니티'인 자료의 수치는 인용하지 않는다. "
+                "정황·분위기 파악에만 참고한다.\n"
+                "3. 리포트 기간을 벗어난 발행일의 기사 내용은 '이번 주 일'로 서술하지 않는다.\n"
+                "4. 근거가 없으면 그 항목을 축소하거나 생략한다. 추정치를 지어내지 않는다.\n\n"
+                "[서술 규칙]\n"
+                "- '제공된 검색 결과에는', '검색 결과 내 확인되지 않음', '재확인이 필요' 같은 "
+                "자료 수집 과정에 대한 메타 언급을 독자에게 노출하지 마세요. "
+                "근거가 부족하면 그 대목을 조용히 빼고 확실한 내용으로 채우세요.\n"
+                "- 텔레그램 메시지 형태로, 이모지를 포함하여 자연스럽게 작성하세요.\n"
+                "- 마크다운 형식 대신 텔레그램에 적합한 플레인 텍스트로 작성하세요."
             ),
             server_names=[]
         )
 
+        message_parts = []
+        if grounded_facts:
+            message_parts.append(grounded_facts)
+        message_parts.append(f"다음은 웹 검색 결과입니다:\n\n{context}")
+        message_parts.append(f"---\n\n{analysis_prompt}")
+
         response = await _generate_telegram_text(
             agent=agent,
-            message=f"다음은 웹 검색 결과입니다:\n\n{context}\n\n---\n\n{analysis_prompt}",
+            message="\n\n".join(message_parts),
             max_tokens=4000,
         )
         logger.info(f"Firecrawl search analysis response: {len(response)} chars")

--- a/weekly_firecrawl_intelligence.py
+++ b/weekly_firecrawl_intelligence.py
@@ -27,52 +27,101 @@ logger = logging.getLogger(__name__)
 _DISCLAIMER = "\n\n⚠️ 본 내용은 투자 참고용이며, 투자 판단의 책임은 본인에게 있습니다."
 
 
-async def _generate_kr_report() -> str:
+# 1차 매체만 허용. 블로그·커뮤니티가 검색 상위를 먹으면 리포트 수치가 오염된다.
+_KR_DOMAINS = [
+    "yna.co.kr", "einfomax.co.kr", "hankyung.com", "mk.co.kr", "edaily.co.kr",
+    "sedaily.com", "fnnews.com", "mt.co.kr", "asiae.co.kr", "newsis.com",
+    "biz.chosun.com", "wowtv.co.kr", "infostock.co.kr", "thebell.co.kr",
+]
+_US_DOMAINS = [
+    "reuters.com", "cnbc.com", "bloomberg.com", "marketwatch.com", "wsj.com",
+    "barrons.com", "ft.com", "investors.com", "apnews.com", "finance.yahoo.com",
+    "fool.com", "seekingalpha.com",
+]
+
+
+async def _generate_kr_report(start, end) -> str:
     """Generate KR market intelligence report via Firecrawl search + Claude."""
     from report_generator import generate_firecrawl_search_response
+    from weekly_market_facts import build_kr_facts
 
-    today_str = datetime.now().strftime("%Y년 %m월 %d일")
+    period = f"{start:%Y-%m-%d} ~ {end:%Y-%m-%d}"
+    md = f"{start:%m월 %d일}~{end:%m월 %d일}"
 
-    search_query = f"코스피 코스닥 주간 시황 {today_str} 외국인 기관 수급"
+    # 쿼리에 오늘 날짜 문자열을 박으면 검색엔진이 그 문자열을 포함한 블로그를 물어온다.
+    # 날짜는 tbs 최신성 필터로 제어하고, 쿼리는 주제별로 쪼갠다.
+    queries = [
+        "코스피 코스닥 주간 증시 마감 시황 정리",
+        "외국인 기관 순매수 순매도 수급 동향 코스피",
+        "이번주 증시 주도 테마 급등 업종 특징주",
+        "다음주 증시 전망 주요 경제지표 실적발표 일정",
+    ]
+
     analysis_prompt = (
-        f"오늘 날짜는 {today_str}입니다.\n"
-        "위 검색 결과를 바탕으로 이번 주 한국 주식시장 주간 인텔리전스 리포트를 작성해줘.\n\n"
+        f"위 자료를 바탕으로 {md}({period}) 한 주간의 한국 주식시장 인텔리전스 리포트를 작성해줘.\n\n"
         "포함 내용:\n"
-        "1. 이번 주 KOSPI/KOSDAQ 주요 흐름 요약\n"
-        "2. 가장 주목받은 테마 3개와 대표 종목\n"
-        "3. 외국인/기관 수급 동향\n"
+        f"1. {md} KOSPI/KOSDAQ 주요 흐름 요약 (지수 수치는 검증 데이터 사용)\n"
+        "2. 가장 주목받은 테마 3개와 대표 종목 (종목명을 반드시 명시)\n"
+        "3. 외국인/기관 수급 동향 (금액은 검증 데이터의 주간 누적 순매수 사용)\n"
         "4. 다음 주 주요 일정 및 이벤트\n"
         "5. 개인투자자를 위한 전략 제안\n\n"
         "텔레그램 메시지 형태로 이모지 포함하여 작성. 4000자 이내."
     )
 
-    result = await generate_firecrawl_search_response(search_query, analysis_prompt, limit=10)
+    result = await generate_firecrawl_search_response(
+        queries,
+        analysis_prompt,
+        limit=8,
+        tbs="qdr:w",                 # 최근 1주일 내 문서만
+        sources=["news", "web"],     # 뉴스 채널은 발행일이 붙어 필터링이 가능하다
+        location="KR",
+        include_domains=_KR_DOMAINS,
+        grounded_facts=build_kr_facts(start, end),
+        period_label=period,
+    )
     if not result:
         logger.error("Failed to generate KR intelligence report")
         return ""
     return result
 
 
-async def _generate_us_report() -> str:
+async def _generate_us_report(start, end) -> str:
     """Generate US market intelligence report via Firecrawl search + Claude."""
     from report_generator import generate_firecrawl_search_response
+    from weekly_market_facts import build_us_facts
 
-    today_str = datetime.now().strftime("%Y년 %m월 %d일")
+    period = f"{start:%Y-%m-%d} ~ {end:%Y-%m-%d}"
+    md = f"{start:%m월 %d일}~{end:%m월 %d일}"
 
-    search_query = f"US stock market weekly recap S&P 500 NASDAQ {today_str}"
+    queries = [
+        "stock market weekly recap S&P 500 Nasdaq close",
+        "sector performance this week best worst performing stocks",
+        "Federal Reserve rate outlook Treasury yields this week",
+        "week ahead economic calendar earnings preview",
+    ]
+
     analysis_prompt = (
-        f"오늘 날짜는 {today_str}입니다.\n"
-        "위 검색 결과를 바탕으로 이번 주 미국 주식시장 주간 인텔리전스 리포트를 작성해줘.\n\n"
+        f"위 자료를 바탕으로 {md}({period}) 한 주간의 미국 주식시장 인텔리전스 리포트를 작성해줘.\n\n"
         "포함 내용:\n"
-        "1. 이번 주 S&P500/NASDAQ 주요 흐름 요약\n"
-        "2. 가장 주목받은 섹터 3개와 대표 종목\n"
+        f"1. {md} S&P500/NASDAQ 주요 흐름 요약 (지수 수치는 검증 데이터 사용)\n"
+        "2. 가장 주목받은 섹터 3개와 대표 종목 (티커 명시)\n"
         "3. 연준(Fed) 관련 동향 및 금리 전망\n"
         "4. 다음 주 주요 일정 (FOMC, 실적 발표 등)\n"
         "5. 개인투자자를 위한 전략 제안\n\n"
         "한국어로, 텔레그램 메시지 형태로 이모지 포함하여 작성. 4000자 이내."
     )
 
-    result = await generate_firecrawl_search_response(search_query, analysis_prompt, limit=10)
+    result = await generate_firecrawl_search_response(
+        queries,
+        analysis_prompt,
+        limit=8,
+        tbs="qdr:w",
+        sources=["news", "web"],
+        location="US",
+        include_domains=_US_DOMAINS,
+        grounded_facts=build_us_facts(start, end),
+        period_label=period,
+    )
     if not result:
         logger.error("Failed to generate US intelligence report")
         return ""
@@ -81,13 +130,20 @@ async def _generate_us_report() -> str:
 
 async def generate_weekly_intelligence() -> str:
     """Generate combined weekly intelligence report."""
+    from weekly_market_facts import resolve_week_range
+
     today = datetime.now()
     date_display = today.strftime("%-m/%-d")
+    start, end = resolve_week_range(today.date())
+    logger.info(f"Weekly intelligence period: {start} ~ {end}")
 
-    kr_report = await _generate_kr_report()
-    us_report = await _generate_us_report()
+    kr_report = await _generate_kr_report(start, end)
+    us_report = await _generate_us_report(start, end)
 
-    sections = [f"🔥 PRISM 주간 Firecrawl 인텔리전스 ({date_display})"]
+    sections = [
+        f"🔥 PRISM 주간 Firecrawl 인텔리전스 ({date_display})",
+        f"📅 대상 기간: {start:%Y.%m.%d} ~ {end:%m.%d}",
+    ]
 
     if kr_report:
         sections.append(f"\n🇰🇷 한국시장 인텔리전스\n━━━━━━━━━━━━━━━━━━━━\n{kr_report}")

--- a/weekly_market_facts.py
+++ b/weekly_market_facts.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""
+Weekly Market Facts — 검증된 수치 근거 블록 생성
+
+주간 인텔리전스 리포트의 숫자(지수 등락, 투자자별 순매수, 등락률 상위 종목)는
+웹 검색 결과에서 뽑으면 안 된다. 블로그·커뮤니티 글이 검색 상위에 올라오면
+LLM이 그 숫자를 그대로 인용해 사실과 다른 리포트가 나온다.
+
+이 모듈은 KRX(pykrx) / yfinance에서 직접 원천 데이터를 가져와
+LLM에게 "이 숫자만 써라"라고 전달할 수 있는 텍스트 블록을 만든다.
+
+모든 조회는 fail-soft: 실패하면 해당 항목만 빠지고 리포트 생성은 계속된다.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta
+from typing import Optional
+
+from dotenv import load_dotenv
+
+# KRX 조회는 KRX_ID/KRX_PW 자격증명을 요구한다. 이 모듈이 단독 실행되거나
+# load_dotenv를 부르지 않은 경로에서 임포트돼도 동작하도록 여기서 로드한다.
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+KOSPI_INDEX = "1001"
+KOSDAQ_INDEX = "2001"
+
+
+# ---------------------------------------------------------------------------
+# 주간 구간 계산
+# ---------------------------------------------------------------------------
+def resolve_week_range(today: Optional[date] = None) -> tuple[date, date]:
+    """
+    리포트가 다루는 '이번 주' 거래 구간(직전 월~금)을 반환한다.
+
+    일요일 11:00에 도는 배치이므로 today 기준 가장 최근 금요일과 그 주 월요일.
+    금요일에 돌리면 당일이 구간 끝이 된다.
+    """
+    today = today or datetime.now().date()
+    days_since_friday = (today.weekday() - 4) % 7  # 금=4
+    friday = today - timedelta(days=days_since_friday)
+    monday = friday - timedelta(days=4)
+    return monday, friday
+
+
+def _ymd(d: date) -> str:
+    return d.strftime("%Y%m%d")
+
+
+def _eok(won: float) -> str:
+    """원 단위를 억원으로 포맷."""
+    return f"{won / 1e8:,.0f}억원"
+
+
+# ---------------------------------------------------------------------------
+# 한국 시장
+# ---------------------------------------------------------------------------
+def _krx_fn(name: str):
+    """
+    Resolve a KRX data function.
+
+    Production runs the `krx_data_client` wrapper (kospi-kosdaq-stock-server),
+    which exposes pykrx-compatible signatures and Korean column names. Bare
+    pykrx is the fallback for functions the wrapper doesn't re-export.
+    Returns None if neither is usable — callers must treat that as "skip".
+    """
+    try:
+        import krx_data_client
+
+        fn = getattr(krx_data_client, name, None)
+        if fn is not None:
+            return fn
+    except Exception:  # noqa: BLE001 - wrapper is server-only, absence is normal
+        pass
+
+    try:
+        from pykrx import stock
+
+        return getattr(stock, name, None)
+    except Exception as e:  # noqa: BLE001 - pykrx import can fail (setuptools/pkg_resources)
+        logger.warning(f"[facts] no KRX backend for {name}: {e}")
+        return None
+
+
+# krx_data_client returns English column names, bare pykrx returns Korean ones.
+# Resolve by intent instead of hardcoding either convention.
+_COLUMN_ALIASES = {
+    "open": ("시가", "Open"),
+    "high": ("고가", "High"),
+    "low": ("저가", "Low"),
+    "close": ("종가", "Close"),
+    "volume": ("거래량", "Volume"),
+    "amount": ("거래대금", "Amount"),
+}
+
+
+def _col(df, key: str) -> Optional[str]:
+    for candidate in _COLUMN_ALIASES[key]:
+        if candidate in df.columns:
+            return candidate
+    return None
+
+
+def _kr_index_block(start: date, end: date) -> list[str]:
+    get_index_ohlcv_by_date = _krx_fn("get_index_ohlcv_by_date")
+    if get_index_ohlcv_by_date is None:
+        return []
+
+    lines: list[str] = []
+    for name, ticker in (("KOSPI", KOSPI_INDEX), ("KOSDAQ", KOSDAQ_INDEX)):
+        try:
+            df = get_index_ohlcv_by_date(_ymd(start), _ymd(end), ticker)
+            if df is None or df.empty:
+                continue
+            c_open, c_close = _col(df, "open"), _col(df, "close")
+            c_high, c_low = _col(df, "high"), _col(df, "low")
+            if not (c_open and c_close):
+                logger.warning(f"[facts] {name}: unexpected columns {list(df.columns)}")
+                continue
+            first_open = float(df.iloc[0][c_open])
+            last_close = float(df.iloc[-1][c_close])
+            week_high = float(df[c_high].max()) if c_high else last_close
+            week_low = float(df[c_low].min()) if c_low else last_close
+            pct = (last_close - first_open) / first_open * 100 if first_open else 0.0
+            lines.append(
+                f"- {name}: 주간 시가 {first_open:,.2f} → 금요일 종가 {last_close:,.2f} "
+                f"({pct:+.2f}%), 주간 고가 {week_high:,.2f} / 저가 {week_low:,.2f}"
+            )
+            daily = " / ".join(
+                f"{idx:%m-%d} {float(row[c_close]):,.2f}"
+                for idx, row in df.iterrows()
+            )
+            lines.append(f"  · 일별 종가: {daily}")
+        except Exception as e:  # noqa: BLE001 - fail-soft by design
+            logger.warning(f"[facts] {name} index fetch failed: {e}")
+    return lines
+
+
+def _kr_investor_block(start: date, end: date) -> list[str]:
+    get_market_trading_value_by_investor = _krx_fn("get_market_trading_value_by_investor")
+    if get_market_trading_value_by_investor is None:
+        return []
+
+    lines: list[str] = []
+    for market in ("KOSPI", "KOSDAQ"):
+        try:
+            df = get_market_trading_value_by_investor(_ymd(start), _ymd(end), market)
+            if df is None or df.empty or "순매수" not in df.columns:
+                continue
+            wanted = ("기관합계", "외국인합계", "개인", "금융투자", "연기금등")
+            parts = [
+                f"{label} {_eok(float(df.loc[label, '순매수']))}"
+                for label in wanted
+                if label in df.index
+            ]
+            if parts:
+                lines.append(f"- {market} 투자자별 주간 누적 순매수: " + ", ".join(parts))
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"[facts] {market} investor fetch failed: {e}")
+    return lines
+
+
+def _kr_movers_block(start: date, end: date, top_n: int = 7) -> list[str]:
+    """
+    주간 등락률 상위 종목.
+
+    krx_data_client에는 get_market_price_change_by_ticker가 없으므로
+    주 시작/종료 시점의 전종목 종가를 받아 직접 계산한다.
+    """
+    get_ohlcv_by_ticker = _krx_fn("get_market_ohlcv_by_ticker")
+    get_ticker_list = _krx_fn("get_market_ticker_list")
+    get_ticker_name = _krx_fn("get_market_ticker_name")
+    if get_ohlcv_by_ticker is None:
+        return []
+
+    try:
+        first = get_ohlcv_by_ticker(_ymd(start))
+        last = get_ohlcv_by_ticker(_ymd(end))
+        if first is None or last is None or first.empty or last.empty:
+            return []
+
+        c_close_f, c_close_l = _col(first, "close"), _col(last, "close")
+        c_amount = _col(last, "amount")
+        if not (c_close_f and c_close_l and c_amount):
+            logger.warning(f"[facts] movers: unexpected columns {list(last.columns)}")
+            return []
+
+        # 거래대금 상위 300종목으로 한정해 품절주·동전주 노이즈 제거
+        universe = last.nlargest(300, c_amount)
+        joined = universe.join(first[[c_close_f]], rsuffix="_start", how="inner")
+        start_col = f"{c_close_f}_start" if c_close_f == c_close_l else c_close_f
+
+        pct = (joined[c_close_l] / joined[start_col] - 1.0) * 100
+        pct = pct[pct.notna()]
+        if pct.empty:
+            return []
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"[facts] movers fetch failed: {e}")
+        return []
+
+    lines: list[str] = []
+    for market in ("KOSPI", "KOSDAQ"):
+        try:
+            subset = pct
+            if get_ticker_list is not None:
+                tickers = set(get_ticker_list(_ymd(end), market=market) or [])
+                subset = pct[pct.index.isin(tickers)]
+            if subset.empty:
+                continue
+            top = subset.nlargest(top_n)
+
+            def label(tk: str) -> str:
+                if get_ticker_name is None:
+                    return tk
+                try:
+                    return get_ticker_name(tk) or tk
+                except Exception:  # noqa: BLE001
+                    return tk
+
+            names = ", ".join(f"{label(tk)} {v:+.1f}%" for tk, v in top.items())
+            lines.append(f"- {market} 주간 상승률 상위(거래대금 상위 300 내): {names}")
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"[facts] {market} movers ranking failed: {e}")
+    return lines
+
+
+def build_kr_facts(start: date, end: date) -> str:
+    """한국 시장 검증 수치 블록. 실패 시 빈 문자열."""
+    index_lines = _kr_index_block(start, end)
+    investor_lines = _kr_investor_block(start, end)
+    movers_lines = _kr_movers_block(start, end)
+    lines = index_lines + investor_lines + movers_lines
+
+    if not lines:
+        logger.warning("[facts] KR facts empty — KRX 조회 전부 실패")
+        return ""
+
+    header = (
+        f"[검증된 시장 데이터 — KRX 원천 조회, {start:%Y-%m-%d} ~ {end:%Y-%m-%d}]\n"
+        "아래 수치는 한국거래소 데이터에서 직접 조회한 확정값이다.\n"
+        "지수 레벨·등락률·종목 등락률은 반드시 아래 값만 사용하고, "
+        "웹 검색 결과에 다른 숫자가 있어도 무시하라.\n"
+    )
+    if not investor_lines:
+        # 시장 전체 수급은 krx_data_client(개별종목 전용)로는 못 받는다.
+        # 없는 값을 지어내는 대신 서술 방식을 제한한다.
+        header += (
+            "단, 외국인·기관 순매수 금액은 확정 데이터를 확보하지 못했다. "
+            "수급은 1차 매체(연합뉴스·인포맥스 등) 기사에 명시된 수치만 인용하고, "
+            "그런 수치가 없으면 금액 없이 매수/매도 방향성만 서술하라.\n"
+        )
+    return header + "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# 미국 시장
+# ---------------------------------------------------------------------------
+_US_TICKERS = (
+    ("S&P 500", "^GSPC"),
+    ("NASDAQ 종합", "^IXIC"),
+    ("다우존스", "^DJI"),
+    ("러셀2000", "^RUT"),
+    ("VIX", "^VIX"),
+    ("미국 10년물 금리", "^TNX"),
+)
+
+
+def build_us_facts(start: date, end: date) -> str:
+    """미국 시장 검증 수치 블록. 실패 시 빈 문자열."""
+    try:
+        import yfinance as yf
+    except ImportError:
+        logger.warning("[facts] yfinance not installed — US facts skipped")
+        return ""
+
+    lines: list[str] = []
+    # 미국장은 한국 대비 하루 늦게 마감되므로 여유를 둔다
+    fetch_start = start.strftime("%Y-%m-%d")
+    fetch_end = (end + timedelta(days=2)).strftime("%Y-%m-%d")
+
+    for name, ticker in _US_TICKERS:
+        try:
+            hist = yf.Ticker(ticker).history(start=fetch_start, end=fetch_end)
+            if hist is None or hist.empty:
+                continue
+            first_open = float(hist.iloc[0]["Open"])
+            last_close = float(hist.iloc[-1]["Close"])
+            pct = (last_close - first_open) / first_open * 100 if first_open else 0.0
+            last_day = hist.index[-1].strftime("%m-%d")
+            if ticker == "^TNX":
+                lines.append(f"- {name}: {last_close:.3f}% ({last_day} 기준, 주간 {pct:+.2f}%)")
+            else:
+                lines.append(
+                    f"- {name}: 주간 시가 {first_open:,.2f} → {last_day} 종가 "
+                    f"{last_close:,.2f} ({pct:+.2f}%)"
+                )
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"[facts] {name} fetch failed: {e}")
+
+    if not lines:
+        logger.warning("[facts] US facts empty — yfinance 조회 전부 실패")
+        return ""
+
+    header = (
+        f"[검증된 시장 데이터 — yfinance 원천 조회, {start:%Y-%m-%d} ~ {end:%Y-%m-%d}]\n"
+        "아래 수치는 시장 데이터에서 직접 조회한 확정값이다.\n"
+        "지수 레벨·등락률은 반드시 아래 값만 사용하고, 웹 검색 결과의 다른 숫자는 무시하라.\n"
+    )
+    return header + "\n".join(lines)
+
+
+def diagnose() -> None:
+    """
+    Print which KRX backend resolves for each function and what the fact blocks
+    look like. Run this on the server after deploy:
+
+        python weekly_market_facts.py
+
+    If the investor line is missing, `krx_data_client` doesn't re-export
+    get_market_trading_value_by_investor and bare pykrx couldn't reach KRX —
+    the flow numbers will be absent from the report (by design, rather than
+    hallucinated from a blog post).
+    """
+    s, e = resolve_week_range()
+    print(f"week range: {s} ~ {e}\n")
+
+    print("[backend resolution]")
+    for name in (
+        "get_index_ohlcv_by_date",
+        "get_market_trading_value_by_investor",
+        "get_market_price_change_by_ticker",
+    ):
+        fn = _krx_fn(name)
+        origin = getattr(fn, "__module__", "?") if fn else "UNRESOLVED"
+        print(f"  {name}: {origin}")
+    print()
+
+    print(build_kr_facts(s, e) or "(KR facts unavailable)")
+    print()
+    print(build_us_facts(s, e) or "(US facts unavailable)")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    diagnose()


### PR DESCRIPTION
## 문제

주간 Firecrawl 리포트가 오래된 블로그 글을 인용해 최신성·정확성이 모두 떨어짐. 실제 발행분에서 "블로그 출처인 만큼 재확인 필요", "검색 결과 내 개별 종목명은 확인되지 않음" 같은 문장이 독자에게 그대로 노출됨.

## 근본 원인

1. 검색 쿼리에 오늘 날짜 문자열 삽입 (`코스피 코스닥 주간 시황 2026년 07월 26일 ...`) → 검색엔진이 그 날짜 문자열을 포함한 문서를 매칭 → 날짜를 제목에 쓰는 네이버 블로그가 상위 차지
2. `tbs` 최신성 필터 미사용 → 수년 전 기사 혼입
3. 단일 쿼리 1회 → 지수/수급/테마/다음주 일정을 한 번에 못 덮음
4. `sources=["news"]`(발행일 포함)와 도메인 통제 미사용, `result.news`는 아예 안 읽음
5. 지수 레벨·수급 금액 등 **수치를 웹 문서에서 추출** — 검색 튜닝으로는 해결 불가

## 변경

- **`weekly_market_facts.py` (신규)** — 지수/등락률을 KRX·yfinance에서 직접 조회해 LLM에 확정값으로 주입. `krx_data_client` → `pykrx` 폴백, 영문/한글 컬럼 양쪽 대응, 전 구간 fail-soft
- **`firecrawl_client.py`** — `tbs`/`sources`/`location`/`include_domains`/`exclude_domains` 지원, `only_main_content=True`, 저신뢰 도메인 자동 태깅, 다중 쿼리 팬아웃 + URL 중복제거
- **`report_generator.py`** — 기사별 발행일·출처 신뢰도 표기, 날짜순 정렬, 검증데이터 우선 규칙, 자료수집 과정 메타 언급 금지
- **`weekly_firecrawl_intelligence.py`** — 대상 기간을 직전 월~금으로 확정 계산, 쿼리 4분할(날짜 문자열 제거), 1차 매체 화이트리스트(KR 14 / US 12), `tbs=qdr:w`

## 검증

`python weekly_market_facts.py`로 실데이터 확인 (7/20~7/24):

- KOSPI 6,643.58 → 6,690.62 (+0.71%), 일별 종가 포함
- KOSDAQ 773.21 → 748.22 (**-3.23%**)
- 상승 상위: SK이터닉스 +44.7%, 휴림에이텍 +90.5% 등 — 기존 리포트가 "종목명 확인 불가"로 비운 자리가 실제 종목명으로 채워짐
- US: S&P500 -1.03%, NASDAQ -2.90%, VIX, 10년물 금리까지 실조회 성공

그 외: 4개 파일 컴파일 통과, `_krx_fn` 백엔드 우선순위 테스트, fail-soft 경로 테스트(백엔드 없을 때 빈 문자열 반환), Firecrawl/LLM 모킹 E2E로 검색 옵션 전달·컨텍스트 신뢰도 태깅·기간 주입 확인. `telegram_ai_bot.py`의 기존 호출부 2곳은 시그니처 하위호환 유지.

## 알려진 한계

- **시장 전체 외국인/기관 순매수 금액은 확보 불가.** `krx_data_client`의 투자자 함수는 개별종목 전용이고 pykrx는 KRX 접근이 막힘. 지어내지 않도록 "1차 매체 명시 수치만 인용, 없으면 금액 없이 방향성만 서술" 지시가 자동 삽입됨
- **실제 Firecrawl API 호출은 미검증** (크레딧 소모). 배포 후 `--dry-run` 1회 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)