### PR TITLE
feat(kakao): 명령어를 외우지 않아도 말이 통하게 한다

### DIFF
--- a/kakao_bot/adapters/kakao/command_renderer.py
+++ b/kakao_bot/adapters/kakao/command_renderer.py
@@ -50,27 +50,31 @@ def help_card() -> dict[str, object]:
     기능입니다" is worse than a shorter list.
     """
 
+    # Tapping sends the title verbatim, so each title is written the way we
+    # want people to type: a bare stock name, or a plain question. Titles that
+    # read `리포트 삼성전자` would teach a command grammar that is no longer
+    # necessary — and that users would then keep using.
     items: list[dict[str, object]] = [
         {
-            "title": f"리포트 {_EXAMPLE_TICKER}",
-            "description": "종목 분석 리포트를 생성합니다",
+            "title": _EXAMPLE_TICKER,
+            "description": "종목 이름만 보내면 분석 리포트를 만들어드려요",
             "action": "message",
-            "messageText": f"리포트 {_EXAMPLE_TICKER}",
+            "messageText": _EXAMPLE_TICKER,
         },
         {
-            "title": "리포트 AAPL",
-            "description": "미국 종목은 티커로 입력합니다",
+            "title": "AAPL",
+            "description": "미국 종목은 티커로 보내주세요",
             "action": "message",
-            "messageText": "리포트 AAPL",
+            "messageText": "AAPL",
         },
     ]
     if CommandKind.ASK in IMPLEMENTED_COMMANDS:
         items.append(
             {
-                "title": "질문 하기",
-                "description": "시장·종목에 대해 자유롭게 물어봅니다",
+                "title": "오늘 시장 어때?",
+                "description": "궁금한 걸 그냥 물어보세요",
                 "action": "message",
-                "messageText": "질문 ",
+                "messageText": "오늘 시장 어때?",
             }
         )
 

--- a/kakao_bot/adapters/kakao/report_renderer.py
+++ b/kakao_bot/adapters/kakao/report_renderer.py
@@ -195,12 +195,14 @@ def _next_actions(
             }
         )
     if CommandKind.ASK in IMPLEMENTED_COMMANDS:
+        # A whole sentence routes to a question on its own, so the title can be
+        # the question itself rather than a command spelling.
         items.append(
             {
-                "title": f"{company_name} 질문",
+                "title": f"{company_name} 지금 사도 될까?",
                 "description": "궁금한 점을 이어서 물어보세요",
                 "action": "message",
-                "messageText": f"질문 {company_name} ",
+                "messageText": f"{company_name} 지금 사도 될까?",
             }
         )
     if not items:

--- a/kakao_bot/application/command_parser.py
+++ b/kakao_bot/application/command_parser.py
@@ -26,6 +26,8 @@ _MENTION = re.compile(r"^@\S+\s*")
 _KR_CODE = re.compile(r"^\d{6}$")
 _US_TICKER = re.compile(r"^[A-Za-z]{1,5}$")
 _NUMERIC = re.compile(r"^\d+(?:[.,]\d+)?$")
+# Marks that make a token part of a sentence rather than a name on its own.
+_SENTENCE_MARK = re.compile(r"[?？!！.,、。]")
 _PERIOD = re.compile(r"^(\d+)\s*(?:개월|달|months?|m)?$", re.IGNORECASE)
 
 
@@ -34,6 +36,10 @@ class CommandKind(Enum):
     EVALUATE = "evaluate"
     ASK = "ask"
     HELP = "help"
+    # No keyword was used. Which command this becomes depends on whether the
+    # text names a stock, and only the ticker resolver knows that — so the
+    # decision belongs to the service, not here (see `ParsedCommand`).
+    NATURAL = "natural"
     UNKNOWN = "unknown"
 
 
@@ -74,6 +80,10 @@ class ParsedCommand:
     market: str | None = None
     avg_price: float | None = None
     period_months: int | None = None
+    # Only meaningful for NATURAL: whether the text is shaped like a single
+    # stock reference and is therefore worth handing to the resolver. A whole
+    # sentence is not, so "삼성전자 어때?" never becomes a report request.
+    resembles_ticker: bool = False
 
     @property
     def is_actionable(self) -> bool:
@@ -88,12 +98,25 @@ def parse_command(utterance: str) -> ParsedCommand:
 
     text = _MENTION.sub("", utterance.strip())
     if not text:
-        return ParsedCommand(kind=CommandKind.UNKNOWN)
+        # A bare mention is someone reaching for the bot without knowing what
+        # to say. Showing what it can do is the whole answer; silence used to
+        # be the answer, which reads as a broken bot.
+        return ParsedCommand(kind=CommandKind.HELP)
 
     tokens = text.split()
     kind, market, rest = _take_keyword(tokens)
     if kind is None:
-        return ParsedCommand(kind=CommandKind.UNKNOWN)
+        # Kakao only delivers group messages the bot was mentioned in, so
+        # anything that reaches here was aimed at the bot on purpose. Demanding
+        # a keyword on top of the mention makes the user say "this is for you"
+        # twice, and answering nothing when they get the grammar wrong is the
+        # worst outcome available.
+        return ParsedCommand(
+            kind=CommandKind.NATURAL,
+            query=text,
+            market=_infer_market(text),
+            resembles_ticker=_resembles_ticker(text),
+        )
 
     if kind is CommandKind.ASK:
         # A free-form question is prose, not arguments. "질문 미국 금리 언제
@@ -186,6 +209,24 @@ def _to_period(token: str) -> int | None:
         return int(match.group(1))
     except ValueError:
         return None
+
+
+def _resembles_ticker(text: str) -> bool:
+    """Is this one stock reference, rather than something said about one?
+
+    Deliberately strict, because the resolver matches substrings: handing it a
+    sentence risks "화장품" quietly resolving to whichever single stock happens
+    to contain that word, and a keyword-free utterance has no explicit intent
+    to justify that guess. One token, no sentence punctuation.
+
+    An explicit `리포트 …` keeps the forgiving path — asking for a report is
+    already an unambiguous intent, so a partial match there is helpful rather
+    than surprising.
+    """
+
+    if len(text.split()) != 1:
+        return False
+    return not _SENTENCE_MARK.search(text)
 
 
 def _infer_market(query: str | None) -> str | None:

--- a/kakao_bot/application/command_service.py
+++ b/kakao_bot/application/command_service.py
@@ -50,23 +50,51 @@ IMPLEMENTED_COMMANDS = frozenset(
 
 _HELP_LINES = {
     CommandKind.REPORT: (
-        " · 리포트 삼성전자 — 종목 분석 리포트\n"
-        " · 리포트 AAPL — 미국 종목은 티커로"
+        " · 삼성전자 — 종목 이름만 보내면 분석 리포트\n"
+        " · AAPL — 미국 종목은 티커로"
     ),
     CommandKind.EVALUATE: " · 평가 삼성전자 70000 6 — 평단가·보유개월 기준 평가",
-    CommandKind.ASK: " · 질문 오늘 시장 어때? — 시장·종목 자유 질문",
+    CommandKind.ASK: " · 오늘 시장 어때? — 그냥 물어보면 답변",
 }
+
+_HELP_FOOTER = "\n\n저를 멘션해서 편하게 말 걸어주세요. 명령어를 외울 필요 없어요."
+
+
+def leads_somewhere(utterance: str) -> bool:
+    """Would this text get a real answer if someone tapped it?
+
+    Card item titles are sent verbatim when tapped, so a title that parses into
+    a command we have not built is a dead end — the card promises something and
+    the bot replies "아직 준비 중인 기능입니다". Cards check their own titles
+    against this.
+
+    Keyword-free text always leads somewhere as long as either report or ask
+    exists, because that is what NATURAL resolves into.
+    """
+
+    kind = parse_command(utterance).kind
+    if kind is CommandKind.NATURAL:
+        return bool(
+            IMPLEMENTED_COMMANDS & {CommandKind.REPORT, CommandKind.ASK}
+        )
+    return kind in IMPLEMENTED_COMMANDS
 
 
 def help_text() -> str:
-    """Describe only the commands that are actually wired up."""
+    """Describe only the commands that are actually wired up.
+
+    Phrased as things to say rather than a command grammar, because there is no
+    grammar to learn any more: a stock name is a report, anything else is a
+    question. Teaching `리포트 …` here would be teaching a longer way to do the
+    same thing.
+    """
 
     lines = [
         text
         for kind, text in _HELP_LINES.items()
         if kind in IMPLEMENTED_COMMANDS
     ]
-    return "📊 PRISM 사용법\n" + "\n".join(lines)
+    return "📊 PRISM 사용법\n" + "\n".join(lines) + _HELP_FOOTER
 
 
 class CommandOutcomeKind(Enum):
@@ -117,15 +145,22 @@ class CommandService:
         command = parse_command(message.text)
 
         if command.kind is CommandKind.UNKNOWN:
-            # Group chatter reaches us only when the bot is addressed, so an
-            # unrecognized utterance is a real miss, not noise. Still, saying
-            # nothing is better than arguing with the room.
+            # Reserved for input that is not text at all. Anything a person
+            # typed now parses as NATURAL, because a mention is already an
+            # unambiguous request for the bot's attention.
             return CommandOutcome(kind=CommandOutcomeKind.IGNORED)
 
         if command.kind is CommandKind.HELP:
             return CommandOutcome(kind=CommandOutcomeKind.HELP, message=help_text())
 
-        if command.kind not in IMPLEMENTED_COMMANDS:
+        # A keyword-free utterance becomes a report or a question depending on
+        # whether it names a stock, and only the resolver knows that. Resolving
+        # it here — before the approval gate — would spend a lookup on a room
+        # that cannot use the answer, so the decision waits until after.
+        if (
+            command.kind is not CommandKind.NATURAL
+            and command.kind not in IMPLEMENTED_COMMANDS
+        ):
             return CommandOutcome(
                 kind=CommandOutcomeKind.REJECTED,
                 message=_NOT_READY,
@@ -157,10 +192,36 @@ class CommandService:
         if refusal is not None:
             return refusal
 
-        if command.kind is CommandKind.ASK:
+        kind = command.kind
+        resolution = None
+        if kind is CommandKind.NATURAL:
+            # "삼성전자" is a request for a report; "삼성전자 어때?" is a
+            # question. Only a bare stock reference is offered to the resolver,
+            # and anything it cannot place falls through to a question rather
+            # than to a refusal — a question can answer almost anything, so
+            # guessing wrong costs a slower answer, not a dead end.
+            if command.resembles_ticker:
+                resolution = self._resolver.resolve(
+                    command.query, market=command.market
+                )
+            kind = (
+                CommandKind.REPORT
+                if resolution is not None and resolution.succeeded
+                else CommandKind.ASK
+            )
+            if kind not in IMPLEMENTED_COMMANDS:
+                return CommandOutcome(
+                    kind=CommandOutcomeKind.REJECTED,
+                    message=_NOT_READY,
+                )
+
+        if kind is CommandKind.ASK:
             return self._enqueue_ask(message, command.query, moment)
 
-        resolution = self._resolver.resolve(command.query, market=command.market)
+        if resolution is None:
+            resolution = self._resolver.resolve(
+                command.query, market=command.market
+            )
         if not resolution.succeeded:
             return CommandOutcome(
                 kind=CommandOutcomeKind.REJECTED,

--- a/tests/test_kakao_ask.py
+++ b/tests/test_kakao_ask.py
@@ -169,7 +169,8 @@ def test_ask_is_actually_enabled():
     # The last switch. Without this the command parses, and then answers
     # "아직 준비 중인 기능입니다".
     assert CommandKind.ASK in IMPLEMENTED_COMMANDS
-    assert "질문" in help_text()
+    # Help advertises asking as a plain question now, not a keyword.
+    assert "물어보" in help_text() or "어때" in help_text()
 
 
 def test_ask_enqueues_without_touching_the_resolver(repository):

--- a/tests/test_kakao_command_parser.py
+++ b/tests/test_kakao_command_parser.py
@@ -168,7 +168,26 @@ class TestEvaluate:
     "utterance",
     ["", "   ", "안녕하세요", "오늘 날씨 어때", "@prism-test", None, 123],
 )
-def test_unrecognized_input_is_unknown_and_never_raises(utterance):
+def test_no_input_ever_raises(utterance):
+    parse_command(utterance)
+
+
+@pytest.mark.parametrize("utterance", ["", "   ", "@prism-test"])
+def test_reaching_for_the_bot_with_nothing_to_say_gets_help(utterance):
+    # Kakao strips the mention before delivery, so all of these arrive empty.
+    assert parse_command(utterance).kind is CommandKind.HELP
+
+
+@pytest.mark.parametrize("utterance", ["안녕하세요", "오늘 날씨 어때"])
+def test_keywordless_text_is_natural_rather_than_unknown(utterance):
+    # The bot only receives messages it was mentioned in, so text without a
+    # keyword is still someone talking to it. Answering nothing was the worst
+    # of the available options.
+    assert parse_command(utterance).kind is CommandKind.NATURAL
+
+
+@pytest.mark.parametrize("utterance", [None, 123])
+def test_only_non_text_is_unknown(utterance):
     command = parse_command(utterance)
 
     assert command.kind is CommandKind.UNKNOWN

--- a/tests/test_kakao_command_service.py
+++ b/tests/test_kakao_command_service.py
@@ -198,11 +198,15 @@ def test_help_is_answered_without_touching_the_room_gate(tmp_path):
         assert "리포트" in outcome.message
 
 
-def test_unrecognized_utterance_is_ignored_silently(repository, service):
+def test_text_without_a_keyword_is_answered_rather_than_ignored(
+    repository, service
+):
+    # Group rooms only deliver messages the bot was mentioned in, so silence
+    # here meant ignoring someone who had deliberately addressed the bot.
     outcome = service.handle(message("아무말"), now=NOW)
 
-    assert outcome.kind is CommandOutcomeKind.IGNORED
-    assert outcome.should_reply is False
+    assert outcome.should_reply is True
+    assert outcome.kind is not CommandOutcomeKind.IGNORED
 
 
 def test_not_yet_implemented_commands_say_so(repository, service):

--- a/tests/test_kakao_natural_commands.py
+++ b/tests/test_kakao_natural_commands.py
@@ -1,0 +1,217 @@
+"""Talking to the bot without knowing its grammar.
+
+Kakao only delivers a group message to the bot when the bot was mentioned, so
+everything that arrives was aimed at it on purpose. Requiring a keyword on top
+of that mention makes the user declare their intent twice, and the old parser
+answered *nothing* whenever the second declaration was missing or misspelled —
+`삼성전자`, `005930`, `오늘 코스피 어때?` and a bare mention were all silence.
+
+These tests pin the routing that replaced it: a bare stock reference is a
+report, anything else is a question, and nothing addressed to the bot goes
+unanswered.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from kakao_bot.adapters.persistence.sqlite import SQLiteKakaoRepository
+from kakao_bot.application.command_parser import CommandKind, parse_command
+from kakao_bot.application.command_service import (
+    CommandOutcomeKind,
+    CommandService,
+)
+from kakao_bot.domain.models import ApprovalStatus, InboundMessage
+from kakao_bot.ports.analysis import ResolvedTicker, TickerResolution
+
+NOW = datetime(2026, 8, 3, 5, 0, tzinfo=timezone.utc)
+ROOM = "room-1"
+
+_KNOWN = {
+    "삼성전자": ResolvedTicker(ticker="005930", company_name="삼성전자", market="kr"),
+    "005930": ResolvedTicker(ticker="005930", company_name="삼성전자", market="kr"),
+    "AAPL": ResolvedTicker(ticker="AAPL", company_name="AAPL", market="us"),
+}
+
+
+class MapResolver:
+    """Resolves the handful of names a test needs; records what it was asked."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def resolve(self, query: str, *, market: str | None) -> TickerResolution:
+        self.calls.append(query)
+        found = _KNOWN.get(query.strip())
+        if found is None:
+            return TickerResolution(error_message="종목을 찾을 수 없습니다.")
+        return TickerResolution(ticker=found)
+
+
+def message(text: str, *, user_id: str = "user-1") -> InboundMessage:
+    return InboundMessage(
+        event_id=f"evt-{text}-{user_id}",
+        sequence=1,
+        room_id=ROOM,
+        user_id=user_id,
+        nickname=None,
+        text=text,
+        callback_token="cb",
+        occurred_at=NOW,
+    )
+
+
+@pytest.fixture
+def repository(tmp_path):
+    with SQLiteKakaoRepository(tmp_path / "kakao.sqlite") as repo:
+        repo.discover_room(ROOM, discovered_at=NOW)
+        repo.set_room_approval(ROOM, ApprovalStatus.APPROVED)
+        yield repo
+
+
+@pytest.fixture
+def resolver():
+    return MapResolver()
+
+
+@pytest.fixture
+def service(repository, resolver):
+    return CommandService(repository, resolver)
+
+
+def kinds_of(repository) -> list[str]:
+    return [row["kind"] for row in repository.list_analysis_jobs()]
+
+
+class TestParsing:
+    @pytest.mark.parametrize(
+        "utterance",
+        ["삼성전자", "005930", "AAPL"],
+    )
+    def test_a_bare_stock_reference_is_offered_to_the_resolver(self, utterance):
+        command = parse_command(utterance)
+
+        assert command.kind is CommandKind.NATURAL
+        assert command.resembles_ticker is True
+        assert command.query == utterance
+
+    @pytest.mark.parametrize(
+        "utterance",
+        ["오늘 코스피 어때?", "삼성전자 어때?", "금리 내리면 뭐 사?", "안녕."],
+    )
+    def test_a_sentence_is_never_taken_for_a_stock_name(self, utterance):
+        # The resolver matches substrings, so handing it a sentence risks a
+        # word inside it quietly resolving to some unrelated stock.
+        command = parse_command(utterance)
+
+        assert command.kind is CommandKind.NATURAL
+        assert command.resembles_ticker is False
+
+    def test_a_bare_mention_asks_for_help_instead_of_saying_nothing(self):
+        # Kakao strips the mention, so reaching for the bot with nothing else
+        # arrives here as an empty string.
+        assert parse_command("").kind is CommandKind.HELP
+        assert parse_command("@프리즘 ").kind is CommandKind.HELP
+
+    def test_an_explicit_keyword_still_wins(self):
+        # Card taps send the item title, and those titles carry keywords.
+        assert parse_command("리포트 삼성전자").kind is CommandKind.REPORT
+        assert parse_command("질문 오늘 어때?").kind is CommandKind.ASK
+        assert parse_command("도움말").kind is CommandKind.HELP
+
+
+class TestRouting:
+    def test_a_stock_name_alone_starts_a_report(self, repository, service):
+        outcome = service.handle(message("삼성전자"), now=NOW)
+
+        assert outcome.kind is CommandOutcomeKind.ACCEPTED
+        assert outcome.company_name == "삼성전자"
+        assert kinds_of(repository) == ["report"]
+
+    def test_a_six_digit_code_alone_starts_a_report(self, repository, service):
+        service.handle(message("005930"), now=NOW)
+
+        assert kinds_of(repository) == ["report"]
+
+    def test_a_us_ticker_alone_starts_a_report(self, repository, service):
+        service.handle(message("AAPL"), now=NOW)
+
+        assert kinds_of(repository) == ["report"]
+
+    def test_a_question_becomes_a_question(self, repository, service):
+        outcome = service.handle(message("오늘 코스피 어때?"), now=NOW)
+
+        assert outcome.kind is CommandOutcomeKind.ACCEPTED
+        assert kinds_of(repository) == ["ask"]
+
+    def test_a_stock_inside_a_sentence_becomes_a_question(self, repository, service):
+        # A report takes minutes; an answer takes seconds and can still talk
+        # about the stock. Guessing this way costs less when it is wrong.
+        service.handle(message("삼성전자 어때?"), now=NOW)
+
+        assert kinds_of(repository) == ["ask"]
+
+    def test_a_sentence_is_never_sent_to_the_resolver(self, service, resolver):
+        service.handle(message("삼성전자 어때?"), now=NOW)
+
+        assert resolver.calls == []
+
+    def test_an_unknown_word_falls_through_to_a_question(
+        self, repository, service
+    ):
+        # Not a refusal: a question can answer almost anything, so an
+        # unrecognised word is still worth trying.
+        outcome = service.handle(message("안녕"), now=NOW)
+
+        assert outcome.kind is CommandOutcomeKind.ACCEPTED
+        assert kinds_of(repository) == ["ask"]
+
+    def test_the_whole_question_is_kept_not_just_the_leftovers(
+        self, repository, service
+    ):
+        service.handle(message("오늘 코스피 왜 빠졌어?"), now=NOW)
+
+        [job] = repository.list_analysis_jobs()
+        assert job["payload"]["question"] == "오늘 코스피 왜 빠졌어?"
+
+    def test_a_bare_mention_answers_with_help(self, service):
+        outcome = service.handle(message(""), now=NOW)
+
+        assert outcome.kind is CommandOutcomeKind.HELP
+        assert "리포트" in outcome.message
+
+    def test_nothing_addressed_to_the_bot_goes_unanswered(self, service):
+        # The old behaviour for all of these was IGNORED — total silence.
+        for text in ["삼성전자", "오늘 코스피 어때?", "안녕", ""]:
+            outcome = service.handle(message(text, user_id=f"u-{text}"), now=NOW)
+            assert outcome.should_reply, text
+
+    def test_an_unapproved_room_is_still_refused(self, tmp_path, resolver):
+        # Natural phrasing must not become a way around the approval gate.
+        with SQLiteKakaoRepository(tmp_path / "k.sqlite") as repo:
+            repo.discover_room("other", discovered_at=NOW)
+            outcome = CommandService(repo, resolver).handle(
+                InboundMessage(
+                    event_id="e",
+                    sequence=1,
+                    room_id="other",
+                    user_id="u",
+                    nickname=None,
+                    text="삼성전자",
+                    callback_token="cb",
+                    occurred_at=NOW,
+                ),
+                now=NOW,
+            )
+
+        assert outcome.kind is CommandOutcomeKind.REJECTED
+        assert "승인" in outcome.message
+
+    def test_natural_input_counts_against_the_same_quota(self, repository, service):
+        for i in range(6):
+            service.handle(message(f"오늘 뭐 사면 좋을까 {i}?", user_id="same"), now=NOW)
+
+        # Five per user per day; the sixth is refused rather than enqueued.
+        assert len(repository.list_analysis_jobs()) == 5

--- a/tests/test_kakao_report_renderer.py
+++ b/tests/test_kakao_report_renderer.py
@@ -133,15 +133,14 @@ def test_follow_up_item_titles_are_commands_that_actually_work():
     a card headed "이어서 해보기" answered "아직 준비 중인 기능입니다" twice.
     """
 
-    from kakao_bot.application.command_service import IMPLEMENTED_COMMANDS
+    from kakao_bot.application.command_service import leads_somewhere
 
     response = render_report_delivery(delivery("analysis_result", result_payload()))
     items = outputs(response)[1]["listCard"]["items"]
 
     assert items, "the card must offer at least one next step"
     for item in items:
-        kind = parse_command(item["title"]).kind
-        assert kind in IMPLEMENTED_COMMANDS, f"{item['title']!r} goes nowhere"
+        assert leads_somewhere(item["title"]), f"{item['title']!r} goes nowhere"
 
 
 def test_a_mention_button_lets_the_user_ask_about_another_stock():

--- a/tests/test_kakao_room_onboarding.py
+++ b/tests/test_kakao_room_onboarding.py
@@ -198,7 +198,9 @@ class TestWelcomeRendering:
 
         card = response["template"]["outputs"][1]["listCard"]
         titles = [item["title"] for item in card["items"]]
-        assert any("리포트" in title for title in titles)
+        # Titles are written the way we want people to type: a bare stock
+        # name, not a command spelling.
+        assert "삼성전자" in titles
 
     def test_the_greeting_only_offers_commands_that_work(self):
         # Reuses the help card, which reads IMPLEMENTED_COMMANDS, so it cannot


### PR DESCRIPTION
## 문제

정확한 주문을 외워야만 답했습니다. 실측:

```
'삼성전자'         -> unknown -> 침묵
'005930'          -> unknown -> 침묵
'오늘 코스피 어때?'  -> unknown -> 침묵
''  (멘션만)       -> unknown -> 침묵
'리포트 삼성전자'    -> report  ✅
```

침묵의 근거는 "인식 못 한 발화에 방을 상대로 따지느니 조용한 게 낫다" 였습니다.
**그 전제가 사실과 다릅니다.** 실계정 검증 §2 — 그룹방은 멘션된 메시지만
전달합니다. 잡담은 애초에 안 옵니다. 여기 도달한 모든 발화는 봇을 향해 한
말인데, 굳이 멘션까지 해서 말을 걸었더니 아무 반응이 없던 겁니다.

같은 이유로 키워드도 중복입니다. 멘션이 이미 "너한테 말한다"를 했는데
`리포트` 가 같은 일을 또 합니다.

## 바뀐 것

키워드는 **선택사항**이 됩니다.

```
@봇 삼성전자        -> 리포트
@봇 005930         -> 리포트
@봇 AAPL           -> 리포트
@봇 오늘 코스피 어때?  -> 질문
@봇 삼성전자 어때?    -> 질문
@봇 (멘션만)        -> 도움말
@봇 리포트 삼성전자   -> 리포트  (키워드가 있으면 그대로 이김)
```

카드 탭이 title 을 발화로 보내므로 키워드 경로는 반드시 유지합니다.

## 안전장치

**모양 판정을 먼저 겁니다.** resolver 가 부분 문자열로 매칭하므로 문장을 그대로
넘기면 문장 속 한 단어가 엉뚱한 종목으로 조용히 해석될 수 있습니다. 키워드 없는
입력은 **한 토큰이고 문장부호가 없을 때만** resolver 를 태웁니다.

해석 실패는 거절이 아니라 **질문으로 흘립니다.** 잘못 추측해도 비용이 "느린 답"
이지 막다른 길이 아닙니다.

승인 게이트·일일 한도는 그대로 적용됩니다(테스트로 고정).

## 문구도 같이

탭하면 title 이 그대로 발화되므로, title 이 `리포트 삼성전자` 면 사용자가 그
문법을 계속 쓰게 됩니다. 이제 title 은 우리가 바라는 입력 그대로입니다.

검증: 295 passed (신규 21), ruff All checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)