### PR TITLE
feat: 봇 5개 커맨드에 일간 검증 수치 근거(grounded_facts) 연결

### DIFF
--- a/cores/market_facts_cache.py
+++ b/cores/market_facts_cache.py
@@ -36,6 +36,7 @@ which is what the bot did before this module existed.
 from __future__ import annotations
 
 import asyncio
+import functools
 import logging
 import time
 from typing import Optional
@@ -54,6 +55,10 @@ _SUPPORTED = ("KR", "US")
 
 # market -> (stored_at_monotonic, payload)
 _cache: dict[str, tuple[float, dict]] = {}
+# market -> the build currently running, if any. A timed-out caller walks away
+# but the build keeps going, so later callers must attach to it rather than
+# starting a second scan of the same data.
+_inflight: dict[str, asyncio.Task] = {}
 _locks: dict[str, asyncio.Lock] = {}
 _locks_guard = asyncio.Lock()
 
@@ -108,6 +113,43 @@ def _build(market: str) -> dict:
     }
 
 
+def _store(market: str, task: asyncio.Task) -> None:
+    """
+    Land a finished build in the cache.
+
+    This is the only writer, so a build that outlives the caller who started it
+    still benefits everyone who asks next — which is the whole point of letting
+    a timed-out build keep running.
+    """
+    _inflight.pop(market, None)
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error(f"[facts] {market} daily facts failed: {exc}", exc_info=exc)
+        _cache[market] = (time.monotonic(), {})
+        return
+
+    payload = task.result()
+    _cache[market] = (time.monotonic(), payload)
+    if payload:
+        logger.info(
+            f"[facts] {market} daily facts ready "
+            f"({len(payload['grounded_facts'])} chars, {payload['period_label']})"
+        )
+
+
+def _build_task(market: str) -> asyncio.Task:
+    """The one build in flight for this market, started if there isn't one."""
+    task = _inflight.get(market)
+    if task is not None and not task.done():
+        return task
+    task = asyncio.create_task(asyncio.to_thread(_build, market))
+    task.add_done_callback(functools.partial(_store, market))
+    _inflight[market] = task
+    return task
+
+
 async def daily_facts(market: str) -> dict:
     """
     Grounding kwargs for the most recent trading session.
@@ -134,31 +176,28 @@ async def daily_facts(market: str) -> dict:
         entry = _cache.get(market)
         if _fresh(entry):
             return entry[1]
+        task = _build_task(market)
 
-        loop = asyncio.get_running_loop()
-        try:
-            payload = await asyncio.wait_for(
-                loop.run_in_executor(None, _build, market),
-                timeout=_BUILD_TIMEOUT,
-            )
-        except asyncio.TimeoutError:
-            logger.warning(
-                f"[facts] {market} daily facts timed out after {_BUILD_TIMEOUT}s "
-                "— answering without numeric grounding"
-            )
-            payload = {}
-        except Exception as e:  # noqa: BLE001 - fail-soft by design
-            logger.error(f"[facts] {market} daily facts failed: {e}", exc_info=True)
-            payload = {}
-
-        _cache[market] = (time.monotonic(), payload)
-        if payload:
-            logger.info(
-                f"[facts] {market} daily facts ready "
-                f"({len(payload['grounded_facts'])} chars, "
-                f"{payload['period_label']})"
-            )
-        return payload
+    # Awaited outside the lock: a caller that gives up on a slow build must not
+    # keep everyone else queued behind it.
+    #
+    # shield() is the point of this whole shape. wait_for() cancels what it
+    # awaits, and cancelling an executor call does NOT stop the thread — the KRX
+    # scan runs to completion regardless. Without the shield the task would be
+    # cancelled, the next caller would start a *second* scan on top of the first,
+    # and a slow upstream would multiply threads instead of sharing one.
+    try:
+        return await asyncio.wait_for(asyncio.shield(task), timeout=_BUILD_TIMEOUT)
+    except asyncio.TimeoutError:
+        logger.warning(
+            f"[facts] {market} daily facts timed out after {_BUILD_TIMEOUT}s "
+            "— answering without numeric grounding; the build continues and "
+            "will populate the cache for later callers"
+        )
+        return {}
+    except Exception as e:  # noqa: BLE001 - fail-soft by design
+        logger.error(f"[facts] {market} daily facts failed: {e}", exc_info=True)
+        return {}
 
 
 def reset_cache() -> None:
@@ -171,3 +210,6 @@ def reset_cache() -> None:
     """
     _cache.clear()
     _locks.clear()
+    for task in _inflight.values():
+        task.cancel()
+    _inflight.clear()

--- a/cores/market_facts_cache.py
+++ b/cores/market_facts_cache.py
@@ -1,0 +1,171 @@
+"""
+Daily grounding facts for the bot's Firecrawl commands.
+
+Why this module exists
+----------------------
+The weekly report grounds its numbers in KRX/yfinance source data
+(`weekly_market_facts`), so it can say "KOSPI closed at 3,2xx". Every daily bot
+command — /signal, /theme, /ask and the US pair — went out with **zero numeric
+grounding**: the model saw search snippets and nothing else, so index levels and
+flow figures were paraphrased from whatever article ranked first, or hedged away.
+
+`generate_firecrawl_search_response()` already accepts `grounded_facts` and
+`period_label`, and the bot already splats `search_opts` straight into it
+(`telegram_ai_bot._run_firecrawl_command`). So the wiring is a dict merge — the
+work is in *producing* those facts safely on a live event loop.
+
+Why a cache and an executor, not a plain call
+---------------------------------------------
+`build_kr_facts()` is synchronous and expensive: it walks the KRX all-ticker
+OHLCV table to rank the top 300 names by trading value, plus a Naver flow page
+per market. On a one-shot batch (the Sunday report) blocking is harmless. Inside
+the bot it is not — the bot is a single-loop asyncio app serving many chats, and
+a bare call would freeze *every* user for the duration of that scan.
+
+So:
+  * the build runs in a thread executor (loop stays responsive),
+  * results are shared per (market, session) — cost does not scale with users,
+  * one in-flight build per market (single-flight lock), so ten simultaneous
+    /ask calls trigger one KRX scan rather than ten,
+  * a hard timeout degrades to *no facts* rather than a hung command. The
+    fallback path is exactly today's behaviour, so degradation is safe.
+
+Failure is always soft. Empty dict means "answer without numeric grounding",
+which is what the bot did before this module existed.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Facts are stable within a session; this bounds staleness while the market moves.
+_TTL_OK = 600.0
+# Do not hammer a broken upstream, but recover well before the TTL above.
+_TTL_EMPTY = 120.0
+# A KRX all-ticker scan is seconds, not tens of seconds. Past this the user is
+# better served by an ungrounded answer than by a spinner.
+_BUILD_TIMEOUT = 30.0
+
+_SUPPORTED = ("KR", "US")
+
+# market -> (stored_at_monotonic, payload)
+_cache: dict[str, tuple[float, dict]] = {}
+_locks: dict[str, asyncio.Lock] = {}
+_locks_guard = asyncio.Lock()
+
+
+def _fresh(entry: Optional[tuple[float, dict]]) -> bool:
+    if entry is None:
+        return False
+    stored_at, payload = entry
+    ttl = _TTL_OK if payload else _TTL_EMPTY
+    return (time.monotonic() - stored_at) < ttl
+
+
+async def _lock_for(market: str) -> asyncio.Lock:
+    async with _locks_guard:
+        lock = _locks.get(market)
+        if lock is None:
+            lock = _locks[market] = asyncio.Lock()
+        return lock
+
+
+def _build(market: str) -> dict:
+    """Blocking fact build. Runs in an executor thread — never call directly."""
+    from weekly_market_facts import (
+        build_kr_facts,
+        build_us_facts,
+        resolve_recent_sessions,
+        resolve_recent_us_sessions,
+    )
+
+    if market == "KR":
+        sessions = resolve_recent_sessions()
+        if not sessions:
+            return {}
+        baseline, latest = sessions
+        # movers compares close(baseline) -> close(latest); passing the same day
+        # twice would print +0.0% for every stock, so the prior session matters.
+        facts = build_kr_facts(latest, latest, kind="daily", baseline=baseline)
+    else:
+        sessions = resolve_recent_us_sessions()
+        if not sessions:
+            return {}
+        _, latest = sessions
+        facts = build_us_facts(latest, latest, kind="daily")
+
+    if not facts:
+        return {}
+    return {
+        "grounded_facts": facts,
+        "period_label": f"{latest:%Y-%m-%d} (최근 거래일)",
+    }
+
+
+async def daily_facts(market: str) -> dict:
+    """
+    Grounding kwargs for the most recent trading session.
+
+    Merge into the retrieval preset at the call site:
+
+        search_opts=search_preset("KR", tbs="qdr:w") | await daily_facts("KR")
+
+    Returns:
+        {"grounded_facts": str, "period_label": str}, or {} when the source data
+        is unavailable — callers must treat {} as "proceed without grounding".
+    """
+    market = market.upper()
+    if market not in _SUPPORTED:
+        raise ValueError(f"unknown market {market!r}; expected one of {_SUPPORTED}")
+
+    entry = _cache.get(market)
+    if _fresh(entry):
+        return entry[1]
+
+    lock = await _lock_for(market)
+    async with lock:
+        # Another coroutine may have filled the slot while we waited.
+        entry = _cache.get(market)
+        if _fresh(entry):
+            return entry[1]
+
+        loop = asyncio.get_running_loop()
+        try:
+            payload = await asyncio.wait_for(
+                loop.run_in_executor(None, _build, market),
+                timeout=_BUILD_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"[facts] {market} daily facts timed out after {_BUILD_TIMEOUT}s "
+                "— answering without numeric grounding"
+            )
+            payload = {}
+        except Exception as e:  # noqa: BLE001 - fail-soft by design
+            logger.error(f"[facts] {market} daily facts failed: {e}", exc_info=True)
+            payload = {}
+
+        _cache[market] = (time.monotonic(), payload)
+        if payload:
+            logger.info(
+                f"[facts] {market} daily facts ready "
+                f"({len(payload['grounded_facts'])} chars, "
+                f"{payload['period_label']})"
+            )
+        return payload
+
+
+def reset_cache() -> None:
+    """
+    Drop cached facts and in-flight locks.
+
+    The locks are cleared too: an asyncio.Lock binds to whichever loop first
+    awaits it, so a lock left over from a previous loop (the bot restarts, tests
+    call asyncio.run repeatedly) would raise once contended on the new one.
+    """
+    _cache.clear()
+    _locks.clear()

--- a/cores/market_facts_cache.py
+++ b/cores/market_facts_cache.py
@@ -95,8 +95,10 @@ def _build(market: str) -> dict:
         sessions = resolve_recent_us_sessions()
         if not sessions:
             return {}
-        _, latest = sessions
-        facts = build_us_facts(latest, latest, kind="daily")
+        baseline, latest = sessions
+        # 지수 등락률은 전일 종가 대비가 관례다. baseline 없이 부르면 시가 대비
+        # (장중 변동)가 나와 기사 수치와 어긋난다.
+        facts = build_us_facts(latest, latest, kind="daily", baseline=baseline)
 
     if not facts:
         return {}

--- a/telegram_ai_bot.py
+++ b/telegram_ai_bot.py
@@ -40,6 +40,7 @@ from report_generator import (
 from tracking.user_memory import UserMemoryManager
 from firecrawl_client import firecrawl_agent
 from cores.search_presets import search_preset
+from cores.market_facts_cache import daily_facts
 from cores.disclaimer_utils import strip_trailing_disclaimer as _strip_trailing_disclaimer
 from datetime import timedelta
 from dataclasses import dataclass
@@ -3077,7 +3078,7 @@ class TelegramAIBot:
             update, prompt, self._DISCLAIMER_KR, model="spark-1-mini",
             fallback_search_query=event, fallback_analysis_prompt=prompt,
             # Event impact is a "what just happened" question — keep the window tight.
-            search_opts=search_preset("KR", tbs="qdr:w"),
+            search_opts=search_preset("KR", tbs="qdr:w") | await daily_facts("KR"),
         )
         if success and msg_id and response_text:
             ctx = FirecrawlConversationContext("signal", event)
@@ -3128,7 +3129,7 @@ class TelegramAIBot:
         success, response_text, msg_id = await self._run_firecrawl_command(
             update, prompt, self._DISCLAIMER_KR, model="spark-1-mini",
             fallback_search_query=event, fallback_analysis_prompt=prompt,
-            search_opts=search_preset("US", tbs="qdr:w"),
+            search_opts=search_preset("US", tbs="qdr:w") | await daily_facts("US"),
         )
         if success and msg_id and response_text:
             ctx = FirecrawlConversationContext("us_signal", event)
@@ -3181,7 +3182,7 @@ class TelegramAIBot:
             update, prompt, self._DISCLAIMER_KR, model="spark-1-mini",
             fallback_search_query=theme, fallback_analysis_prompt=prompt,
             # Theme health needs a longer arc than a single news week.
-            search_opts=search_preset("KR", tbs="qdr:m"),
+            search_opts=search_preset("KR", tbs="qdr:m") | await daily_facts("KR"),
         )
         if success and msg_id and response_text:
             ctx = FirecrawlConversationContext("theme", theme)
@@ -3233,7 +3234,7 @@ class TelegramAIBot:
         success, response_text, msg_id = await self._run_firecrawl_command(
             update, prompt, self._DISCLAIMER_KR, model="spark-1-mini",
             fallback_search_query=theme, fallback_analysis_prompt=prompt,
-            search_opts=search_preset("US", tbs="qdr:m"),
+            search_opts=search_preset("US", tbs="qdr:m") | await daily_facts("US"),
         )
         if success and msg_id and response_text:
             ctx = FirecrawlConversationContext("us_theme", theme)
@@ -3289,7 +3290,8 @@ class TelegramAIBot:
             # Free-form: the subject is unpredictable ("워렌 버핏이 올해 뭘 샀어?"), so a
             # KR-press allowlist would drop legitimate sources. Keep recency + news
             # channel, drop the allowlist.
-            search_opts=search_preset("KR", tbs="qdr:m", allowlist=False),
+            search_opts=search_preset("KR", tbs="qdr:m", allowlist=False)
+                        | await daily_facts("KR"),
         )
         if success:
             if remaining > 0:

--- a/tools/bench/verify_grounded_facts.py
+++ b/tools/bench/verify_grounded_facts.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""
+Verify daily grounded-facts wiring for the bot commands.
+
+The weekly report has been grounded in KRX/yfinance numbers for a while; the
+daily commands were not. Wiring them up meant teaching weekly_market_facts to
+speak about a single session, and that is where the traps are:
+
+1. weekly output is unchanged            — the Sunday report must not regress
+2. daily prose drops the weekly wording  — "금요일 종가" on a Tuesday is a lie the
+                                           LLM will faithfully repeat
+3. movers refuses baseline == end        — close(x)/close(x) is +0.0% for every
+                                           stock; silent corruption, not an error
+4. facts never block the event loop      — one KRX scan shared by N callers
+5. timeouts degrade to no facts          — an ungrounded answer beats a hung bot
+6. every command call site merges facts  — the failure mode is silent omission
+7. the receiving signature accepts them
+
+Usage:  python3 tools/bench/verify_grounded_facts.py [--live]
+        --live hits KRX/yfinance for real and checks the numbers are non-degenerate.
+"""
+import ast
+import asyncio
+import inspect
+import sys
+import time
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(ROOT / ".env")
+
+import weekly_market_facts as wmf  # noqa: E402
+from cores import market_facts_cache as mfc  # noqa: E402
+
+failures: list[str] = []
+
+
+def check(label: str, ok: bool, detail: str = "") -> None:
+    print(f"  {'PASS' if ok else 'FAIL'}  {label}" + (f"  — {detail}" if detail else ""))
+    if not ok:
+        failures.append(label)
+
+
+# ---------------------------------------------------------------------------
+# Fakes — the KRX backend is resolved through _krx_fn, so one patch covers all.
+# ---------------------------------------------------------------------------
+_TICKERS = {"KOSPI": ["005930", "000660"], "KOSDAQ": ["247540"]}
+_NAMES = {"005930": "삼성전자", "000660": "SK하이닉스", "247540": "에코프로비엠"}
+# close by (yyyymmdd, ticker) — day 2 moves, day 5 moves more
+_CLOSES = {
+    "20260727": {"005930": 100.0, "000660": 200.0, "247540": 50.0},
+    "20260728": {"005930": 110.0, "000660": 190.0, "247540": 55.0},
+    "20260731": {"005930": 120.0, "000660": 180.0, "247540": 60.0},
+}
+
+
+def _install_fakes(monkey: dict) -> None:
+    import pandas as pd
+
+    def fake_index_ohlcv(start: str, end: str, ticker: str):
+        rows = [d for d in sorted(_CLOSES) if start <= d <= end]
+        if not rows:
+            return pd.DataFrame()
+        base = 1.0 if ticker == wmf.KOSPI_INDEX else 2.0
+        return pd.DataFrame(
+            {
+                "시가": [base * 1000 + i for i, _ in enumerate(rows)],
+                "고가": [base * 1000 + 50 + i for i, _ in enumerate(rows)],
+                "저가": [base * 1000 - 50 + i for i, _ in enumerate(rows)],
+                "종가": [base * 1000 + 10 + i * 5 for i, _ in enumerate(rows)],
+            },
+            index=pd.to_datetime(rows),
+        )
+
+    def fake_all_ticker_ohlcv(ymd: str):
+        closes = _CLOSES.get(ymd)
+        if closes is None:
+            return pd.DataFrame()
+        return pd.DataFrame(
+            {
+                "종가": [closes[t] for t in _NAMES],
+                "거래대금": [10_000 - i for i, _ in enumerate(_NAMES)],
+            },
+            index=list(_NAMES),
+        )
+
+    def fake_ticker_list(ymd: str, market: str = "KOSPI"):
+        return _TICKERS.get(market, [])
+
+    table = {
+        "get_index_ohlcv_by_date": fake_index_ohlcv,
+        "get_market_ohlcv_by_ticker": fake_all_ticker_ohlcv,
+        "get_market_ticker_list": fake_ticker_list,
+        "get_market_ticker_name": lambda tk: _NAMES.get(tk, tk),
+    }
+    monkey["_krx_fn"] = wmf._krx_fn
+    wmf._krx_fn = lambda name: table.get(name)
+
+    # Investor flows come from Naver over HTTP; stub the whole fetch.
+    monkey["_naver_investor_daily"] = wmf._naver_investor_daily
+    wmf._naver_investor_daily = lambda sosok, bizdate: {
+        date(2026, 7, 27): {"외국인": 100.0, "기관계": -50.0, "개인": -50.0},
+        date(2026, 7, 28): {"외국인": 200.0, "기관계": -80.0, "개인": -120.0},
+        date(2026, 7, 31): {"외국인": -30.0, "기관계": 10.0, "개인": 20.0},
+    }
+
+
+def _restore(monkey: dict) -> None:
+    for name, original in monkey.items():
+        setattr(wmf, name, original)
+
+
+# ---------------------------------------------------------------------------
+def test_weekly_unchanged() -> None:
+    """The Sunday report is live. Its wording must survive this refactor."""
+    print("\n[1] weekly output unchanged")
+    out = wmf.build_kr_facts(date(2026, 7, 27), date(2026, 7, 31))
+    check("weekly keeps '주간 시가'", "주간 시가" in out)
+    check("weekly keeps '금요일 종가'", "금요일 종가" in out)
+    check("weekly keeps '주간 누적 순매수'", "주간 누적 순매수" in out)
+    check("weekly keeps '주간 상승률 상위'", "주간 상승률 상위" in out)
+    check("weekly keeps '일별 종가'", "일별 종가" in out)
+    check("weekly header spans the range", "2026-07-27 ~ 2026-07-31" in out)
+
+
+def test_daily_labels() -> None:
+    print("\n[2] daily prose drops weekly wording")
+    out = wmf.build_kr_facts(
+        date(2026, 7, 31), date(2026, 7, 31),
+        kind="daily", baseline=date(2026, 7, 28),
+    )
+    check("no '금요일 종가' in daily", "금요일 종가" not in out, out[:120])
+    check("no '주간' anywhere in daily", "주간" not in out,
+          next((ln for ln in out.splitlines() if "주간" in ln), ""))
+    check("uses '당일 순매수'", "당일 순매수" in out)
+    check("uses '당일 상승률 상위'", "당일 상승률 상위" in out)
+    check("header shows a single date", "2026-07-31]" in out)
+    try:
+        wmf.build_kr_facts(date(2026, 7, 31), date(2026, 7, 31), kind="hourly")
+        check("unknown kind rejected", False, "no ValueError raised")
+    except ValueError:
+        check("unknown kind rejected", True)
+
+
+def test_movers_guard() -> None:
+    print("\n[3] movers refuses a degenerate baseline")
+    labels = wmf._PERIOD_LABELS["daily"]
+    same = wmf._kr_movers_block(date(2026, 7, 31), date(2026, 7, 31), labels)
+    check("baseline == end yields no lines", same == [], f"got {same}")
+
+    ok = wmf._kr_movers_block(date(2026, 7, 28), date(2026, 7, 31), labels)
+    check("distinct sessions yield lines", bool(ok), f"got {len(ok)} lines")
+    check("percentages are not all zero",
+          bool(ok) and not all("+0.0%" in ln for ln in ok),
+          " | ".join(ok))
+
+
+def test_cache_single_flight() -> None:
+    print("\n[4] one build shared by concurrent callers")
+    mfc.reset_cache()
+    calls = {"n": 0}
+
+    def slow_build(market: str) -> dict:
+        calls["n"] += 1
+        time.sleep(0.25)
+        return {"grounded_facts": "X", "period_label": "2026-07-31 (최근 거래일)"}
+
+    original, mfc._build = mfc._build, slow_build
+    try:
+        async def run():
+            return await asyncio.gather(*(mfc.daily_facts("KR") for _ in range(10)))
+
+        started = time.monotonic()
+        results = asyncio.run(run())
+        elapsed = time.monotonic() - started
+    finally:
+        mfc._build = original
+        mfc.reset_cache()
+
+    check("10 concurrent callers -> 1 build", calls["n"] == 1, f"builds={calls['n']}")
+    check("all callers get the payload",
+          all(r.get("grounded_facts") == "X" for r in results))
+    check("did not serialize (10x0.25s)", elapsed < 1.5, f"{elapsed:.2f}s")
+
+
+def test_cache_degrades() -> None:
+    print("\n[5] timeout and failure degrade to no facts")
+    mfc.reset_cache()
+
+    def hang(market: str) -> dict:
+        time.sleep(1.0)
+        return {"grounded_facts": "late"}
+
+    orig_build, orig_timeout = mfc._build, mfc._BUILD_TIMEOUT
+    mfc._build, mfc._BUILD_TIMEOUT = hang, 0.2
+    try:
+        out = asyncio.run(mfc.daily_facts("KR"))
+    finally:
+        mfc._build, mfc._BUILD_TIMEOUT = orig_build, orig_timeout
+        mfc.reset_cache()
+    check("timeout returns {}", out == {}, f"got {out!r}")
+
+    def boom(market: str) -> dict:
+        raise RuntimeError("KRX down")
+
+    mfc._build = boom
+    try:
+        out = asyncio.run(mfc.daily_facts("KR"))
+    finally:
+        mfc._build = orig_build
+        mfc.reset_cache()
+    check("exception returns {}", out == {}, f"got {out!r}")
+
+    try:
+        asyncio.run(mfc.daily_facts("JP"))
+        check("unknown market rejected", False, "no ValueError raised")
+    except ValueError:
+        check("unknown market rejected", True)
+
+    check("empty result merges into a preset cleanly",
+          ({"tbs": "qdr:w"} | {}) == {"tbs": "qdr:w"})
+
+
+def test_signature() -> None:
+    print("\n[6] receiver accepts the grounding kwargs")
+    from report_generator import generate_firecrawl_search_response
+    params = inspect.signature(generate_firecrawl_search_response).parameters
+    for key in ("grounded_facts", "period_label"):
+        check(f"accepts {key}", key in params)
+
+
+def test_call_sites() -> None:
+    """A command that forgets the merge fails silently — pin it in the AST."""
+    print("\n[7] every command call site merges daily_facts")
+    src = (ROOT / "telegram_ai_bot.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    merged = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        name = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", "")
+        if name not in ("_run_firecrawl_command", "_run_search_and_claude"):
+            continue
+        opts = next((k.value for k in node.keywords if k.arg == "search_opts"), None)
+        if opts is None:
+            continue
+        merges = (
+            isinstance(opts, ast.BinOp)
+            and isinstance(opts.op, ast.BitOr)
+            and "daily_facts" in ast.dump(opts.right)
+        )
+        check(f"line {node.lineno} merges daily_facts", merges,
+              "" if merges else ast.dump(opts)[:90])
+        merged += int(merges)
+    check("all 5 commands grounded", merged == 5, f"merged={merged}")
+
+
+def test_live() -> None:
+    print("\n[8] LIVE: real KRX / yfinance daily facts")
+    sessions = wmf.resolve_recent_sessions()
+    check("KR sessions resolve", sessions is not None, str(sessions))
+    if sessions:
+        baseline, latest = sessions
+        check("KR sessions are distinct days", baseline != latest, f"{baseline} vs {latest}")
+        facts = wmf.build_kr_facts(latest, latest, kind="daily", baseline=baseline)
+        check("KR daily facts non-empty", bool(facts), f"{len(facts)} chars")
+        if facts:
+            print("\n".join("     " + ln for ln in facts.splitlines()[:8]))
+            movers = [ln for ln in facts.splitlines() if "상승률 상위" in ln]
+            check("movers present and not all +0.0%",
+                  bool(movers) and not all("+0.0%" in m for m in movers),
+                  f"{len(movers)} lines")
+            check("no weekly wording leaked", "주간" not in facts and "금요일" not in facts)
+
+    us = wmf.resolve_recent_us_sessions()
+    check("US sessions resolve", us is not None, str(us))
+    if us:
+        us_facts = wmf.build_us_facts(us[1], us[1], kind="daily")
+        check("US daily facts non-empty", bool(us_facts), f"{len(us_facts)} chars")
+        check("US drops weekly wording", "주간" not in us_facts)
+
+
+def main() -> int:
+    monkey: dict = {}
+    _install_fakes(monkey)
+    try:
+        test_weekly_unchanged()
+        test_daily_labels()
+        test_movers_guard()
+    finally:
+        _restore(monkey)
+
+    test_cache_single_flight()
+    test_cache_degrades()
+    test_signature()
+    test_call_sites()
+
+    if "--live" in sys.argv:
+        test_live()
+    else:
+        print("\n[8] LIVE skipped (pass --live to run)")
+
+    print("\n" + "=" * 60)
+    if failures:
+        print(f"FAILED ({len(failures)}): " + "; ".join(failures))
+        return 1
+    print("ALL PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/bench/verify_grounded_facts.py
+++ b/tools/bench/verify_grounded_facts.py
@@ -24,7 +24,7 @@ import asyncio
 import inspect
 import sys
 import time
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -237,8 +237,58 @@ def test_cache_degrades() -> None:
           ({"tbs": "qdr:w"} | {}) == {"tbs": "qdr:w"})
 
 
+def test_timeout_does_not_duplicate() -> None:
+    """
+    Regression: wait_for cancels the await, never the thread.
+
+    The first version cached {} on timeout and released the lock, so once that
+    short empty-TTL expired the next caller launched a *second* KRX scan while
+    the first was still running. Under a slow upstream that multiplies threads
+    exactly when the system can least afford it. shield() + a shared in-flight
+    task is what prevents it, and this pins that behaviour.
+    """
+    print("\n[6] a timed-out build is never restarted")
+    mfc.reset_cache()
+    active = {"now": 0, "peak": 0, "builds": 0}
+
+    def slow(market: str) -> dict:
+        active["builds"] += 1
+        active["now"] += 1
+        active["peak"] = max(active["peak"], active["now"])
+        time.sleep(0.6)
+        active["now"] -= 1
+        return {"grounded_facts": "X", "period_label": "2026-07-31 (최근 거래일)"}
+
+    orig_build, orig_timeout, orig_ttl = mfc._build, mfc._BUILD_TIMEOUT, mfc._TTL_EMPTY
+    mfc._build, mfc._BUILD_TIMEOUT, mfc._TTL_EMPTY = slow, 0.15, 0.0
+    try:
+        async def run():
+            first = await mfc.daily_facts("KR")      # gives up at 0.15s
+            second = await mfc.daily_facts("KR")     # must attach, not restart
+            await asyncio.sleep(0.8)                 # let the build land
+            third = await mfc.daily_facts("KR")      # served from cache
+            return first, second, third
+
+        first, second, third = asyncio.run(run())
+    finally:
+        mfc._build = orig_build
+        mfc._BUILD_TIMEOUT = orig_timeout
+        mfc._TTL_EMPTY = orig_ttl
+        mfc.reset_cache()
+
+    check("timed-out caller gets {}", first == {}, f"got {first!r}")
+    check("second caller does not start a new build", active["peak"] == 1,
+          f"peak_concurrent={active['peak']}")
+    check("only one build ever ran", active["builds"] == 1,
+          f"builds={active['builds']}")
+    check("the survivor populates the cache",
+          third.get("grounded_facts") == "X", f"got {third!r}")
+    check("second caller also timed out (build still running)", second == {},
+          f"got {second!r}")
+
+
 def test_signature() -> None:
-    print("\n[6] receiver accepts the grounding kwargs")
+    print("\n[7] receiver accepts the grounding kwargs")
     from report_generator import generate_firecrawl_search_response
     params = inspect.signature(generate_firecrawl_search_response).parameters
     for key in ("grounded_facts", "period_label"):
@@ -247,7 +297,7 @@ def test_signature() -> None:
 
 def test_call_sites() -> None:
     """A command that forgets the merge fails silently — pin it in the AST."""
-    print("\n[7] every command call site merges daily_facts")
+    print("\n[8] every command call site merges daily_facts")
     src = (ROOT / "telegram_ai_bot.py").read_text(encoding="utf-8")
     tree = ast.parse(src)
     merged = 0
@@ -273,7 +323,7 @@ def test_call_sites() -> None:
 
 
 def test_live() -> None:
-    print("\n[8] LIVE: real KRX / yfinance daily facts")
+    print("\n[9] LIVE: real KRX / yfinance daily facts")
     sessions = wmf.resolve_recent_sessions()
     check("KR sessions resolve", sessions is not None, str(sessions))
     if sessions:
@@ -303,9 +353,25 @@ def test_live() -> None:
     us = wmf.resolve_recent_us_sessions()
     check("US sessions resolve", us is not None, str(us))
     if us:
-        us_facts = wmf.build_us_facts(us[1], us[1], kind="daily")
+        # Must mirror cores.market_facts_cache._build exactly — calling without
+        # baseline would exercise a branch production never takes.
+        us_facts = wmf.build_us_facts(us[1], us[1], kind="daily", baseline=us[0])
         check("US daily facts non-empty", bool(us_facts), f"{len(us_facts)} chars")
         check("US drops weekly wording", "주간" not in us_facts)
+        check("US references 전일 종가", "전일 종가" in us_facts,
+              next((ln for ln in us_facts.splitlines() if "S&P" in ln), ""))
+
+        import yfinance as yf
+        hist = yf.Ticker("^GSPC").history(
+            start=us[0].strftime("%Y-%m-%d"),
+            end=(us[1] + timedelta(days=1)).strftime("%Y-%m-%d"),
+        )
+        if len(hist) >= 2:
+            prev, last = float(hist.iloc[0]["Close"]), float(hist.iloc[-1]["Close"])
+            expected = f"({(last - prev) / prev * 100:+.2f}%)"
+            sp = next((ln for ln in us_facts.splitlines() if "S&P 500" in ln), "")
+            check("US S&P pct equals close-to-close", expected in sp,
+                  f"expected {expected} in {sp!r}")
 
 
 def main() -> int:
@@ -320,13 +386,14 @@ def main() -> int:
 
     test_cache_single_flight()
     test_cache_degrades()
+    test_timeout_does_not_duplicate()
     test_signature()
     test_call_sites()
 
     if "--live" in sys.argv:
         test_live()
     else:
-        print("\n[8] LIVE skipped (pass --live to run)")
+        print("\n[9] LIVE skipped (pass --live to run)")
 
     print("\n" + "=" * 60)
     if failures:

--- a/tools/bench/verify_grounded_facts.py
+++ b/tools/bench/verify_grounded_facts.py
@@ -140,6 +140,17 @@ def test_daily_labels() -> None:
     check("uses '당일 순매수'", "당일 순매수" in out)
     check("uses '당일 상승률 상위'", "당일 상승률 상위" in out)
     check("header shows a single date", "2026-07-31]" in out)
+
+    # 등락률의 기준점. 한국 시장 관례는 전일 종가 대비이고, 시가 대비(장중
+    # 변동)를 쓰면 같은 날인데 기사와 다른 숫자가 나온다.
+    # fake: 07-28 종가 1010 / 07-31 종가 1015 -> +0.50% (시가 대비면 +1.50%)
+    check("daily references 전일 종가", "전일 종가" in out)
+    check("daily pct is close-to-close, not open-to-close",
+          "(+0.50%)" in out and "(+1.50%)" not in out,
+          next((ln for ln in out.splitlines() if "KOSPI:" in ln), ""))
+    check("daily bar shows only the session itself",
+          "07-28" not in out.split("· 종가:")[1].split("\n")[0]
+          if "· 종가:" in out else False)
     try:
         wmf.build_kr_facts(date(2026, 7, 31), date(2026, 7, 31), kind="hourly")
         check("unknown kind rejected", False, "no ValueError raised")
@@ -277,6 +288,17 @@ def test_live() -> None:
                   bool(movers) and not all("+0.0%" in m for m in movers),
                   f"{len(movers)} lines")
             check("no weekly wording leaked", "주간" not in facts and "금요일" not in facts)
+
+            # 실데이터 교차검증: 리포트에 실린 등락률이 정말 전일 종가 대비인가.
+            # 2026-07-31 KOSPI 는 시가 대비 +16.57%, 전일 종가 대비 +17.91% 로
+            # 두 기준의 차이가 큰 날이라 이 검사가 실제로 변별력을 가진다.
+            fn = wmf._krx_fn("get_index_ohlcv_by_date")
+            raw = fn(wmf._ymd(baseline), wmf._ymd(latest), wmf.KOSPI_INDEX)
+            col = wmf._col(raw, "close")
+            expected = (float(raw.iloc[-1][col]) / float(raw.iloc[-2][col]) - 1) * 100
+            check("KOSPI pct equals close-to-close",
+                  f"({expected:+.2f}%)" in facts,
+                  f"expected {expected:+.2f}%")
 
     us = wmf.resolve_recent_us_sessions()
     check("US sessions resolve", us is not None, str(us))

--- a/weekly_market_facts.py
+++ b/weekly_market_facts.py
@@ -518,13 +518,14 @@ def resolve_recent_us_sessions(
         return None
 
 
-def build_us_facts(start: date, end: date, *, kind: str = "weekly") -> str:
+def build_us_facts(
+    start: date, end: date, *, kind: str = "weekly", baseline: Optional[date] = None
+) -> str:
     """
     미국 시장 검증 수치 블록. 실패 시 빈 문자열.
 
-    KR 과 달리 movers 블록이 없어 baseline 개념이 필요 없다. yfinance history 는
-    [start, end+2) 구간의 첫 시가 → 마지막 종가를 쓰므로 단일일 구간에서도
-    계산은 옳다. 문구만 kind 로 고른다.
+    KR 과 달리 movers 블록이 없어 종목 등락률용 baseline 은 필요 없지만, 지수
+    등락률의 기준점 문제는 동일하다. baseline 을 주면 전일 종가 대비로 낸다.
     """
     if kind not in _PERIOD_LABELS:
         raise ValueError(f"unknown kind {kind!r}; expected 'weekly' or 'daily'")
@@ -537,7 +538,7 @@ def build_us_facts(start: date, end: date, *, kind: str = "weekly") -> str:
 
     lines: list[str] = []
     # 미국장은 한국 대비 하루 늦게 마감되므로 여유를 둔다
-    fetch_start = start.strftime("%Y-%m-%d")
+    fetch_start = (baseline or start).strftime("%Y-%m-%d")
     fetch_end = (end + timedelta(days=2)).strftime("%Y-%m-%d")
 
     for name, ticker in _US_TICKERS:
@@ -545,9 +546,22 @@ def build_us_facts(start: date, end: date, *, kind: str = "weekly") -> str:
             hist = yf.Ticker(ticker).history(start=fetch_start, end=fetch_end)
             if hist is None or hist.empty:
                 continue
-            first_open = float(hist.iloc[0]["Open"])
+
+            if baseline is not None:
+                if len(hist) < 2:
+                    logger.warning(
+                        f"[facts] {name}: need a prior session for the daily change, "
+                        f"got {len(hist)} row(s)"
+                    )
+                    continue
+                ref = float(hist.iloc[-2]["Close"])
+                ref_label = labels["ref"]
+            else:
+                ref = float(hist.iloc[0]["Open"])
+                ref_label = labels["open"]
+
             last_close = float(hist.iloc[-1]["Close"])
-            pct = (last_close - first_open) / first_open * 100 if first_open else 0.0
+            pct = (last_close - ref) / ref * 100 if ref else 0.0
             last_day = hist.index[-1].strftime("%m-%d")
             if ticker == "^TNX":
                 lines.append(
@@ -556,7 +570,7 @@ def build_us_facts(start: date, end: date, *, kind: str = "weekly") -> str:
                 )
             else:
                 lines.append(
-                    f"- {name}: {labels['open']} {first_open:,.2f} → {last_day} 종가 "
+                    f"- {name}: {ref_label} {ref:,.2f} → {last_day} 종가 "
                     f"{last_close:,.2f} ({pct:+.2f}%)"
                 )
         except Exception as e:  # noqa: BLE001

--- a/weekly_market_facts.py
+++ b/weekly_market_facts.py
@@ -46,6 +46,68 @@ def resolve_week_range(today: Optional[date] = None) -> tuple[date, date]:
     return monday, friday
 
 
+def resolve_recent_sessions(
+    today: Optional[date] = None, lookback_days: int = 14
+) -> Optional[tuple[date, date]]:
+    """
+    (직전 거래일, 최근 거래일)을 KRX 지수 캘린더에서 직접 읽어 반환한다.
+
+    주말·공휴일을 달력 계산으로 흉내내지 않는다. KOSPI 지수가 값을 가진 날이
+    곧 거래일이므로, 그 인덱스의 마지막 두 행이 정답이다. 임시휴장·조기폐장도
+    자동으로 따라간다.
+
+    일간 팩트에 이 두 날짜가 모두 필요한 이유는 _kr_movers_block 이
+    close(직전 거래일) → close(최근 거래일) 로 등락률을 계산하기 때문이다.
+    한 날짜만 넘기면 등락률이 전부 0% 로 나온다.
+
+    Returns:
+        (baseline, latest) 또는 조회 실패/거래일 부족 시 None.
+    """
+    get_index_ohlcv_by_date = _krx_fn("get_index_ohlcv_by_date")
+    if get_index_ohlcv_by_date is None:
+        return None
+
+    today = today or datetime.now().date()
+    try:
+        df = get_index_ohlcv_by_date(
+            _ymd(today - timedelta(days=lookback_days)), _ymd(today), KOSPI_INDEX
+        )
+        if df is None or len(df) < 2:
+            logger.warning("[facts] session calendar: fewer than 2 sessions in window")
+            return None
+        sessions = [idx.date() if hasattr(idx, "date") else idx for idx in df.index[-2:]]
+        return sessions[0], sessions[1]
+    except Exception as e:  # noqa: BLE001 - fail-soft by design
+        logger.warning(f"[facts] session calendar lookup failed: {e}")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# 기간 라벨
+# ---------------------------------------------------------------------------
+# 같은 숫자라도 문구가 틀리면 LLM 이 그 문구를 그대로 인용한다. 일간 종가를
+# "금요일 종가" 로 넘기면 리포트에 금요일이라고 적힌다. 그래서 산문을 기간
+# 종류에서 분리한다.
+_PERIOD_LABELS = {
+    "weekly": {
+        "open": "주간 시가", "close": "금요일 종가",
+        "high": "주간 고가", "low": "저가",
+        "daily_closes": "일별 종가",
+        "flow": "주간 누적 순매수", "movers": "주간 상승률 상위",
+        "span": "주간",
+        "ref": "전주 종가",  # baseline 경로 전용 (주간은 사용하지 않음)
+    },
+    "daily": {
+        "open": "시가", "close": "종가",
+        "high": "고가", "low": "저가",
+        "daily_closes": "종가",
+        "flow": "당일 순매수", "movers": "당일 상승률 상위",
+        "span": "당일",
+        "ref": "전일 종가",
+    },
+}
+
+
 def _ymd(d: date) -> str:
     return d.strftime("%Y%m%d")
 
@@ -99,15 +161,29 @@ def _col(df, key: str) -> Optional[str]:
     return None
 
 
-def _kr_index_block(start: date, end: date) -> list[str]:
+def _kr_index_block(
+    start: date, end: date, labels: dict, *, baseline: Optional[date] = None
+) -> list[str]:
+    """
+    지수 블록.
+
+    baseline 이 없으면(주간) 구간 첫 시가 → 마지막 종가로 구간 수익률을 낸다.
+
+    baseline 이 있으면(일간) **전일 종가 대비** 등락률을 낸다. 시가 대비가
+    아니다 — 한국 시장에서 "등락률"은 전일 종가 기준이고, 언론·HTS 가 모두
+    그 숫자를 쓴다. 시가 대비(장중 변동)를 확정값이라며 넘기면 기사 수치와
+    어긋나 오히려 근거를 오염시킨다.
+    실측 2026-07-31 KOSPI: 시가 대비 +16.57% vs 전일 종가 대비 +17.91%.
+    """
     get_index_ohlcv_by_date = _krx_fn("get_index_ohlcv_by_date")
     if get_index_ohlcv_by_date is None:
         return []
 
+    fetch_from = baseline or start
     lines: list[str] = []
     for name, ticker in (("KOSPI", KOSPI_INDEX), ("KOSDAQ", KOSDAQ_INDEX)):
         try:
-            df = get_index_ohlcv_by_date(_ymd(start), _ymd(end), ticker)
+            df = get_index_ohlcv_by_date(_ymd(fetch_from), _ymd(end), ticker)
             if df is None or df.empty:
                 continue
             c_open, c_close = _col(df, "open"), _col(df, "close")
@@ -115,20 +191,38 @@ def _kr_index_block(start: date, end: date) -> list[str]:
             if not (c_open and c_close):
                 logger.warning(f"[facts] {name}: unexpected columns {list(df.columns)}")
                 continue
-            first_open = float(df.iloc[0][c_open])
-            last_close = float(df.iloc[-1][c_close])
-            week_high = float(df[c_high].max()) if c_high else last_close
-            week_low = float(df[c_low].min()) if c_low else last_close
-            pct = (last_close - first_open) / first_open * 100 if first_open else 0.0
+
+            if baseline is not None:
+                if len(df) < 2:
+                    logger.warning(
+                        f"[facts] {name}: need a prior session for the daily change, "
+                        f"got {len(df)} row(s) for {fetch_from}~{end}"
+                    )
+                    continue
+                # 마지막 행이 당일, 그 앞이 직전 거래일.
+                session = df.iloc[-1:]
+                ref = float(df.iloc[-2][c_close])
+                ref_label = labels["ref"]
+            else:
+                session = df
+                ref = float(df.iloc[0][c_open])
+                ref_label = labels["open"]
+
+            last_close = float(session.iloc[-1][c_close])
+            week_high = float(session[c_high].max()) if c_high else last_close
+            week_low = float(session[c_low].min()) if c_low else last_close
+            pct = (last_close - ref) / ref * 100 if ref else 0.0
             lines.append(
-                f"- {name}: 주간 시가 {first_open:,.2f} → 금요일 종가 {last_close:,.2f} "
-                f"({pct:+.2f}%), 주간 고가 {week_high:,.2f} / 저가 {week_low:,.2f}"
+                f"- {name}: {ref_label} {ref:,.2f} → "
+                f"{labels['close']} {last_close:,.2f} "
+                f"({pct:+.2f}%), {labels['high']} {week_high:,.2f} / "
+                f"{labels['low']} {week_low:,.2f}"
             )
             daily = " / ".join(
                 f"{idx:%m-%d} {float(row[c_close]):,.2f}"
-                for idx, row in df.iterrows()
+                for idx, row in session.iterrows()
             )
-            lines.append(f"  · 일별 종가: {daily}")
+            lines.append(f"  · {labels['daily_closes']}: {daily}")
         except Exception as e:  # noqa: BLE001 - fail-soft by design
             logger.warning(f"[facts] {name} index fetch failed: {e}")
     return lines
@@ -210,7 +304,7 @@ def _naver_investor_daily(sosok: str, bizdate: date) -> dict[date, dict[str, flo
     return result
 
 
-def _kr_investor_block(start: date, end: date) -> list[str]:
+def _kr_investor_block(start: date, end: date, labels: dict) -> list[str]:
     lines: list[str] = []
     for market, sosok in (("KOSPI", "01"), ("KOSDAQ", "02")):
         try:
@@ -233,7 +327,7 @@ def _kr_investor_block(start: date, end: date) -> list[str]:
             ]
             if parts:
                 lines.append(
-                    f"- {market} 투자자별 주간 누적 순매수({len(in_week)}거래일): "
+                    f"- {market} 투자자별 {labels['flow']}({len(in_week)}거래일): "
                     + ", ".join(parts)
                 )
         except Exception as e:  # noqa: BLE001
@@ -241,12 +335,19 @@ def _kr_investor_block(start: date, end: date) -> list[str]:
     return lines
 
 
-def _kr_movers_block(start: date, end: date, top_n: int = 7) -> list[str]:
+def _kr_movers_block(
+    baseline: date, end: date, labels: dict, top_n: int = 7
+) -> list[str]:
     """
-    주간 등락률 상위 종목.
+    등락률 상위 종목.
 
     krx_data_client에는 get_market_price_change_by_ticker가 없으므로
-    주 시작/종료 시점의 전종목 종가를 받아 직접 계산한다.
+    baseline/end 두 시점의 전종목 종가를 받아 직접 계산한다.
+
+    ⚠️ baseline 은 end 와 **다른 거래일**이어야 한다. 같은 날을 넘기면
+    close(x)/close(x)-1 이라 전 종목이 +0.0% 로 나온다 — 예외가 아니라
+    조용히 틀린 값이 리포트에 실린다. 일간 팩트는 resolve_recent_sessions()
+    가 돌려주는 직전 거래일을 baseline 으로 쓴다.
     """
     get_ohlcv_by_ticker = _krx_fn("get_market_ohlcv_by_ticker")
     get_ticker_list = _krx_fn("get_market_ticker_list")
@@ -254,8 +355,15 @@ def _kr_movers_block(start: date, end: date, top_n: int = 7) -> list[str]:
     if get_ohlcv_by_ticker is None:
         return []
 
+    if baseline == end:
+        logger.warning(
+            f"[facts] movers skipped: baseline == end ({end}); "
+            "every stock would print +0.0%"
+        )
+        return []
+
     try:
-        first = get_ohlcv_by_ticker(_ymd(start))
+        first = get_ohlcv_by_ticker(_ymd(baseline))
         last = get_ohlcv_by_ticker(_ymd(end))
         if first is None or last is None or first.empty or last.empty:
             return []
@@ -299,25 +407,59 @@ def _kr_movers_block(start: date, end: date, top_n: int = 7) -> list[str]:
                     return tk
 
             names = ", ".join(f"{label(tk)} {v:+.1f}%" for tk, v in top.items())
-            lines.append(f"- {market} 주간 상승률 상위(거래대금 상위 300 내): {names}")
+            lines.append(
+                f"- {market} {labels['movers']}(거래대금 상위 300 내): {names}"
+            )
         except Exception as e:  # noqa: BLE001
             logger.warning(f"[facts] {market} movers ranking failed: {e}")
     return lines
 
 
-def build_kr_facts(start: date, end: date) -> str:
-    """한국 시장 검증 수치 블록. 실패 시 빈 문자열."""
-    index_lines = _kr_index_block(start, end)
-    investor_lines = _kr_investor_block(start, end)
-    movers_lines = _kr_movers_block(start, end)
+def build_kr_facts(
+    start: date,
+    end: date,
+    *,
+    kind: str = "weekly",
+    baseline: Optional[date] = None,
+) -> str:
+    """
+    한국 시장 검증 수치 블록. 실패 시 빈 문자열.
+
+    Args:
+        start, end: 집계 구간. index(시가→종가)와 investor(순매수 합산)가 쓴다.
+                    일간이면 start == end == 최근 거래일.
+        kind: "weekly" | "daily". 숫자가 아니라 **문구**를 고른다. 일간 종가를
+              주간 문구로 넘기면 LLM 이 "금요일 종가"라고 받아쓴다.
+        baseline: movers 등락률의 기준 시점. 생략하면 start.
+                  주간은 start(월요일)가 곧 기준이라 기존 동작과 동일하고,
+                  일간은 직전 거래일을 넘겨야 한다(같은 날이면 전부 0%).
+
+    주간 호출(build_kr_facts(mon, fri))의 출력은 이 변경 전후로 동일하다.
+    """
+    if kind not in _PERIOD_LABELS:
+        raise ValueError(f"unknown kind {kind!r}; expected 'weekly' or 'daily'")
+    labels = _PERIOD_LABELS[kind]
+    baseline = baseline or start
+
+    # 주간은 구간 시가 기준, 일간은 전일 종가 기준. 주간 경로에 baseline 을
+    # 넘기면 살아 있는 일요일 리포트의 숫자가 바뀌므로 daily 에서만 넘긴다.
+    index_lines = _kr_index_block(
+        start, end, labels, baseline=baseline if kind == "daily" else None
+    )
+    investor_lines = _kr_investor_block(start, end, labels)
+    movers_lines = _kr_movers_block(baseline, end, labels)
     lines = index_lines + investor_lines + movers_lines
 
     if not lines:
         logger.warning("[facts] KR facts empty — KRX 조회 전부 실패")
         return ""
 
+    period_text = (
+        f"{end:%Y-%m-%d}" if start == end
+        else f"{start:%Y-%m-%d} ~ {end:%Y-%m-%d}"
+    )
     header = (
-        f"[검증된 시장 데이터 — KRX 원천 조회, {start:%Y-%m-%d} ~ {end:%Y-%m-%d}]\n"
+        f"[검증된 시장 데이터 — KRX 원천 조회, {period_text}]\n"
         "아래 수치는 한국거래소 데이터에서 직접 조회한 확정값이다.\n"
         "지수 레벨·등락률·종목 등락률은 반드시 아래 값만 사용하고, "
         "웹 검색 결과에 다른 숫자가 있어도 무시하라.\n"
@@ -346,8 +488,47 @@ _US_TICKERS = (
 )
 
 
-def build_us_facts(start: date, end: date) -> str:
-    """미국 시장 검증 수치 블록. 실패 시 빈 문자열."""
+def resolve_recent_us_sessions(
+    today: Optional[date] = None, lookback_days: int = 14
+) -> Optional[tuple[date, date]]:
+    """
+    (직전 거래일, 최근 거래일) — S&P 500 캘린더 기준.
+
+    KR 과 같은 이유로 달력 계산 대신 지수 인덱스를 신뢰한다. 미국 공휴일은
+    한국과 겹치지 않으므로 시장별로 따로 풀어야 한다.
+    """
+    try:
+        import yfinance as yf
+    except ImportError:
+        logger.warning("[facts] yfinance not installed — US session lookup skipped")
+        return None
+
+    today = today or datetime.now().date()
+    try:
+        hist = yf.Ticker("^GSPC").history(
+            start=(today - timedelta(days=lookback_days)).strftime("%Y-%m-%d"),
+            end=(today + timedelta(days=2)).strftime("%Y-%m-%d"),
+        )
+        if hist is None or len(hist) < 2:
+            logger.warning("[facts] US session calendar: fewer than 2 sessions")
+            return None
+        return hist.index[-2].date(), hist.index[-1].date()
+    except Exception as e:  # noqa: BLE001 - fail-soft by design
+        logger.warning(f"[facts] US session calendar lookup failed: {e}")
+        return None
+
+
+def build_us_facts(start: date, end: date, *, kind: str = "weekly") -> str:
+    """
+    미국 시장 검증 수치 블록. 실패 시 빈 문자열.
+
+    KR 과 달리 movers 블록이 없어 baseline 개념이 필요 없다. yfinance history 는
+    [start, end+2) 구간의 첫 시가 → 마지막 종가를 쓰므로 단일일 구간에서도
+    계산은 옳다. 문구만 kind 로 고른다.
+    """
+    if kind not in _PERIOD_LABELS:
+        raise ValueError(f"unknown kind {kind!r}; expected 'weekly' or 'daily'")
+    labels = _PERIOD_LABELS[kind]
     try:
         import yfinance as yf
     except ImportError:
@@ -369,10 +550,13 @@ def build_us_facts(start: date, end: date) -> str:
             pct = (last_close - first_open) / first_open * 100 if first_open else 0.0
             last_day = hist.index[-1].strftime("%m-%d")
             if ticker == "^TNX":
-                lines.append(f"- {name}: {last_close:.3f}% ({last_day} 기준, 주간 {pct:+.2f}%)")
+                lines.append(
+                    f"- {name}: {last_close:.3f}% "
+                    f"({last_day} 기준, {labels['span']} {pct:+.2f}%)"
+                )
             else:
                 lines.append(
-                    f"- {name}: 주간 시가 {first_open:,.2f} → {last_day} 종가 "
+                    f"- {name}: {labels['open']} {first_open:,.2f} → {last_day} 종가 "
                     f"{last_close:,.2f} ({pct:+.2f}%)"
                 )
         except Exception as e:  # noqa: BLE001
@@ -382,8 +566,12 @@ def build_us_facts(start: date, end: date) -> str:
         logger.warning("[facts] US facts empty — yfinance 조회 전부 실패")
         return ""
 
+    period_text = (
+        f"{end:%Y-%m-%d}" if start == end
+        else f"{start:%Y-%m-%d} ~ {end:%Y-%m-%d}"
+    )
     header = (
-        f"[검증된 시장 데이터 — yfinance 원천 조회, {start:%Y-%m-%d} ~ {end:%Y-%m-%d}]\n"
+        f"[검증된 시장 데이터 — yfinance 원천 조회, {period_text}]\n"
         "아래 수치는 시장 데이터에서 직접 조회한 확정값이다.\n"
         "지수 레벨·등락률은 반드시 아래 값만 사용하고, 웹 검색 결과의 다른 숫자는 무시하라.\n"
     )


### PR DESCRIPTION
## 무엇을 왜

주간 리포트만 KRX/yfinance 원천 수치를 근거로 받고 있었다. 정작 매일 쓰는
`/signal` `/theme` `/ask` `/us_signal` `/us_theme` 는 검색 스니펫만 들고 답을 썼다 —
지수가 몇이었는지, 외국인이 얼마 샀는지 **숫자 근거가 0**이었다.

`generate_firecrawl_search_response` 가 이미 `grounded_facts`/`period_label` 을 받고,
봇이 `search_opts` 를 `**` splat 으로 넘기므로 **헬퍼 시그니처는 건드리지 않았다.**
호출부 dict 병합으로 끝난다.

```python
search_opts=search_preset("KR", tbs="qdr:w") | await daily_facts("KR")
```

## 막은 결함 3가지

**1. movers 등락률 전량 0% (조용한 오염)**
`_kr_movers_block` 은 `close(baseline) → close(end)` 비교다. 단일일이라고 같은 날을
두 번 넘기면 전 종목이 `+0.0%` 로 나온다. 예외가 아니라 *그럴듯한 거짓값*이
"확정값이니 이것만 써라" 헤더를 달고 리포트에 실린다. `baseline` 을 명시 인자로
드러내고 `baseline == end` 면 라인을 버린다.

**2. 일간 종가가 "금요일 종가" 로 라벨링**
산문이 주간 전용으로 하드코딩돼 있었다. LLM 은 그 문구를 그대로 받아쓴다.
`_PERIOD_LABELS` 로 분리.

**3. 등락률 기준점이 시가 (장중 변동폭)**
한국 시장 등락률은 전일 종가 기준이고 언론·HTS 가 전부 그 숫자를 쓴다.
실측 2026-07-31 KOSPI: 시가 대비 `+16.57%` vs 전일 종가 대비 `+17.91%` — 기사와 1.34pp 어긋난다.

## 이벤트 루프 보호

`build_kr_facts` 는 KRX 전종목 스캔(거래대금 상위 300 선별)을 도는 동기 함수다.
주간 배치는 일회성이라 무해하지만 **봇은 단일 루프 asyncio 앱**이라 그대로 부르면
스캔 동안 모든 사용자가 멈춘다.

`cores/market_facts_cache.py` 가 executor 실행 + market 별 single-flight + TTL 공유 캐시
+ 타임아웃을 담당한다. 실패하면 근거 없이 진행한다(= 기존 동작).

`asyncio.wait_for` 는 await 만 취소하고 스레드는 못 죽이므로, in-flight Task 를 공유하고
`asyncio.shield` 로 감쌌다. 타임아웃은 호출자만 떠나보내고 빌드는 계속 돌며 다음
호출자가 같은 Task 에 붙는다. 이게 없으면 느린 업스트림에서 스레드가 배로 늘어난다.

## 거래일 판정

달력 계산으로 주말·공휴일을 흉내내지 않는다. **지수에 값이 있는 날이 거래일**이므로
인덱스 마지막 두 행을 쓴다(`resolve_recent_sessions`). 임시휴장·조기폐장도 자동 처리.
미국 공휴일은 한국과 겹치지 않아 시장별로 따로 푼다.

## 검증

`tools/bench/verify_grounded_facts.py` — 9개 섹션

- **오프라인 ALL PASS**: 주간 문구 6종 보존(일요일 리포트 무회귀), 일간 close-to-close
  `+0.50%`(시가 대비 `+1.50%` 아님), `baseline == end` → 빈 리스트,
  동시 10건 → 빌드 1회 0.40s, 타임아웃/예외 → `{}`,
  타임아웃 중복 실행 회귀(`peak_concurrent=1`, `builds=1`), AST 로 5개 호출부 병합 확인
- **라이브 ALL PASS**: `KOSPI 전일 종가 5,593.56 → 종가 6,595.45 (+17.91%)`,
  `S&P 500 전일 종가 7,437.63 → 07-31 종가 7,489.72 (+0.70%)` —
  둘 다 yfinance close-to-close 와 독립 대조 일치
- 기존 `verify_search_presets.py` 회귀 없음

## 교차 리뷰

codex-cli 0.144.1 리뷰에서 MEDIUM 2건 + LOW 1건 지적, 전부 반영했다.
`shield` 누락(코덱스가 `max_active=2` 재현), US 라이브 검사가 프로덕션 미경유 분기를
검증하던 문제, 그리고 그 회귀 테스트 부재.

## 배포 노트

- 봇은 **app-server**, 주간 리포트는 **db-server** — 서로 다른 서버다
- 봇 재기동은 반드시 `bash utils/restart_telegram_bot.sh` (kill/start 분리 금지)
- 주간 리포트 크론 `0 11 * * 0` 은 서버 TZ 가 KST 라 **일요일 11:00 KST** 다

🤖 Generated with [Claude Code](https://claude.com/claude-code)