### PR TITLE
fix(messaging): 테스트 실행이 실전 매매 시그널을 발행하던 문제 차단

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,48 @@
+"""Repo-root pytest configuration.
+
+Its ONE job today is to make it impossible for a test run to emit a real
+trading signal.
+
+Background: the trading agents (and the publisher modules themselves) call
+``load_dotenv()`` at import time, so importing one inside a test hands the
+process the production ``GCP_PROJECT_ID`` / ``GCP_PUBSUB_TOPIC_ID`` and Upstash
+Redis credentials. The publishers read "credentials present" as "publish for
+real". A plain ``pytest`` run therefore broadcast fixture sells — buy 100.00,
+sell 92.00/98.00, ``TIER1_ABS7`` / ``TIER1.5_MA50`` — onto the LIVE public
+signal topic that real mirroring subscribers trade on. 44 such signals reached
+production between 2026-07-11 and 2026-07-29, on tickers including 005930.
+
+pytest imports the nearest ``conftest.py`` before any test module, so setting
+the kill switch here closes the window that ``PYTEST_CURRENT_TEST`` alone does
+not cover: collection and module-level code in test files.
+
+This is deliberately at the repo root rather than in ``tests/`` so it also
+applies to any future test directory.
+"""
+
+import os
+
+from messaging.publish_guard import DISABLE_ENV_VAR
+
+# Set at import time — before pytest imports a single test module, and before
+# any of them can import a trading agent and trigger load_dotenv().
+os.environ[DISABLE_ENV_VAR] = "1"
+
+
+def pytest_configure(config):
+    """Re-assert the kill switch and record it in the header.
+
+    Re-asserted because a test may legitimately manipulate os.environ; the
+    header line makes it visible in CI logs that the guard was active for
+    the run.
+    """
+    os.environ[DISABLE_ENV_VAR] = "1"
+    config.addinivalue_line(
+        "markers",
+        "publishes_signals: test intentionally exercises a signal publisher "
+        "(still blocked from reaching a real transport by publish_guard)",
+    )
+
+
+def pytest_report_header(config):
+    return f"signal publishing: DISABLED ({DISABLE_ENV_VAR}=1)"

--- a/messaging/gcp_pubsub_signal_publisher.py
+++ b/messaging/gcp_pubsub_signal_publisher.py
@@ -33,6 +33,11 @@ try:
 except ImportError:
     pass
 
+# NOTE: the load_dotenv() above is exactly why publish_guard exists — merely
+# importing this module pulls the production GCP project/topic into the process,
+# including inside a test run.
+from .publish_guard import signal_publishing_disabled, block_reason
+
 logger = logging.getLogger(__name__)
 
 
@@ -76,6 +81,17 @@ class SignalPublisher:
 
     async def connect(self):
         """Connect to GCP Pub/Sub"""
+        # Fail closed under test: importing a trading agent loads the production
+        # .env, so without this a pytest run publishes fixture sells to the LIVE
+        # public topic that real mirroring subscribers trade on. See
+        # messaging/publish_guard.py.
+        if signal_publishing_disabled():
+            logger.warning(
+                "GCP Pub/Sub connect REFUSED — signal publishing is disabled (%s). "
+                "No trading signal will be published from this process.",
+                block_reason(),
+            )
+            return
         if not self.project_id:
             logger.warning("GCP not configured, signals will not be published")
             return

--- a/messaging/publish_guard.py
+++ b/messaging/publish_guard.py
@@ -1,0 +1,58 @@
+"""Fail-closed guard that stops trading signals escaping a test run.
+
+WHY THIS EXISTS
+---------------
+The trading agents call ``load_dotenv()`` at *module import* time, so merely
+importing one inside a test populates the process with the production
+``.env`` — including ``GCP_PROJECT_ID`` / ``GCP_PUBSUB_TOPIC_ID`` and the
+Upstash Redis credentials. The signal publishers treat "credentials present"
+as "publish for real", so a plain ``pytest`` run broadcast synthetic fixture
+sells to the LIVE topic.
+
+That topic is a public feed (``docs/EXTERNAL_SUBSCRIBER_GUIDE.md``) consumed by
+real mirroring subscribers that place real orders. Between 2026-07-11 and
+2026-07-29, 44 fixture signals reached it — buy price 100.00, sell 92.00/98.00,
+``TIER1_ABS7`` / ``TIER1.5_MA50`` reasons — on tickers including 005930
+(삼성전자). Any subscriber holding those symbols would have sold on a test.
+
+DESIGN
+------
+Fail closed at the transport boundary rather than mocking per test: a new test
+file, a new test directory, or a forgotten monkeypatch must not be able to
+reopen this hole. Two independent triggers, either of which blocks publishing:
+
+  * ``PYTEST_CURRENT_TEST`` — set by pytest around every test's
+    setup/call/teardown. Covers anything that runs during a test.
+  * ``PRISM_DISABLE_SIGNAL_PUBLISH`` — set by ``conftest.py`` at import time.
+    Covers collection and module-level code, where ``PYTEST_CURRENT_TEST`` is
+    not yet set, and gives operators a manual kill switch.
+
+Production sets neither, so live behaviour is unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+#: Operators/conftest set this to force publishing off for the whole process.
+DISABLE_ENV_VAR = "PRISM_DISABLE_SIGNAL_PUBLISH"
+
+
+def signal_publishing_disabled() -> bool:
+    """True when no trading signal may leave this process.
+
+    Checked at connect() time in every publisher, so a disabled process never
+    builds a transport client and every downstream publish call no-ops.
+    """
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return True
+    return str(os.environ.get(DISABLE_ENV_VAR, "")).strip().lower() in _TRUTHY
+
+
+def block_reason() -> str:
+    """Human-readable reason, for the warning a blocked publisher logs."""
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return "running under pytest (PYTEST_CURRENT_TEST is set)"
+    return f"{DISABLE_ENV_VAR} is set"

--- a/messaging/publish_guard.py
+++ b/messaging/publish_guard.py
@@ -28,6 +28,19 @@ reopen this hole. Two independent triggers, either of which blocks publishing:
     not yet set, and gives operators a manual kill switch.
 
 Production sets neither, so live behaviour is unchanged.
+
+KNOWN GAP
+---------
+Several CI steps run ``pytest --noconftest``, which skips conftest.py and so
+leaves ``PRISM_DISABLE_SIGNAL_PUBLISH`` unset; those runs are protected by
+``PYTEST_CURRENT_TEST`` alone. That covers test execution but NOT collection or
+module-level code in a test file. CI injects no credentials, so nothing can
+leak there — but a developer running ``--noconftest`` locally against a real
+``.env`` would have that narrow window open.
+
+Deliberately NOT closed by treating "pytest in sys.modules" as a third trigger:
+a false positive there would silently stop publishing in *production*, which is
+a worse failure than the narrow window it closes.
 """
 
 from __future__ import annotations

--- a/messaging/redis_signal_publisher.py
+++ b/messaging/redis_signal_publisher.py
@@ -35,6 +35,11 @@ try:
 except ImportError:
     pass  # If dotenv is not available, read from environment variables directly
 
+# NOTE: the load_dotenv() above is exactly why publish_guard exists — merely
+# importing this module pulls the production Redis credentials into the process,
+# including inside a test run.
+from .publish_guard import signal_publishing_disabled, block_reason
+
 logger = logging.getLogger(__name__)
 
 
@@ -82,6 +87,16 @@ class SignalPublisher:
 
     async def connect(self):
         """Connect to Redis"""
+        # Fail closed under test — see messaging/publish_guard.py. Importing a
+        # trading agent loads the production .env, so without this a pytest run
+        # publishes fixture sells to the live signal stream.
+        if signal_publishing_disabled():
+            logger.warning(
+                "Redis connect REFUSED — signal publishing is disabled (%s). "
+                "No trading signal will be published from this process.",
+                block_reason(),
+            )
+            return
         if not self.redis_url or not self.redis_token:
             logger.warning("Redis not configured, signals will not be published")
             return

--- a/prism-us/tests/conftest.py
+++ b/prism-us/tests/conftest.py
@@ -25,6 +25,16 @@ sys.path.insert(0, str(PRISM_US_DIR))
 # Ensure we can import from prism-us
 os.chdir(str(PRISM_US_DIR))
 
+# Block real trading-signal publishing for the whole US test session.
+# The US suite runs from prism-us/, so the repo-root conftest.py is not
+# guaranteed to be loaded — set the kill switch explicitly rather than rely on
+# pytest's rootdir resolution. See messaging/publish_guard.py: importing a
+# trading agent loads the production .env, and a test run previously broadcast
+# fixture sells onto the live public signal topic.
+from messaging.publish_guard import DISABLE_ENV_VAR  # noqa: E402
+
+os.environ[DISABLE_ENV_VAR] = "1"
+
 
 # =============================================================================
 # Fixtures - Database

--- a/tests/test_publish_guard.py
+++ b/tests/test_publish_guard.py
@@ -1,0 +1,145 @@
+"""Tests for the fail-closed trading-signal publish guard.
+
+Regression cover for the 2026-07 incident: running the test suite broadcast
+synthetic fixture sells (buy 100.00 / sell 92.00 / TIER1_ABS7, tickers 005930
+and AAPL) onto the LIVE public Pub/Sub topic that real mirroring subscribers
+trade on. 44 signals reached production between 07-11 and 07-29.
+
+The invariant these tests protect: **no test run may open a real signal
+transport, even with full production credentials present in the environment.**
+"""
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT))
+
+from messaging.publish_guard import (  # noqa: E402
+    DISABLE_ENV_VAR,
+    block_reason,
+    signal_publishing_disabled,
+)
+
+
+class TestGuardPredicate:
+    def test_disabled_while_running_under_pytest(self):
+        """PYTEST_CURRENT_TEST is set by pytest around every test — the guard
+        must trip on it with no other configuration."""
+        assert os.environ.get("PYTEST_CURRENT_TEST")
+        assert signal_publishing_disabled() is True
+
+    def test_conftest_set_the_kill_switch(self):
+        """The repo-root conftest must have armed the switch at import time,
+        which is what covers collection and module-level code."""
+        assert os.environ.get(DISABLE_ENV_VAR) == "1"
+
+    def test_explicit_env_var_alone_is_sufficient(self, monkeypatch):
+        """Outside pytest, the operator kill switch alone must block."""
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        monkeypatch.setenv(DISABLE_ENV_VAR, "1")
+        assert signal_publishing_disabled() is True
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", " on "])
+    def test_truthy_spellings(self, monkeypatch, value):
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        monkeypatch.setenv(DISABLE_ENV_VAR, value)
+        assert signal_publishing_disabled() is True
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "off"])
+    def test_production_is_not_blocked(self, monkeypatch, value):
+        """Critical: the guard must NOT disable publishing in production."""
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        monkeypatch.setenv(DISABLE_ENV_VAR, value)
+        assert signal_publishing_disabled() is False
+
+    def test_unset_environment_is_not_blocked(self, monkeypatch):
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        monkeypatch.delenv(DISABLE_ENV_VAR, raising=False)
+        assert signal_publishing_disabled() is False
+
+    def test_block_reason_is_informative(self):
+        assert "pytest" in block_reason()
+
+
+class TestPublishersRefuseToConnect:
+    """The transports must stay unconnected even with valid-looking creds."""
+
+    def test_gcp_publisher_refuses_with_production_credentials(self, monkeypatch):
+        from messaging.gcp_pubsub_signal_publisher import SignalPublisher
+
+        monkeypatch.setenv("GCP_PROJECT_ID", "prism-prod")
+        monkeypatch.setenv("GCP_PUBSUB_TOPIC_ID", "prism-trading-signals")
+
+        pub = SignalPublisher()
+        assert pub.project_id == "prism-prod"  # creds really are present
+        asyncio.run(pub.connect())
+
+        assert pub._is_connected() is False, "GCP client was built during a test"
+        assert pub._publisher is None
+
+    def test_redis_publisher_refuses_with_production_credentials(self, monkeypatch):
+        from messaging.redis_signal_publisher import SignalPublisher
+
+        monkeypatch.setenv("UPSTASH_REDIS_REST_URL", "https://example.upstash.io")
+        monkeypatch.setenv("UPSTASH_REDIS_REST_TOKEN", "token")
+
+        pub = SignalPublisher()
+        assert pub.redis_url  # creds really are present
+        asyncio.run(pub.connect())
+
+        assert pub._redis is None, "Redis client was built during a test"
+
+    def test_gcp_publish_is_a_noop_when_unconnected(self, monkeypatch):
+        """Even if something calls publish directly, nothing leaves."""
+        from messaging.gcp_pubsub_signal_publisher import SignalPublisher
+
+        monkeypatch.setenv("GCP_PROJECT_ID", "prism-prod")
+        pub = SignalPublisher()
+        asyncio.run(pub.connect())
+
+        message_id = asyncio.run(
+            pub.publish_signal(
+                signal_type="SELL",
+                ticker="005930",
+                company_name="005930",
+                price=92.0,
+            )
+        )
+        assert message_id is None
+
+
+class TestEndToEndBroadcastIsBlocked:
+    def test_publish_loop_sell_emits_nothing(self):
+        """sell_broadcast.publish_loop_sell is the loops' broadcast entry point.
+
+        This reproduces the exact shape of the leaked signal (005930, buy 100,
+        sell 92, TIER1_ABS7) and asserts it cannot reach a transport.
+        """
+        import sell_broadcast
+
+        # Must not raise, and must not construct any transport client.
+        asyncio.run(
+            sell_broadcast.publish_loop_sell(
+                market="KR",
+                ticker="005930",
+                company_name="005930",
+                price=92.0,
+                buy_price=100.0,
+                sell_reason="TIER1_ABS7: loss -8.00% <= -7.0%",
+            )
+        )
+
+        from messaging.gcp_pubsub_signal_publisher import SignalPublisher as GcpPub
+        from messaging.redis_signal_publisher import SignalPublisher as RedisPub
+
+        gcp = GcpPub()
+        asyncio.run(gcp.connect())
+        assert gcp._is_connected() is False
+
+        redis_pub = RedisPub()
+        asyncio.run(redis_pub.connect())
+        assert redis_pub._redis is None


### PR DESCRIPTION
## 무슨 일이 있었나

**테스트를 돌리면 운영 GCP Pub/Sub 토픽으로 진짜 매도 시그널이 나갔습니다.** 2026-07-11 ~ 07-29 사이 **44건**이 실제로 발행됐습니다.

```
2026-07-29 16:56:48 [SELL] AAPL(AAPL) @ 98.00 USD
  Buy price: 100.00 USD | Profit rate: -2.00%
  Sell reason: TIER1.5_MA50: below 50MA(105.0000) while losing (-2.00%)

2026-07-29 16:58:58 [SELL] 005930(005930) @ 92.00 KRW
  Buy price: 100.00 KRW | Profit rate: -8.00%
  Sell reason: TIER1_ABS7: loss -8.00% <= -7.0%
```

전부 `tests/test_hardstop_seller.py`, `tests/test_trend_exit_seller.py`의 픽스처 값입니다. 매수가 100.00 / 50MA 105.0000 — 실거래에 존재할 수 없는 수치입니다.

날짜별: 07-11 8건, 07-15 3건, 07-18 4건, 07-19 10건, 07-23 1건, 07-27 4건, 07-29 14건

## 원인

1. 트레이딩 에이전트와 publisher 모듈이 **import 시점에** `load_dotenv()` 호출 → 테스트가 import 하는 순간 운영 `.env`(`GCP_PROJECT_ID`/`GCP_PUBSUB_TOPIC_ID`/`UPSTASH_REDIS_*`)가 프로세스에 올라옴
2. publisher는 "자격증명 있음 = 실제 발행"으로 동작
3. 루트에 `conftest.py`가 **없어** 격리 장치 전무

## 위험도

이 토픽은 `docs/EXTERNAL_SUBSCRIBER_GUIDE.md`로 **공개된 무료 시그널 피드**이고, 실제 미러링 구독자가 받아서 실주문을 냅니다.

발행된 티커에 **005930(삼성전자)**가 포함돼 있습니다. 해당 종목을 보유한 외부 구독자는 테스트 신호에 매도했을 수 있습니다. 내부 미러 계좌는 미보유로 거부됐습니다 (`not found in portfolio`).

## 수정 — 전송 경계에서 fail-closed

개별 테스트에 mock을 다는 방식은 새 테스트 파일 하나, 깜빡한 monkeypatch 하나로 다시 뚫립니다. **전송 경계에서 막았습니다.**

`messaging/publish_guard.py` 신설. 두 트리거 중 하나라도 걸리면 차단:

- `PYTEST_CURRENT_TEST` — pytest가 테스트마다 설정. 실행 구간 전체 커버.
- `PRISM_DISABLE_SIGNAL_PUBLISH` — conftest가 import 시점에 설정. `PYTEST_CURRENT_TEST`가 아직 없는 **수집/모듈레벨** 구간 커버 + 운영자 수동 킬스위치

양쪽 publisher의 `connect()` 최상단에서 검사 → 차단 시 transport 클라이언트를 **아예 만들지 않고**, 하위 publish는 기존 `_is_connected()` 가드로 안전하게 no-op.

**운영은 두 환경변수가 모두 없으므로 동작 불변입니다.**

루트 `conftest.py` 신설 + `prism-us/tests/conftest.py`에도 명시적 설정 (US 스위트는 `prism-us/`에서 실행돼 루트 conftest 로드가 보장되지 않음 — 프로브로 확인함).

## 검증

**실증이 핵심입니다.** 유출됐던 스위트를 그대로 재실행하고 구독자 로그를 대조했습니다:

```
실행 전: 픽스처 신호 44건 (로그 2554줄)
  → pytest test_hardstop_seller + test_trend_exit_seller + test_kr_pending_exit  (95 passed)
실행 후: 픽스처 신호 44건 (로그 2554줄)
신규 유출: 0건
```

로그가 **한 줄도 늘지 않았습니다.**

- 신규 테스트 20개. 운영 자격증명을 넣은 상태에서도 `connect()`가 거부하고 클라이언트가 생성되지 않음을 확인. **운영 조건에서는 차단되지 않음**도 함께 assert.
- KR 326 passed / US 71 passed
- 잔여 실패 8건은 **가드를 제거해도 동일 재현**되는 기존 문제 (`test_kr_pending_exit` 파일간 오염, `test_phase4_agents` yfinance). `test_kr_pending_exit` 단독 실행은 가드 포함 35/35 통과.

## 후속 (별건)

이미 발행된 44건에 대한 **외부 구독자 고지 여부는 운영 판단**이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)