### PR TITLE
feat: Temporal Gate — 날짜를 확인할 수 없는 문서는 컨텍스트에 넣지 않는다

### DIFF
--- a/cores/temporal_gate.py
+++ b/cores/temporal_gate.py
@@ -65,7 +65,12 @@ _KO = re.compile(r"(20\d{2})\s*년\s*(\d{1,2})\s*월\s*(\d{1,2})\s*일")
 
 # URL 복원. 구분자가 있는 형태를 먼저 보고, 없으면 8자리 연속 숫자를 본다.
 _URL_SEP = re.compile(r"/(20\d{2})[/._-](\d{1,2})[/._-](\d{1,2})(?:\D|$)")
-_URL_RUN = re.compile(r"(20\d{2})(\d{2})(\d{2})")
+# 8자리 연속 숫자는 경계를 좁게 잡는다. 앞이 `/` 이거나 대문자 기사코드
+# (연합 `AKR20260731...`) 인 경우만 인정한다. 그냥 어디서든 잡으면
+# `.../company-20260731-results-preview` 같은 슬러그가 "발행일이 확인된 문서"로
+# 승격되는데, 그건 날짜를 지어내는 것이라 게이트가 막으려던 바로 그 오염이다.
+# 놓치는 쪽(본문 복원으로 넘어감)이 지어내는 쪽보다 훨씬 싸다.
+_URL_RUN = re.compile(r"(?:/|[A-Z]{2,})(20\d{2})(\d{2})(\d{2})")
 
 
 def _mk(y: int, m: int, d: int) -> Optional[date]:
@@ -204,6 +209,7 @@ def apply_temporal_gate(
         "recovered_from_body": 0,
         "dropped_undated": 0,
         "dropped_out_of_window": 0,
+        "dropped_future": 0,
     }
 
     days = window_days(tbs)
@@ -214,6 +220,10 @@ def apply_temporal_gate(
 
     as_of = as_of or datetime.now().date()
     oldest = as_of - timedelta(days=days)
+    # 복원 경로에만 상한이 있고 메타데이터 경로에 없으면 미래 날짜가 그대로
+    # 통과한다. 실제로 as_of=2026-08-03 / qdr:w 에서 "September 1, 2026" 이
+    # 살아남았다. 미래 발행일은 신선한 게 아니라 소스가 잘못된 것이다.
+    horizon = as_of + timedelta(days=1)
     kept: list = []
 
     for item in items:
@@ -239,6 +249,9 @@ def apply_temporal_gate(
         if published < oldest:
             stats["dropped_out_of_window"] += 1
             continue
+        if published > horizon:
+            stats["dropped_future"] += 1
+            continue
 
         item["_published"] = published
         kept.append(item)
@@ -249,6 +262,7 @@ def apply_temporal_gate(
         f"{stats['kept']}/{stats['total']} kept, "
         f"{stats['dropped_undated']} undated, "
         f"{stats['dropped_out_of_window']} out-of-window, "
+        f"{stats['dropped_future']} future-dated, "
         f"{stats['recovered_from_url']} recovered from URL, "
         f"{stats['recovered_from_body']} from body"
     )

--- a/cores/temporal_gate.py
+++ b/cores/temporal_gate.py
@@ -1,0 +1,255 @@
+"""
+Temporal Gate — 창 밖 문서를 컨텍스트에 넣지 않는다.
+
+왜 필요한가
+-----------
+`tbs=qdr:w` 는 검색 엔진에 대한 **힌트지 보장이 아니다.** 실측으로 `qdr:m` 창에
+`May 28, 2026` 기사가 통과했다. 지금까지는 그걸 그대로 LLM 에 넘기면서
+발행일을 함께 적어주고 "기간을 벗어난 기사는 이번 주 일로 서술하지 말라"고
+프롬프트로 부탁했다. 부탁은 지켜질 때도 있고 아닐 때도 있다.
+
+이 모듈은 그 부탁을 **필터로 승격**시킨다. 창 밖이면 down-rank 가 아니라 drop 이고,
+발행일을 끝내 복원하지 못해도 drop 이다. 날짜를 모르는 문서는 신선도를 주장할
+근거가 없으므로 신선도가 핵심인 리포트에 들어갈 자격이 없다.
+
+drop 이 안전한 이유
+-------------------
+grounded_facts(KRX/yfinance 원천 수치)가 먼저 붙었기 때문이다. 웹 항목이 0건이어도
+지수·수급 숫자는 남아 있어 리포트가 성립한다. 순서가 반대였으면 이 게이트는
+위험했다 — 그래서 근거 연결을 먼저 했다.
+
+날짜 파싱
+---------
+firecrawl_client._absolute_date 는 상대 표현("2 days ago")만 절대화하고 나머지는
+**그대로 통과시킨다.** 따라서 여기 들어오는 값은 형식이 섞여 있다:
+
+    ""                          없음
+    "2026-08-01 (2 days ago)"   _absolute_date 가 만든 형태
+    "2026-07-31T09:00:00+09:00" ISO datetime
+    "May 28, 2026"              영문 롱폼 ← 실제로 창을 새어 나온 그 형식
+    "2026.07.31" / "2026/07/31" 한국 매체
+    "2026년 7월 31일"
+
+메타데이터에서 못 찾으면 URL 에서 복원을 시도한다. 한국 매체 URL 은 대개 날짜를
+품고 있다(`/2026/07/31/`, `AKR20260731...`). 복원도 실패하면 그때 버린다.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from datetime import date, datetime, timedelta
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# tbs 창을 일수로. 검색 엔진이 힌트로만 쓰는 값을 여기서는 계약으로 쓴다.
+# 경계는 관대하게 잡는다 — 타임존 차이로 하루 어긋난 정상 기사를 버리면 손해다.
+_WINDOW_DAYS = {
+    "qdr:d": 2,
+    "qdr:w": 8,
+    "qdr:m": 32,
+    "qdr:y": 367,
+}
+
+_MONTHS = {
+    "jan": 1, "feb": 2, "mar": 3, "apr": 4, "may": 5, "jun": 6,
+    "jul": 7, "aug": 8, "sep": 9, "oct": 10, "nov": 11, "dec": 12,
+}
+
+# 앞부분에 붙은 절대 날짜. "2026-08-01 (2 days ago)" 와 ISO datetime 을 함께 잡는다.
+_ISO = re.compile(r"(20\d{2})[-/.](\d{1,2})[-/.](\d{1,2})")
+# "May 28, 2026" / "28 May 2026" / "May 2026" 은 일자가 없으므로 제외
+_EN_MDY = re.compile(r"([A-Za-z]{3,9})\.?\s+(\d{1,2}),?\s+(20\d{2})")
+_EN_DMY = re.compile(r"(\d{1,2})\s+([A-Za-z]{3,9})\.?,?\s+(20\d{2})")
+_KO = re.compile(r"(20\d{2})\s*년\s*(\d{1,2})\s*월\s*(\d{1,2})\s*일")
+
+# URL 복원. 구분자가 있는 형태를 먼저 보고, 없으면 8자리 연속 숫자를 본다.
+_URL_SEP = re.compile(r"/(20\d{2})[/._-](\d{1,2})[/._-](\d{1,2})(?:\D|$)")
+_URL_RUN = re.compile(r"(20\d{2})(\d{2})(\d{2})")
+
+
+def _mk(y: int, m: int, d: int) -> Optional[date]:
+    try:
+        return date(y, m, d)
+    except ValueError:
+        return None
+
+
+def parse_published(raw: str) -> Optional[date]:
+    """섞여 들어오는 발행일 표기를 date 로. 못 읽으면 None."""
+    if not raw:
+        return None
+    text = str(raw).strip()
+
+    m = _ISO.search(text)
+    if m:
+        got = _mk(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+        if got:
+            return got
+
+    m = _KO.search(text)
+    if m:
+        got = _mk(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+        if got:
+            return got
+
+    m = _EN_MDY.search(text)
+    if m:
+        mon = _MONTHS.get(m.group(1)[:3].lower())
+        if mon:
+            got = _mk(int(m.group(3)), mon, int(m.group(2)))
+            if got:
+                return got
+
+    m = _EN_DMY.search(text)
+    if m:
+        mon = _MONTHS.get(m.group(2)[:3].lower())
+        if mon:
+            got = _mk(int(m.group(3)), mon, int(m.group(1)))
+            if got:
+                return got
+
+    return None
+
+
+def recover_from_url(url: str, *, as_of: Optional[date] = None) -> Optional[date]:
+    """
+    URL 에 박힌 날짜를 복원한다.
+
+    기사 ID 가 우연히 날짜처럼 보일 수 있으므로 결과를 반드시 검증한다 —
+    2000년 이전이거나 as_of 다음날을 넘어가면 날짜가 아니라 우연이다.
+    """
+    if not url:
+        return None
+    as_of = as_of or datetime.now().date()
+    horizon = as_of + timedelta(days=1)
+
+    for pattern in (_URL_SEP, _URL_RUN):
+        for m in pattern.finditer(url):
+            got = _mk(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+            if got and date(2000, 1, 1) <= got <= horizon:
+                return got
+    return None
+
+
+# 본문 상단의 발행 스탬프. 시:분이 붙은 형태를 먼저 본다 — 기사 본문에 등장하는
+# 다른 날짜("2026년 상반기 실적")와 달리 시각이 붙어 있으면 발행 스탬프일 확률이 높다.
+_BODY_STAMPED = re.compile(
+    r"(20\d{2})[-./년]\s*(\d{1,2})[-./월]\s*(\d{1,2})\s*일?"
+    r"[\sT]+\d{1,2}\s*[:시]\s*\d{2}"
+)
+_BODY_LABELED = re.compile(
+    r"(?:입력|등록|송고|발행|기사입력|Updated|Published)\D{0,12}"
+    r"(20\d{2})[-./년]\s*(\d{1,2})[-./월]\s*(\d{1,2})"
+)
+_BODY_HEAD_CHARS = 800
+
+
+def recover_from_body(body: str, *, as_of: Optional[date] = None) -> Optional[date]:
+    """
+    본문 상단에서 발행일을 복원한다.
+
+    검색 결과의 web 채널은 발행일 메타데이터를 거의 달고 오지 않는다. 실측에서
+    `/theme` 은 7건 중 5건이 발행일 미상이었고, 그대로 두면 게이트가 web 채널을
+    통째로 죽인다. 본문은 이미 손에 있으므로 추가 비용 없이 되살릴 수 있다.
+
+    본문 전체를 뒤지면 "2026년 상반기 실적" 같은 서술상의 날짜를 발행일로
+    오인한다. 그래서 (1) 앞부분만 보고, (2) 시각이 붙었거나 '입력/등록' 같은
+    라벨이 앞선 형태만 인정한다.
+    """
+    if not body:
+        return None
+    head = body[:_BODY_HEAD_CHARS]
+    as_of = as_of or datetime.now().date()
+    horizon = as_of + timedelta(days=1)
+    floor = date(as_of.year - 3, 1, 1)
+
+    for pattern in (_BODY_LABELED, _BODY_STAMPED):
+        for m in pattern.finditer(head):
+            got = _mk(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+            if got and floor <= got <= horizon:
+                return got
+    return None
+
+
+def window_days(tbs: Optional[str]) -> Optional[int]:
+    """tbs 를 일수로. 모르는 값이면 None (= 게이트 미적용)."""
+    return _WINDOW_DAYS.get(tbs or "")
+
+
+def apply_temporal_gate(
+    items: list,
+    *,
+    tbs: Optional[str],
+    as_of: Optional[date] = None,
+) -> tuple[list, dict]:
+    """
+    창 밖 문서와 발행일 미상 문서를 걸러낸다.
+
+    Args:
+        items: normalize_search_items() 결과.
+        tbs: 요청한 신선도 창. 모르는 값이면 게이트를 적용하지 않고 전량 통과시킨다
+             (알 수 없는 창을 임의 해석해 버리는 것보다 안전하다).
+        as_of: 기준일. 생략하면 오늘.
+
+    Returns:
+        (통과 항목, 통계). 통계는 소스 품질 관측용이며 그대로 로깅된다.
+        복원 건수가 크면 메타데이터 소스가 나쁘다는 뜻이고, 창밖 폐기가 크면
+        tbs 가 먹지 않는다는 뜻이다 — 둘 다 조치가 다르므로 따로 센다.
+    """
+    stats = {
+        "total": len(items),
+        "kept": 0,
+        "recovered_from_url": 0,
+        "recovered_from_body": 0,
+        "dropped_undated": 0,
+        "dropped_out_of_window": 0,
+    }
+
+    days = window_days(tbs)
+    if days is None:
+        stats["kept"] = len(items)
+        logger.info(f"Temporal gate skipped (tbs={tbs!r}): {len(items)} items passed through")
+        return list(items), stats
+
+    as_of = as_of or datetime.now().date()
+    oldest = as_of - timedelta(days=days)
+    kept: list = []
+
+    for item in items:
+        published = parse_published(item.get("date") or "")
+        if published is None:
+            published = recover_from_url(item.get("url") or "", as_of=as_of)
+            if published is not None:
+                stats["recovered_from_url"] += 1
+                # 하위 렌더링이 그대로 쓰도록 정규화한 값을 되돌려 넣는다.
+                item["date"] = f"{published:%Y-%m-%d} (URL 복원)"
+
+        if published is None:
+            published = recover_from_body(
+                item.get("body") or item.get("snippet") or "", as_of=as_of
+            )
+            if published is not None:
+                stats["recovered_from_body"] += 1
+                item["date"] = f"{published:%Y-%m-%d} (본문 복원)"
+
+        if published is None:
+            stats["dropped_undated"] += 1
+            continue
+        if published < oldest:
+            stats["dropped_out_of_window"] += 1
+            continue
+
+        item["_published"] = published
+        kept.append(item)
+
+    stats["kept"] = len(kept)
+    logger.info(
+        f"Temporal gate (tbs={tbs}, window={oldest}~{as_of}): "
+        f"{stats['kept']}/{stats['total']} kept, "
+        f"{stats['dropped_undated']} undated, "
+        f"{stats['dropped_out_of_window']} out-of-window, "
+        f"{stats['recovered_from_url']} recovered from URL, "
+        f"{stats['recovered_from_body']} from body"
+    )
+    return kept, stats

--- a/report_generator.py
+++ b/report_generator.py
@@ -7,7 +7,7 @@ import logging
 import os
 import subprocess
 import sys
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 from typing import Optional
 
@@ -1328,6 +1328,7 @@ async def generate_firecrawl_search_response(
     try:
         from firecrawl_client import firecrawl_search_multi
         from cores.search_presets import widen_tbs
+        from cores.temporal_gate import apply_temporal_gate
 
         queries = [search_query] if isinstance(search_query, str) else list(search_query)
 
@@ -1348,19 +1349,23 @@ async def generate_firecrawl_search_response(
                 ),
             )
 
-        items = await _search(tbs)
+        window = tbs
+        items, _gate = apply_temporal_gate(await _search(window), tbs=window)
 
         # A tight recency window legitimately returns nothing on a quiet news day.
-        # Widening one rung at a time beats handing the user "결과 없음" — every
-        # article still carries its publish date downstream, so the model can see
-        # for itself that the material is older than asked for.
-        window = tbs
+        # Widening one rung at a time beats handing the user "결과 없음".
+        #
+        # The condition is what *survives the gate*, not what the search returned.
+        # tbs is a hint the engine may ignore, so a full-looking result set can be
+        # entirely out of window — that case used to read as success and never
+        # widened, which is exactly how stale articles reached the report.
         while not items and (window := widen_tbs(window)):
-            logger.info(f"No results at tbs={tbs!r}; widening to {window!r}")
-            items = await _search(window)
+            logger.info(f"No in-window results at tbs={tbs!r}; widening to {window!r}")
+            items, _gate = apply_temporal_gate(await _search(window), tbs=window)
 
-        # Prefer dated results, newest first; undated ones sink to the bottom.
-        items.sort(key=lambda it: (bool(it.get("date")), it.get("date") or ""), reverse=True)
+        # Newest first. Survivors all carry a parsed date; the fallback only
+        # matters when the gate was skipped for an unrecognized window.
+        items.sort(key=lambda it: it.get("_published") or date.min, reverse=True)
 
         context = _build_search_context(items)
         if not context:

--- a/report_generator.py
+++ b/report_generator.py
@@ -1280,6 +1280,11 @@ def _build_search_context(items: list) -> str:
         body = body[:MAX_ARTICLE_CHARS]
         tag = "블로그·커뮤니티(수치 인용 금지)" if item.get("low_trust") else item.get("channel", "web")
         published = item.get("date") or "발행일 미상"
+        if item.get("_stale"):
+            # Only set on the last-resort path, where the temporal gate rejected
+            # everything and no grounded facts survived. Say so in the context
+            # instead of letting it read as current material.
+            published += " ⚠️ 신선도 미검증 — 최근 일로 서술 금지"
         chunk = (
             f"[{item.get('title') or '제목 없음'}]\n"
             f"발행일: {published} | 출처유형: {tag}\n"
@@ -1350,7 +1355,8 @@ async def generate_firecrawl_search_response(
             )
 
         window = tbs
-        items, _gate = apply_temporal_gate(await _search(window), tbs=window)
+        raw = await _search(window)
+        items, _gate = apply_temporal_gate(raw, tbs=window)
 
         # A tight recency window legitimately returns nothing on a quiet news day.
         # Widening one rung at a time beats handing the user "결과 없음".
@@ -1361,10 +1367,27 @@ async def generate_firecrawl_search_response(
         # widened, which is exactly how stale articles reached the report.
         while not items and (window := widen_tbs(window)):
             logger.info(f"No in-window results at tbs={tbs!r}; widening to {window!r}")
-            items, _gate = apply_temporal_gate(await _search(window), tbs=window)
+            raw = await _search(window)
+            items, _gate = apply_temporal_gate(raw, tbs=window)
+
+        # Last resort. The gate emptied every rung *and* there are no grounded
+        # facts to stand on — build_kr_facts() returns "" and daily_facts()
+        # returns {} when their sources fail, so "grounded facts always cover the
+        # floor" is only true while those lookups work. With both gone, returning
+        # None deletes the section outright; the Sunday report would simply lose
+        # its KR or US half. Stale material the model is explicitly told is stale
+        # beats no material at all, so pass it through marked.
+        if not items and raw and not grounded_facts:
+            logger.warning(
+                f"Temporal gate dropped all {len(raw)} results and no grounded "
+                "facts are available — falling back to unverified-freshness items"
+            )
+            items = raw
+            for item in items:
+                item["_stale"] = True
 
         # Newest first. Survivors all carry a parsed date; the fallback only
-        # matters when the gate was skipped for an unrecognized window.
+        # matters when the gate was skipped or the stale path above fired.
         items.sort(key=lambda it: it.get("_published") or date.min, reverse=True)
 
         context = _build_search_context(items)

--- a/tools/bench/verify_temporal_gate.py
+++ b/tools/bench/verify_temporal_gate.py
@@ -88,6 +88,10 @@ def test_url_recovery() -> None:
         "https://example.com/2099/01/01/future",       # 미래
         "https://example.com/1999/12/31/too-old",      # 2000년 이전
         "https://example.com/no-digits-here",
+        # 창 안의 날짜처럼 보이지만 발행일이 아닌 슬러그. 이걸 승격시키면
+        # 날짜를 지어내는 셈이라 게이트가 막으려던 오염 그 자체가 된다.
+        "https://example.com/company-20260731-results-preview",
+        "https://example.com/reports?id=20260731999",
     ]
     for url in bad:
         check(f"rejects {url[-26:]}", recover_from_url(url, as_of=AS_OF) is None,
@@ -156,6 +160,14 @@ def test_gate_drops() -> None:
     check("survivors carry _published for sorting",
           all(isinstance(i.get("_published"), date) for i in kept))
 
+    # 복원 경로에만 상한이 있고 메타데이터 경로에 없어서 미래 발행일이 통과했다.
+    # 미래 날짜는 신선한 게 아니라 소스가 틀린 것이다.
+    future = [_item("September 1, 2026"), _item("2026-12-31"), _item("2026-08-04")]
+    kept_f, st_f = apply_temporal_gate(future, tbs="qdr:w", as_of=AS_OF)
+    check("future-dated items are dropped", st_f["dropped_future"] == 2, str(st_f))
+    check("as_of+1 is still allowed (timezone skew)",
+          len(kept_f) == 1 and kept_f[0]["date"] == "2026-08-04", str(st_f))
+
 
 def test_boundary() -> None:
     print("\n[5] boundary is tolerant of timezone skew")
@@ -212,6 +224,13 @@ def test_widening_uses_survivors() -> None:
               ast.dump(loop.test)[:110])
 
     check("sort uses the parsed date", "_published" in src)
+
+    # 팩트 조회는 fail-soft 다 — build_kr_facts 는 "", daily_facts 는 {} 를
+    # 돌려준다. 그게 게이트 전량 폐기와 겹치면 섹션이 통째로 사라진다.
+    check("last-resort keeps stale items when facts are also missing",
+          "_stale" in src and "not grounded_facts" in src)
+    check("stale items are labelled in the context",
+          "신선도 미검증" in src)
 
 
 def test_live() -> None:

--- a/tools/bench/verify_temporal_gate.py
+++ b/tools/bench/verify_temporal_gate.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""
+Verify the Temporal Gate.
+
+`tbs` is a hint the search engine may ignore — a `qdr:m` request really did
+return a `May 28, 2026` article. Until now that article reached the model with
+its date attached and a prompt asking politely not to treat it as this week's
+news. This gate turns that request into a filter.
+
+What has to hold:
+
+1. every date format the pipeline actually sees parses    — a format we cannot
+                                                             read is a document
+                                                             we silently drop
+2. URL recovery works and rejects coincidences            — article IDs look
+                                                             like dates
+3. out-of-window and undated items are dropped
+4. boundary is tolerant                                   — timezone skew must
+                                                             not evict good news
+5. an unknown window disables the gate                    — never guess a window
+6. widening keys off survivors, not raw hits              — the whole point
+
+Usage:  python3 tools/bench/verify_temporal_gate.py
+"""
+import ast
+import sys
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from cores.temporal_gate import (  # noqa: E402
+    apply_temporal_gate, parse_published, recover_from_body, recover_from_url,
+    window_days,
+)
+
+failures: list[str] = []
+AS_OF = date(2026, 8, 3)
+
+
+def check(label: str, ok: bool, detail: str = "") -> None:
+    print(f"  {'PASS' if ok else 'FAIL'}  {label}" + (f"  — {detail}" if detail else ""))
+    if not ok:
+        failures.append(label)
+
+
+def test_parsing() -> None:
+    print("\n[1] every observed date format parses")
+    cases = [
+        # 실제로 파이프라인에 들어오는 형태들
+        ("2026-07-31", date(2026, 7, 31)),
+        ("2026-08-01 (2 days ago)", date(2026, 8, 1)),      # _absolute_date 출력
+        ("2026-07-31T09:00:00Z", date(2026, 7, 31)),
+        ("2026-07-31T09:00:00+09:00", date(2026, 7, 31)),
+        ("May 28, 2026", date(2026, 5, 28)),                # 창을 새어 나온 그 형식
+        ("Jul 31, 2026", date(2026, 7, 31)),
+        ("September 1, 2026", date(2026, 9, 1)),
+        ("28 May 2026", date(2026, 5, 28)),
+        ("2026.07.31", date(2026, 7, 31)),
+        ("2026/07/31", date(2026, 7, 31)),
+        ("2026년 7월 31일", date(2026, 7, 31)),
+    ]
+    for raw, want in cases:
+        check(f"{raw!r} -> {want}", parse_published(raw) == want,
+              f"got {parse_published(raw)}")
+
+    print("  -- unparseable stays unparseable --")
+    for raw in ("", "발행일 미상", "May 2026", "yesterday", "2026-13-45"):
+        check(f"{raw!r} -> None", parse_published(raw) is None,
+              f"got {parse_published(raw)}")
+
+
+def test_url_recovery() -> None:
+    print("\n[2] URL recovery, and coincidences rejected")
+    good = [
+        ("https://www.yna.co.kr/view/AKR20260731012300002", date(2026, 7, 31)),
+        ("https://n.news.naver.com/article/2026/07/31/0001", date(2026, 7, 31)),
+        ("https://biz.chosun.com/stock/2026-07-31/abc/", date(2026, 7, 31)),
+    ]
+    for url, want in good:
+        check(f"...{url[-28:]} -> {want}",
+              recover_from_url(url, as_of=AS_OF) == want,
+              f"got {recover_from_url(url, as_of=AS_OF)}")
+
+    bad = [
+        "https://example.com/article/1234567890",      # 날짜 아님
+        "https://example.com/2099/01/01/future",       # 미래
+        "https://example.com/1999/12/31/too-old",      # 2000년 이전
+        "https://example.com/no-digits-here",
+    ]
+    for url in bad:
+        check(f"rejects {url[-26:]}", recover_from_url(url, as_of=AS_OF) is None,
+              f"got {recover_from_url(url, as_of=AS_OF)}")
+
+
+def test_body_recovery() -> None:
+    """
+    The web channel barely ever carries a publish date. Measured: /theme kept
+    only 2 of 7 before body recovery, so the gate was effectively deleting the
+    whole channel. Body text is already in hand, so recovery is free.
+    """
+    print("\n[3] body recovery, and prose dates rejected")
+    good = [
+        ("입력 2026-07-31 15:56  코스피가 급등했다", date(2026, 7, 31)),
+        ("기사입력 2026년 7월 31일 오전 9시", date(2026, 7, 31)),
+        ("2026.07.31 15:56 | 기자 홍길동", date(2026, 7, 31)),
+        ("Published 2026-07-29 by Reuters", date(2026, 7, 29)),
+        ("등록 2026/07/28  반도체 업황", date(2026, 7, 28)),
+    ]
+    for body, want in good:
+        check(f"{body[:26]!r} -> {want}",
+              recover_from_body(body, as_of=AS_OF) == want,
+              f"got {recover_from_body(body, as_of=AS_OF)}")
+
+    bad = [
+        "2026년 상반기 실적이 크게 개선됐다",          # 서술상의 날짜, 시각·라벨 없음
+        "목표가는 2026년 12월 31일까지 유효하다",       # 미래
+        "2019년 7월 31일 당시와 비교하면",             # 3년 초과 과거
+        "특별한 날짜가 없는 본문",
+    ]
+    for body in bad:
+        check(f"rejects {body[:24]!r}",
+              recover_from_body(body, as_of=AS_OF) is None,
+              f"got {recover_from_body(body, as_of=AS_OF)}")
+
+    tail = ("x" * 900) + " 입력 2026-07-31 15:56"
+    check("only the head is scanned", recover_from_body(tail, as_of=AS_OF) is None,
+          f"got {recover_from_body(tail, as_of=AS_OF)}")
+
+
+def _item(dt: str = "", url: str = "https://example.com/x", title: str = "t") -> dict:
+    return {"date": dt, "url": url, "title": title, "body": "b"}
+
+
+def test_gate_drops() -> None:
+    print("\n[4] out-of-window and undated are dropped")
+    items = [
+        _item("2026-08-02"),                      # 창 안
+        _item("2026-07-30"),                      # 창 안 (qdr:w = 8일)
+        _item("May 28, 2026"),                    # 창 밖 — 실제 유출 사례
+        _item(""),                                # 발행일 미상
+        _item("", "https://www.yna.co.kr/view/AKR20260801010000001"),  # URL 복원
+    ]
+    kept, stats = apply_temporal_gate(items, tbs="qdr:w", as_of=AS_OF)
+
+    check("kept 3 of 5", stats["kept"] == 3, str(stats))
+    check("out-of-window counted", stats["dropped_out_of_window"] == 1, str(stats))
+    check("undated counted", stats["dropped_undated"] == 1, str(stats))
+    check("URL recovery counted", stats["recovered_from_url"] == 1, str(stats))
+    check("May 28 article is gone",
+          not any("May 28" in (i.get("date") or "") for i in kept))
+    check("recovered item carries a normalized date",
+          any("URL 복원" in (i.get("date") or "") for i in kept),
+          str([i.get("date") for i in kept]))
+    check("survivors carry _published for sorting",
+          all(isinstance(i.get("_published"), date) for i in kept))
+
+
+def test_boundary() -> None:
+    print("\n[5] boundary is tolerant of timezone skew")
+    # qdr:d 를 24시간으로 잡으면 KST 기사가 UTC 기준으로 하루 밀려 전량 탈락한다.
+    kept, _ = apply_temporal_gate(
+        [_item("2026-08-02"), _item("2026-08-03")], tbs="qdr:d", as_of=AS_OF)
+    check("qdr:d keeps yesterday and today", len(kept) == 2, f"kept={len(kept)}")
+
+    kept, _ = apply_temporal_gate([_item("2026-07-26")], tbs="qdr:w", as_of=AS_OF)
+    check("qdr:w keeps 8 days back", len(kept) == 1)
+
+    kept, _ = apply_temporal_gate([_item("2026-07-01")], tbs="qdr:w", as_of=AS_OF)
+    check("qdr:w drops 33 days back", len(kept) == 0)
+
+    check("window_days maps the ladder",
+          [window_days(t) for t in ("qdr:d", "qdr:w", "qdr:m", "qdr:y")] == [2, 8, 32, 367])
+
+
+def test_unknown_window() -> None:
+    print("\n[6] an unknown window disables the gate")
+    items = [_item("May 28, 2026"), _item("")]
+    for tbs in (None, "", "qdr:decade"):
+        kept, stats = apply_temporal_gate(items, tbs=tbs, as_of=AS_OF)
+        check(f"tbs={tbs!r} passes everything through",
+              len(kept) == 2 and stats["kept"] == 2, str(stats))
+    check("window_days(None) is None", window_days(None) is None)
+
+
+def test_widening_uses_survivors() -> None:
+    """
+    The gate is worthless if widening still keys off the raw hit count: a search
+    that returns eight out-of-window articles would look like a success, gate to
+    zero, and never widen.
+    """
+    print("\n[7] widening keys off gated survivors")
+    src = (ROOT / "report_generator.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.AsyncFunctionDef)
+        and n.name == "generate_firecrawl_search_response"
+    )
+    body = ast.dump(fn)
+    check("gate is applied in the search path", "apply_temporal_gate" in body)
+
+    whiles = [n for n in ast.walk(fn) if isinstance(n, ast.While)]
+    check("a widening loop still exists", len(whiles) >= 1)
+    if whiles:
+        loop = whiles[0]
+        check("loop re-applies the gate on each rung",
+              "apply_temporal_gate" in ast.dump(loop))
+        check("loop condition is the gated list",
+              "widen_tbs" in ast.dump(loop.test) and "items" in ast.dump(loop.test),
+              ast.dump(loop.test)[:110])
+
+    check("sort uses the parsed date", "_published" in src)
+
+
+def test_live() -> None:
+    """
+    Pass rate against the real search. A gate that drops everything is worse
+    than no gate — the answer loses its web context entirely. This is the check
+    that cannot be faked with fixtures.
+    """
+    print("\n[8] LIVE: pass rate on real search results (costs credits)")
+    from dotenv import load_dotenv
+    load_dotenv(ROOT / ".env")
+    from firecrawl_client import firecrawl_search_multi
+    from cores.search_presets import search_preset
+
+    probes = [
+        ("signal KR", "KR", "qdr:w", True, "코스피 증시 마감 시황"),
+        ("theme KR", "KR", "qdr:m", True, "주식 테마 주도주 상승"),
+        ("ask KR", "KR", "qdr:m", False, "반도체 업황 전망"),
+    ]
+    for label, mkt, tbs, allow, query in probes:
+        opts = search_preset(mkt, tbs=tbs, allowlist=allow)
+        items = firecrawl_search_multi([query], limit=8, with_content=True, **opts)
+        kept, st = apply_temporal_gate(items, tbs=tbs)
+        print(f"     {label:10} tbs={tbs:6} raw={st['total']:2} kept={st['kept']:2} "
+              f"undated={st['dropped_undated']:2} outwin={st['dropped_out_of_window']:2} "
+              f"urlrec={st['recovered_from_url']}")
+        for i in kept[:2]:
+            print(f"       KEEP {i.get('date')}  {(i.get('title') or '')[:42]}")
+        check(f"{label}: gate leaves usable context", st["kept"] > 0,
+              f"kept={st['kept']}/{st['total']}")
+
+
+def main() -> int:
+    test_parsing()
+    test_url_recovery()
+    test_body_recovery()
+    test_gate_drops()
+    test_boundary()
+    test_unknown_window()
+    test_widening_uses_survivors()
+    if "--live" in sys.argv:
+        test_live()
+    else:
+        print("\n[8] LIVE skipped (pass --live to run)")
+
+    print("\n" + "=" * 60)
+    if failures:
+        print(f"FAILED ({len(failures)}): " + "; ".join(failures))
+        return 1
+    print("ALL PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 무엇을 왜

`tbs` 는 검색 엔진에 대한 **힌트지 보장이 아니다.** 지금까지는 창 밖 문서가 섞여 들어와도
발행일만 함께 적어주고 "기간을 벗어난 기사는 이번 주 일로 서술하지 말라"고 프롬프트로
부탁했다. 부탁은 지켜질 때도 있고 아닐 때도 있다. 이 PR 이 그 부탁을 **필터로 승격**시킨다.

drop 이 안전한 근거는 `grounded_facts`(KRX/yfinance 원천 수치)가 먼저 붙었기 때문이다.
웹 항목이 0건이어도 지수·수급 숫자가 남아 리포트가 성립한다. 순서가 반대였으면 위험했다.

## 확장재시도 조건을 생존분으로

기존 루프는 **원시 검색 건수**가 0일 때만 창을 넓혔다. `tbs` 가 무시돼 8건이 전부 창 밖이어도
"성공"으로 읽혀 넓히지 않았다 — 오래된 기사가 리포트에 도달한 경로가 이것이다.
이제 **게이트 생존분** 기준이다. 미결로 남아 있던 "확장 재시도 실전 미검증"도 실경로가 된다.

## 날짜 복원: 메타데이터 → URL → 본문

본문 복원은 처음에 빼먹었다가 라이브 측정에서 추가했다. web 채널이 발행일을 거의 안 달고
와서, 없으면 게이트가 그 채널을 통째로 죽인다.

```
              본문 복원 전      후
signal KR     kept 6/8    →   7/8   (undated 2 → 1)
theme  KR     kept 2/7    →   5/7   (undated 5 → 2)   손실 71% → 29%
```

## 정직하게 기록해 둘 것

라이브 3표본 모두 **`outwin=0`** 이었다. 이 게이트가 지금 실제로 걸러내는 것은 창 밖 문서가
아니라 **발행일 미상 문서**다. 즉 실질 보증은 "창 밖 차단"이 아니라
**"컨텍스트의 모든 문서는 날짜가 확인된다"** 이다. 창 밖 유출(`qdr:m` 에 `May 28`)은 과거에
관측됐으나 이번 표본에선 재현되지 않았다.

## 코덱스 교차 리뷰 반영 (HIGH 1 + MEDIUM 2)

**HIGH — 미래 날짜가 통과했다.** 복원 경로엔 `as_of+1일` 상한이 있는데 메타데이터 경로엔
하한만 있었다. `qdr:w` 에서 `"September 1, 2026"` 이 살아남는다(코덱스가 실행해 재현).
→ `dropped_future` 로 폐기. `as_of+1일` 은 타임존 차이를 위해 유지.

**MEDIUM — `_URL_RUN` 오탐.** URL 어디서든 8자리 숫자를 발행일로 승격해
`.../company-20260731-results-preview` 가 "날짜가 확인된 문서"가 됐다. **날짜를 지어내는
것**이라 이 게이트가 막으려던 오염 그 자체다. → 앞이 `/` 이거나 대문자 기사코드일 때만 인정.
놓치면 본문 복원으로 넘어가므로 놓치는 쪽이 지어내는 쪽보다 싸다.

**MEDIUM — 섹션이 통째로 사라질 수 있었다.** `build_kr_facts` 는 실패 시 `""`,
`daily_facts` 는 타임아웃 시 `{}` 를 돌려주는 fail-soft 계약이다. 팩트 조회 실패와 게이트
전량 폐기가 겹치면 `None` 이 반환돼 **주간 리포트의 KR 또는 US 섹션이 없어진다.**
→ 사다리를 다 쓰고도 0건이고 `grounded_facts` 도 없으면 미게이트 항목을 `_stale` 로 표시해
통과시키고 컨텍스트에 `⚠️ 신선도 미검증 — 최근 일로 서술 금지` 를 붙인다.

## 검증

`tools/bench/verify_temporal_gate.py` (8섹션) — 오프라인 ALL PASS
- 파이프라인에 실제로 들어오는 날짜 형식 11종 파싱, 못 읽는 5종은 `None`
- URL/본문 복원과 우연 일치 거부 (미래·3년 초과 과거·라벨 없는 서술상 날짜·슬러그 숫자)
- 경계는 관대하게 (`qdr:w` = 8일) — 타임존 하루 밀림으로 정상 기사를 버리면 손해
- 모르는 창이면 게이트 미적용 (임의 해석 금지)
- AST 로 확장재시도가 생존분 기준인지 확인

기존 `verify_search_presets` / `verify_grounded_facts` 회귀 없음.

## 배포 후 확인할 것

주간 리포트가 같은 경로를 탄다 (**일요일 11:00 KST**, db-server). 다음 실행 후
`logs/weekly_firecrawl_intelligence.log` 에서 `Temporal gate` 로그의 kept/dropped 분포와
KR/US 섹션 존재를 확인할 것.

🤖 Generated with [Claude Code](https://claude.com/claude-code)