### PR TITLE
fix(firecrawl): SDK 버전 차이로 검색 옵션이 조용히 사라지던 문제

### DIFF
--- a/firecrawl_client.py
+++ b/firecrawl_client.py
@@ -51,6 +51,61 @@ def get_firecrawl_app():
     return _firecrawl_app
 
 
+_UNSUPPORTED_KWARG = re.compile(r"unexpected keyword argument '([^']+)'")
+
+
+def _build_scrape_options():
+    """
+    ScrapeOptions moved around between firecrawl-py releases. Try the known
+    locations so full article bodies still get scraped on older installs.
+    Returns None when the SDK offers no equivalent.
+    """
+    for module, name in (
+        ("firecrawl", "ScrapeOptions"),
+        ("firecrawl.v2.types", "ScrapeOptions"),
+        ("firecrawl.types", "ScrapeOptions"),
+    ):
+        try:
+            mod = __import__(module, fromlist=[name])
+            cls = getattr(mod, name)
+            # only_main_content strips nav/menu/footer boilerplate — without it
+            # the first chars of an article are usually junk.
+            return cls(formats=["markdown"], only_main_content=True)
+        except Exception:  # noqa: BLE001 - probing optional SDK surface
+            continue
+    logger.warning("ScrapeOptions unavailable in this firecrawl-py; bodies will not be scraped")
+    return None
+
+
+def _search_dropping_unsupported(app, query: str, limit: int, extra: dict):
+    """
+    Call app.search, dropping only the kwargs this SDK version rejects.
+
+    Older firecrawl-py builds reject individual options (e.g. include_domains).
+    Dropping the whole option set on the first TypeError would also throw away
+    recency and source filters, which silently degrades result quality — so
+    remove one offending kwarg at a time.
+    """
+    opts = dict(extra)
+    while True:
+        try:
+            return app.search(query, limit=limit, **opts)
+        except TypeError as e:
+            match = _UNSUPPORTED_KWARG.search(str(e))
+            if not match or match.group(1) not in opts:
+                if not opts:
+                    raise
+                logger.warning(f"Firecrawl search TypeError ({e}); retrying with no extra options")
+                opts = {}
+                continue
+            dropped = match.group(1)
+            opts.pop(dropped)
+            logger.warning(
+                f"firecrawl-py does not support '{dropped}'; retrying without it "
+                f"(remaining: {sorted(opts)})"
+            )
+
+
 def firecrawl_search(
     query: str,
     limit: int = 10,
@@ -94,37 +149,24 @@ def firecrawl_search(
     }
     extra = {k: v for k, v in extra.items() if v}
 
+    if with_content:
+        scrape_opts = _build_scrape_options()
+        if scrape_opts is not None:
+            extra["scrape_options"] = scrape_opts
+
     try:
         app = get_firecrawl_app()
-        if with_content:
-            try:
-                from firecrawl import ScrapeOptions  # available in firecrawl-py >= 1.0
-                # only_main_content strips nav/menu/footer boilerplate — without it
-                # the first 2000 chars of an article are usually junk.
-                scrape_opts = ScrapeOptions(formats=["markdown"], only_main_content=True)
-                result = app.search(query, limit=limit, scrape_options=scrape_opts, **extra)
-            except (ImportError, TypeError) as ie:
-                # Fallback: SDK version doesn't support ScrapeOptions — use plain search
-                logger.warning(f"ScrapeOptions not available ({ie}), falling back to plain search")
-                result = app.search(query, limit=limit, **extra)
-        else:
-            result = app.search(query, limit=limit, **extra)
+        result = _search_dropping_unsupported(app, query, limit, extra)
+        if result is None:
+            return None
 
-        n_web = len(result.web) if result and getattr(result, "web", None) else 0
-        n_news = len(result.news) if result and getattr(result, "news", None) else 0
+        n_web = len(result.web) if getattr(result, "web", None) else 0
+        n_news = len(result.news) if getattr(result, "news", None) else 0
         logger.info(
             f"Firecrawl search: query='{query[:60]}', web={n_web}, news={n_news}, "
-            f"with_content={with_content}, opts={extra}"
+            f"with_content={with_content}, opts={sorted(extra)}"
         )
         return result
-    except TypeError as e:
-        # SDK too old for one of the extra kwargs — retry without them rather than
-        # silently returning nothing.
-        if extra:
-            logger.warning(f"Firecrawl search rejected extra opts ({e}); retrying without {list(extra)}")
-            return firecrawl_search(query, limit=limit, with_content=with_content)
-        logger.error(f"Firecrawl search failed: {e}")
-        return None
     except Exception as e:
         logger.error(f"Firecrawl search failed: {e}")
         return None

--- a/firecrawl_client.py
+++ b/firecrawl_client.py
@@ -60,18 +60,15 @@ def _build_scrape_options():
     locations so full article bodies still get scraped on older installs.
     Returns None when the SDK offers no equivalent.
     """
-    for module, name in (
-        ("firecrawl", "ScrapeOptions"),
-        ("firecrawl.v2.types", "ScrapeOptions"),
-        ("firecrawl.types", "ScrapeOptions"),
-    ):
+    import importlib
+
+    for module in ("firecrawl", "firecrawl.v2.types", "firecrawl.types"):
         try:
-            mod = __import__(module, fromlist=[name])
-            cls = getattr(mod, name)
+            cls = getattr(importlib.import_module(module), "ScrapeOptions")
             # only_main_content strips nav/menu/footer boilerplate — without it
             # the first chars of an article are usually junk.
             return cls(formats=["markdown"], only_main_content=True)
-        except Exception:  # noqa: BLE001 - probing optional SDK surface
+        except (ImportError, AttributeError, TypeError):
             continue
     logger.warning("ScrapeOptions unavailable in this firecrawl-py; bodies will not be scraped")
     return None


### PR DESCRIPTION
#495 배포 후 서버 드라이런 로그를 확인하다 발견한 문제입니다. 로컬(4.30.1)과 db-server(4.22.1)의 firecrawl-py 버전이 달라 서버에서만 옵션이 무시되고 있었습니다.

## 증상

서버 로그:
```
WARNING - ScrapeOptions not available (cannot import name 'ScrapeOptions' from 'firecrawl')
WARNING - Firecrawl search rejected extra opts (got an unexpected keyword argument 'include_domains');
          retrying without ['tbs', 'sources', 'location', 'include_domains']
INFO - Firecrawl search: web=4, news=0, opts={}
```

두 가지가 조용히 죽어 있었습니다:

1. **`include_domains` 하나가 거부되자 `tbs`(최신성)·`sources`·`location`까지 전부 버려졌습니다.** 기존 폴백이 TypeError 한 번에 extra 옵션 전체를 드롭했기 때문입니다. 결과적으로 web 패스가 **아무 필터 없이** 조회되고 있었습니다 — 이번 작업의 핵심인 최신성 필터가 무력화된 상태였습니다.
2. **본문 스크래핑이 통째로 비활성화**됐습니다. 4.22.1에서는 `from firecrawl import ScrapeOptions`가 실패하는데, 예외를 잡고 plain search로 넘어가 버려서 기사 본문 없이 스니펫만 LLM에 전달됐습니다.

## 수정

- `_search_dropping_unsupported`: TypeError 메시지에서 거부된 kwarg **이름만** 파싱해 하나씩 제거하고 재시도. 나머지 옵션은 보존
- `_build_scrape_options`: `firecrawl` → `firecrawl.v2.types` → `firecrawl.types` 순으로 탐색

## 환경 정렬

db-server의 firecrawl-py를 로컬과 동일한 4.30.1로 업그레이드했습니다 (requirements.txt의 `>=4.22.0` 범위 내). 코드 수정만으로도 구버전에서 우아하게 degrade 하지만, 도메인 필터와 본문 스크래핑을 실제로 쓰려면 최신 SDK가 필요합니다.

## 검증

구버전 SDK를 흉내낸 스텁으로 선택적 드롭 확인:
```
include_domains 거부 → 제거, 남음: [location, scrape_options, sources, tbs]
scrape_options 거부  → 제거, 남음: [location, sources, tbs]
```
최신성·소스 옵션이 보존됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)