### PR TITLE
fix: 봇 일간 근거에서 movers 제외 — KR 근거가 실전에서 안 붙던 문제

### DIFF
--- a/cores/market_facts_cache.py
+++ b/cores/market_facts_cache.py
@@ -95,7 +95,15 @@ def _build(market: str) -> dict:
         baseline, latest = sessions
         # movers compares close(baseline) -> close(latest); passing the same day
         # twice would print +0.0% for every stock, so the prior session matters.
-        facts = build_kr_facts(latest, latest, kind="daily", baseline=baseline)
+        #
+        # movers is OFF here. Measured on app-server: index 0.1s + investor 0.2s
+        # against 63.0s for movers alone — it scans every ticker twice through a
+        # KRX client that re-logs-in per call. That is fine for the Sunday batch
+        # and hopeless for a chat command; with it on, KR grounding never landed
+        # inside the timeout and every /signal answer went out ungrounded.
+        facts = build_kr_facts(
+            latest, latest, kind="daily", baseline=baseline, include_movers=False
+        )
     else:
         sessions = resolve_recent_us_sessions()
         if not sessions:

--- a/tools/bench/verify_grounded_facts.py
+++ b/tools/bench/verify_grounded_facts.py
@@ -170,6 +170,20 @@ def test_movers_guard() -> None:
           bool(ok) and not all("+0.0%" in ln for ln in ok),
           " | ".join(ok))
 
+    # Latency guard. movers costs 63.0s on app-server against 0.3s for the other
+    # two blocks combined; leaving it on made KR grounding miss the timeout every
+    # time, so the interactive path must never request it.
+    fast = wmf.build_kr_facts(
+        date(2026, 7, 31), date(2026, 7, 31),
+        kind="daily", baseline=date(2026, 7, 28), include_movers=False,
+    )
+    check("include_movers=False drops the movers block", "상승률 상위" not in fast)
+    check("...but keeps index and investor", "KOSPI:" in fast and "순매수" in fast)
+
+    src = inspect.getsource(mfc._build)
+    check("production KR path disables movers", "include_movers=False" in src,
+          "cores.market_facts_cache._build must not pay the 63s cost")
+
 
 def test_cache_single_flight() -> None:
     print("\n[4] one build shared by concurrent callers")

--- a/weekly_market_facts.py
+++ b/weekly_market_facts.py
@@ -421,6 +421,7 @@ def build_kr_facts(
     *,
     kind: str = "weekly",
     baseline: Optional[date] = None,
+    include_movers: bool = True,
 ) -> str:
     """
     한국 시장 검증 수치 블록. 실패 시 빈 문자열.
@@ -433,6 +434,18 @@ def build_kr_facts(
         baseline: movers 등락률의 기준 시점. 생략하면 start.
                   주간은 start(월요일)가 곧 기준이라 기존 동작과 동일하고,
                   일간은 직전 거래일을 넘겨야 한다(같은 날이면 전부 0%).
+        include_movers: 등락률 상위 블록 포함 여부.
+
+            **대화형 호출에서는 반드시 False 로 꺼라.** app-server 실측:
+
+                resolve 0.7s | index 0.1s | investor 0.2s | movers 63.0s
+
+            movers 혼자 전체의 98% 다. 전종목 스냅샷 2회 + 종목명 조회 14회를
+            krx_data_client 로 도는데, 서버 자격증명 경로는 호출마다 KRX
+            브라우저 로그인(안정화 대기 7~13초, 지터 5~15초)을 태운다.
+            주간 배치는 일회성이라 1분이 무해하지만 봇 커맨드는 못 기다린다.
+            끄면 1.0초에 끝나고, 시장 질문의 핵심 근거(지수 레벨·등락률·수급)는
+            index/investor 에 다 들어 있다.
 
     주간 호출(build_kr_facts(mon, fri))의 출력은 이 변경 전후로 동일하다.
     """
@@ -447,7 +460,9 @@ def build_kr_facts(
         start, end, labels, baseline=baseline if kind == "daily" else None
     )
     investor_lines = _kr_investor_block(start, end, labels)
-    movers_lines = _kr_movers_block(baseline, end, labels)
+    movers_lines = (
+        _kr_movers_block(baseline, end, labels) if include_movers else []
+    )
     lines = index_lines + investor_lines + movers_lines
 
     if not lines:


### PR DESCRIPTION
## 증상

PR #513 배포 직후 app-server 실측에서 **KR 근거가 30초 타임아웃에 걸려 한 번도 안 붙었다.**
US 는 3.3초에 정상 생성. 즉 주 시장인 한국 쪽 grounding 이 실전에서 전혀 동작하지 않았다.

## 원인

블록별 실측 (app-server):

```
resolve_recent_sessions  0.7s
index                    0.1s
investor                 0.2s
movers                  63.0s   ← 98%
TOTAL                   64.1s
```

`_kr_movers_block` 은 전종목 스냅샷 2회 + 종목명 조회 14회를 돈다. 서버의
`krx_data_client` 자격증명 경로는 호출마다 KRX 브라우저 로그인을 태우고,
그 안에 안정화 대기 7~13초와 지터 5~15초가 박혀 있다.

주간 배치(일요일 1회)는 1분이 무해하다. 대화형 봇 커맨드는 못 기다린다.

## 수정

`build_kr_facts(..., include_movers=True)` 를 두고 봇 경로에서만 껐다.
**1.0초**에 끝나고, 시장 질문의 핵심 근거(지수 레벨·등락률·수급)는
index/investor 에 전부 들어 있다. 주간 리포트는 기본값 그대로다.

## 왜 로컬 검증이 못 잡았나

로컬은 bare pykrx 로 붙어 브라우저 로그인을 타지 않는다. 같은 코드가 백엔드에
따라 지연 특성이 완전히 다르다. `_krx_fn` 이 `krx_data_client` → pykrx 순으로
resolve 하는 구조라 환경마다 다른 백엔드가 잡힌다.

테스트로 못 박았다 — `cores.market_facts_cache._build` 소스에
`include_movers=False` 가 실제로 있는지 직접 확인한다. 지연은 로컬에서 재현할
수 없으니 정책을 검사한다.

## 검증

오프라인 ALL PASS. 신규 3건:
- `include_movers=False` 가 movers 만 빼고 index/investor 는 남기는지
- 프로덕션 경로가 실제로 끄는지

## 후속 (이 PR 범위 밖)

movers 를 봇에도 되살리려면 프리워밍이 필요하다 — 장중 크론으로 캐시를
채워두면 대화형 경로는 항상 캐시 히트가 된다. TTL 이 600초이므로 8분 주기면 된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)