### PR TITLE
fix(deps): kospi_kosdaq_stock_server 0.4.2 — KRX IP 제한 대응

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ holidays~=0.68
 
 python-telegram-bot[job-queue]>=20.0
 
-kospi_kosdaq_stock_server>=0.4.0
+kospi_kosdaq_stock_server>=0.4.2  # 0.4.2: KRX IP 제한을 재시도 대상에서 제외 + 24h 서킷 브레이커
 DateTime~=5.5
 matplotlib~=3.10.1
 seaborn~=0.13.2


### PR DESCRIPTION
## 장애 요약

2026-08-04 오후 배치가 KRX 데이터를 한 건도 못 받고 두 시간을 보냈습니다.
`로그인 iframe을 찾을 수 없습니다` 265건 때문에 "카카오 로그인 페이지 구조 변경"
으로 오진됐으나, 실제 원인은 **KRX 의 IP 접속 제한**이었습니다.

같은 코드·같은 UA 로 세 호스트에서 확인:

```
로컬 맥         iframe 1개  title='로그인 - KRX'
prism-backend  iframe 1개  title='로그인 - KRX'
db-server      iframe 0개  title='에러페이지 - 한국거래소'   ← 여기만
```

KRX 안내문:

> 자동화 수단을 통한 비정상 대량 조회가 감지되어 해당 IP의 접속이 일시적으로
> 제한되었습니다. ... **탐지일로부터 1일간** 제한되며, 제한기간 경과 후 다시
> 탐지되는 경우 접속 제한이 **재적용**될 수 있습니다. ... **KRX Open API**
> (openapi.krx.co.kr) 등 공식 경로를 이용해 주시기 바랍니다.

클라이언트가 이를 일시 오류로 오인해 265회 재시도했고, **그 재시도가 제한을
유지·심화**시켰습니다.

## 0.4.2 가 하는 것

- 제한을 `KRXBlockedError` 로 분리해 재시도 대상에서 제외
- 24시간 서킷 브레이커(안내문의 "1일"에 맞춤), 파일 기록으로 프로세스 간 공유
- 재시도 5회 → 2회
- 진단 가능한 에러 메시지(실제 원인 + 공식 경로)

**제한을 우회하지 않습니다.** 제한 중에 덜 두드리게 할 뿐입니다.

## 실서버 검증 (제한 상태)

```
1회차  KRXBlockedError  44.3초   재시도 없음 (이전 116.7초)
2회차  쿨다운으로 즉시 차단  0.00초
```

## 남은 과제 (별건)

제한 중 pykrx/KIS fallback 이 실제로 동작하는지 확인해야 합니다. 8/4 오후 리포트가
**17K자**(정상 351K자)로 쪼그라든 것이 fallback 미작동의 증거입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)