### PR TITLE
fix(firecrawl): news 채널 복구 + 시장 전체 수급 데이터 확보

### DIFF
--- a/firecrawl_client.py
+++ b/firecrawl_client.py
@@ -7,6 +7,8 @@ API key is loaded from FIRECRAWL_API_KEY env var or mcp_agent.config.yaml fallba
 """
 import logging
 import os
+import re
+from datetime import datetime, timedelta
 from typing import Literal, Optional
 
 from dotenv import load_dotenv
@@ -136,6 +138,27 @@ _LOW_TRUST_HOSTS = (
 )
 
 
+_RELATIVE_DATE = re.compile(r"^\s*(\d+)\s+(minute|hour|day|week|month)s?\s+ago\s*$", re.I)
+_UNIT_DAYS = {"minute": 0, "hour": 0, "day": 1, "week": 7, "month": 30}
+
+
+def _absolute_date(raw: str) -> str:
+    """
+    Firecrawl news results report dates like "2 days ago". The report needs to
+    decide whether an article falls inside the target week, which relative
+    phrasing makes impossible — so resolve it to a real date.
+    Non-relative values pass through untouched.
+    """
+    if not raw:
+        return ""
+    match = _RELATIVE_DATE.match(raw)
+    if not match:
+        return raw
+    amount, unit = int(match.group(1)), match.group(2).lower()
+    delta = timedelta(days=amount * _UNIT_DAYS[unit])
+    return f"{(datetime.now() - delta):%Y-%m-%d} ({raw.strip()})"
+
+
 def _pick(raw, meta, *names) -> str:
     """First non-empty value among `names`, checked on the object then its metadata."""
     for name in names:
@@ -173,7 +196,9 @@ def normalize_search_items(result) -> list[dict]:
             items.append({
                 "title": _pick(raw, meta, "title", "og_title", "ogTitle"),
                 "url": url,
-                "date": _pick(raw, meta, "date", "publishedTime", "published_time", "modifiedTime"),
+                "date": _absolute_date(
+                    _pick(raw, meta, "date", "publishedTime", "published_time", "modifiedTime")
+                ),
                 "body": (getattr(raw, "markdown", "") or ""),
                 "snippet": _pick(raw, meta, "snippet", "description"),
                 "channel": channel,
@@ -182,7 +207,36 @@ def normalize_search_items(result) -> list[dict]:
     return items
 
 
-def firecrawl_search_multi(queries: list[str], **kwargs) -> list[dict]:
+def _search_passes(sources, include_domains, limit) -> list[dict]:
+    """
+    Split one logical search into the API calls it actually needs.
+
+    Verified against the live API: passing `include_domains` suppresses the
+    news channel entirely (news=0, results silently fall back to web). Since
+    news is the only channel carrying publish dates, it has to be fetched in
+    its own unfiltered pass whenever a domain allowlist is in play.
+    """
+    srcs = list(sources) if sources else ["web"]
+
+    if not (include_domains and "news" in srcs):
+        return [{"sources": srcs, "include_domains": include_domains, "limit": limit}]
+
+    news_limit = max(1, limit // 2)
+    web_srcs = [s for s in srcs if s != "news"] or ["web"]
+    return [
+        {"sources": ["news"], "include_domains": None, "limit": news_limit},
+        {"sources": web_srcs, "include_domains": include_domains, "limit": limit - news_limit},
+    ]
+
+
+def firecrawl_search_multi(
+    queries: list[str],
+    *,
+    sources=None,
+    include_domains=None,
+    limit: int = 10,
+    **kwargs,
+) -> list[dict]:
     """
     Fan out several queries and merge results, de-duplicated by URL.
 
@@ -190,17 +244,26 @@ def firecrawl_search_multi(queries: list[str], **kwargs) -> list[dict]:
     index moves, flows, themes and the forward calendar — those are different
     searches, not different paragraphs of one search.
     """
+    passes = _search_passes(sources, include_domains, limit)
     seen: set[str] = set()
     merged: list[dict] = []
+
     for q in queries:
-        for item in normalize_search_items(firecrawl_search(q, **kwargs)):
-            url = item["url"].split("?")[0].rstrip("/")
-            if url in seen:
-                continue
-            seen.add(url)
-            item["query"] = q
-            merged.append(item)
-    logger.info(f"firecrawl_search_multi: {len(queries)} queries -> {len(merged)} unique results")
+        for opts in passes:
+            result = firecrawl_search(q, **opts, **kwargs)
+            for item in normalize_search_items(result):
+                url = item["url"].split("?")[0].rstrip("/")
+                if url in seen:
+                    continue
+                seen.add(url)
+                item["query"] = q
+                merged.append(item)
+
+    n_dated = sum(1 for i in merged if i.get("date"))
+    logger.info(
+        f"firecrawl_search_multi: {len(queries)} queries x {len(passes)} passes "
+        f"-> {len(merged)} unique results ({n_dated} dated)"
+    )
     return merged
 
 

--- a/weekly_market_facts.py
+++ b/weekly_market_facts.py
@@ -50,11 +50,6 @@ def _ymd(d: date) -> str:
     return d.strftime("%Y%m%d")
 
 
-def _eok(won: float) -> str:
-    """원 단위를 억원으로 포맷."""
-    return f"{won / 1e8:,.0f}억원"
-
-
 # ---------------------------------------------------------------------------
 # 한국 시장
 # ---------------------------------------------------------------------------
@@ -139,25 +134,108 @@ def _kr_index_block(start: date, end: date) -> list[str]:
     return lines
 
 
-def _kr_investor_block(start: date, end: date) -> list[str]:
-    get_market_trading_value_by_investor = _krx_fn("get_market_trading_value_by_investor")
-    if get_market_trading_value_by_investor is None:
-        return []
+_NAVER_INVESTOR_URL = (
+    "https://finance.naver.com/sise/investorDealTrendDay.naver?bizdate={bizdate}&sosok={sosok}"
+)
+_INVESTOR_LABELS = ("개인", "외국인", "기관계", "금융투자", "연기금등")
 
-    lines: list[str] = []
-    for market in ("KOSPI", "KOSDAQ"):
+
+def _flatten_columns(df) -> list[str]:
+    """read_html gives a 2-level header here; take the most specific label."""
+    out: list[str] = []
+    for col in df.columns:
+        if isinstance(col, tuple):
+            parts = [str(c) for c in col if str(c) and not str(c).startswith("Unnamed")]
+            out.append(parts[-1] if parts else "")
+        else:
+            out.append(str(col))
+    return out
+
+
+def _naver_investor_daily(sosok: str, bizdate: date) -> dict[date, dict[str, float]]:
+    """
+    네이버 금융 '투자자별 매매동향' 일별 순매수 (단위: 억원).
+
+    시장 전체 수급은 krx_data_client(개별종목 전용)로도, pykrx(KRX 응답 포맷
+    변경으로 파싱 실패)로도 받을 수 없어 네이버를 1차 소스로 쓴다.
+    페이지는 bizdate 기준 최근 약 15거래일을 담고 있다.
+    """
+    import io
+
+    import pandas as pd
+    import requests
+
+    session = requests.Session()
+    session.headers.update({
+        "User-Agent": "Mozilla/5.0",
+        "Referer": "https://finance.naver.com/",
+    })
+    url = _NAVER_INVESTOR_URL.format(bizdate=_ymd(bizdate), sosok=sosok)
+    resp = session.get(url, timeout=15)
+    resp.raise_for_status()
+
+    tables = pd.read_html(io.StringIO(resp.text))
+    table = next(
+        (t for t in tables if t.shape[0] > 2 and t.shape[1] >= 5),
+        None,
+    )
+    if table is None:
+        raise ValueError("investor table not found")
+
+    names = _flatten_columns(table)
+    idx = {label: names.index(label) for label in _INVESTOR_LABELS if label in names}
+    if "날짜" not in names or not idx:
+        raise ValueError(f"unexpected investor columns: {names}")
+    date_pos = names.index("날짜")
+
+    result: dict[date, dict[str, float]] = {}
+    for _, row in table.iterrows():
+        raw_date = str(row.iloc[date_pos]).strip()
+        # "26.07.24" 형식
+        parts = raw_date.split(".")
+        if len(parts) != 3 or not all(p.isdigit() for p in parts):
+            continue
         try:
-            df = get_market_trading_value_by_investor(_ymd(start), _ymd(end), market)
-            if df is None or df.empty or "순매수" not in df.columns:
+            day = date(2000 + int(parts[0]), int(parts[1]), int(parts[2]))
+        except ValueError:
+            continue
+
+        values: dict[str, float] = {}
+        for label, pos in idx.items():
+            val = row.iloc[pos]
+            if pd.notna(val):
+                values[label] = float(val)
+        if values:
+            result[day] = values
+    return result
+
+
+def _kr_investor_block(start: date, end: date) -> list[str]:
+    lines: list[str] = []
+    for market, sosok in (("KOSPI", "01"), ("KOSDAQ", "02")):
+        try:
+            daily = _naver_investor_daily(sosok, end)
+            in_week = {d: v for d, v in daily.items() if start <= d <= end}
+            if not in_week:
+                logger.warning(f"[facts] {market} investor: no rows in {start}~{end}")
                 continue
-            wanted = ("기관합계", "외국인합계", "개인", "금융투자", "연기금등")
+
+            totals: dict[str, float] = {}
+            for row in in_week.values():
+                for label, value in row.items():
+                    totals[label] = totals.get(label, 0.0) + value
+
+            order = ("외국인", "기관계", "개인", "금융투자", "연기금등")
             parts = [
-                f"{label} {_eok(float(df.loc[label, '순매수']))}"
-                for label in wanted
-                if label in df.index
+                f"{label} {totals[label]:+,.0f}억원"
+                for label in order
+                if label in totals
             ]
             if parts:
-                lines.append(f"- {market} 투자자별 주간 누적 순매수: " + ", ".join(parts))
+                lines.append(
+                    f"- {market} 투자자별 주간 누적 순매수({len(in_week)}거래일): "
+                    + ", ".join(parts)
+                )
         except Exception as e:  # noqa: BLE001
             logger.warning(f"[facts] {market} investor fetch failed: {e}")
     return lines


### PR DESCRIPTION
#494 배포 후 실제 드라이런에서 드러난 두 가지 문제를 수정합니다.

## 1. news 채널이 항상 0건

드라이런 로그에서 8개 쿼리 전부 `web=8, news=0`이었습니다. 라이브 API로 격리 실험한 결과:

- news만, 도메인 없음 → `news=5` ✅
- news만, `include_domains` 있음 → `news=0` (결과가 조용히 web으로 대체) ❌
- news+web, 도메인 없음 → `news=5` ✅

즉 **`include_domains`가 news 채널을 통째로 억제**합니다. news는 발행일을 가진 유일한 채널이라, 도메인 화이트리스트가 걸린 경우 news를 별도의 비필터 패스로 분리하도록 `_search_passes`를 추가했습니다.

추가로 news의 상대 날짜(`"2 days ago"`)를 실제 날짜로 변환합니다. 이게 없으면 프롬프트의 "리포트 기간을 벗어난 기사는 이번 주 일로 서술하지 말라" 규칙이 판정 불가라 무의미했습니다.

## 2. 외국인/기관 수급 금액 부재

#494에서 미해결로 남긴 항목입니다. 원인을 끝까지 확인했습니다:

- `krx_data_client.get_market_trading_value_by_investor` → 개별종목 전용 (`종목을 찾을 수 없습니다: KOSPI`)
- `pykrx` 시장 전체 엔드포인트 → KRX 응답 포맷 변경으로 파싱 실패 (`KeyError '거래대금'`). **서버에서도 동일**

네이버 금융 '투자자별 매매동향'(단위: 억원)을 1차 소스로 사용하도록 `_naver_investor_daily`를 추가했습니다.

## 검증 (7/20~7/24 실데이터)

- KOSPI: 외국인 +23,037억원, 기관계 -27,992억원, 개인 +4,598억원, 연기금등 +1,704억원
- KOSDAQ: 외국인 -2,333억원, 기관계 -6,310억원, 개인 +8,525억원
- 정합성: 개인+외국인+기관계 합계가 기타법인과 상쇄되어 0에 수렴
- 5거래일만 정확히 필터링됨 (페이지는 15거래일치를 반환)

`_search_passes` / `_absolute_date` 단위 동작, 컴파일, 린트(W0640/E/W0611) 확인 완료.

## 참고

기존 리포트가 블로그에서 인용했던 **"외국인 약 4조3,032억원 순매도"**는 실제로는 주간 **2조3,037억원 순매수**였습니다. 금액뿐 아니라 방향까지 틀린 수치가 나갔던 셈입니다.

## 비용 영향

도메인 화이트리스트가 걸린 검색은 쿼리당 2회 호출이 됩니다. limit을 반씩 나눠(news 4 / web 4) 결과 수와 크레딧은 기존과 비슷하게 유지했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)