### PR TITLE
fix(report): KRX 가 막혀도 차트와 시세는 나오게 한다

### DIFF
--- a/cores/market_data_source.py
+++ b/cores/market_data_source.py
@@ -1,0 +1,223 @@
+"""Per-stock market data with a source that survives KRX being unavailable.
+
+Screening already degrades gracefully: `trigger_batch.load_market_snapshot_bundle`
+falls back to `cores.naver_market_snapshot` and still returns ~2,700 stocks. The
+report path did not. `cores/stock_chart.py` called `krx_data_client` directly and
+returned `None` on any failure, so on 2026-08-04 — when KRX restricted the
+server's IP — every chart silently vanished and the afternoon report came out at
+17,387 characters against a normal 351,311. The analysis text was there; the
+prices, flows and charts were not.
+
+This module is the seam that was missing. Callers ask here instead of asking KRX,
+and here decides where the data comes from. Today that means KRX first and
+FinanceDataReader (Naver) second, matching the `[FDR-FALLBACK]` pattern already
+proven in `trigger_batch._get_recent_ohlcv`. When the broker migration lands,
+only this file changes.
+
+What the fallback cannot do is worth stating plainly: FinanceDataReader has no
+investor-flow data. Those functions are re-exported unchanged so callers keep
+their existing behaviour rather than silently receiving something different.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+
+import pandas as pd
+from krx_data_client import get_index_ohlcv_by_date as _krx_index_ohlcv
+from krx_data_client import get_market_cap_by_date as _krx_market_cap
+
+# Re-exported untouched: no free source offers an equivalent, so pretending
+# otherwise would be worse than failing. The broker migration covers these.
+from krx_data_client import (  # noqa: F401
+    get_market_fundamental_by_date,
+    get_market_ticker_name,
+    get_market_trading_volume_by_date,
+    get_market_trading_volume_by_investor,
+)
+from krx_data_client import get_market_ohlcv_by_date as _krx_ohlcv
+
+logger = logging.getLogger(__name__)
+
+# FinanceDataReader index symbols for the two indices the reports chart.
+_INDEX_SYMBOLS = {
+    "1001": "KS11",  # KOSPI
+    "2001": "KQ11",  # KOSDAQ
+}
+
+# Both Korean and English headers appear depending on source and version.
+_COLUMN_MAP = {
+    "open": "Open",
+    "high": "High",
+    "low": "Low",
+    "close": "Close",
+    "volume": "Volume",
+    "change": "Change",
+    "시가": "Open",
+    "고가": "High",
+    "저가": "Low",
+    "종가": "Close",
+    "거래량": "Volume",
+    "등락률": "Change",
+}
+
+
+def _normalize(df: pd.DataFrame) -> pd.DataFrame:
+    """Give the frame the English headers and DatetimeIndex charts expect."""
+    df = df.rename(
+        columns={c: _COLUMN_MAP[str(c).lower()] for c in df.columns
+                 if str(c).lower() in _COLUMN_MAP}
+    )
+    if not isinstance(df.index, pd.DatetimeIndex):
+        df.index = pd.to_datetime(df.index)
+    return df.sort_index()
+
+
+def _to_dashed(yyyymmdd: str) -> str:
+    # A calendar date with no clock or zone; naive is the correct type here.
+    return datetime.datetime.strptime(  # noqa: DTZ007
+        yyyymmdd, "%Y%m%d"
+    ).strftime("%Y-%m-%d")
+
+
+def _fdr_read(symbol: str, start_date: str, end_date: str) -> pd.DataFrame:
+    import FinanceDataReader as fdr
+
+    df = fdr.DataReader(symbol, _to_dashed(start_date), _to_dashed(end_date))
+    return _normalize(df) if df is not None and not df.empty else pd.DataFrame()
+
+
+def _with_fallback(label: str, symbol: str, primary, start_date: str, end_date: str):
+    """Try KRX, then Naver. Empty is a failure, not an answer.
+
+    An empty frame reaches the caller as "no data for this stock", which renders
+    as a missing chart rather than an error — that is precisely how the outage
+    stayed invisible for two hours.
+    """
+    try:
+        df = primary()
+        if df is not None and len(df) > 0:
+            return _normalize(df)
+        logger.warning("%s: KRX returned no rows; trying FinanceDataReader", label)
+    except Exception as exc:  # noqa: BLE001 - any KRX failure is a fallback trigger
+        logger.warning("%s: KRX failed (%s); trying FinanceDataReader", label, exc)
+
+    try:
+        df = _fdr_read(symbol, start_date, end_date)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("%s: FinanceDataReader also failed: %s", label, exc)
+        return pd.DataFrame()
+
+    if df.empty:
+        logger.error("%s: FinanceDataReader returned no rows either", label)
+        return df
+
+    logger.warning("[FDR-FALLBACK] %s: FinanceDataReader(네이버) used", label)
+    return df
+
+
+def get_market_ohlcv_by_date(
+    start_date: str,
+    end_date: str,
+    ticker: str,
+    adjusted: bool = True,
+) -> pd.DataFrame:
+    """Daily OHLCV for one stock, from KRX or Naver."""
+    return _with_fallback(
+        f"ohlcv {ticker}",
+        ticker,
+        lambda: _krx_ohlcv(start_date, end_date, ticker, adjusted=adjusted),
+        start_date,
+        end_date,
+    )
+
+
+def get_index_ohlcv_by_date(
+    start_date: str,
+    end_date: str,
+    index_ticker: str,
+) -> pd.DataFrame:
+    """Daily OHLCV for an index, from KRX or Naver."""
+    symbol = _INDEX_SYMBOLS.get(str(index_ticker))
+    if symbol is None:
+        # Unknown index: no mapping to fall back to, so let the primary answer.
+        try:
+            df = _krx_index_ohlcv(start_date, end_date, index_ticker)
+            return _normalize(df) if df is not None and len(df) else pd.DataFrame()
+        except Exception as exc:  # noqa: BLE001
+            logger.error("index %s: KRX failed and no fallback mapping: %s",
+                         index_ticker, exc)
+            return pd.DataFrame()
+
+    return _with_fallback(
+        f"index {index_ticker}",
+        symbol,
+        lambda: _krx_index_ohlcv(start_date, end_date, index_ticker),
+        start_date,
+        end_date,
+    )
+
+
+def get_market_cap_by_date(
+    start_date: str,
+    end_date: str,
+    ticker: str,
+) -> pd.DataFrame:
+    """Market cap history.
+
+    FinanceDataReader has no market-cap series, so the fallback reconstructs it
+    from close price times shares outstanding. Shares outstanding is taken as a
+    constant from the latest listing snapshot, which is wrong across splits and
+    issuance — acceptable for a chart of relative movement, not for a figure
+    quoted as fact. The frame is marked so callers can tell.
+    """
+    try:
+        df = _krx_market_cap(start_date, end_date, ticker)
+        if df is not None and len(df) > 0:
+            return _normalize(df)
+        logger.warning("cap %s: KRX returned no rows", ticker)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("cap %s: KRX failed (%s)", ticker, exc)
+
+    try:
+        import FinanceDataReader as fdr
+
+        ohlcv = _fdr_read(ticker, start_date, end_date)
+        if ohlcv.empty:
+            return pd.DataFrame()
+
+        listing = fdr.StockListing("KRX")
+        row = listing[listing["Code"] == ticker]
+        shares = None
+        for column in ("Stocks", "Shares", "ListedShares"):
+            if column in listing.columns and not row.empty:
+                shares = row.iloc[0][column]
+                break
+        if not shares or pd.isna(shares):
+            logger.error("cap %s: shares outstanding unavailable", ticker)
+            return pd.DataFrame()
+
+        out = pd.DataFrame(index=ohlcv.index)
+        out["MarketCap"] = ohlcv["Close"] * float(shares)
+        out.attrs["approximate"] = True
+        logger.warning(
+            "[FDR-FALLBACK] cap %s: reconstructed from close x shares "
+            "(constant shares — approximate)",
+            ticker,
+        )
+        return out
+    except Exception as exc:  # noqa: BLE001
+        logger.error("cap %s: FinanceDataReader fallback failed: %s", ticker, exc)
+        return pd.DataFrame()
+
+
+def resolve_ticker_name(ticker: str) -> str | None:
+    """Company name, falling back to the ticker itself.
+
+    Charts label with this; a failed lookup should cost the label, not the chart.
+    """
+    try:
+        return get_market_ticker_name(ticker)
+    except Exception:  # noqa: BLE001
+        return ticker

--- a/cores/stock_chart.py
+++ b/cores/stock_chart.py
@@ -402,15 +402,20 @@ def create_mpf_style(base_mpl_style='seaborn-v0_8-whitegrid'):
 
     return s
 
-# Import functions from krx_data_client (pykrx compatible)
-from krx_data_client import (
-    get_market_ohlcv_by_date,
+# Sourced through cores.market_data_source rather than krx_data_client directly.
+# Charts used to die whole whenever KRX was unavailable: every call returned
+# None and the report shipped with no prices and no charts (2026-08-04: 17,387
+# characters against a normal 351,311, with no error anywhere). The seam adds a
+# Naver fallback for the price series and keeps the investor-flow calls
+# unchanged, since no free source replaces those.
+from cores.market_data_source import (
+    get_index_ohlcv_by_date,
     get_market_cap_by_date,
     get_market_fundamental_by_date,
-    get_market_trading_volume_by_investor,
-    get_market_trading_volume_by_date,
+    get_market_ohlcv_by_date,
     get_market_ticker_name,
-    get_index_ohlcv_by_date,
+    get_market_trading_volume_by_date,
+    get_market_trading_volume_by_investor,
 )
 
 # Professional chart style configuration


### PR DESCRIPTION
## 문제

8/4 오후 배치에서 **스크리닝은 살아남고 리포트만 죽었습니다.**

```
리포트 17,387자  (정상 351,311자 — 95% 손실)
차트 0건
에러 로그 0건    ← 아무도 몰랐던 이유
```

두 경로의 대응이 달랐습니다.

| 경로 | KRX 실패 시 |
|---|---|
| 스크리닝 (`trigger_batch`) | `cores.naver_market_snapshot` 전환 → **2,686종목 확보** |
| 리포트 (`cores/stock_chart.py`) | `return None` — **fallback 없음** |

`return None` 이라 호출부엔 "이 종목은 데이터가 없다"로 보입니다. 그래서 차트가
조용히 사라졌고 에러가 안 남았습니다.

## 수정

`cores/market_data_source.py` 를 seam 으로 둡니다. `stock_chart` 는 이제 KRX 가
아니라 여기에 묻고, 어디서 가져올지는 여기가 정합니다.

- 가격 계열(일봉·지수·시총) → KRX 우선, FinanceDataReader(네이버) 폴백
- `trigger_batch._get_recent_ohlcv` 에서 이미 검증된 `[FDR-FALLBACK]` 패턴 재사용
- **브로커 이전 시 이 파일만 바꾸면 됩니다**

### 폴백이 못 하는 것은 그대로 둡니다

- **투자자별 수급** — FinanceDataReader 에 없습니다. KRX 직결로 재수출해 조용히
  다른 데이터를 받는 대신 기존 동작을 유지합니다
- **시가총액** — 종가×상장주식수로 재구성하되 주식수를 상수로 쓰므로 분할·증자에서
  틀립니다. `attrs['approximate']` 로 표시하고 주석에 명시했습니다

## 실측 검증 (제한된 db-server, 10/10)

```
삼성전자/NAVER/디앤디파마텍 일봉 각 63행, OHLCV 컬럼 전부
KOSPI/KOSDAQ 지수 각 63행, Close 존재
로그: [FDR-FALLBACK] ohlcv 347850 / index 1001 / index 2001
```

## 이건 임시 조치입니다

근본은 KRX 의존 자체를 걷어내는 것(Plan A)이고, 이 파일이 그 작업의 착점입니다.
투자자별 수급은 KIS 에 있으므로 다음 단계에서 여기를 KIS 로 갈아끼웁니다.

검증: 19 passed, ruff 신규 파일 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)