### PR TITLE
fix(trend_exit): 상승 중인 승자를 목표가에서 조기 청산하던 문제 수정

### DIFF
--- a/cores/oneil_fallback.py
+++ b/cores/oneil_fallback.py
@@ -39,6 +39,12 @@ TRAIL_DROP_WEAK = 0.95          # 약세/횡보: 고점 대비 -5% (더 타이�
 TRAIL_DROP_UNKNOWN = 0.90       # regime 불명/stale: 고점 대비 -10% (불확실 시 과매도 방지)
 BULL_REGIMES = {"parabolic", "strong_bull", "moderate_bull"}
 WEAK_REGIMES = {"sideways", "moderate_bear", "strong_bear"}
+# TIER3 목표가 자동익절 '보류' 조건 — 레짐은 약세/횡보인데 개별 종목만 강할 때.
+# regime 은 지수(S&P500/KOSPI) 기준이라, 시장과 무관하게 치고 나가는 주도주를
+# 상승 초입에 잘라내는 문제가 있었다(2026-07-29 INCY: 목표가 도달 당일 +11%
+# 상승 중 전량 청산, 같은 날 매수 트리거는 oneil_pct=95 최상위 후보로 평가).
+TARGET_HOLD_MA50_MARGIN = 1.03      # 자기 50일선을 +3% 이상 상회 → 상승추세 확인
+TARGET_HOLD_PEAK_PROXIMITY = 0.97   # 진입 후 고점의 97% 이상 → 아직 안 꺾임
 
 
 @dataclass
@@ -71,6 +77,29 @@ def _normalize_regime(raw: str) -> str:
     if "횡보" in r or "side" in r:
         return "sideways"
     return "moderate_bull"   # 정보 없으면 보수적으로 보유 우선(강세 가정)
+
+
+def _stock_is_strong(current_price: float, peak: float, ma_50: float) -> bool:
+    """개별 종목이 '명백한 상승추세'인지 — TIER3 목표가 익절 보류 판정.
+
+    시장 레짐(지수 기준)이 약세/횡보여도, 종목 자신이 아래 두 조건을 모두
+    만족하면 추세가 살아있는 것으로 보고 청산을 TIER2 트레일링에 위임한다.
+
+      1) 자기 50일선을 TARGET_HOLD_MA50_MARGIN 이상 상회   (상승추세 확인)
+      2) 진입 후 고점 대비 TARGET_HOLD_PEAK_PROXIMITY 이상  (아직 안 꺾임)
+
+    ma_50 미주입(0 = fetch 실패/dormant)이면 강도를 판정할 근거가 없으므로
+    False — 기존 동작(약세 레짐에서 목표가 익절)을 그대로 유지한다(보수적).
+
+    ※ 보류 밴드(>=0.97·peak)와 TIER2 트레일링(약세 -5% = 0.95·peak)은 겹치지
+      않는다. 고점 대비 3% 이상 밀리면 강도 판정이 풀려 TIER3 익절이 다시
+      살아나고, 5% 밀리면 그 전에 TIER2 가 청산한다 — 사각지대 없음.
+    """
+    if ma_50 <= 0 or peak <= 0:
+        return False
+    above_ma50 = current_price >= ma_50 * TARGET_HOLD_MA50_MARGIN
+    near_peak = current_price >= peak * TARGET_HOLD_PEAK_PROXIMITY
+    return above_ma50 and near_peak
 
 
 def evaluate_oneil_sell(inp: SellInputs) -> Tuple[bool, str]:
@@ -122,6 +151,12 @@ def evaluate_oneil_sell(inp: SellInputs) -> Tuple[bool, str]:
     # O'Neil: 목표가는 강세장에서 '트레일링 전환 마일스톤'이지 자동매도 아님.
     if inp.target_price > 0 and cp >= inp.target_price:
         if regime in WEAK_REGIMES:
+            # 지수는 약세/횡보라도 종목 자신이 상승추세면 자동익절 보류 →
+            # 청산은 TIER2 트레일링(약세 밴드 -5%)이 관리한다.
+            if _stock_is_strong(cp, peak, inp.ma_50):
+                return False, (f"HOLD: target hit in {regime} but stock strong "
+                               f"(50MA +{(cp / inp.ma_50 - 1) * 100:.1f}%, "
+                               f"{cp / peak * 100:.1f}% of peak) -> let it run")
             return True, f"TIER3_TARGET(weak): regime={regime} target reached"
         # 강세: 목표 도달해도 보유(트레일링이 청산을 관리)
         return False, f"HOLD: target hit but bull regime({regime}) -> let it run"

--- a/prism-us/cores/oneil_fallback.py
+++ b/prism-us/cores/oneil_fallback.py
@@ -39,6 +39,12 @@ TRAIL_DROP_WEAK = 0.95          # 약세/횡보: 고점 대비 -5% (더 타이�
 TRAIL_DROP_UNKNOWN = 0.90       # regime 불명/stale: 고점 대비 -10% (불확실 시 과매도 방지)
 BULL_REGIMES = {"parabolic", "strong_bull", "moderate_bull"}
 WEAK_REGIMES = {"sideways", "moderate_bear", "strong_bear"}
+# TIER3 목표가 자동익절 '보류' 조건 — 레짐은 약세/횡보인데 개별 종목만 강할 때.
+# regime 은 지수(S&P500/KOSPI) 기준이라, 시장과 무관하게 치고 나가는 주도주를
+# 상승 초입에 잘라내는 문제가 있었다(2026-07-29 INCY: 목표가 도달 당일 +11%
+# 상승 중 전량 청산, 같은 날 매수 트리거는 oneil_pct=95 최상위 후보로 평가).
+TARGET_HOLD_MA50_MARGIN = 1.03      # 자기 50일선을 +3% 이상 상회 → 상승추세 확인
+TARGET_HOLD_PEAK_PROXIMITY = 0.97   # 진입 후 고점의 97% 이상 → 아직 안 꺾임
 
 
 @dataclass
@@ -71,6 +77,29 @@ def _normalize_regime(raw: str) -> str:
     if "횡보" in r or "side" in r:
         return "sideways"
     return "moderate_bull"   # 정보 없으면 보수적으로 보유 우선(강세 가정)
+
+
+def _stock_is_strong(current_price: float, peak: float, ma_50: float) -> bool:
+    """개별 종목이 '명백한 상승추세'인지 — TIER3 목표가 익절 보류 판정.
+
+    시장 레짐(지수 기준)이 약세/횡보여도, 종목 자신이 아래 두 조건을 모두
+    만족하면 추세가 살아있는 것으로 보고 청산을 TIER2 트레일링에 위임한다.
+
+      1) 자기 50일선을 TARGET_HOLD_MA50_MARGIN 이상 상회   (상승추세 확인)
+      2) 진입 후 고점 대비 TARGET_HOLD_PEAK_PROXIMITY 이상  (아직 안 꺾임)
+
+    ma_50 미주입(0 = fetch 실패/dormant)이면 강도를 판정할 근거가 없으므로
+    False — 기존 동작(약세 레짐에서 목표가 익절)을 그대로 유지한다(보수적).
+
+    ※ 보류 밴드(>=0.97·peak)와 TIER2 트레일링(약세 -5% = 0.95·peak)은 겹치지
+      않는다. 고점 대비 3% 이상 밀리면 강도 판정이 풀려 TIER3 익절이 다시
+      살아나고, 5% 밀리면 그 전에 TIER2 가 청산한다 — 사각지대 없음.
+    """
+    if ma_50 <= 0 or peak <= 0:
+        return False
+    above_ma50 = current_price >= ma_50 * TARGET_HOLD_MA50_MARGIN
+    near_peak = current_price >= peak * TARGET_HOLD_PEAK_PROXIMITY
+    return above_ma50 and near_peak
 
 
 def evaluate_oneil_sell(inp: SellInputs) -> Tuple[bool, str]:
@@ -122,6 +151,12 @@ def evaluate_oneil_sell(inp: SellInputs) -> Tuple[bool, str]:
     # O'Neil: 목표가는 강세장에서 '트레일링 전환 마일스톤'이지 자동매도 아님.
     if inp.target_price > 0 and cp >= inp.target_price:
         if regime in WEAK_REGIMES:
+            # 지수는 약세/횡보라도 종목 자신이 상승추세면 자동익절 보류 →
+            # 청산은 TIER2 트레일링(약세 밴드 -5%)이 관리한다.
+            if _stock_is_strong(cp, peak, inp.ma_50):
+                return False, (f"HOLD: target hit in {regime} but stock strong "
+                               f"(50MA +{(cp / inp.ma_50 - 1) * 100:.1f}%, "
+                               f"{cp / peak * 100:.1f}% of peak) -> let it run")
             return True, f"TIER3_TARGET(weak): regime={regime} target reached"
         # 강세: 목표 도달해도 보유(트레일링이 청산을 관리)
         return False, f"HOLD: target hit but bull regime({regime}) -> let it run"

--- a/tests/test_oneil_target_take_profit.py
+++ b/tests/test_oneil_target_take_profit.py
@@ -1,0 +1,157 @@
+"""Tests for the TIER3 target take-profit hold-when-strong exception.
+
+Regression cover for the 2026-07-29 INCY liquidation:
+  regime (S&P500-derived) was `sideways` -> WEAK_REGIMES -> TIER3_TARGET fired
+  the moment the target was touched, and the position was closed for +16.76%
+  while the stock itself was +11% ON THE DAY and sitting at its post-entry high.
+  The same session's buy-trigger batch had scored INCY oneil_pct=95 / RS=0.80.
+
+The fix: in a weak/sideways regime the target take-profit is HELD while the
+*stock* is demonstrably still trending (above its own 50MA and near its peak);
+the exit is then delegated to the TIER2 trailing stop.
+
+Safety invariants asserted here (these must never regress):
+  - TIER1 hard stops still fire on a "strong" stock.
+  - ma_50 unavailable (0) -> conservative, keeps the ORIGINAL take-profit.
+  - No dead band between the hold window and the TIER2 trail.
+
+Pure function, no network, no DB. Run in the KR (root) session.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT))
+from cores.oneil_fallback import (  # noqa: E402
+    SellInputs,
+    evaluate_oneil_sell,
+    TARGET_HOLD_MA50_MARGIN,
+    TARGET_HOLD_PEAK_PROXIMITY,
+)
+
+
+# ── Real INCY position, 2026-07-29 (from loop_b_trend_exit.log) ────────────────
+INCY_BUY = 113.11
+INCY_STOP = 113.62          # scenario stop at time of sale (raised from 109.25)
+# Target back-solved from the logged entry scenario: initial stop 109.25 -> risk
+# 3.86/share, and the trigger batch logged R/R=3.00 -> 113.11 + 3*3.86.
+INCY_TARGET = 124.69
+INCY_PEAK = 132.43          # post-entry high (intraday, day of sale)
+INCY_SELL_PRICE = 132.07    # price the batch actually sold at (+16.76%)
+INCY_MA50 = 116.00          # ~50d MA over the Jun-Jul $113-119 base
+
+
+def _incy(current_price=INCY_SELL_PRICE, regime="sideways", ma_50=INCY_MA50,
+          peak=INCY_PEAK):
+    return SellInputs(
+        buy_price=INCY_BUY,
+        current_price=current_price,
+        stop_loss=INCY_STOP,
+        target_price=INCY_TARGET,
+        highest_price=peak,
+        market_condition=regime,
+        regime_is_live=True,
+        ma_50=ma_50,
+    )
+
+
+class TestIncyRegression:
+    def test_strong_stock_in_sideways_regime_is_held(self):
+        """THE REGRESSION: INCY must NOT be sold at target while still trending."""
+        should_sell, reason = evaluate_oneil_sell(_incy())
+        assert should_sell is False, f"INCY sold again: {reason}"
+        assert "let it run" in reason
+        assert "stock strong" in reason
+
+    def test_profit_at_sale_matches_the_incident(self):
+        """Sanity-check the fixture against the logged +16.76% so the test
+        genuinely reproduces the incident rather than a nearby scenario."""
+        profit = (INCY_SELL_PRICE - INCY_BUY) / INCY_BUY * 100
+        assert profit == pytest.approx(16.76, abs=0.01)
+
+    @pytest.mark.parametrize("regime", ["sideways", "moderate_bear", "strong_bear"])
+    def test_hold_applies_across_all_weak_regimes(self, regime):
+        should_sell, _ = evaluate_oneil_sell(_incy(regime=regime))
+        assert should_sell is False
+
+
+class TestOriginalBehaviourPreserved:
+    """The exception must be narrow — everything else keeps the old semantics."""
+
+    def test_rolled_over_stock_still_takes_profit(self):
+        """Pulled >3% off the peak -> no longer 'strong' -> TIER3 fires as before."""
+        rolled = INCY_PEAK * 0.96
+        should_sell, reason = evaluate_oneil_sell(_incy(current_price=rolled))
+        assert should_sell is True
+        assert reason.startswith("TIER3_TARGET(weak)")
+
+    def test_ma50_unavailable_is_conservative(self):
+        """ma_50=0 (fetch failed / dormant) -> cannot prove strength -> sell."""
+        should_sell, reason = evaluate_oneil_sell(_incy(ma_50=0.0))
+        assert should_sell is True
+        assert reason.startswith("TIER3_TARGET(weak)")
+
+    def test_extended_but_below_ma50_margin_still_sells(self):
+        """Near peak but barely above its own 50MA -> not a real uptrend."""
+        weak_ma = INCY_SELL_PRICE / (TARGET_HOLD_MA50_MARGIN * 0.99)
+        should_sell, reason = evaluate_oneil_sell(_incy(ma_50=weak_ma))
+        assert should_sell is True
+        assert reason.startswith("TIER3_TARGET(weak)")
+
+    def test_bull_regime_unchanged(self):
+        should_sell, reason = evaluate_oneil_sell(_incy(regime="moderate_bull"))
+        assert should_sell is False
+        assert "bull regime" in reason
+
+
+class TestSafetyInvariants:
+    """Strength must never suppress a loss-cutting tier."""
+
+    def test_hard_stop_still_fires_on_a_strong_stock(self):
+        """TIER1 is evaluated before TIER3 and must be untouched."""
+        inp = _incy(current_price=INCY_STOP * 0.98)
+        should_sell, reason = evaluate_oneil_sell(inp)
+        assert should_sell is True
+        assert reason.startswith("TIER1")
+
+    def test_abs_7pct_stop_still_fires(self):
+        inp = _incy(current_price=INCY_BUY * 0.92)
+        should_sell, reason = evaluate_oneil_sell(inp)
+        assert should_sell is True
+        assert reason.startswith("TIER1")
+
+    def test_trailing_stop_still_fires_below_the_hold_band(self):
+        """TIER2 (-5% weak band) catches the position once it breaks down."""
+        inp = _incy(current_price=INCY_PEAK * 0.94)
+        should_sell, reason = evaluate_oneil_sell(inp)
+        assert should_sell is True
+        assert reason.startswith("TIER2_TRAIL")
+
+    def test_no_dead_band_between_hold_window_and_trail(self):
+        """While the target is still exceeded, every price from the TIER2 trail up
+        to the peak must resolve to a definite decision — hold-because-strong, or
+        an exit — never a silent fall-through to the generic 'trend intact' HOLD.
+
+        (Below the target price TIER3 cannot fire at all by design; that region is
+        owned by TIER2 and is asserted separately.)"""
+        assert TARGET_HOLD_PEAK_PROXIMITY > 0.95, "hold band must sit above the -5% trail"
+        for pct in [0.950, 0.955, 0.960, 0.970, 0.980, 0.990, 1.000]:
+            assert INCY_PEAK * pct >= INCY_TARGET, "fixture: price must still be above target"
+            inp = _incy(current_price=INCY_PEAK * pct)
+            should_sell, reason = evaluate_oneil_sell(inp)
+            if pct >= TARGET_HOLD_PEAK_PROXIMITY:
+                assert should_sell is False, f"{pct}: expected hold, got {reason}"
+            else:
+                assert should_sell is True, f"{pct}: expected an exit, got {reason}"
+                assert reason.startswith(("TIER2_TRAIL", "TIER3_TARGET")), reason
+
+
+class TestKrUsParity:
+    def test_kr_and_us_copies_are_identical(self):
+        """The two oneil_fallback.py copies are hand-synced; drift silently makes
+        KR and US trade differently."""
+        kr = (_ROOT / "cores" / "oneil_fallback.py").read_bytes()
+        us = (_ROOT / "prism-us" / "cores" / "oneil_fallback.py").read_bytes()
+        assert kr == us, "cores/ and prism-us/cores/ oneil_fallback.py have diverged"

--- a/tests/test_trend_exit_seller.py
+++ b/tests/test_trend_exit_seller.py
@@ -378,6 +378,7 @@ def test_gate_fires_when_streak_reaches_n(tmp_db, monkeypatch):
 
 def test_gate_fires_in_close_window_even_at_streak_1(tmp_db, monkeypatch):
     # confirm=2 normally gates streak=1, but TREND_EXIT_CLOSE_WINDOW=true confirms now.
+    # NOTE: cur=98 is a LOSS -> TIER1.5 (damage control), which KEEPS the fast-path.
     _enable(monkeypatch, live=False, confirm=2, close_window=True)
     _seed(tmp_db, [_row(1, "005930", 100.0)])
     calls = []
@@ -387,6 +388,72 @@ def test_gate_fires_in_close_window_even_at_streak_1(tmp_db, monkeypatch):
     summary = asyncio.run(lb.run_market("KR", "run1"))
 
     assert summary["acted"] == 1 and summary["shadow"] == 1
+
+
+# ── TIER3 target take-profit is EXCLUDED from the close-window fast-path ───────
+# Regression: 2026-07-29 INCY. The close-window cron runs every session, so
+# `or CLOSE_WINDOW` made CONFIRM_CHECKS dead for take-profits and sold a winner
+# at streak=0 while it was +11% on the day.
+def _seed_target_hit(db, ma50_strong=False):
+    """Position sitting above its target, below the TIER2 trail line.
+
+    buy 100 / cur 130 / target 120 / peak 132 -> +30%, no TIER1 (profit), no
+    TIER1.5 (profit), no TIER2 (trail = 132*0.95*0.995 = 124.8 < 130).
+    Only TIER3 can fire.
+    """
+    _seed(db, [_row(1, "005930", 100.0, stop_loss=0.0,
+                    target_price=120.0, highest_price=132.0)])
+
+
+def test_tier3_target_is_gated_in_close_window_at_streak_0(tmp_db, monkeypatch):
+    """THE FIX: a take-profit gets no urgency discount from the closing bell."""
+    _enable(monkeypatch, live=False, confirm=2, close_window=True)
+    _seed_target_hit(tmp_db)
+    calls = []
+    trader = FakeTrader({"005930": 130.0}, calls=calls)
+    # ma50=0 -> cannot prove strength -> TIER3 fires (rather than holding).
+    _patch(monkeypatch, trader, agent_holder=FakeAgent(calls),
+           ma50=0.0, regime="sideways")
+
+    summary = asyncio.run(lb.run_market("KR", "run1"))
+
+    assert summary["signaled"] == 1, "TIER3 must still be recognised as a signal"
+    assert summary["gated"] == 1
+    assert summary["acted"] == 0, "take-profit must not ride the close-window fast-path"
+    assert calls == []
+    assert _inflight(tmp_db) == 0
+
+
+def test_tier3_target_still_sells_once_properly_confirmed(tmp_db, monkeypatch):
+    """The exclusion must DELAY the take-profit, never disable it."""
+    _enable(monkeypatch, live=False, confirm=1, close_window=True)
+    _seed_target_hit(tmp_db)
+    calls = []
+    trader = FakeTrader({"005930": 130.0}, calls=calls)
+    _patch(monkeypatch, trader, agent_holder=FakeAgent(calls),
+           ma50=0.0, regime="sideways")
+
+    summary = asyncio.run(lb.run_market("KR", "run1"))
+
+    assert summary["acted"] == 1 and summary["shadow"] == 1
+
+
+def test_strong_stock_at_target_never_signals_in_weak_regime(tmp_db, monkeypatch):
+    """End-to-end INCY: real numbers, wired through the loop's ma50/regime fetch.
+    buy 113.11 / cur 132.07 / target 124.69 / peak 132.43 / 50MA 116, sideways."""
+    _enable(monkeypatch, live=False, confirm=1, close_window=True)
+    _seed(tmp_db, [_row(1, "005930", 113.11, stop_loss=0.0,
+                        target_price=124.69, highest_price=132.43)])
+    calls = []
+    trader = FakeTrader({"005930": 132.07}, calls=calls)
+    _patch(monkeypatch, trader, agent_holder=FakeAgent(calls),
+           ma50=116.0, regime="sideways")
+
+    summary = asyncio.run(lb.run_market("KR", "run1"))
+
+    assert summary["signaled"] == 0, "strong stock at target must not signal at all"
+    assert summary["acted"] == 0
+    assert calls == []
 
 
 # ── SHADOW vs LIVE ─────────────────────────────────────────────────────────────

--- a/tools/trend_exit_seller.py
+++ b/tools/trend_exit_seller.py
@@ -25,7 +25,17 @@ THE CORE OF LOOP B — close-confirmation / consecutive-breach gate (anti-whipsa
         breach_streak >= TREND_EXIT_CONFIRM_CHECKS            (N consecutive days)
       OR
         TREND_EXIT_CLOSE_WINDOW=true AND a signal exists now  (session-close confirm)
+        AND the signal is NOT a TIER3 target take-profit      (see below)
   i.e. "N consecutive checkpoint breaches OR a session-close confirmation."
+
+  EXCEPTION — TIER3_TARGET is excluded from the session-close fast-path.
+  That fast-path is damage control: a TIER1.5/TIER2 breach still standing at the
+  closing bell is confirmed by the close, and carrying a broken position overnight
+  is the larger risk. A target take-profit is the opposite situation — the position
+  is at a profit high — so it earns no urgency discount and must clear the full
+  N-day confirmation. (The close-window cron runs every session, so before this
+  exception CONFIRM_CHECKS was effectively dead for take-profits and winners were
+  liquidated on the first touch: 2026-07-29 INCY sold at streak=0, +11% on the day.)
 
 On an actual ACT it closes the position the SAME way the batch and Hardstop do, so
 the simulator, the real KIS account and the Telegram channel all stay consistent:
@@ -531,11 +541,23 @@ async def run_market(market: str, run_id: str) -> Dict[str, Any]:
                     summary["signaled"] += 1
 
                     # Close-confirmation / consecutive-breach gate.
-                    gate_open = (streak >= TREND_EXIT_CONFIRM_CHECKS) or TREND_EXIT_CLOSE_WINDOW
+                    # The close-window fast-path is DAMAGE CONTROL: "a breach still
+                    # standing at the closing bell is confirmed by the close — don't
+                    # carry a broken position overnight." A TIER3 target take-profit
+                    # is not damage control (the position is at a profit high), so it
+                    # is excluded from the fast-path and must earn the full N-day
+                    # confirmation. Without this, the close-window line (which runs
+                    # EVERY session) made CONFIRM_CHECKS dead for target take-profits
+                    # and liquidated winners same-day (2026-07-29 INCY, streak=0).
+                    is_target_take = reason.startswith("TIER3_TARGET")
+                    gate_open = (streak >= TREND_EXIT_CONFIRM_CHECKS) or (
+                        TREND_EXIT_CLOSE_WINDOW and not is_target_take)
                     if not gate_open:
                         summary["gated"] += 1
-                        logger.info("[%s] %s signal (%s) streak=%d < %d, not close-window -> gated",
-                                    market, ticker, reason, streak, TREND_EXIT_CONFIRM_CHECKS)
+                        logger.info("[%s] %s signal (%s) streak=%d < %d, close_window=%s, "
+                                    "target_take=%s -> gated",
+                                    market, ticker, reason, streak, TREND_EXIT_CONFIRM_CHECKS,
+                                    TREND_EXIT_CLOSE_WINDOW, is_target_take)
                         continue
                     summary["acted"] += 1
                     h = dict(h)


### PR DESCRIPTION
## 배경 — 2026-07-29 INCY

목표가 도달 당일 **+11% 상승 중**이던 INCY를 전량 청산했습니다 (+16.76%).
같은 세션의 매수 트리거 배치는 동일 종목을 `oneil_pct=95 / RS=0.80 / Final=0.839`로 **최상위 매수 후보**로 평가했습니다. 매수 로직과 매도 로직이 29분 간격으로 정반대 판단을 내렸습니다.

```
03:46~04:36  TIER3_TARGET(weak) 신호 6회 발생 → streak=0 < 2 로 전부 gated
04:46        close_window=False → 막힘
04:50        close_window=True  → 통과, 즉시 전량 시장가 매도
```

## 원인 1 — close-window 즉시확정이 익절에도 적용됨

`gate_open = (streak >= CONFIRM) or CLOSE_WINDOW` 인데 close-window cron이 **매 세션** 돕니다 (`50-59/3 4 * * 2-6`). 따라서 `CONFIRM_CHECKS`는 TIER3 익절에 대해 사실상 죽은 코드였습니다.

즉시확정의 취지는 *"마감까지 살아있는 이탈은 종가가 확정한 것 → 망가진 포지션을 밤새 들고 가지 말자"* 는 **손상방어**입니다. 익절은 손상방어가 아닙니다(포지션이 수익 고점에 있음). → TIER3만 예외에서 제외, TIER1.5/TIER2는 **그대로 유지**.

## 원인 2 — regime이 지수 기준이라 개별 주도주를 잘라냄

regime은 S&P500/KOSPI로 산출됩니다. 당일 `sideways`(50일선 아래, 4주 -0.82%, distribution_days=5) → `WEAK_REGIMES` → TIER3 자동익절 활성화. 정작 INCY 본인은 +11% 돌파 중이었습니다.

→ 약세/횡보 레짐이라도 종목 자신이 **(a) 자기 50일선 +3% 이상 상회** 하고 **(b) 진입 후 고점의 97% 이상** 이면 자동익절을 보류하고, 청산을 TIER2 트레일링(약세 밴드 -5%)에 위임합니다.

## 안전성

- **사각지대 없음**: 보류 밴드(≥0.97·peak)와 TIER2 트레일(0.95·peak)이 겹치지 않습니다. 고점 대비 3% 밀리면 익절이 되살아나고, 5% 밀리면 그 전에 TIER2가 청산합니다.
- **손절 무영향**: TIER1 하드스톱은 TIER3보다 먼저 평가됩니다. 강한 종목이어도 손절은 그대로 나갑니다.
- **보수적 폴백**: `ma_50` 미주입(0 = fetch 실패/dormant)이면 강도 판정 불가 → **기존 동작 유지**.
- `cores/`와 `prism-us/cores/`의 `oneil_fallback.py`는 수동 동기 사본이라 양쪽 동일 반영 + 드리프트 방지 테스트 추가.

## 테스트

신규 17개. **구버전에서 실패함을 확인**했습니다 (vacuous 아님):

```
FAILED test_tier3_target_is_gated_in_close_window_at_streak_0
FAILED test_strong_stock_at_target_never_signals_in_weak_regime
```

영향권 스위트: KR 306 passed / US 71 passed.
잔여 실패(`test_kr_pending_exit` 4건, `test_phase4_agents` 4건)는 **origin/main에서도 동일 재현**되는 기존 문제입니다 — 각각 파일간 테스트 오염, yfinance 관련.

## 미포함

분할 익절(부분매도)은 제외했습니다. `sell_stock()`에 수량 파라미터가 없고 분할매도는 피라미딩 다중행 포지션 전용이라(단일행은 행 자체가 원자적), 포지션 상태 모델 변경이 필요합니다. 별건으로 다룹니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)