### PR TITLE
feat(kakao): 평가 커맨드 — 검색이 아니라 평가 에이전트로

### DIFF
--- a/kakao_bot/adapters/kakao/delivery_renderer.py
+++ b/kakao_bot/adapters/kakao/delivery_renderer.py
@@ -15,6 +15,8 @@ from kakao_bot.adapters.kakao.report_renderer import (
     ANALYSIS_RESULT,
     ASK_FAILED,
     ASK_RESULT,
+    EVALUATE_FAILED,
+    EVALUATE_RESULT,
     render_report_delivery,
 )
 from kakao_bot.adapters.kakao.welcome_renderer import (
@@ -24,7 +26,16 @@ from kakao_bot.adapters.kakao.welcome_renderer import (
 from kakao_bot.domain.models import ClaimedOutboundDelivery
 
 CAMPAIGN_TYPES = frozenset({"signal_campaign", "campaign_rest_notice"})
-REPORT_TYPES = frozenset({ANALYSIS_RESULT, ANALYSIS_FAILED, ASK_RESULT, ASK_FAILED})
+REPORT_TYPES = frozenset(
+    {
+        ANALYSIS_RESULT,
+        ANALYSIS_FAILED,
+        ASK_RESULT,
+        ASK_FAILED,
+        EVALUATE_RESULT,
+        EVALUATE_FAILED,
+    }
+)
 LIFECYCLE_TYPES = frozenset({ROOM_WELCOME})
 
 SUPPORTED_TYPES = CAMPAIGN_TYPES | REPORT_TYPES | LIFECYCLE_TYPES

--- a/kakao_bot/adapters/kakao/report_renderer.py
+++ b/kakao_bot/adapters/kakao/report_renderer.py
@@ -30,6 +30,8 @@ ANALYSIS_RESULT = "analysis_result"
 ANALYSIS_FAILED = "analysis_failed"
 ASK_RESULT = "ask_result"
 ASK_FAILED = "ask_failed"
+EVALUATE_RESULT = "evaluate_result"
+EVALUATE_FAILED = "evaluate_failed"
 
 _SUMMARY_BUDGET = MAX_SIMPLE_TEXT_LENGTH - 120  # leave room for the header
 # The echoed question is a header, so it has to fit inside that same slack.
@@ -62,6 +64,10 @@ def render_report_delivery(
         return _ask_result(delivery.payload)
     if delivery.message_type == ASK_FAILED:
         return _ask_failed(delivery.payload)
+    if delivery.message_type == EVALUATE_RESULT:
+        return _evaluate_result(delivery.payload)
+    if delivery.message_type == EVALUATE_FAILED:
+        return _evaluate_failed(delivery.payload)
     raise ValueError(f"unsupported Kakao delivery type: {delivery.message_type}")
 
 
@@ -99,6 +105,53 @@ def _failed(payload: Mapping[str, object]) -> dict[str, object]:
             _next_actions(ticker, company_name),
         ]
     )
+
+
+def _evaluate_result(payload: Mapping[str, object]) -> dict[str, object]:
+    """Render a verdict on someone's holding.
+
+    The header repeats the entry price back. In a group room the answer lands
+    minutes after the request, and "삼성전자 평가" alone would leave everyone —
+    including the person who asked — unsure which position it is about.
+    """
+
+    ticker = _required_text(payload, "ticker")
+    company_name = _required_text(payload, "company_name")
+    verdict = payload.get("verdict")
+    body = _condense(verdict if isinstance(verdict, str) else "")
+    if not body:
+        return _evaluate_failed(payload)
+
+    header = f"🧮 {company_name} ({ticker}) 평가{_position_suffix(payload)}"
+    return skill_response(
+        [
+            simple_text_output(f"{header}\n\n{body}"[:MAX_SIMPLE_TEXT_LENGTH]),
+            _next_actions(ticker, company_name),
+        ]
+    )
+
+
+def _evaluate_failed(payload: Mapping[str, object]) -> dict[str, object]:
+    ticker = _required_text(payload, "ticker")
+    company_name = _required_text(payload, "company_name")
+    return skill_response(
+        [
+            simple_text_output(
+                f"⚠️ {company_name} ({ticker}) 평가에 실패했습니다.\n"
+                "잠시 후 다시 시도해주세요."
+            ),
+            _next_actions(ticker, company_name),
+        ]
+    )
+
+
+def _position_suffix(payload: Mapping[str, object]) -> str:
+    avg_price = payload.get("avg_price")
+    if not isinstance(avg_price, (int, float)):
+        return ""
+    months = payload.get("period_months")
+    held = f" · {months}개월 보유" if isinstance(months, int) else ""
+    return f"\n평단 {avg_price:,.0f}{held}"
 
 
 def _ask_result(payload: Mapping[str, object]) -> dict[str, object]:
@@ -186,10 +239,14 @@ def _next_actions(
 
     items: list[dict[str, object]] = []
     if CommandKind.EVALUATE in IMPLEMENTED_COMMANDS:
+        # Tapping sends this title as-is, which is deliberately incomplete: the
+        # bot replies asking for the price, showing the exact line to copy. A
+        # card cannot prefill part of the input box (`messageText` is ignored),
+        # so one refusal that teaches the format is the shortest honest path.
         items.append(
             {
-                "title": f"{company_name} 평가",
-                "description": "평단가와 보유 개월을 붙여 보내주세요",
+                "title": f"평가 {company_name}",
+                "description": "내 평단가 기준으로 평가받기",
                 "action": "message",
                 "messageText": f"평가 {company_name}",
             }

--- a/kakao_bot/adapters/prism/report_adapter.py
+++ b/kakao_bot/adapters/prism/report_adapter.py
@@ -23,9 +23,28 @@ GENERATION_ERROR = "generation_error"
 ASK_EMPTY = "ask_empty"
 ASK_ERROR = "ask_error"
 ASK_TIMEOUT = "ask_timeout"
+EVALUATE_EMPTY = "evaluate_empty"
+EVALUATE_ERROR = "evaluate_error"
+EVALUATE_TIMEOUT = "evaluate_timeout"
+
+# `generate_evaluation_response` swallows its own exceptions and returns this
+# apology as ordinary text. Delivered as-is it would look like a considered
+# answer and would never be retried, so it is recognised and turned back into a
+# failure. Coupled to a message on purpose — the alternative is shipping "죄송
+#합니다" into a chat room as the final word on someone's position.
+_EVALUATION_FAILURE_MARK = "평가 중 오류가 발생했습니다"
+
+# Telegram asks for these; a group chat cannot afford the extra round trips, so
+# the command carries three arguments and these stand in for the rest.
+DEFAULT_TONE = "친근한 투자 동료처럼, 근거는 짚어주되 길지 않게"
+DEFAULT_BACKGROUND = ""
 
 # Telegram's /ask allows 240s for the same work.
 _ASK_TIMEOUT = 240
+# Evaluation runs several MCP tool calls (price series, investor flows, one
+# search) before it writes, so it needs more room than a single search does.
+_EVALUATE_TIMEOUT = 420
+_DEFAULT_PERIOD_MONTHS = 6
 
 # Telegram's /ask answers in 3000 characters; Kakao's bubble is far smaller and
 # the renderer condenses anyway, but asking for less up front keeps the model
@@ -50,7 +69,7 @@ class PrismReportAdapter:
     ) -> AnalysisOutcome:
         try:
             artifact = generate_report(ticker, company_name, market=market)
-        except Exception as exc:  # noqa: BLE001 - worker records and moves on
+        except Exception as exc:  # worker records the failure and moves on
             logger.exception("Report generation raised for %s", ticker)
             return AnalysisOutcome(
                 succeeded=False,
@@ -80,7 +99,7 @@ class PrismReportAdapter:
         except FuturesTimeoutError:
             logger.warning("Ask timed out after %ss: %r", _ASK_TIMEOUT, question[:80])
             return AnalysisOutcome(succeeded=False, error_code=ASK_TIMEOUT)
-        except Exception as exc:  # noqa: BLE001 - worker records and moves on
+        except Exception as exc:  # worker records the failure and moves on
             logger.exception("Ask failed for %r", question[:80])
             return AnalysisOutcome(
                 succeeded=False,
@@ -90,6 +109,57 @@ class PrismReportAdapter:
 
         if not text or not text.strip():
             return AnalysisOutcome(succeeded=False, error_code=ASK_EMPTY)
+        return AnalysisOutcome(succeeded=True, summary=text)
+
+    def evaluate(
+        self,
+        ticker: str,
+        company_name: str,
+        *,
+        market: str,
+        avg_price: float,
+        period_months: int | None,
+        tone: str,
+        background: str,
+    ) -> AnalysisOutcome:
+        """Evaluate a holding through Prism's own evaluation agent.
+
+        Not the ask path. That one reads the web; this one has to state a
+        return against `avg_price`, which needs the real price series and
+        investor flows. Routing it through search would invite a plausible
+        invented number, and a wrong number about someone's own money is the
+        most expensive mistake this bot can make.
+        """
+
+        try:
+            future = asyncio.run_coroutine_threadsafe(
+                _evaluate(
+                    ticker,
+                    company_name,
+                    market=market,
+                    avg_price=avg_price,
+                    period_months=period_months,
+                    tone=tone or DEFAULT_TONE,
+                    background=background or DEFAULT_BACKGROUND,
+                ),
+                _ask_loop(),
+            )
+            text = future.result(timeout=_EVALUATE_TIMEOUT)
+        except FuturesTimeoutError:
+            logger.warning("Evaluation timed out for %s", ticker)
+            return AnalysisOutcome(succeeded=False, error_code=EVALUATE_TIMEOUT)
+        except Exception as exc:  # worker records the failure and moves on
+            logger.exception("Evaluation failed for %s", ticker)
+            return AnalysisOutcome(
+                succeeded=False,
+                error_code=EVALUATE_ERROR,
+                summary=str(exc)[:500],
+            )
+
+        if not text or not text.strip():
+            return AnalysisOutcome(succeeded=False, error_code=EVALUATE_EMPTY)
+        if _EVALUATION_FAILURE_MARK in text:
+            return AnalysisOutcome(succeeded=False, error_code=EVALUATE_ERROR)
         return AnalysisOutcome(succeeded=True, summary=text)
 
 
@@ -124,6 +194,46 @@ def _ask_loop() -> asyncio.AbstractEventLoop:
         return _loop
 
 
+async def _evaluate(
+    ticker: str,
+    company_name: str,
+    *,
+    market: str,
+    avg_price: float,
+    period_months: int | None,
+    tone: str,
+    background: str,
+) -> str | None:
+    """One evaluation. KR and US have separate agents with the same shape.
+
+    Imported inside the coroutine for the same reason as `_ask`: these modules
+    drag in the whole Prism data stack, and a worker that only ever handles
+    reports should not pay for it.
+    """
+
+    from report_generator import (
+        generate_evaluation_response,
+        generate_us_evaluation_response,
+    )
+
+    responder = (
+        generate_us_evaluation_response
+        if market == "us"
+        else generate_evaluation_response
+    )
+    return await responder(
+        ticker,
+        company_name,
+        avg_price,
+        # The agent reads this as months and the prompt branches on it (short
+        # holdings get technical framing, long ones fundamentals), so a missing
+        # period becomes the neutral middle rather than zero.
+        period_months if period_months is not None else _DEFAULT_PERIOD_MONTHS,
+        tone,
+        background,
+    )
+
+
 async def _ask(question: str) -> str | None:
     """Retrieval + analysis for one question.
 
@@ -136,7 +246,9 @@ async def _ask(question: str) -> str | None:
     from cores.search_presets import search_preset
     from report_generator import generate_firecrawl_search_response
 
-    today = datetime.now().strftime("%Y년 %m월 %d일")
+    # Local time on purpose: this is the date the user and the market are
+    # living in, not a timestamp to be compared across zones.
+    today = datetime.now().strftime("%Y년 %m월 %d일")  # noqa: DTZ005
     prompt = (
         f"오늘은 {today}입니다. 다음 투자 관련 질문에 대해 최신 정보를 기반으로 답변해줘:\n\n"
         f"{question}\n\n"

--- a/kakao_bot/application/analysis_service.py
+++ b/kakao_bot/application/analysis_service.py
@@ -23,6 +23,7 @@ _TOKEN_BYTES = 32
 # `AnalysisJob.kind` for a free-form question. Anything else is a report, which
 # is what every job was before ask existed.
 ASK_KIND = "ask"
+EVALUATE_KIND = "evaluate"
 
 
 @dataclass(frozen=True)
@@ -73,7 +74,7 @@ class AnalysisService:
                 now=now,
                 expires_at=now + self._link_ttl,
             )
-        except Exception:  # noqa: BLE001 - a missing link must not lose the report
+        except Exception:  # a missing link must not cost us the report
             logger.exception("Could not mint a report link for %s", job.job_id)
             return None
         return token
@@ -103,16 +104,31 @@ class AnalysisService:
 
         for job in jobs:
             is_ask = job.kind == ASK_KIND
+            is_evaluate = job.kind == EVALUATE_KIND
             try:
                 if is_ask:
                     outcome = self._analysis.answer(_question_of(job))
+                elif is_evaluate:
+                    payload = job.payload or {}
+                    outcome = self._analysis.evaluate(
+                        job.ticker,
+                        job.company_name,
+                        market=job.market,
+                        avg_price=float(payload.get("avg_price") or 0.0),
+                        period_months=payload.get("period_months"),
+                        # Empty is meaningful: the adapter owns the default
+                        # tone, because the tone only means anything to the
+                        # prompt that consumes it.
+                        tone=str(payload.get("tone") or ""),
+                        background="",
+                    )
                 else:
                     outcome = self._analysis.generate(
                         job.ticker,
                         job.company_name,
                         market=job.market,
                     )
-            except Exception as exc:  # noqa: BLE001 - transient vs. permanent below
+            except Exception as exc:  # noqa: BLE001 - transient vs permanent below
                 if job.attempt_count >= self._max_attempts:
                     error_code = str(exc) or type(exc).__name__
                     self._repository.fail_analysis_job(
@@ -144,6 +160,17 @@ class AnalysisService:
                         "job_id": job.job_id,
                         "question": _question_of(job),
                         "answer": summary[:_SUMMARY_PAYLOAD_LIMIT],
+                    }
+                elif is_evaluate:
+                    message_type = "evaluate_result"
+                    payload = {
+                        "job_id": job.job_id,
+                        "ticker": job.ticker,
+                        "company_name": job.company_name,
+                        "avg_price": (job.payload or {}).get("avg_price"),
+                        "period_months": (job.payload or {}).get("period_months"),
+                        "verdict": summary[:_SUMMARY_PAYLOAD_LIMIT],
+                        "market": job.market,
                     }
                 else:
                     message_type = "analysis_result"
@@ -180,6 +207,14 @@ class AnalysisService:
                     failure: dict[str, object] = {
                         "job_id": job.job_id,
                         "question": _question_of(job),
+                        "error_code": error_code,
+                    }
+                elif is_evaluate:
+                    message_type = "evaluate_failed"
+                    failure = {
+                        "job_id": job.job_id,
+                        "ticker": job.ticker,
+                        "company_name": job.company_name,
                         "error_code": error_code,
                     }
                 else:

--- a/kakao_bot/application/command_parser.py
+++ b/kakao_bot/application/command_parser.py
@@ -80,6 +80,8 @@ class ParsedCommand:
     market: str | None = None
     avg_price: float | None = None
     period_months: int | None = None
+    # Free text after the numbers on an evaluate: the requested feedback style.
+    tone: str | None = None
     # Only meaningful for NATURAL: whether the text is shaped like a single
     # stock reference and is therefore worth handing to the resolver. A whole
     # sentence is not, so "삼성전자 어때?" never becomes a report request.
@@ -166,31 +168,46 @@ def _take_market_hint(tokens: list[str]) -> tuple[str | None, list[str]]:
 
 
 def _parse_evaluate(market: str | None, tokens: list[str]) -> ParsedCommand:
-    """``평가 <종목> <평단가> [기간]`` — trailing numbers are the arguments."""
+    """``평가 <종목> <평단가> [기간] [말투]``.
 
+    The numbers are located rather than taken off the end, because anything
+    after them is a requested tone — "평가 삼성전자 70000 6 취한 친구처럼".
+    Reading from the end would see "친구처럼", find no number, and silently
+    drop the price the user did supply.
+    """
+
+    stock: list[str] = []
     numbers: list[str] = []
-    while tokens and (_NUMERIC.match(tokens[-1]) or _PERIOD.match(tokens[-1])):
-        # A six-digit KR code is a ticker, not a price.
-        if _KR_CODE.match(tokens[-1]) and len(numbers) >= 1:
-            break
-        numbers.insert(0, tokens.pop())
-        if len(numbers) == 2:
-            break
+    tone: list[str] = []
 
-    avg_price: float | None = None
-    period: int | None = None
-    if numbers:
-        avg_price = _to_price(numbers[0])
-    if len(numbers) == 2:
-        period = _to_period(numbers[1])
+    for index, token in enumerate(tokens):
+        if numbers:
+            # Past the numbers: a second number is the holding period, anything
+            # else begins the tone.
+            if len(numbers) < 2 and _PERIOD.match(token):
+                numbers.append(token)
+            else:
+                tone = tokens[index:]
+                break
+            continue
+        # A six-digit KR code is a ticker, not a price, and a price cannot come
+        # before the stock it belongs to.
+        if stock and _NUMERIC.match(token) and not _KR_CODE.match(token):
+            numbers.append(token)
+            continue
+        stock.append(token)
 
-    query = " ".join(tokens).strip() or None
+    avg_price = _to_price(numbers[0]) if numbers else None
+    period = _to_period(numbers[1]) if len(numbers) == 2 else None
+
+    query = " ".join(stock).strip() or None
     return ParsedCommand(
         kind=CommandKind.EVALUATE,
         query=query,
         market=market or _infer_market(query),
         avg_price=avg_price,
         period_months=period,
+        tone=" ".join(tone).strip() or None,
     )
 
 

--- a/kakao_bot/application/command_service.py
+++ b/kakao_bot/application/command_service.py
@@ -34,6 +34,10 @@ _USER_LIMIT = "오늘 요청 한도를 모두 사용했습니다. 내일 다시 
 _ROOM_LIMIT = "이 채팅방의 오늘 요청 한도를 모두 사용했습니다."
 _NEED_TICKER = "종목을 함께 알려주세요. 예: 리포트 삼성전자"
 _NEED_QUESTION = "궁금한 내용을 함께 적어주세요. 예: 질문 오늘 코스피 왜 빠졌어?"
+_NEED_AVG_PRICE = (
+    "평단가를 함께 알려주세요.\n예: 평가 {stock} 70000 6\n"
+    "(종목 · 평단가 · 보유개월 순서, 보유개월은 생략해도 됩니다)"
+)
 _NOT_READY = "아직 준비 중인 기능입니다."
 
 # Telegram's /ask truncates at the same length; a question longer than this is
@@ -45,7 +49,12 @@ _QUESTION_LIMIT = 500
 # "이어서 해보기" and both of its items answered "아직 준비 중인 기능입니다".
 # Add a kind here only when it is wired end to end.
 IMPLEMENTED_COMMANDS = frozenset(
-    {CommandKind.REPORT, CommandKind.ASK, CommandKind.HELP}
+    {
+        CommandKind.REPORT,
+        CommandKind.ASK,
+        CommandKind.EVALUATE,
+        CommandKind.HELP,
+    }
 )
 
 _HELP_LINES = {
@@ -53,7 +62,7 @@ _HELP_LINES = {
         " · 삼성전자 — 종목 이름만 보내면 분석 리포트\n"
         " · AAPL — 미국 종목은 티커로"
     ),
-    CommandKind.EVALUATE: " · 평가 삼성전자 70000 6 — 평단가·보유개월 기준 평가",
+    CommandKind.EVALUATE: " · 평가 삼성전자 70000 6 — 내 평단가 기준으로 평가",
     CommandKind.ASK: " · 오늘 시장 어때? — 그냥 물어보면 답변",
 }
 
@@ -218,6 +227,15 @@ class CommandService:
         if kind is CommandKind.ASK:
             return self._enqueue_ask(message, command.query, moment)
 
+        if kind is CommandKind.EVALUATE and command.avg_price is None:
+            # Not a refusal with nothing after it: the user already named the
+            # stock, so tell them the one thing still missing and show it in
+            # their own words.
+            return CommandOutcome(
+                kind=CommandOutcomeKind.REJECTED,
+                message=_NEED_AVG_PRICE.format(stock=command.query),
+            )
+
         if resolution is None:
             resolution = self._resolver.resolve(
                 command.query, market=command.market
@@ -229,6 +247,7 @@ class CommandService:
             )
 
         resolved = resolution.ticker
+        is_evaluate = kind is CommandKind.EVALUATE
         job = AnalysisJob(
             job_id=str(uuid.uuid4()),
             room_id=message.room_id,
@@ -236,15 +255,36 @@ class CommandService:
             ticker=resolved.ticker,
             company_name=resolved.company_name,
             market=resolved.market,
+            kind="evaluate" if is_evaluate else "report",
+            payload=(
+                {
+                    "avg_price": command.avg_price,
+                    "period_months": command.period_months,
+                    # Whatever was left after the numbers were taken off the
+                    # end is the requested tone: "평가 삼성전자 70000 6 취한
+                    # 친구처럼". Empty means the default.
+                    "tone": command.tone or "",
+                }
+                if is_evaluate
+                else None
+            ),
         )
         self._repository.enqueue_analysis_job(job, now=moment)
 
-        return CommandOutcome(
-            kind=CommandOutcomeKind.ACCEPTED,
-            message=(
+        if is_evaluate:
+            ack = (
+                f"🧮 {resolved.company_name} ({resolved.ticker}) 평가를 시작했습니다.\n"
+                "완료되면 이 방으로 결과를 보내드릴게요."
+            )
+        else:
+            ack = (
                 f"📊 {resolved.company_name} ({resolved.ticker}) 분석을 시작했습니다.\n"
                 "완료되면 이 방으로 결과를 보내드릴게요."
-            ),
+            )
+
+        return CommandOutcome(
+            kind=CommandOutcomeKind.ACCEPTED,
+            message=ack,
             job_id=job.job_id,
             ticker=resolved.ticker,
             company_name=resolved.company_name,

--- a/kakao_bot/ports/analysis.py
+++ b/kakao_bot/ports/analysis.py
@@ -68,3 +68,23 @@ class AnalysisPort(Protocol):
         There is no ticker and no PDF — the answer arrives whole in
         ``summary``. Blocking, like :meth:`generate`.
         """
+
+    def evaluate(
+        self,
+        ticker: str,
+        company_name: str,
+        *,
+        market: str,
+        avg_price: float,
+        period_months: int | None,
+        tone: str,
+        background: str,
+    ) -> AnalysisOutcome:
+        """Judge a holding against its entry price.
+
+        Distinct from :meth:`answer` on purpose. This one has to state a
+        return, so it needs the actual price series and flow data rather than
+        whatever the web happens to say — a number invented from search results
+        would be worse than no answer. No PDF; the verdict arrives in
+        ``summary``. Blocking, like the rest.
+        """

--- a/tests/test_kakao_command_service.py
+++ b/tests/test_kakao_command_service.py
@@ -209,8 +209,25 @@ def test_text_without_a_keyword_is_answered_rather_than_ignored(
     assert outcome.kind is not CommandOutcomeKind.IGNORED
 
 
-def test_not_yet_implemented_commands_say_so(repository, service):
-    outcome = service.handle(message("평가 삼성전자 70000 6"), now=NOW)
+def test_a_command_that_is_not_wired_up_says_so(repository, service):
+    """Every parsed kind is implemented today, so this checks the gate itself.
 
-    assert outcome.kind is CommandOutcomeKind.REJECTED
-    assert "준비" in outcome.message
+    The gate is what stops help and cards from advertising a command that
+    answers "아직 준비 중인 기능입니다"; it has to keep working for whatever
+    lands in the parser next.
+    """
+
+    from kakao_bot.application.command_parser import CommandKind
+    from kakao_bot.application.command_service import IMPLEMENTED_COMMANDS
+
+    unimplemented = {
+        kind
+        for kind in CommandKind
+        if kind
+        not in IMPLEMENTED_COMMANDS
+        | {CommandKind.UNKNOWN, CommandKind.NATURAL}
+    }
+    assert not unimplemented, (
+        f"{sorted(k.value for k in unimplemented)} parses but has no handler; "
+        "either wire it up or keep it out of the parser"
+    )

--- a/tests/test_kakao_evaluate.py
+++ b/tests/test_kakao_evaluate.py
@@ -1,0 +1,381 @@
+"""The `평가` command: judging a holding against its entry price.
+
+Deliberately not routed through ask. Ask reads the web; this has to state a
+return against a price the user gave us, which needs the real series and flow
+data. A number invented from search results, about someone's own money, is the
+most expensive mistake this bot can make — so the split is pinned here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from kakao_bot.adapters.kakao.delivery_renderer import render_delivery
+from kakao_bot.adapters.persistence.sqlite import SQLiteKakaoRepository
+from kakao_bot.application.analysis_service import AnalysisService
+from kakao_bot.application.command_parser import CommandKind, parse_command
+from kakao_bot.application.command_service import (
+    IMPLEMENTED_COMMANDS,
+    CommandOutcomeKind,
+    CommandService,
+)
+from kakao_bot.domain.models import (
+    ApprovalStatus,
+    ClaimedOutboundDelivery,
+    InboundMessage,
+)
+from kakao_bot.ports.analysis import AnalysisOutcome, ResolvedTicker, TickerResolution
+
+NOW = datetime(2026, 8, 4, 5, 0, tzinfo=timezone.utc)
+ROOM = "room-1"
+
+
+class FakeResolver:
+    def resolve(self, query: str, *, market: str | None) -> TickerResolution:
+        if market == "us":
+            return TickerResolution(
+                ticker=ResolvedTicker(ticker="AAPL", company_name="AAPL", market="us")
+            )
+        return TickerResolution(
+            ticker=ResolvedTicker(
+                ticker="005930", company_name="삼성전자", market="kr"
+            )
+        )
+
+
+class SpyAnalysis:
+    """Records which port method the worker reached for."""
+
+    def __init__(self, outcome: AnalysisOutcome | None = None) -> None:
+        self.outcome = outcome or AnalysisOutcome(
+            succeeded=True, summary="지금 12% 수익 중이야. 절반은 익절해도 좋아 보여."
+        )
+        self.evaluate_calls: list[dict] = []
+        self.generate_calls: list[tuple] = []
+        self.answer_calls: list[str] = []
+
+    def generate(self, ticker, company_name, *, market):
+        self.generate_calls.append((ticker, company_name, market))
+        return self.outcome
+
+    def answer(self, question):
+        self.answer_calls.append(question)
+        return self.outcome
+
+    def evaluate(
+        self,
+        ticker,
+        company_name,
+        *,
+        market,
+        avg_price,
+        period_months,
+        tone,
+        background,
+    ):
+        self.evaluate_calls.append(
+            {
+                "ticker": ticker,
+                "company_name": company_name,
+                "market": market,
+                "avg_price": avg_price,
+                "period_months": period_months,
+                "tone": tone,
+                "background": background,
+            }
+        )
+        return self.outcome
+
+
+def message(text: str, *, user_id: str = "user-1") -> InboundMessage:
+    return InboundMessage(
+        event_id=f"evt-{text}-{user_id}",
+        sequence=1,
+        room_id=ROOM,
+        user_id=user_id,
+        nickname=None,
+        text=text,
+        callback_token="cb",
+        occurred_at=NOW,
+    )
+
+
+def delivery(message_type: str, payload: dict) -> ClaimedOutboundDelivery:
+    return ClaimedOutboundDelivery(
+        delivery_key="d-1",
+        room_id=ROOM,
+        message_type=message_type,
+        payload=payload,
+        attempt_count=1,
+        lease_owner="worker-1",
+        lease_expires_at=NOW,
+        created_at=NOW,
+    )
+
+
+@pytest.fixture
+def repository(tmp_path):
+    with SQLiteKakaoRepository(tmp_path / "kakao.sqlite") as repo:
+        repo.discover_room(ROOM, discovered_at=NOW)
+        repo.set_room_approval(ROOM, ApprovalStatus.APPROVED)
+        yield repo
+
+
+@pytest.fixture
+def service(repository):
+    return CommandService(repository, FakeResolver())
+
+
+class TestParsing:
+    def test_stock_price_and_period(self):
+        command = parse_command("평가 삼성전자 70000 6")
+
+        assert command.kind is CommandKind.EVALUATE
+        assert (command.query, command.avg_price, command.period_months) == (
+            "삼성전자",
+            70000.0,
+            6,
+        )
+
+    def test_the_period_may_be_left_out(self):
+        command = parse_command("평가 삼성전자 70000")
+
+        assert command.avg_price == 70000.0
+        assert command.period_months is None
+
+    def test_a_six_digit_code_is_the_stock_not_the_price(self):
+        command = parse_command("평가 005930 70000 6")
+
+        assert command.query == "005930"
+        assert command.avg_price == 70000.0
+
+    def test_trailing_words_are_a_requested_tone(self):
+        # Reading numbers from the end would see "친구처럼", find no number,
+        # and silently drop the price the user did supply.
+        command = parse_command("평가 삼성전자 70000 6 취한 친구처럼")
+
+        assert command.avg_price == 70000.0
+        assert command.period_months == 6
+        assert command.tone == "취한 친구처럼"
+
+    def test_us_keywords_carry_the_market(self):
+        command = parse_command("us평가 TSLA 300 12 냉정하게")
+
+        assert command.market == "us"
+        assert (command.avg_price, command.period_months) == (300.0, 12)
+        assert command.tone == "냉정하게"
+
+
+class TestEnqueue:
+    def test_evaluate_is_actually_enabled(self):
+        assert CommandKind.EVALUATE in IMPLEMENTED_COMMANDS
+
+    def test_an_evaluate_becomes_an_evaluate_job(self, repository, service):
+        outcome = service.handle(message("평가 삼성전자 70000 6"), now=NOW)
+
+        assert outcome.kind is CommandOutcomeKind.ACCEPTED
+        [job] = repository.list_analysis_jobs()
+        assert job["kind"] == "evaluate"
+        assert job["ticker"] == "005930"
+        assert job["payload"]["avg_price"] == 70000.0
+        assert job["payload"]["period_months"] == 6
+
+    def test_the_tone_travels_with_the_job(self, repository, service):
+        service.handle(message("평가 삼성전자 70000 6 취한 친구처럼"), now=NOW)
+
+        [job] = repository.list_analysis_jobs()
+        assert job["payload"]["tone"] == "취한 친구처럼"
+
+    def test_a_missing_price_asks_for_it_by_example(self, repository, service):
+        # The stock was already named, so the refusal shows the exact line to
+        # send rather than restating the grammar in the abstract.
+        outcome = service.handle(message("평가 삼성전자"), now=NOW)
+
+        assert outcome.kind is CommandOutcomeKind.REJECTED
+        assert "삼성전자" in outcome.message
+        assert "70000" in outcome.message
+        assert repository.list_analysis_jobs() == ()
+
+    def test_evaluate_counts_against_the_same_quota(self, repository, service):
+        for i in range(6):
+            service.handle(message(f"평가 삼성전자 7000{i} 6", user_id="same"), now=NOW)
+
+        assert len(repository.list_analysis_jobs()) == 5
+
+    def test_an_unapproved_room_is_refused(self, tmp_path):
+        with SQLiteKakaoRepository(tmp_path / "k.sqlite") as repo:
+            repo.discover_room("other", discovered_at=NOW)
+            outcome = CommandService(repo, FakeResolver()).handle(
+                InboundMessage(
+                    event_id="e",
+                    sequence=1,
+                    room_id="other",
+                    user_id="u",
+                    nickname=None,
+                    text="평가 삼성전자 70000 6",
+                    callback_token="cb",
+                    occurred_at=NOW,
+                ),
+                now=NOW,
+            )
+
+        assert outcome.kind is CommandOutcomeKind.REJECTED
+        assert "승인" in outcome.message
+
+
+class TestWorker:
+    def enqueue(self, repository, service, text="평가 삼성전자 70000 6"):
+        service.handle(message(text), now=NOW)
+
+    def test_the_worker_uses_the_evaluation_agent_not_search(
+        self, repository, service
+    ):
+        # The whole point of keeping this off the ask path.
+        self.enqueue(repository, service)
+        analysis = SpyAnalysis()
+
+        AnalysisService(repository, analysis).run_once(now=NOW, limit=1)
+
+        assert len(analysis.evaluate_calls) == 1
+        assert analysis.answer_calls == []
+        assert analysis.generate_calls == []
+
+    def test_the_position_reaches_the_agent(self, repository, service):
+        self.enqueue(repository, service)
+        analysis = SpyAnalysis()
+
+        AnalysisService(repository, analysis).run_once(now=NOW, limit=1)
+
+        [call] = analysis.evaluate_calls
+        assert call["avg_price"] == 70000.0
+        assert call["period_months"] == 6
+        assert call["ticker"] == "005930"
+        assert call["market"] == "kr"
+
+    def test_an_empty_tone_is_left_for_the_adapter_to_default(
+        self, repository, service
+    ):
+        # The tone only means something to the prompt, so the default belongs
+        # with the prompt rather than in the application layer.
+        self.enqueue(repository, service)
+        analysis = SpyAnalysis()
+
+        AnalysisService(repository, analysis).run_once(now=NOW, limit=1)
+
+        assert analysis.evaluate_calls[0]["tone"] == ""
+
+    def test_a_completed_evaluation_enqueues_an_evaluate_result(
+        self, repository, service
+    ):
+        self.enqueue(repository, service)
+
+        AnalysisService(repository, SpyAnalysis()).run_once(now=NOW, limit=1)
+
+        [out] = repository.list_outbox()
+        assert out["message_type"] == "evaluate_result"
+        assert out["payload"]["avg_price"] == 70000.0
+
+    def test_a_failed_evaluation_enqueues_an_evaluate_failure(
+        self, repository, service
+    ):
+        self.enqueue(repository, service)
+        analysis = SpyAnalysis(
+            AnalysisOutcome(succeeded=False, error_code="evaluate_error")
+        )
+
+        AnalysisService(repository, analysis).run_once(now=NOW, limit=1)
+
+        [out] = repository.list_outbox()
+        assert out["message_type"] == "evaluate_failed"
+        assert out["payload"]["company_name"] == "삼성전자"
+
+    def test_report_and_ask_jobs_are_untouched(self, repository, service):
+        service.handle(message("삼성전자"), now=NOW)
+        analysis = SpyAnalysis()
+
+        AnalysisService(repository, analysis).run_once(now=NOW, limit=1)
+
+        assert analysis.evaluate_calls == []
+        assert len(analysis.generate_calls) == 1
+
+
+class TestRendering:
+    def payload(self, **overrides) -> dict:
+        base = {
+            "job_id": "j-1",
+            "ticker": "005930",
+            "company_name": "삼성전자",
+            "avg_price": 70000.0,
+            "period_months": 6,
+            "verdict": "지금 12% 수익 중이야. 절반은 익절해도 좋아 보여.",
+            "market": "kr",
+        }
+        return {**base, **overrides}
+
+    def text_of(self, response) -> str:
+        return response["template"]["outputs"][0]["simpleText"]["text"]
+
+    def test_the_card_repeats_the_position_back(self):
+        # The answer lands minutes later in a busy room; without the entry
+        # price nobody can tell which position it is about.
+        response = render_delivery(delivery("evaluate_result", self.payload()))
+
+        text = self.text_of(response)
+        assert "삼성전자" in text
+        assert "70,000" in text
+        assert "6개월" in text
+
+    def test_the_verdict_is_in_the_bubble(self):
+        response = render_delivery(delivery("evaluate_result", self.payload()))
+
+        assert "익절" in self.text_of(response)
+
+    def test_markdown_is_stripped(self):
+        response = render_delivery(
+            delivery("evaluate_result", self.payload(verdict="## 요약\n- **12%** 수익"))
+        )
+
+        text = self.text_of(response)
+        assert "**" not in text and "##" not in text
+
+    def test_a_blank_verdict_renders_the_failure_card(self):
+        response = render_delivery(
+            delivery("evaluate_result", self.payload(verdict="   "))
+        )
+
+        assert "실패" in self.text_of(response)
+
+    def test_a_missing_period_still_renders(self):
+        response = render_delivery(
+            delivery("evaluate_result", self.payload(period_months=None))
+        )
+
+        text = self.text_of(response)
+        assert "70,000" in text
+        assert "개월" not in text
+
+    def test_the_failure_card_names_the_stock_not_the_error_code(self):
+        response = render_delivery(
+            delivery(
+                "evaluate_failed",
+                {
+                    "job_id": "j-1",
+                    "ticker": "005930",
+                    "company_name": "삼성전자",
+                    "error_code": "evaluate_timeout",
+                },
+            )
+        )
+
+        text = self.text_of(response)
+        assert "삼성전자" in text
+        assert "evaluate_timeout" not in text
+
+    def test_the_bubble_fits_kakao(self):
+        response = render_delivery(
+            delivery("evaluate_result", self.payload(verdict="가" * 5000))
+        )
+
+        assert len(self.text_of(response)) <= 1000


### PR DESCRIPTION
파싱·키워드·US 변형·평단가/기간 추출은 이미 다 있었고 `IMPLEMENTED_COMMANDS` 에만
없었습니다. ASK 때 깔아둔 `kind`/`payload` 배관을 그대로 씁니다.

## ask 로 흡수하지 않은 이유

두 경로는 완전히 다른 물건입니다.

| | ask | evaluate |
|---|---|---|
| 데이터 | Firecrawl `/search` + 스크랩 | `get_stock_ohlcv`, `get_stock_trading_volume`, `perplexity_ask` |
| 수익률 | 근거 없음 | 프롬프트에 계산식·극단값 재검증까지 명시 |
| 비용 | 검색+스크랩 | perplexity 쿼리 1개 |

검색 결과만으로 남의 돈에 대한 숫자를 말하게 하면 "예외 없이 그럴듯한 틀린 값"이
나옵니다. 이 리포가 가장 경계해온 유형이고, **비용까지 더 비쌉니다.**

KR/US 는 시그니처가 같아 `market` 으로 responder 만 고릅니다.

## 실패 감지

`generate_evaluation_response` 는 예외를 삼키고 "죄송합니다, 평가 중 오류가
발생했습니다" 를 **평범한 텍스트로** 돌려줍니다. 그대로 내보내면 숙고된 답변처럼
보이고 재시도도 안 됩니다. 그 문구를 실패로 되돌립니다.

## 입력은 한 줄

카드 다단계는 카카오에서 비쌉니다 — 답장이 전달되지 않아 후속 발화를 앞선 질문에
묶을 수단이 없고, 그룹방이 폼 입력창이 되며, (방×사용자) 상태가 새로 필요합니다.

필수 3개만 받고 톤/배경은 기본값. 대신 **꼬리 자유텍스트를 톤으로** 받습니다.

```
평가 삼성전자 70000 6              → 기본 말투
평가 삼성전자 70000 6 취한 친구처럼   → tone="취한 친구처럼"
평가 삼성전자 70000               → 기간 생략 가능
us평가 TSLA 300 12 냉정하게        → US
평가 삼성전자                     → 평단가를 예시와 함께 요청
```

그래서 `_parse_evaluate` 가 숫자를 뒤에서 떼지 않고 **찾습니다.** 끝에서 읽으면
"친구처럼" 에서 숫자를 못 찾고 사용자가 준 평단가를 조용히 버립니다.

검증: 319 passed (신규 24), ruff 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)