### PR TITLE
fix(firecrawl): 스크래핑 결과가 정규화 단계에서 전부 버려지던 문제

### DIFF
--- a/firecrawl_client.py
+++ b/firecrawl_client.py
@@ -199,16 +199,23 @@ def _absolute_date(raw: str) -> str:
 
 
 def _pick(raw, meta, *names) -> str:
-    """First non-empty value among `names`, checked on the object then its metadata."""
+    """
+    First non-empty value among `names`, checked on the object then its metadata.
+
+    Scraped results come back as Document with a `DocumentMetadata` pydantic
+    model — not a dict — so metadata must be probed by attribute as well.
+    Treating it as dict-only silently dropped every scraped result.
+    """
     for name in names:
         val = getattr(raw, name, None)
         if val:
             return val
-    if isinstance(meta, dict):
-        for name in names:
-            val = meta.get(name)
-            if val:
-                return val
+    if meta is None:
+        return ""
+    for name in names:
+        val = meta.get(name) if isinstance(meta, dict) else getattr(meta, name, None)
+        if val:
+            return val
     return ""
 
 
@@ -286,10 +293,14 @@ def firecrawl_search_multi(
     passes = _search_passes(sources, include_domains, limit)
     seen: set[str] = set()
     merged: list[dict] = []
+    raw_count = 0
 
     for q in queries:
         for opts in passes:
             result = firecrawl_search(q, **opts, **kwargs)
+            raw_count += (
+                len(getattr(result, "web", None) or []) + len(getattr(result, "news", None) or [])
+            ) if result else 0
             for item in normalize_search_items(result):
                 url = item["url"].split("?")[0].rstrip("/")
                 if url in seen:
@@ -303,6 +314,14 @@ def firecrawl_search_multi(
         f"firecrawl_search_multi: {len(queries)} queries x {len(passes)} passes "
         f"-> {len(merged)} unique results ({n_dated} dated)"
     )
+    # A near-empty merge after successful searches means results were fetched but
+    # dropped during normalization (e.g. an SDK shape change). That silently
+    # produces an ungrounded report, so make it loud.
+    if raw_count and len(merged) < raw_count / 3:
+        logger.warning(
+            f"firecrawl_search_multi: {raw_count} raw results collapsed to {len(merged)} "
+            "after normalization — check result shape handling"
+        )
     return merged
 
 


### PR DESCRIPTION
#496 배포 후 드라이런에서 **검색 결과가 27건 → 1건으로 붕괴**한 것을 발견했습니다.

## 원인

#496으로 `ScrapeOptions`가 처음으로 실제 동작하기 시작하자 응답 형태가 바뀌었습니다:

- 스크래핑 전: `SearchResultWeb` — `.url` 속성 보유
- 스크래핑 후: `Document` — `.url`은 `None`, URL은 `metadata.source_url`에 있음

그런데 `Document.metadata`는 dict가 아니라 **`DocumentMetadata` pydantic 모델**입니다. `_pick`이 `isinstance(meta, dict)`일 때만 metadata를 뒤졌기 때문에 URL을 못 찾고 전 항목이 조용히 버려졌습니다.

서버 실측:
```
TYPE: Document
  has .url: None
  metadata type: DocumentMetadata | is dict: False
    source_url = 'https://finance.naver.com/...'
  markdown chars: 9092
```

본문 스크래핑(9,092자)은 정상 작동하는데 그걸 담은 객체를 통째로 버리고 있었습니다. 결과적으로 마지막 드라이런은 **컨텍스트 194자**로 리포트를 생성했습니다 — 검증 데이터 블록이 있어 숫자는 맞았지만 서술 부분은 근거가 없는 상태였습니다.

## 수정

- `_pick`: metadata가 dict가 아니면 `getattr`로 접근
- `firecrawl_search_multi`: 원시 결과 수 대비 정규화 후 결과가 1/3 미만이면 **경고 로그**. 이번 같은 조용한 붕괴는 리포트를 근거 없이 만들어내므로 반드시 드러나야 합니다

## 검증

실제 `DocumentMetadata` 형태를 모사한 스텁으로 확인:
```
{'title': '기사', 'url': 'https://hankyung.com/a', 'date': '2026-07-23', 'low_trust': False}
{'title': '블로그', 'url': 'https://blog.naver.com/x', 'date': '', 'low_trust': True}
```
Document(속성 metadata)와 SearchResultWeb(metadata 없음) 양쪽 모두 정상 추출됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)