### PR TITLE
fix(firecrawl): 봇 커맨드 폴백에 검색 필터 전달

### DIFF
--- a/cores/search_presets.py
+++ b/cores/search_presets.py
@@ -1,0 +1,93 @@
+"""
+Retrieval presets for Firecrawl-backed commands.
+
+Why this module exists
+----------------------
+`generate_firecrawl_search_response()` accepts recency/source/domain filters, but
+they are optional keyword arguments. Calling it without them is silently legal and
+silently terrible: a bare call for "코스피 증시 마감 시황" comes back with eight
+undated *quote pages* (naver/KB/daum ticker screens) and zero news articles, so the
+model has nothing to reason about and invents or hedges instead.
+
+Measured on 2026-08-01 with tools/bench/probe_firecrawl_tbs.py:
+
+    bare  (no options)                 8 results | 0 dated (0%)   | all quote pages
+    tuned (tbs+sources+location+dom)   8 results | 4 dated (50%)  | 마감시황 articles
+
+The weekly report already passed the right options; every bot command did not.
+Centralizing them here keeps the two call paths from drifting apart again.
+
+Notes on the individual knobs
+-----------------------------
+tbs             Recency window. Without it the engine happily returns years-old
+                pages — the single biggest cause of stale reports.
+sources         ["news", "web"]. The news channel is the only one that carries a
+                publish date, which is what makes date filtering possible at all.
+location        Country bias for the backend.
+include_domains Primary-outlet allowlist. Firecrawl suppresses the news channel
+                when a domain allowlist is set, so firecrawl_client._search_passes()
+                issues a separate unfiltered news pass; that is expected.
+"""
+from __future__ import annotations
+
+# 1차 매체만 허용. 블로그·커뮤니티가 검색 상위를 먹으면 리포트 수치가 오염된다.
+KR_PRIMARY_DOMAINS = [
+    "yna.co.kr", "einfomax.co.kr", "hankyung.com", "mk.co.kr", "edaily.co.kr",
+    "sedaily.com", "fnnews.com", "mt.co.kr", "asiae.co.kr", "newsis.com",
+    "biz.chosun.com", "wowtv.co.kr", "infostock.co.kr", "thebell.co.kr",
+]
+
+US_PRIMARY_DOMAINS = [
+    "reuters.com", "cnbc.com", "bloomberg.com", "marketwatch.com", "wsj.com",
+    "barrons.com", "ft.com", "investors.com", "apnews.com", "finance.yahoo.com",
+    "fool.com", "seekingalpha.com",
+]
+
+_DOMAINS_BY_MARKET = {"KR": KR_PRIMARY_DOMAINS, "US": US_PRIMARY_DOMAINS}
+
+# Progressive widening ladder used when a tight window returns nothing at all.
+# Falling back to a wider window beats returning "결과 없음" to the user.
+TBS_LADDER = ["qdr:d", "qdr:w", "qdr:m", "qdr:y"]
+
+
+def widen_tbs(tbs: str | None) -> str | None:
+    """Next wider recency window, or None once the ladder is exhausted."""
+    if tbs not in TBS_LADDER:
+        return None
+    idx = TBS_LADDER.index(tbs)
+    return TBS_LADDER[idx + 1] if idx + 1 < len(TBS_LADDER) else None
+
+
+def search_preset(
+    market: str,
+    *,
+    tbs: str = "qdr:w",
+    allowlist: bool = True,
+) -> dict:
+    """
+    Build retrieval kwargs for generate_firecrawl_search_response().
+
+    Args:
+        market: "KR" or "US" — sets country bias and which primary-outlet list to use.
+        tbs: Recency window. Event-impact questions want "qdr:w"; theme health and
+             free-form research need "qdr:m" so a slow news week does not empty the
+             result set.
+        allowlist: Restrict to primary outlets. Turn this OFF for free-form questions
+             (/ask), where the subject is unpredictable and a KR/US press allowlist
+             would drop legitimate sources.
+
+    Returns:
+        dict of keyword arguments, splat directly into the search call.
+    """
+    market = market.upper()
+    if market not in _DOMAINS_BY_MARKET:
+        raise ValueError(f"unknown market {market!r}; expected 'KR' or 'US'")
+
+    preset: dict = {
+        "tbs": tbs,
+        "sources": ["news", "web"],
+        "location": market,
+    }
+    if allowlist:
+        preset["include_domains"] = _DOMAINS_BY_MARKET[market]
+    return preset

--- a/report_generator.py
+++ b/report_generator.py
@@ -1327,23 +1327,37 @@ async def generate_firecrawl_search_response(
     """
     try:
         from firecrawl_client import firecrawl_search_multi
+        from cores.search_presets import widen_tbs
 
         queries = [search_query] if isinstance(search_query, str) else list(search_query)
 
         loop = asyncio.get_running_loop()
-        items = await loop.run_in_executor(
-            None,
-            lambda: firecrawl_search_multi(
-                queries,
-                limit=limit,
-                with_content=True,
-                tbs=tbs,
-                sources=sources,
-                location=location,
-                include_domains=include_domains,
-                exclude_domains=exclude_domains,
-            ),
-        )
+
+        async def _search(recency: Optional[str]) -> list:
+            return await loop.run_in_executor(
+                None,
+                lambda: firecrawl_search_multi(
+                    queries,
+                    limit=limit,
+                    with_content=True,
+                    tbs=recency,
+                    sources=sources,
+                    location=location,
+                    include_domains=include_domains,
+                    exclude_domains=exclude_domains,
+                ),
+            )
+
+        items = await _search(tbs)
+
+        # A tight recency window legitimately returns nothing on a quiet news day.
+        # Widening one rung at a time beats handing the user "결과 없음" — every
+        # article still carries its publish date downstream, so the model can see
+        # for itself that the material is older than asked for.
+        window = tbs
+        while not items and (window := widen_tbs(window)):
+            logger.info(f"No results at tbs={tbs!r}; widening to {window!r}")
+            items = await _search(window)
 
         # Prefer dated results, newest first; undated ones sink to the bottom.
         items.sort(key=lambda it: (bool(it.get("date")), it.get("date") or ""), reverse=True)

--- a/telegram_ai_bot.py
+++ b/telegram_ai_bot.py
@@ -39,6 +39,7 @@ from report_generator import (
 )
 from tracking.user_memory import UserMemoryManager
 from firecrawl_client import firecrawl_agent
+from cores.search_presets import search_preset
 from cores.disclaimer_utils import strip_trailing_disclaimer as _strip_trailing_disclaimer
 from datetime import timedelta
 from dataclasses import dataclass
@@ -2868,7 +2869,8 @@ class TelegramAIBot:
                                      model: str = "spark-1-mini", max_credits: int = 200,
                                      fallback_search_query: str = None,
                                      fallback_analysis_prompt: str = None,
-                                     timeout: int = None):
+                                     timeout: int = None,
+                                     search_opts: dict = None):
         """
         Common helper for Firecrawl-based commands.
         Sends a waiting message, calls firecrawl_agent, then replaces it with the result.
@@ -2883,6 +2885,10 @@ class TelegramAIBot:
             timeout: Seconds to wait for the Spark agent before giving up (defaults to
                 _FIRECRAWL_AGENT_TIMEOUT). Heavy spark-1-pro jobs need a larger budget so
                 legitimate deep-research runs are not cut off prematurely.
+            search_opts: Retrieval filters for the fallback search, from
+                cores.search_presets.search_preset(). Omitting these is what made the
+                fallback return undated quote pages instead of dated news — measured
+                0% dated bare vs 50% dated tuned (tools/bench/probe_firecrawl_tbs.py).
 
         Returns:
             tuple: (success: bool, response_text: str | None, sent_msg_id: int | None)
@@ -2915,7 +2921,8 @@ class TelegramAIBot:
                     pass
                 try:
                     result = await generate_firecrawl_search_response(
-                        fallback_search_query, fallback_analysis_prompt
+                        fallback_search_query, fallback_analysis_prompt,
+                        **(search_opts or {}),
                     )
                 except Exception as fe:
                     logger.error(f"Search+LLM fallback failed: {fe}", exc_info=True)
@@ -2965,9 +2972,14 @@ class TelegramAIBot:
             )
             return False, None, None
 
-    async def _run_search_and_claude(self, update: Update, search_query: str, analysis_prompt: str, disclaimer: str):
+    async def _run_search_and_claude(self, update: Update, search_query: str, analysis_prompt: str, disclaimer: str,
+                                     search_opts: dict = None):
         """
         Cost-efficient helper using Firecrawl /search (2 credits) plus shared LLM analysis.
+
+        Args:
+            search_opts: Retrieval filters from cores.search_presets.search_preset().
+                See _run_firecrawl_command for why omitting these degrades results.
 
         Returns:
             tuple: (success: bool, response_text: str | None, sent_msg_id: int | None)
@@ -2976,7 +2988,9 @@ class TelegramAIBot:
         waiting_msg = await update.message.reply_text("🔍 리서치 중...")
 
         try:
-            result = await generate_firecrawl_search_response(search_query, analysis_prompt)
+            result = await generate_firecrawl_search_response(
+                search_query, analysis_prompt, **(search_opts or {})
+            )
 
             try:
                 await waiting_msg.delete()
@@ -3061,7 +3075,9 @@ class TelegramAIBot:
         ) + self._FIRECRAWL_GROUNDING
         success, response_text, msg_id = await self._run_firecrawl_command(
             update, prompt, self._DISCLAIMER_KR, model="spark-1-mini",
-            fallback_search_query=event, fallback_analysis_prompt=prompt
+            fallback_search_query=event, fallback_analysis_prompt=prompt,
+            # Event impact is a "what just happened" question — keep the window tight.
+            search_opts=search_preset("KR", tbs="qdr:w"),
         )
         if success and msg_id and response_text:
             ctx = FirecrawlConversationContext("signal", event)
@@ -3111,7 +3127,8 @@ class TelegramAIBot:
         ) + self._FIRECRAWL_GROUNDING
         success, response_text, msg_id = await self._run_firecrawl_command(
             update, prompt, self._DISCLAIMER_KR, model="spark-1-mini",
-            fallback_search_query=event, fallback_analysis_prompt=prompt
+            fallback_search_query=event, fallback_analysis_prompt=prompt,
+            search_opts=search_preset("US", tbs="qdr:w"),
         )
         if success and msg_id and response_text:
             ctx = FirecrawlConversationContext("us_signal", event)
@@ -3162,7 +3179,9 @@ class TelegramAIBot:
         ) + self._FIRECRAWL_GROUNDING
         success, response_text, msg_id = await self._run_firecrawl_command(
             update, prompt, self._DISCLAIMER_KR, model="spark-1-mini",
-            fallback_search_query=theme, fallback_analysis_prompt=prompt
+            fallback_search_query=theme, fallback_analysis_prompt=prompt,
+            # Theme health needs a longer arc than a single news week.
+            search_opts=search_preset("KR", tbs="qdr:m"),
         )
         if success and msg_id and response_text:
             ctx = FirecrawlConversationContext("theme", theme)
@@ -3213,7 +3232,8 @@ class TelegramAIBot:
         ) + self._FIRECRAWL_GROUNDING
         success, response_text, msg_id = await self._run_firecrawl_command(
             update, prompt, self._DISCLAIMER_KR, model="spark-1-mini",
-            fallback_search_query=theme, fallback_analysis_prompt=prompt
+            fallback_search_query=theme, fallback_analysis_prompt=prompt,
+            search_opts=search_preset("US", tbs="qdr:m"),
         )
         if success and msg_id and response_text:
             ctx = FirecrawlConversationContext("us_theme", theme)
@@ -3265,7 +3285,11 @@ class TelegramAIBot:
         ) + self._FIRECRAWL_GROUNDING
         success, response_text, msg_id = await self._run_firecrawl_command(
             update, prompt, self._DISCLAIMER_KR, model="spark-1-pro", max_credits=2000,
-            fallback_search_query=question, fallback_analysis_prompt=prompt, timeout=240
+            fallback_search_query=question, fallback_analysis_prompt=prompt, timeout=240,
+            # Free-form: the subject is unpredictable ("워렌 버핏이 올해 뭘 샀어?"), so a
+            # KR-press allowlist would drop legitimate sources. Keep recency + news
+            # channel, drop the allowlist.
+            search_opts=search_preset("KR", tbs="qdr:m", allowlist=False),
         )
         if success:
             if remaining > 0:

--- a/tools/bench/probe_firecrawl_tbs.py
+++ b/tools/bench/probe_firecrawl_tbs.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+Probe: does tbs/sources/include_domains actually change Firecrawl result freshness?
+
+Compares the current bare call (no options) against the weekly-report options
+on the same query, and reports how many results carry a usable publish date.
+
+Usage:  python3 tools/bench/probe_firecrawl_tbs.py
+Costs a handful of Firecrawl search credits. Read-only; touches no prod state.
+"""
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from dotenv import load_dotenv
+
+load_dotenv(ROOT / ".env")
+
+from firecrawl_client import firecrawl_search_multi  # noqa: E402
+
+KR_DOMAINS = [
+    "yna.co.kr", "einfomax.co.kr", "hankyung.com", "mk.co.kr", "edaily.co.kr",
+    "sedaily.com", "fnnews.com", "mt.co.kr", "asiae.co.kr", "newsis.com",
+    "biz.chosun.com", "wowtv.co.kr", "infostock.co.kr", "thebell.co.kr",
+]
+
+QUERY = "코스피 증시 마감 시황"
+
+
+def summarize(label: str, items: list) -> None:
+    dated = [i for i in items if i.get("date")]
+    low_trust = [i for i in items if i.get("low_trust")]
+    print(f"\n===== {label} =====")
+    print(f"  results={len(items)}  dated={len(dated)}  undated={len(items) - len(dated)}  low_trust={len(low_trust)}")
+    for i in items[:8]:
+        print(f"    [{i.get('date') or '발행일미상':<22}] {i.get('channel','?'):4} "
+              f"{'LOW ' if i.get('low_trust') else '    '}{(i.get('title') or '')[:52]}")
+
+
+def main() -> int:
+    if not os.getenv("FIRECRAWL_API_KEY"):
+        try:
+            from firecrawl_client import _get_api_key
+            _get_api_key()
+        except Exception as exc:
+            print(f"FIRECRAWL_API_KEY unavailable: {type(exc).__name__}: {exc}")
+            return 1
+
+    # A) what the bot fallback does today
+    bare = firecrawl_search_multi([QUERY], limit=8, with_content=False)
+    summarize("A. BARE (현행 봇 폴백 — 옵션 없음)", bare)
+
+    # B) what the weekly report does
+    tuned = firecrawl_search_multi(
+        [QUERY], limit=8, with_content=False,
+        tbs="qdr:w", sources=["news", "web"], location="KR",
+        include_domains=KR_DOMAINS,
+    )
+    summarize("B. TUNED (주간리포트 옵션 — tbs+sources+location+domains)", tuned)
+
+    print("\n===== 판정 =====")
+    for label, items in (("A(bare)", bare), ("B(tuned)", tuned)):
+        n = len(items)
+        d = sum(1 for i in items if i.get("date"))
+        lt = sum(1 for i in items if i.get("low_trust"))
+        rate = (d / n * 100) if n else 0.0
+        print(f"  {label:9} 총 {n:3}건 | 날짜보유 {d:3}건 ({rate:5.1f}%) | 저신뢰 {lt}건")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/bench/verify_search_presets.py
+++ b/tools/bench/verify_search_presets.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+Verify the search-preset wiring end to end.
+
+1. presets resolve to the expected kwargs
+2. every /command call site actually passes search_opts
+3. generate_firecrawl_search_response accepts the preset kwargs (signature check)
+4. widen_tbs ladder terminates
+5. live: the tuned path returns dated news where the bare path returned none
+
+Usage:  python3 tools/bench/verify_search_presets.py [--live]
+"""
+import ast
+import inspect
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(ROOT / ".env")
+
+from cores.search_presets import (  # noqa: E402
+    KR_PRIMARY_DOMAINS, US_PRIMARY_DOMAINS, search_preset, widen_tbs,
+)
+
+failures: list[str] = []
+
+
+def check(label: str, ok: bool, detail: str = "") -> None:
+    print(f"  {'PASS' if ok else 'FAIL'}  {label}" + (f"  — {detail}" if detail else ""))
+    if not ok:
+        failures.append(label)
+
+
+def test_presets() -> None:
+    print("\n[1] preset shape")
+    kr = search_preset("KR", tbs="qdr:w")
+    check("KR preset has tbs/sources/location/domains",
+          kr["tbs"] == "qdr:w" and kr["sources"] == ["news", "web"]
+          and kr["location"] == "KR" and kr["include_domains"] == KR_PRIMARY_DOMAINS)
+    us = search_preset("US", tbs="qdr:m")
+    check("US preset uses US domains",
+          us["location"] == "US" and us["include_domains"] == US_PRIMARY_DOMAINS)
+    free = search_preset("KR", tbs="qdr:m", allowlist=False)
+    check("allowlist=False drops include_domains", "include_domains" not in free)
+    try:
+        search_preset("JP")
+        check("unknown market rejected", False, "no ValueError raised")
+    except ValueError:
+        check("unknown market rejected", True)
+
+
+def test_ladder() -> None:
+    print("\n[2] widening ladder terminates")
+    seen, cur, steps = [], "qdr:d", 0
+    while cur and steps < 10:
+        seen.append(cur)
+        cur = widen_tbs(cur)
+        steps += 1
+    check("qdr:d -> ... -> None", cur is None and seen == ["qdr:d", "qdr:w", "qdr:m", "qdr:y"],
+          " -> ".join(seen))
+    check("unknown window returns None", widen_tbs("bogus") is None)
+
+
+def test_signature() -> None:
+    print("\n[3] generate_firecrawl_search_response accepts preset kwargs")
+    from report_generator import generate_firecrawl_search_response
+    params = inspect.signature(generate_firecrawl_search_response).parameters
+    for key in ("tbs", "sources", "location", "include_domains"):
+        check(f"accepts {key}", key in params)
+
+
+def test_call_sites() -> None:
+    """Every _run_firecrawl_command call must pass search_opts."""
+    print("\n[4] bot call sites pass search_opts")
+    src = (ROOT / "telegram_ai_bot.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    found = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        name = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", "")
+        if name not in ("_run_firecrawl_command", "_run_search_and_claude"):
+            continue
+        found += 1
+        kwargs = {k.arg for k in node.keywords}
+        # definition site has no keywords; skip the def by requiring a call with args
+        if not node.args and not kwargs:
+            continue
+        check(f"line {node.lineno} passes search_opts", "search_opts" in kwargs,
+              f"kwargs={sorted(kwargs)}")
+    check("found all 5 command call sites", found >= 5, f"found={found}")
+
+
+def test_live() -> None:
+    print("\n[5] LIVE: bare vs tuned (costs a few credits)")
+    from firecrawl_client import firecrawl_search_multi
+    q = "코스피 증시 마감 시황"
+    bare = firecrawl_search_multi([q], limit=6, with_content=False)
+    tuned = firecrawl_search_multi([q], limit=6, with_content=False,
+                                   **search_preset("KR", tbs="qdr:w"))
+    bd = sum(1 for i in bare if i.get("date"))
+    td = sum(1 for i in tuned if i.get("date"))
+    print(f"     bare : {len(bare)} results, {bd} dated")
+    print(f"     tuned: {len(tuned)} results, {td} dated")
+    check("tuned yields more dated results than bare", td > bd, f"{td} > {bd}")
+
+
+def main() -> int:
+    test_presets()
+    test_ladder()
+    test_signature()
+    test_call_sites()
+    if "--live" in sys.argv:
+        test_live()
+    else:
+        print("\n[5] LIVE skipped (pass --live to run)")
+
+    print("\n" + "=" * 60)
+    if failures:
+        print(f"FAILED ({len(failures)}): " + "; ".join(failures))
+        return 1
+    print("ALL PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/restart_telegram_bot.sh
+++ b/utils/restart_telegram_bot.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# 텔레그램 봇 멱등 재기동.
+#
+# 몇 번을 실행하든 결과는 "정확히 1개 인스턴스"로 수렴한다.
+#
+# 왜 필요한가
+# -----------
+# 2026-08-01~02, 재기동을 kill 단계와 start 단계로 나눠 실행하다가 start만 5번
+# 착지했다. 기존 프로세스를 죽이지 않은 채 새로 띄우기를 반복한 결과 인스턴스가
+# 5개까지 쌓였고, 텔레그램이 다음을 뱉으며 봇이 사실상 마비됐다:
+#
+#   telegram.error.Conflict: terminated by other getUpdates request;
+#   make sure that only one bot instance is running
+#
+# 원인은 SSH 너머로 kill/start를 따로 호출한 것. 이 스크립트는 둘을 하나의
+# 원자적 단위로 묶어 그 실패 양식을 구조적으로 차단한다.
+#
+# SSH 행잉 방지
+# -------------
+# `ssh host "nohup cmd &"` 는 자식이 SSH 채널의 stdout/stderr 를 물고 있으면
+# 채널이 안 닫혀 그대로 매달린다. setsid 로 새 세션을 만들고 세 fd 를 전부
+# 끊어야 즉시 반환된다. 호출부에서도 `ssh -n` 을 쓸 것.
+#
+# 사용법
+#   ssh -n app-server 'bash /home/prism/prism-insight/utils/restart_telegram_bot.sh'
+#   bash utils/restart_telegram_bot.sh --status   # 죽이지 않고 상태만
+set -uo pipefail
+
+APP_DIR="${APP_DIR:-/home/prism/prism-insight}"
+ENTRY="telegram_ai_bot.py"
+LOG="${APP_DIR}/telegram_bot.log"
+PY="${PY:-python3}"
+
+# pyenv python 이 ENTRY 를 직접 실행하는 프로세스만 매칭한다.
+# `-bash -c ... nohup python3 telegram_ai_bot.py ...` 형태의 래퍼 셸까지
+# 잡으면 애먼 것을 죽이게 되므로 정규식을 실행 이미지에 고정한다.
+find_pids() {
+    ps -eo pid,args \
+        | awk -v e="$ENTRY" '$0 ~ ("(^|/)python[0-9.]*[[:space:]]+" e "$") {print $1}'
+}
+
+status() {
+    local pids
+    pids=$(find_pids | tr '\n' ' ' | sed 's/ *$//')
+    local n=0
+    [ -n "$pids" ] && n=$(printf '%s\n' $pids | grep -c .)
+    echo "instances=${n} pids=[${pids}]"
+    return 0
+}
+
+if [ "${1:-}" = "--status" ]; then
+    status
+    exit 0
+fi
+
+echo "[restart] before: $(status)"
+
+# ---- 1. 전부 종료 (TERM -> 확인 -> 남으면 KILL) -----------------------------
+pids=$(find_pids)
+if [ -n "$pids" ]; then
+    echo "[restart] SIGTERM -> $(echo $pids | tr '\n' ' ')"
+    # shellcheck disable=SC2086
+    kill -TERM $pids 2>/dev/null
+
+    for _ in $(seq 1 15); do
+        sleep 1
+        [ -z "$(find_pids)" ] && break
+    done
+
+    leftover=$(find_pids)
+    if [ -n "$leftover" ]; then
+        echo "[restart] 15초 후에도 생존 -> SIGKILL: $(echo $leftover | tr '\n' ' ')"
+        # shellcheck disable=SC2086
+        kill -KILL $leftover 2>/dev/null
+        sleep 2
+    fi
+else
+    echo "[restart] 실행 중인 인스턴스 없음"
+fi
+
+# 여기서 0개가 아니면 기동하지 않는다. 확인 못 한 채 띄우면 사고가 재현된다.
+remaining=$(find_pids)
+if [ -n "$remaining" ]; then
+    echo "[restart] FATAL: 종료 실패, 기동 중단. 생존 PID: $(echo $remaining | tr '\n' ' ')" >&2
+    exit 1
+fi
+echo "[restart] 전부 종료 확인"
+
+# ---- 2. 정확히 1개 기동 (완전 분리) ----------------------------------------
+cd "$APP_DIR" || { echo "[restart] FATAL: cd $APP_DIR 실패" >&2; exit 1; }
+{
+    echo "===== RESTART $(date -Is) branch=$(git branch --show-current 2>/dev/null) head=$(git rev-parse --short HEAD 2>/dev/null) ====="
+} >> "$LOG"
+
+setsid nohup "$PY" "$ENTRY" >> "$LOG" 2>&1 < /dev/null &
+disown 2>/dev/null || true
+
+# ---- 3. 기동 확인 -----------------------------------------------------------
+for _ in $(seq 1 15); do
+    sleep 1
+    [ -n "$(find_pids)" ] && break
+done
+
+final=$(find_pids | tr '\n' ' ' | sed 's/ *$//')
+count=0
+[ -n "$final" ] && count=$(printf '%s\n' $final | grep -c .)
+
+echo "[restart] after: instances=${count} pids=[${final}]"
+
+if [ "$count" -ne 1 ]; then
+    echo "[restart] FATAL: 인스턴스가 1개가 아니다 (${count}개). 즉시 확인 필요." >&2
+    exit 1
+fi
+
+echo "[restart] OK — 단일 인스턴스 기동 완료"
+exit 0

--- a/weekly_firecrawl_intelligence.py
+++ b/weekly_firecrawl_intelligence.py
@@ -28,16 +28,11 @@ _DISCLAIMER = "\n\n⚠️ 본 내용은 투자 참고용이며, 투자 판단의
 
 
 # 1차 매체만 허용. 블로그·커뮤니티가 검색 상위를 먹으면 리포트 수치가 오염된다.
-_KR_DOMAINS = [
-    "yna.co.kr", "einfomax.co.kr", "hankyung.com", "mk.co.kr", "edaily.co.kr",
-    "sedaily.com", "fnnews.com", "mt.co.kr", "asiae.co.kr", "newsis.com",
-    "biz.chosun.com", "wowtv.co.kr", "infostock.co.kr", "thebell.co.kr",
-]
-_US_DOMAINS = [
-    "reuters.com", "cnbc.com", "bloomberg.com", "marketwatch.com", "wsj.com",
-    "barrons.com", "ft.com", "investors.com", "apnews.com", "finance.yahoo.com",
-    "fool.com", "seekingalpha.com",
-]
+# Shared with the Telegram bot commands so the two paths cannot drift apart.
+from cores.search_presets import (  # noqa: E402
+    KR_PRIMARY_DOMAINS as _KR_DOMAINS,
+    US_PRIMARY_DOMAINS as _US_DOMAINS,
+)
 
 
 async def _generate_kr_report(start, end) -> str:


### PR DESCRIPTION
## 문제

봇 커맨드 5개(`/signal`, `/us_signal`, `/theme`, `/us_theme`, `/ask`)의 Spark 폴백이
`generate_firecrawl_search_response()`를 **검색 옵션 없이** 호출하고 있었다.
`tbs`/`sources`/`location`/`include_domains`가 전부 기본값 `None`으로 들어가면서
최신성 필터도, 1차 매체 allowlist도 적용되지 않았다.

주간 인텔리전스 리포트는 이미 올바른 인자를 넘기고 있었으므로, 같은 저장소 안에
정답 호출과 누락 호출이 공존하는 상태였다.

## 실측 (`tools/bench/probe_firecrawl_tbs.py`, 2026-08-01, "코스피 증시 마감 시황")

```
bare  (현행)  8건 | 날짜보유 0건 (0%)  | 전부 네이버/KB/다음 시세 조회 페이지
tuned (수정)  8건 | 날짜보유 4건 (50%) | 마감시황 기사
```

폴백은 뉴스가 아니라 **정적 시세 페이지**를 컨텍스트로 넘기고 있었고, 모델은
시황을 설명할 근거 없이 답을 써야 했다. `tasks/eval/` 리포트들이
"제공된 뉴스 목록 페이지에서는 개별 뉴스 제목이 노출되지 않아"를 반복한 원인.

## 변경

- **`cores/search_presets.py` 신규** — KR/US 1차 매체 목록 + `search_preset()` + `widen_tbs()`.
  주간 리포트가 중복 정의하던 도메인 목록을 여기로 통일해 두 경로가 갈라지지 않게 함.
- **`telegram_ai_bot.py`** — `_run_firecrawl_command` / `_run_search_and_claude`에
  `search_opts` 추가, 커맨드별 프리셋 배선.
  `signal`=`qdr:w`, `theme`=`qdr:m`, `ask`=`qdr:m` + allowlist off
  (`/ask`는 주제를 예측할 수 없어 매체 allowlist가 정상 출처를 죽인다).
- **`report_generator.py`** — 좁은 기간 필터가 0건이면 `qdr:d→w→m→y` 한 단계씩 넓혀 재시도.
  변경은 `generate_firecrawl_search_response` 함수 내부 단일 hunk로 한정.
- **`tools/bench/`** — 실측 프로브 + 배선 검증 스위트.

## 검증

- `tools/bench/verify_search_presets.py --live` — 프리셋 형태 / 래더 종료 / 함수 시그니처 /
  5개 호출부 AST 배선 / 라이브 대조 **ALL PASS** (로컬 + app-server + db-server)
- 관련 기존 테스트 37 passed
- **app-server 내부 테스트**: 5개 커맨드 프리셋 전부 bare 0/5 → tuned 2/5 이상,
  `/ask`는 2시간 전 기사 확보. 엔드투엔드 생성 정상.
- **db-server 내부 테스트**: `weekly_firecrawl_intelligence.py --dry-run` KR/US 정상 생성, 에러 0.

## 알려진 제약 (후속 과제)

1. **app-server의 firecrawl-py가 4.22.1이라 `include_domains`를 드롭한다**
   (`_search_dropping_unsupported`가 graceful 처리). db-server는 4.30.1이라 정상.
   → app-server 업그레이드 필요.
2. **`tbs`는 백엔드 힌트이지 보장이 아니다.** `qdr:m`에서 `May 28, 2026` 기사가 통과했다.
   창 밖 항목을 폐기하는 Temporal Gate가 별도로 필요하다
   (`tasks/evidence-engine-design.md` 참조).
3. 확장 재시도 경로는 단위 검증만 됐고 라이브에서 트리거된 적 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)