### PR TITLE
fix(us-screening): 오후 트리거 2개에 누락된 양봉 필터 추가

### DIFF
--- a/prism-us/tests/test_us_screening_bullish_candle.py
+++ b/prism-us/tests/test_us_screening_bullish_candle.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+US 스크리너 양봉(Close > Open) 필터 회귀 테스트 (no network).
+
+배경: 2026-08-01 오후 배치에서 MU 가 `Macro Sector Leader` 로 선정됐는데
+당일(07-31) 캔들이 시가 919.65 → 종가 823.03 (−10.51%) 인 음봉이었다.
+
+원인: 8개 스크리너 중 일부만 양봉 필터를 적용하고 있었다.
+  적용됨 — morning_volume_surge / morning_gap_up_momentum /
+           morning_value_to_cap_ratio / afternoon_closing_strength
+  누락됨 — afternoon_daily_rise_top, macro_sector_leader   ← 이 PR 에서 추가
+  의도적 제외 — contrarian_value(역발상은 약세를 사는 트리거),
+               afternoon_volume_surge_flat(횡보 축적 트리거)
+
+이 테스트는 '누락됨' 두 트리거가 음봉을 배제하는지 고정한다.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pandas as pd
+
+passed = 0
+failed = 0
+
+
+def check(label, cond):
+    global passed, failed
+    if cond:
+        passed += 1
+        print(f"  PASS: {label}")
+    else:
+        failed += 1
+        print(f"  FAIL: {label}")
+
+
+import us_trigger_batch as u
+
+
+def _frames():
+    """실제 2026-07-31 값 기반. BULL=양봉, BEAR=음봉(둘 다 전일대비 상승)."""
+    idx = ["BULL", "BEAR"]
+    snap = pd.DataFrame(
+        {
+            # BEAR: 갭상승 후 밀려 음봉이지만 전일대비로는 +5%
+            "Open": [154.01, 919.65],
+            "High": [162.57, 930.88],
+            "Low": [153.61, 818.00],
+            "Close": [161.95, 823.03],
+            "Volume": [5_000_000, 9_000_000],
+            "Amount": [8.0e8, 7.5e9],
+        },
+        index=idx,
+    )
+    prev = pd.DataFrame(
+        {
+            "Open": [148.27, 793.14],
+            "High": [154.99, 882.50],
+            "Low": [143.77, 789.00],
+            # BEAR 전일종가를 낮게 둬서 DailyChange 를 양수로 만든다
+            "Close": [154.25, 780.00],
+            "Volume": [4_000_000, 8_000_000],
+            "Amount": [7.0e8, 7.0e9],
+        },
+        index=idx,
+    )
+    cap = pd.DataFrame({"MarketCap": [8.0e10, 9.0e11]}, index=idx)
+    return snap, prev, cap
+
+
+snap, prev, cap = _frames()
+print("입력: BULL 종가>시가(양봉), BEAR 종가<시가(음봉) — 둘 다 전일대비 상승")
+print(f"  BULL  시 {snap.loc['BULL','Open']} → 종 {snap.loc['BULL','Close']}  "
+      f"(전일대비 {(snap.loc['BULL','Close']/prev.loc['BULL','Close']-1)*100:+.2f}%)")
+print(f"  BEAR  시 {snap.loc['BEAR','Open']} → 종 {snap.loc['BEAR','Close']}  "
+      f"(전일대비 {(snap.loc['BEAR','Close']/prev.loc['BEAR','Close']-1)*100:+.2f}%)")
+
+print("\n[Test 1] afternoon_daily_rise_top — 음봉 배제")
+try:
+    res = u.trigger_afternoon_daily_rise_top("20260731", snap, prev, cap)
+    names = list(res.index) if res is not None and not res.empty else []
+    check(f"BEAR(음봉) 제외됨 (결과: {names})", "BEAR" not in names)
+    check(f"BULL(양봉) 유지됨 (결과: {names})", "BULL" in names)
+except Exception as e:
+    check(f"실행 예외 없음 ({type(e).__name__}: {e})", False)
+
+print("\n[Test 2] macro_sector_leader — 음봉 배제")
+# leading_sectors 가 비면 필터를 타기 전에 조기 return 하므로(공허한 통과),
+# 섹터 맵을 주입해 실제로 필터 구간까지 진입시킨다.
+macro = {"leading_sectors": [{"sector": "Technology", "confidence": 0.8}]}
+_orig_map = u.get_us_sector_map
+try:
+    u.get_us_sector_map = lambda tickers: {t: "Technology" for t in tickers}
+    res2 = u.trigger_macro_sector_leader("20260731", snap, prev, cap, macro_context=macro)
+    names2 = list(res2.index) if res2 is not None and not res2.empty else []
+    # 음성 대조군: BULL 이 살아남아야 "필터가 BEAR 를 걸렀다"가 증명된다.
+    check(f"BULL(양봉) 유지됨 — 조기 return 이 아님 (결과: {names2})", "BULL" in names2)
+    check(f"BEAR(음봉) 제외됨 (결과: {names2})", "BEAR" not in names2)
+except Exception as e:
+    check(f"실행 예외 없음 ({type(e).__name__}: {e})", False)
+finally:
+    u.get_us_sector_map = _orig_map
+
+print("\n[Test 3] 의도적 제외 트리거는 건드리지 않았다")
+import inspect
+check("contrarian_value 에 양봉 필터 없음(역발상 트리거)",
+      "IsRising" not in inspect.getsource(u.trigger_contrarian_value))
+
+print(f"\n===== RESULT: {passed} passed, {failed} failed =====")
+sys.exit(1 if failed else 0)

--- a/prism-us/us_trigger_batch.py
+++ b/prism-us/us_trigger_batch.py
@@ -581,8 +581,13 @@ def trigger_afternoon_daily_rise_top(trade_date: str, snapshot: pd.DataFrame,
     snap["IntradayChange"] = (snap["Close"] / snap["Open"] - 1) * 100
     snap["DailyChange"] = ((snap["Close"] - prev["Close"]) / prev["Close"]) * 100
 
-    # Filter: 3% <= change <= 15%
-    snap = snap[(snap["DailyChange"] >= 3.0) & (snap["DailyChange"] <= 15.0)]
+    # Bullish candle required (Close > Open) — same rule the other triggers already apply.
+    # Without it a stock that gapped up and then faded all day still qualifies on
+    # DailyChange alone, which contradicts the "Intraday Rise" premise of this trigger.
+    snap["IsRising"] = snap["Close"] > snap["Open"]
+
+    # Filter: 3% <= change <= 15%, bullish candle only
+    snap = snap[(snap["DailyChange"] >= 3.0) & (snap["DailyChange"] <= 15.0) & snap["IsRising"]]
 
     if snap.empty:
         logger.debug("trigger_afternoon_daily_rise_top: No qualifying stocks")
@@ -839,6 +844,14 @@ def trigger_macro_sector_leader(trade_date: str, snapshot: pd.DataFrame,
     # Calculate daily change for relative strength
     snap_filtered["DailyChange"] = ((snap_filtered["Close"] - prev.loc[matched_rows, "Close"]) /
                                      prev.loc[matched_rows, "Close"]) * 100
+
+    # Bullish candle required (Close > Open) — same rule the other triggers already apply.
+    # A "sector leader" that closes below its own open is not showing leadership today;
+    # relative strength alone can stay positive in a falling market.
+    snap_filtered = snap_filtered[snap_filtered["Close"] > snap_filtered["Open"]]
+    if snap_filtered.empty:
+        logger.debug("trigger_macro_sector_leader: No leaders with a bullish candle")
+        return pd.DataFrame()
 
     # Market average change for relative strength calculation
     market_avg_change = (


### PR DESCRIPTION
## 발단

2026-08-01 오후 배치에서 **MU** 가 `Macro Sector Leader` 로 선정됐는데, 당일(07-31) 캔들이
시가 919.65 → 종가 823.03 (**−10.51% 음봉**) 이었다.

## 원인 — 8개 스크리너 중 2개에만 양봉 필터가 없었다

| 스크리너 | Close > Open 필터 |
|---|---|
| morning_volume_surge | ✅ `:395` |
| morning_gap_up_momentum | ✅ `:458` |
| morning_value_to_cap_ratio | ✅ `:540` |
| **afternoon_daily_rise_top** | ❌ → 이 PR 에서 추가 |
| afternoon_closing_strength | ✅ `:663` |
| **macro_sector_leader** | ❌ → 이 PR 에서 추가 |

두 트리거 모두 **전일대비 등락률(DailyChange) 또는 상대강도만** 본다. 갭상승 후 종일 밀려
음봉으로 마감해도 통과한다. `"Intraday Rise"` / `"Leader"` 라는 트리거 전제와 모순된다.

## 의도적으로 제외한 트리거

- `contrarian_value` — 역발상은 **약세를 사는** 트리거다
- `afternoon_volume_surge_flat` — 횡보 축적 트리거라 음봉이 결격이 아니다

## 성격

**새 진입 필터 추가가 아니라 기존 4개 스크리너와의 일관성 회복이다.**
이 저장소는 진입 필터를 발명했다가 4번 실패한 이력이 있는데, 이번 건은 그 범주가 아니다.

## 검증

- 신규 테스트 **5 passed**
- 수정을 되돌리면 **2 failed** — 음봉 종목이 두 트리거 모두에서 통과(오늘 MU 상황 재현)
- 조기 return 으로 인한 공허한 통과를 막기 위해 **음성 대조군**(양봉 종목이 살아남는지) 포함
- 인덱스 정합성 확인: 필터 이후 `matched_rows`/`matched_confs`/`prev.loc` 재사용 없음.
  `SectorConfidence` 는 필터 전에 컬럼으로 설정돼 함께 걸러진다
- 빈 결과 처리 확인: 호출부가 `if not res_macro.empty:` 로 가드

## ⚠️ 알려진 한계 (이 PR 범위 밖, 기존 4개 스크리너도 동일)

이 배치는 크론 `10 15 * * 1-5` (America/New_York) = **장 마감 50분 전**에 돈다.
따라서 `Close` 는 확정 종가가 아니라 **그 시점의 현재가**다. 막판 반전이 있으면 오판할 수 있다.
예: GDDY 07-31 은 시가 76.83 → 종가 82.74 로 최종은 양봉이었으나, 15:10 시점 값은 미확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)