### PR TITLE
feat(kakao): 초대되면 바로 쓸 수 있고, 들어가면 인사한다

### DIFF
--- a/kakao_bot/adapters/kakao/command_renderer.py
+++ b/kakao_bot/adapters/kakao/command_renderer.py
@@ -36,14 +36,14 @@ def render_command_outcome(outcome: CommandOutcome) -> dict[str, object]:
         return skill_response(
             [
                 simple_text_output(outcome.message),
-                _help_card(),
+                help_card(),
             ]
         )
 
     return simple_text(outcome.message)
 
 
-def _help_card() -> dict[str, object]:
+def help_card() -> dict[str, object]:
     """Item titles are commands, because tapping one sends its title.
 
     Only advertises what is wired up: a first impression of "아직 준비 중인

--- a/kakao_bot/adapters/kakao/delivery_renderer.py
+++ b/kakao_bot/adapters/kakao/delivery_renderer.py
@@ -17,12 +17,17 @@ from kakao_bot.adapters.kakao.report_renderer import (
     ASK_RESULT,
     render_report_delivery,
 )
+from kakao_bot.adapters.kakao.welcome_renderer import (
+    ROOM_WELCOME,
+    render_welcome_delivery,
+)
 from kakao_bot.domain.models import ClaimedOutboundDelivery
 
 CAMPAIGN_TYPES = frozenset({"signal_campaign", "campaign_rest_notice"})
 REPORT_TYPES = frozenset({ANALYSIS_RESULT, ANALYSIS_FAILED, ASK_RESULT, ASK_FAILED})
+LIFECYCLE_TYPES = frozenset({ROOM_WELCOME})
 
-SUPPORTED_TYPES = CAMPAIGN_TYPES | REPORT_TYPES
+SUPPORTED_TYPES = CAMPAIGN_TYPES | REPORT_TYPES | LIFECYCLE_TYPES
 
 
 def render_delivery(delivery: ClaimedOutboundDelivery) -> dict[str, object]:
@@ -30,4 +35,6 @@ def render_delivery(delivery: ClaimedOutboundDelivery) -> dict[str, object]:
         return render_campaign_delivery(delivery)
     if delivery.message_type in REPORT_TYPES:
         return render_report_delivery(delivery)
+    if delivery.message_type in LIFECYCLE_TYPES:
+        return render_welcome_delivery(delivery)
     raise ValueError(f"unsupported Kakao delivery type: {delivery.message_type}")

--- a/kakao_bot/adapters/kakao/welcome_renderer.py
+++ b/kakao_bot/adapters/kakao/welcome_renderer.py
@@ -1,0 +1,44 @@
+"""Introduce the bot to a room it has just been added to.
+
+Kakao only delivers group messages the bot was mentioned in, so a bot that
+waits to be spoken to is invisible: nobody in the room has been told it is
+there, and nobody guesses the command grammar unprompted. Arriving with one
+message that says what it does — and gives tappable examples — is the
+difference between a room that uses the bot and a room that forgets it.
+
+The same card the help command shows is reused on purpose. It already only
+advertises commands that are wired up, so the greeting cannot promise a
+feature that answers "아직 준비 중인 기능입니다".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from kakao_bot.adapters.kakao.command_renderer import help_card
+from kakao_bot.adapters.kakao.skill_response import (
+    simple_text_output,
+    skill_response,
+)
+from kakao_bot.domain.models import ClaimedOutboundDelivery
+
+ROOM_WELCOME = "room_welcome"
+
+_GREETING = (
+    "👋 안녕하세요, PRISM입니다.\n"
+    "종목 분석 리포트와 시장 질문에 답해드려요.\n\n"
+    "저를 부르려면 메시지에 저를 멘션해주세요.\n"
+    "아래 항목을 눌러 바로 시작할 수 있어요."
+)
+
+
+def render_welcome_delivery(
+    delivery: ClaimedOutboundDelivery,
+) -> dict[str, object]:
+    if delivery.message_type != ROOM_WELCOME:
+        raise ValueError(f"unsupported Kakao delivery type: {delivery.message_type}")
+    return _welcome(delivery.payload)
+
+
+def _welcome(_payload: Mapping[str, object]) -> dict[str, object]:
+    return skill_response([simple_text_output(_GREETING), help_card()])

--- a/kakao_bot/adapters/persistence/sqlite.py
+++ b/kakao_bot/adapters/persistence/sqlite.py
@@ -502,8 +502,17 @@ class SQLiteKakaoRepository:
         room_id: str,
         event_type: RoomLifecycleType | None,
         occurred_at: datetime,
+        auto_approve: bool = False,
     ) -> bool:
-        """Deduplicate and apply room lifecycle state in one transaction."""
+        """Deduplicate and apply room lifecycle state in one transaction.
+
+        `auto_approve` decides what an invitation means. Off, a new room lands
+        in PENDING and someone has to approve it by hand — right for a bot with
+        real users. On, an invitation is the approval, which is what a review
+        period needs: ten reviewers adding the bot to their own rooms cannot
+        each wait for an operator to run a CLI. The gate itself stays; only its
+        default moves.
+        """
 
         if not event_id.strip():
             raise ValueError("event_id must not be empty")
@@ -528,40 +537,64 @@ class SQLiteKakaoRepository:
                 return False
 
             if event_type is RoomLifecycleType.ENTRANCE:
+                existing = self._connection.execute(
+                    "SELECT approval_status FROM kakao_rooms WHERE room_id = ?",
+                    (room_id,),
+                ).fetchone()
+                # A re-invitation must not cost a room its approval. Kakao
+                # redelivers ENTRANCE, and being kicked and re-added is normal;
+                # both used to drop the room silently back to PENDING, which
+                # reads in the room as "the bot stopped working" — no error
+                # anywhere, just refusals.
+                was_approved = (
+                    existing is not None
+                    and existing["approval_status"] == ApprovalStatus.APPROVED.value
+                )
+                status = (
+                    ApprovalStatus.APPROVED
+                    if (was_approved or auto_approve)
+                    else ApprovalStatus.PENDING
+                )
                 self._connection.execute(
                     """
                     INSERT INTO kakao_rooms(
                         room_id, approval_status, discovered_at, updated_at
                     )
-                    VALUES (?, 'PENDING', ?, ?)
+                    VALUES (?, ?, ?, ?)
                     ON CONFLICT(room_id) DO UPDATE SET
-                        approval_status = 'PENDING',
+                        approval_status = excluded.approval_status,
                         updated_at = excluded.updated_at
                     """,
-                    (room_id, occurred_iso, recorded_iso),
+                    (room_id, status.value, occurred_iso, recorded_iso),
                 )
-                self._connection.execute(
-                    """
-                    INSERT INTO kakao_room_subscriptions(
-                        room_id,
-                        kr_morning,
-                        kr_afternoon,
-                        us_morning,
-                        us_afternoon,
-                        rest_notices,
-                        updated_at
+                if not was_approved:
+                    # Same default profile `set_room_approval` applies, so an
+                    # auto-approved room is subscribed exactly like a
+                    # hand-approved one. An already-approved room is left alone
+                    # — its owner may have changed these on purpose.
+                    afternoon = 1 if status is ApprovalStatus.APPROVED else 0
+                    self._connection.execute(
+                        """
+                        INSERT INTO kakao_room_subscriptions(
+                            room_id,
+                            kr_morning,
+                            kr_afternoon,
+                            us_morning,
+                            us_afternoon,
+                            rest_notices,
+                            updated_at
+                        )
+                        VALUES (?, 0, ?, 0, 0, 0, ?)
+                        ON CONFLICT(room_id) DO UPDATE SET
+                            kr_morning = 0,
+                            kr_afternoon = excluded.kr_afternoon,
+                            us_morning = 0,
+                            us_afternoon = 0,
+                            rest_notices = 0,
+                            updated_at = excluded.updated_at
+                        """,
+                        (room_id, afternoon, recorded_iso),
                     )
-                    VALUES (?, 0, 0, 0, 0, 0, ?)
-                    ON CONFLICT(room_id) DO UPDATE SET
-                        kr_morning = 0,
-                        kr_afternoon = 0,
-                        us_morning = 0,
-                        us_afternoon = 0,
-                        rest_notices = 0,
-                        updated_at = excluded.updated_at
-                    """,
-                    (room_id, recorded_iso),
-                )
             elif event_type is RoomLifecycleType.LEAVE:
                 self._connection.execute(
                     """

--- a/kakao_bot/application/gateway_inbound_service.py
+++ b/kakao_bot/application/gateway_inbound_service.py
@@ -2,19 +2,96 @@
 
 from __future__ import annotations
 
-from kakao_bot.domain.models import InboundMessage, RoomLifecycleEvent
+import logging
+
+from kakao_bot.domain.errors import RoomNotFoundError
+from kakao_bot.domain.models import (
+    ApprovalStatus,
+    InboundMessage,
+    OutboundDelivery,
+    RoomLifecycleEvent,
+    RoomLifecycleType,
+)
 from kakao_bot.ports.repositories import KakaoRepository
+
+logger = logging.getLogger(__name__)
+
+WELCOME = "room_welcome"
 
 
 class GatewayInboundService:
-    def __init__(self, repository: KakaoRepository) -> None:
+    """Turn a lifecycle or message event into persisted room state.
+
+    Two policies live here rather than in the repository, because they are
+    decisions about how the product should behave rather than about how rows
+    get written:
+
+    `auto_approve` — whether an invitation counts as approval. Off by default,
+    which is right once the bot has real users. On during the review period:
+    ten reviewers adding the bot to their own rooms cannot each wait for an
+    operator to SSH in and run the approval CLI, and what they would see in the
+    meantime is "이 채팅방은 아직 승인되지 않았습니다" — a bot that looks broken.
+
+    `greet_on_join` — whether to say anything on arrival. Kakao delivers group
+    messages to the bot only when it is mentioned, so a silent bot is invisible:
+    nobody has been told it is there, let alone what to type at it.
+    """
+
+    def __init__(
+        self,
+        repository: KakaoRepository,
+        *,
+        auto_approve: bool = False,
+        greet_on_join: bool = True,
+    ) -> None:
         self._repository = repository
+        self._auto_approve = auto_approve
+        self._greet_on_join = greet_on_join
 
     def handle(self, event: InboundMessage | RoomLifecycleEvent) -> bool:
         event_type = event.event_type if isinstance(event, RoomLifecycleEvent) else None
-        return self._repository.apply_gateway_event(
+        created = self._repository.apply_gateway_event(
             event.event_id,
             room_id=event.room_id,
             event_type=event_type,
             occurred_at=event.occurred_at,
+            auto_approve=self._auto_approve,
         )
+
+        # Only a first-time event greets. Redelivery after RESUME returns False
+        # here, which is exactly what keeps the room from being greeted twice.
+        if created and event_type is RoomLifecycleType.ENTRANCE:
+            self._greet(event.room_id)
+        return created
+
+    def _greet(self, room_id: str) -> None:
+        """Introduce the bot, but only where it can actually be used.
+
+        Greeting a room that is still PENDING would promise something the very
+        next message refuses, so an unapproved room is left alone.
+
+        Failure here must not propagate: the room row is already committed, and
+        losing the Gateway session over a greeting would cost far more than the
+        greeting is worth.
+        """
+
+        if not self._greet_on_join:
+            return
+        try:
+            room = self._repository.get_room(room_id)
+        except RoomNotFoundError:
+            return
+        if room is None or room.approval_status is not ApprovalStatus.APPROVED:
+            return
+
+        try:
+            self._repository.enqueue_outbound(
+                OutboundDelivery(
+                    delivery_key=f"welcome:{room_id}",
+                    room_id=room_id,
+                    message_type=WELCOME,
+                    payload={"room_id": room_id},
+                )
+            )
+        except Exception:  # never break the Gateway session over a greeting
+            logger.exception("Could not queue a welcome for room %s", room_id)

--- a/kakao_bot/ports/repositories.py
+++ b/kakao_bot/ports/repositories.py
@@ -54,8 +54,13 @@ class KakaoRepository(Protocol):
         room_id: str,
         event_type: RoomLifecycleType | None,
         occurred_at: datetime,
+        auto_approve: bool = False,
     ) -> bool:
-        """Atomically deduplicate an event and apply room lifecycle state."""
+        """Atomically deduplicate an event and apply room lifecycle state.
+
+        With `auto_approve`, an invitation is the approval. Either way an
+        already-approved room keeps its approval when ENTRANCE repeats.
+        """
 
     def save_campaign(self, campaign: BatchCampaign) -> bool:
         """Return True only when a new campaign_id is recorded."""

--- a/kakao_bot/runtime/gateway_main.py
+++ b/kakao_bot/runtime/gateway_main.py
@@ -132,7 +132,17 @@ async def run_gateway(
             repository = SQLiteKakaoRepository(config.database_path)
         resolved_state_store = state_store or SQLiteGatewayStateStore(repository)
         resolved_handler = event_handler or GatewayDispatchHandler(
-            GatewayInboundService(repository),
+            GatewayInboundService(
+                repository,
+                # Off by default: with real users an invitation should not be
+                # enough to start broadcasting into someone's room. Turned on
+                # for the review period, where an operator cannot approve ten
+                # reviewers' rooms by hand fast enough to matter.
+                auto_approve=_is_enabled(
+                    "KAKAO_AUTO_APPROVE_ROOMS", default=False
+                ),
+                greet_on_join=_is_enabled("KAKAO_GREET_ON_JOIN"),
+            ),
             message_handler=_build_message_handler(config, repository),
         )
         async with aiohttp.ClientSession() as session:

--- a/tests/test_kakao_room_onboarding.py
+++ b/tests/test_kakao_room_onboarding.py
@@ -1,0 +1,222 @@
+"""What happens when the bot is added to a room.
+
+Two things used to make the bot look broken to someone who had just invited
+it: it said nothing at all, and the first command it was sent was refused
+because the room sat in PENDING until an operator ran a CLI. Both are on the
+very first impression, so both are pinned here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from kakao_bot.adapters.kakao.delivery_renderer import render_delivery
+from kakao_bot.adapters.persistence.sqlite import SQLiteKakaoRepository
+from kakao_bot.application.gateway_inbound_service import (
+    WELCOME,
+    GatewayInboundService,
+)
+from kakao_bot.domain.models import (
+    ApprovalStatus,
+    ClaimedOutboundDelivery,
+    RoomLifecycleEvent,
+    RoomLifecycleType,
+    RoomSubscription,
+)
+
+NOW = datetime(2026, 8, 3, 5, 0, tzinfo=timezone.utc)
+ROOM = "room-1"
+
+
+def entrance(room_id: str = ROOM, *, at: datetime = NOW) -> RoomLifecycleEvent:
+    return RoomLifecycleEvent(
+        event_id=f"ENTRANCE:{room_id}:{at.isoformat()}",
+        sequence=1,
+        room_id=room_id,
+        event_type=RoomLifecycleType.ENTRANCE,
+        occurred_at=at,
+    )
+
+
+def leave(room_id: str = ROOM, *, at: datetime = NOW) -> RoomLifecycleEvent:
+    return RoomLifecycleEvent(
+        event_id=f"LEAVE:{room_id}:{at.isoformat()}",
+        sequence=2,
+        room_id=room_id,
+        event_type=RoomLifecycleType.LEAVE,
+        occurred_at=at,
+    )
+
+
+@pytest.fixture
+def repository(tmp_path):
+    with SQLiteKakaoRepository(tmp_path / "kakao.sqlite") as repo:
+        yield repo
+
+
+class TestApprovalOnInvite:
+    def test_an_invite_stays_pending_by_default(self, repository):
+        # Real users: being added to a room is not consent to broadcast into it.
+        GatewayInboundService(repository).handle(entrance())
+
+        assert repository.get_room(ROOM).approval_status is ApprovalStatus.PENDING
+
+    def test_auto_approve_makes_the_invite_the_approval(self, repository):
+        GatewayInboundService(repository, auto_approve=True).handle(entrance())
+
+        assert repository.get_room(ROOM).approval_status is ApprovalStatus.APPROVED
+
+    def test_an_auto_approved_room_gets_the_same_profile_as_a_hand_approved_one(
+        self, repository
+    ):
+        GatewayInboundService(repository, auto_approve=True).handle(entrance())
+
+        # `set_room_approval` turns on KR afternoon and nothing else; an
+        # auto-approved room must not end up subscribed differently.
+        assert repository.list_delivery_targets(
+            *_kr_afternoon()
+        ) == (ROOM,)
+
+    def test_a_pending_room_is_not_a_delivery_target(self, repository):
+        GatewayInboundService(repository).handle(entrance())
+
+        assert repository.list_delivery_targets(*_kr_afternoon()) == ()
+
+
+class TestReInvite:
+    def test_re_entrance_does_not_strip_an_existing_approval(self, repository):
+        # Kakao redelivers ENTRANCE, and being kicked then re-added is normal.
+        # This used to silently reset the room to PENDING: no error anywhere,
+        # the bot simply started refusing every command.
+        service = GatewayInboundService(repository)
+        service.handle(entrance())
+        repository.set_room_approval(ROOM, ApprovalStatus.APPROVED)
+
+        service.handle(entrance(at=NOW + timedelta(days=1)))
+
+        assert repository.get_room(ROOM).approval_status is ApprovalStatus.APPROVED
+
+    def test_re_entrance_keeps_the_subscriptions_the_room_chose(self, repository):
+        service = GatewayInboundService(repository)
+        service.handle(entrance())
+        repository.set_room_approval(ROOM, ApprovalStatus.APPROVED)
+        repository.configure_subscription(
+            RoomSubscription(room_id=ROOM, kr_afternoon=False, us_afternoon=True)
+        )
+
+        service.handle(entrance(at=NOW + timedelta(days=1)))
+
+        targets = repository.list_delivery_targets(*_us_afternoon())
+        assert targets == (ROOM,)
+
+    def test_a_room_that_removed_the_bot_can_come_back(self, repository):
+        service = GatewayInboundService(repository, auto_approve=True)
+        service.handle(entrance())
+        service.handle(leave(at=NOW + timedelta(hours=1)))
+        assert repository.get_room(ROOM).approval_status is ApprovalStatus.REJECTED
+
+        service.handle(entrance(at=NOW + timedelta(hours=2)))
+
+        assert repository.get_room(ROOM).approval_status is ApprovalStatus.APPROVED
+
+
+class TestWelcome:
+    def test_an_approved_room_is_greeted_on_arrival(self, repository):
+        GatewayInboundService(repository, auto_approve=True).handle(entrance())
+
+        [delivery] = repository.list_outbox()
+        assert delivery["message_type"] == WELCOME
+        assert delivery["room_id"] == ROOM
+
+    def test_a_pending_room_is_not_greeted(self, repository):
+        # A greeting the next message refuses is worse than silence.
+        GatewayInboundService(repository).handle(entrance())
+
+        assert repository.list_outbox() == ()
+
+    def test_redelivery_does_not_greet_twice(self, repository):
+        service = GatewayInboundService(repository, auto_approve=True)
+        event = entrance()
+
+        service.handle(event)
+        service.handle(event)
+
+        assert len(repository.list_outbox()) == 1
+
+    def test_greeting_can_be_switched_off(self, repository):
+        GatewayInboundService(
+            repository, auto_approve=True, greet_on_join=False
+        ).handle(entrance())
+
+        assert repository.list_outbox() == ()
+
+    def test_a_message_event_never_greets(self, repository):
+        from kakao_bot.domain.models import InboundMessage
+
+        GatewayInboundService(repository, auto_approve=True).handle(
+            InboundMessage(
+                event_id="evt-1",
+                sequence=3,
+                room_id=ROOM,
+                user_id="user-1",
+                nickname=None,
+                text="리포트 삼성전자",
+                callback_token="cb",
+                occurred_at=NOW,
+            )
+        )
+
+        assert repository.list_outbox() == ()
+
+
+class TestWelcomeRendering:
+    def delivery(self) -> ClaimedOutboundDelivery:
+        return ClaimedOutboundDelivery(
+            delivery_key=f"welcome:{ROOM}",
+            room_id=ROOM,
+            message_type=WELCOME,
+            payload={"room_id": ROOM},
+            attempt_count=1,
+            lease_owner="worker-1",
+            lease_expires_at=NOW,
+            created_at=NOW,
+        )
+
+    def test_the_greeting_says_what_the_bot_is_and_how_to_reach_it(self):
+        response = render_delivery(self.delivery())
+
+        text = response["template"]["outputs"][0]["simpleText"]["text"]
+        assert "PRISM" in text
+        # Group rooms only deliver mentioned messages, so this is the one thing
+        # the room has to be told.
+        assert "멘션" in text
+
+    def test_the_greeting_offers_tappable_commands(self):
+        response = render_delivery(self.delivery())
+
+        card = response["template"]["outputs"][1]["listCard"]
+        titles = [item["title"] for item in card["items"]]
+        assert any("리포트" in title for title in titles)
+
+    def test_the_greeting_only_offers_commands_that_work(self):
+        # Reuses the help card, which reads IMPLEMENTED_COMMANDS, so it cannot
+        # advertise something that answers "아직 준비 중인 기능입니다".
+        response = render_delivery(self.delivery())
+
+        card = response["template"]["outputs"][1]["listCard"]
+        titles = [item["title"] for item in card["items"]]
+        assert not any("평가" in title for title in titles)
+
+
+def _kr_afternoon():
+    from kakao_bot.domain.models import Market, Session
+
+    return (Market.KR, Session.AFTERNOON)
+
+
+def _us_afternoon():
+    from kakao_bot.domain.models import Market, Session
+
+    return (Market.US, Session.AFTERNOON)


### PR DESCRIPTION
봇을 방에 초대한 사람이 마주치던 첫인상 두 가지를 고칩니다. 둘 다 심사 기준
①(사용성)·②(상호작용)이 시작도 못 하고 막히던 지점입니다.

## 1. 초대해도 못 쓴다

`ENTRANCE` 는 방을 `PENDING` 으로만 만들고, 그 방의 첫 명령은
"이 채팅방은 아직 승인되지 않았습니다" 로 거절됩니다. 운영자가 SSH 로 들어가
CLI 로 승인해야 비로소 쓸 수 있습니다. 심사위원들이 각자 방에 봇을 넣는
상황에서는 전원이 "안 되는 봇" 을 보게 됩니다.

→ `KAKAO_AUTO_APPROVE_ROOMS` (기본 OFF). 켜면 초대가 곧 승인이고, 구독은
`set_room_approval` 이 적용하는 것과 같은 기본 프로필(KR 오후만)을 받습니다.
게이트 자체는 남깁니다 — 실사용자가 붙은 뒤엔 초대만으로 남의 방에
브로드캐스트를 시작하면 안 됩니다.

## 2. 재초대가 승인을 깬다

```sql
ON CONFLICT(room_id) DO UPDATE SET approval_status = 'PENDING'
```

이미 승인된 방도 `ENTRANCE` 가 다시 오면 PENDING 으로 되돌아갔습니다. 카카오는
`ENTRANCE` 를 재전송하고 강퇴 후 재초대도 흔한데, **에러가 아무 데도 안 남고**
봇이 조용히 모든 명령을 거절하기 시작합니다.

→ 이미 APPROVED 인 방은 상태·구독을 유지합니다. `LEAVE` 로 REJECTED 가 된 방은
재초대 시 다시 열립니다.

## 3. 들어가도 아무 말을 안 한다

카카오는 멘션된 메시지만 봇에 전달하므로 말 없는 봇은 존재가 안 보입니다.

→ 승인된 방에 한해 입장 시 환영 카드를 outbox 로 넣습니다. PENDING 방엔 보내지
않습니다 — 바로 다음 메시지가 거절할 인사는 침묵보다 나쁩니다. 카드는 헬프
카드를 재사용하므로 "아직 준비 중인 기능" 을 광고할 수 없습니다.

검증: 267 passed (신규 15), ruff All checks passed, bandit 0건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)