### PR TITLE
fix(campaign): forwarder 원격 enqueue 를 리포 엔트리포인트로 호출

### DIFF
--- a/messaging/campaign_forwarder.py
+++ b/messaging/campaign_forwarder.py
@@ -60,16 +60,11 @@ class CampaignShipper(Protocol):
         """
 
 
-# Runs on the remote host. Reads one event on stdin so the payload never
-# appears in argv, where `ps` would show it, and no shell quoting can mangle it.
-_REMOTE_SCRIPT = """
-import json, sys
-sys.path.insert(0, {repo!r})
-from messaging.local_campaign_queue import SQLiteBatchCampaignQueue
-payload = json.load(sys.stdin)
-with SQLiteBatchCampaignQueue({queue!r}) as queue:
-    print("NEW" if queue.enqueue(payload) else "DUPLICATE")
-"""
+# The remote half ships with the repo. Sending it inline as `python -c` does
+# not survive the hop: ssh joins its trailing arguments into one string for the
+# *remote shell*, which then splits a multi-line script into separate commands
+# and reports "import: command not found". A file has no quoting surface.
+_REMOTE_ENTRYPOINT = "tools/enqueue_campaign_event.py"
 
 
 class SshCampaignShipper:
@@ -103,11 +98,14 @@ class SshCampaignShipper:
         command = [self._ssh_binary, "-o", "BatchMode=yes"]
         if self._identity_file:
             command += ["-i", self._identity_file]
-        script = _REMOTE_SCRIPT.format(
-            repo=self._repo_path,
-            queue=self._queue_path,
-        )
-        command += [self._host, self._python_path, "-c", script]
+        entrypoint = f"{self._repo_path.rstrip('/')}/{_REMOTE_ENTRYPOINT}"
+        command += [
+            self._host,
+            self._python_path,
+            entrypoint,
+            "--queue-path",
+            self._queue_path,
+        ]
         return command
 
     def ship(self, payload: Mapping[str, object]) -> bool:

--- a/tests/test_campaign_forwarder.py
+++ b/tests/test_campaign_forwarder.py
@@ -195,14 +195,26 @@ class TestSshShipper:
 
         assert "BatchMode=yes" in command
 
-    def test_the_remote_runs_the_projects_own_enqueue(self):
+    def test_the_remote_runs_the_projects_own_entrypoint(self):
         # Not a raw sqlite3 INSERT — validation and INSERT OR IGNORE stay in
-        # one implementation.
-        script = self.shipper()._command()[-1]
+        # one implementation, shipped with the repo.
+        command = self.shipper()._command()
 
-        assert "SQLiteBatchCampaignQueue" in script
-        assert "queue.enqueue(payload)" in script
-        assert "/home/prism/prism-insight" in script
+        assert "/home/prism/prism-insight/tools/enqueue_campaign_event.py" in command
+        assert "/home/prism/venv/bin/python" in command
+        assert "--queue-path" in command
+
+    def test_nothing_is_sent_inline_for_the_remote_shell_to_mangle(self):
+        # `ssh host python -c "<multi-line script>"` does not survive the hop:
+        # ssh joins its trailing args into one string for the REMOTE SHELL,
+        # which then splits the script into separate commands and reports
+        # "import: command not found". Only a file path has no quoting surface.
+        # Found in production, not by unit tests — so it is pinned here.
+        command = self.shipper()._command()
+
+        assert "-c" not in command
+        assert not any("import " in part for part in command)
+        assert not any("\n" in part for part in command)
 
     def test_an_identity_file_is_passed_through_when_given(self):
         command = self.shipper(identity_file="/root/.ssh/id_ed25519")._command()

--- a/tools/enqueue_campaign_event.py
+++ b/tools/enqueue_campaign_event.py
@@ -1,0 +1,51 @@
+"""Place one campaign event on this host's queue. Reads the event on stdin.
+
+The remote half of `forward_campaign_events.py`. It lives in the repo as a
+file rather than being sent inline as `python -c "<script>"`, because ssh joins
+its trailing arguments into a single string and hands that to the *remote
+shell* — a multi-line script arrives split into separate shell commands
+("import: command not found"). Quoting could paper over it; shipping the code
+with the repo removes the class of bug entirely and makes the remote half
+readable and testable like anything else.
+
+The event arrives on stdin so it never appears in argv, where `ps` would show
+it to every user on the box.
+
+Prints NEW when the queue accepted the event and DUPLICATE when it already had
+it. Both mean the caller is done: `campaign_id` is UNIQUE and the insert is
+INSERT OR IGNORE, so re-sending is a no-op by design.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from messaging.local_campaign_queue import SQLiteBatchCampaignQueue
+
+DEFAULT_QUEUE = "/var/lib/prism-kakao/prism_campaign_queue.sqlite"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--queue-path",
+        default=os.getenv("PRISM_CAMPAIGN_QUEUE_PATH", DEFAULT_QUEUE),
+    )
+    args = parser.parse_args(argv)
+
+    payload = json.load(sys.stdin)
+    with SQLiteBatchCampaignQueue(Path(args.queue_path).expanduser()) as queue:
+        accepted = queue.enqueue(payload)
+
+    print("NEW" if accepted else "DUPLICATE")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
프로덕션 첫 실행에서 드러난 결함.

`ssh host python -c "<여러 줄 스크립트>"` 는 홉을 못 넘는다. ssh 가 뒤따르는
인자를 하나의 문자열로 합쳐 **원격 셸**에 넘기고, 셸이 그걸 줄 단위로 쪼갠다:

```
bash: line 2: import: command not found
bash: -c: line 3: syntax error near unexpected token `0,'
```

payload 는 stdin 으로 보호했는데 스크립트 자체가 인용부호에 노출돼 있었다.
원격 코드를 리포 파일(`tools/enqueue_campaign_event.py`)로 옮겨 이 부류의
버그를 없앴다.

forwarder 의 실패 처리는 설계대로 동작해 이벤트를 잃지 않고 `retry=1` 로
재시도를 예약했다.

유닛 테스트 전량 통과 상태에서 **실서버 실행에서만** 드러났으므로 회귀
테스트를 추가했다 — 인라인 스크립트 금지(`-c` 없음, 개행 없음).

검증: 15 passed, ruff All checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)