### PR TITLE
feat(market-data): KRX 정식 OPEN API 로 전종목 스냅샷을 받는다

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,18 @@ KRX_LOGIN_METHOD=krx  # "krx" (default) or "kakao"
 # KAKAO_PW=your_kakao_password
 # KRX_LOGIN_METHOD=kakao
 
+# KRX Data Marketplace OPEN API (정식 경로 - 위 스크래핑 로그인을 대체할 예정)
+# https://openapi.krx.co.kr 에서 신청해 발급받는 40자리 인증키.
+# HTTP 요청 헤더 AUTH_KEY 에 그대로 실어 보낸다.
+#
+# 배경: 2026-08-04 KRX가 자동화 수단을 통한 대량 조회를 탐지해 서버 IP를 차단했다.
+# 이용약관 제10조 제2호가 자동 수집을 금지하고 있어 스크래핑은 고쳐서 되는 문제가
+# 아니며, KRX 안내문이 직접 이 OPEN API를 공식 경로로 지목했다.
+# 전환 설계: tasks/plan-a-krx-exit-design.md
+#
+# 주의: 일별매매정보는 EOD(장 마감 후) 데이터라 장중 스크리닝에는 쓸 수 없다.
+KRX_OPENAPI_AUTH_KEY=
+
 # Telegram Bot Settings
 TELEGRAM_BOT_TOKEN=your_bot_token
 TELEGRAM_AI_BOT_TOKEN=your_bot_token

--- a/cores/krx_openapi_snapshot.py
+++ b/cores/krx_openapi_snapshot.py
@@ -1,0 +1,295 @@
+"""Market snapshot from the KRX Data Marketplace OPEN API — the sanctioned route.
+
+On 2026-08-04 KRX restricted the server's IP for "자동화 수단을 통한 비정상 대량
+조회" and cited 이용약관 제10조 제2호, which forbids automated collection. The same
+notice named `openapi.krx.co.kr` as the official alternative. This module is that
+alternative: an authenticated, contracted API instead of a scraped session.
+
+It produces the same ``MarketSnapshotBundle`` the screening batch already consumes,
+so it slots in beside the KRX-scraping and Naver paths without changing callers.
+
+What this source can and cannot do — verified by live calls on 2026-08-04:
+
+- **Full universe, one call per market.** KOSPI 943 + KOSDAQ 1,820 rows; filtering
+  to six-digit codes leaves exactly 2,686 — the same count the Naver fallback
+  produced during the outage. No ETFs or ETNs are mixed in.
+- **Every field the triggers need**: open/high/low/close, volume, traded value and
+  market capitalisation all arrive in the one response, so ``cap_df`` needs no
+  second request and cannot disagree with the prices.
+- **End-of-day only.** ``basDd`` for the current session returned zero rows at
+  23:44 KST on the same day, so this cannot serve the intraday 09:30 and 14:46
+  screening snapshots. It is a previous-day and historical source.
+- **One date per call.** There is no range parameter; ``strtDd``/``endDd`` are
+  ignored and return nothing. Time series would cost one request per day, so the
+  chart path stays with a source that supports ranges.
+- **No investor flows.** The 주식 category offers daily trading and issue master
+  data only; 투자자별 거래실적 is not among the published services.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import time
+from typing import Callable
+
+import pandas as pd
+import requests
+
+from cores.naver_market_snapshot import MarketSnapshotBundle
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://data-dbg.krx.co.kr/svc/apis/sto"
+_ENDPOINTS = {"KOSPI": "stk_bydd_trd", "KOSDAQ": "ksq_bydd_trd"}
+_REQUIRED_COLUMNS = ["Open", "High", "Low", "Close", "Volume", "Amount"]
+
+# The response names its payload consistently across services.
+_PAYLOAD_KEY = "OutBlock_1"
+
+# KRX ships preferred shares and SPACs in the same feed; both carry six-digit
+# codes and both are present in the universe the screening triggers have always
+# seen, so the filter is deliberately only "is this a stock code".
+_TICKER_RE = re.compile(r"\d{6}")
+
+_FIELD_MAP = {
+    "Open": "TDD_OPNPRC",
+    "High": "TDD_HGPRC",
+    "Low": "TDD_LWPRC",
+    "Close": "TDD_CLSPRC",
+    "Volume": "ACC_TRDVOL",
+    "Amount": "ACC_TRDVAL",
+}
+
+
+class KrxOpenApiError(RuntimeError):
+    """The OPEN API could not produce a usable snapshot."""
+
+
+def _auth_key(explicit: str | None) -> str:
+    key = explicit or os.getenv("KRX_OPENAPI_AUTH_KEY", "")
+    if not key:
+        raise KrxOpenApiError(
+            "KRX_OPENAPI_AUTH_KEY is not set; apply at https://openapi.krx.co.kr"
+        )
+    return key
+
+
+def _as_number(value) -> float:
+    """Parse a KRX numeric string.
+
+    Fields arrive as strings and a suspended or newly listed issue can carry an
+    empty one. Returning NaN rather than 0 matters: zero would read as a real
+    price of zero and pass filters that a missing value should not.
+    """
+    if value in (None, ""):
+        return float("nan")
+    try:
+        return float(str(value).replace(",", ""))
+    except ValueError:
+        return float("nan")
+
+
+def _fetch_market(
+    market: str,
+    trade_date: str,
+    auth_key: str,
+    request_get: Callable,
+    *,
+    timeout: float,
+    max_attempts: int,
+    retry_wait_sec: float,
+) -> list[dict]:
+    url = f"{_BASE_URL}/{_ENDPOINTS[market]}"
+    last_error: Exception | None = None
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            response = request_get(
+                url,
+                params={"basDd": trade_date},
+                headers={"AUTH_KEY": auth_key},
+                timeout=timeout,
+            )
+            if response.status_code == 401:
+                # Distinct from a transient failure: the key is valid but this
+                # service was never approved for it, and retrying cannot help.
+                raise KrxOpenApiError(
+                    f"{market} 일별매매정보 is not authorised for this key "
+                    "(apply for the service at openapi.krx.co.kr)"
+                )
+            response.raise_for_status()
+            payload = response.json()
+        except KrxOpenApiError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - retried below, re-raised if final
+            last_error = exc
+            if attempt < max_attempts:
+                logger.warning(
+                    "KRX OPEN API %s %s failed (attempt %d/%d): %s",
+                    market,
+                    trade_date,
+                    attempt,
+                    max_attempts,
+                    exc,
+                )
+                time.sleep(retry_wait_sec * attempt)
+                continue
+            raise KrxOpenApiError(
+                f"{market} {trade_date} request failed after {max_attempts} attempts: {exc}"
+            ) from exc
+
+        rows = payload.get(_PAYLOAD_KEY)
+        if rows is None:
+            raise KrxOpenApiError(
+                f"{market} {trade_date}: unexpected response shape {list(payload)}"
+            )
+        return rows
+
+    raise KrxOpenApiError(f"{market} {trade_date} failed: {last_error}")
+
+
+def _rows_for_date(
+    trade_date: str,
+    auth_key: str,
+    request_get: Callable,
+    **kwargs,
+) -> list[dict]:
+    """Both markets for one date, keyed to stocks only."""
+    rows: list[dict] = []
+    for market in _ENDPOINTS:
+        rows.extend(
+            _fetch_market(market, trade_date, auth_key, request_get, **kwargs)
+        )
+
+    kept = [row for row in rows if _TICKER_RE.fullmatch(str(row.get("ISU_CD", "")))]
+
+    # A date the exchange did not trade returns an empty list rather than an
+    # error, and so does a session whose data has not been published yet. The
+    # caller has to tell those apart from a real failure, so both surface as
+    # "no rows" and the decision is made there.
+    stale = {row.get("BAS_DD") for row in kept} - {trade_date}
+    if stale:
+        raise KrxOpenApiError(
+            f"{trade_date}: response carried other dates {sorted(stale)}"
+        )
+    return kept
+
+
+def _frames(rows: list[dict]) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Split rows into an OHLCV frame and a market-cap frame on one index."""
+    index = sorted(str(row["ISU_CD"]) for row in rows)
+    by_code = {str(row["ISU_CD"]): row for row in rows}
+
+    ohlcv = pd.DataFrame(
+        [
+            {name: _as_number(by_code[code][field]) for name, field in _FIELD_MAP.items()}
+            for code in index
+        ],
+        index=index,
+        columns=_REQUIRED_COLUMNS,
+        dtype=float,
+    )
+    cap = pd.DataFrame(
+        {"시가총액": [_as_number(by_code[code].get("MKTCAP")) for code in index]},
+        index=index,
+        dtype=float,
+    )
+    return ohlcv, cap
+
+
+def fetch_krx_openapi_bundle(
+    trade_date: str,
+    *,
+    auth_key: str | None = None,
+    request_get: Callable = requests.get,
+    min_stock_count: int = 2500,
+    timeout: float = 20.0,
+    max_attempts: int = 3,
+    retry_wait_sec: float = 0.5,
+    max_lookback_days: int = 10,
+) -> MarketSnapshotBundle:
+    """Build the screening bundle for ``trade_date`` from the OPEN API.
+
+    ``trade_date`` must be a session whose data has already been published —
+    same-day data is not available (see the module docstring), so the live
+    morning and afternoon batches cannot call this for the current session. It
+    serves previous-day, historical and backtest requests.
+
+    Raises ``KrxOpenApiError`` rather than returning a thin frame: a partial
+    universe silently changes what every trigger scores, which is the failure
+    mode that made the 2026-08-04 outage take two hours to recognise.
+    """
+    if not re.fullmatch(r"\d{8}", trade_date):
+        raise ValueError("trade_date must be YYYYMMDD")
+
+    key = _auth_key(auth_key)
+    request_kwargs = dict(
+        timeout=timeout, max_attempts=max_attempts, retry_wait_sec=retry_wait_sec
+    )
+
+    rows = _rows_for_date(trade_date, key, request_get, **request_kwargs)
+    if not rows:
+        raise KrxOpenApiError(
+            f"{trade_date}: no rows. Either not a trading day, or end-of-day data "
+            "is not published yet (this API does not serve the current session)."
+        )
+    if len(rows) < min_stock_count:
+        raise KrxOpenApiError(
+            f"{trade_date}: universe too small ({len(rows)}/{min_stock_count})"
+        )
+
+    prev_date, prev_rows = _previous_session(
+        trade_date, key, request_get, max_lookback_days, request_kwargs
+    )
+    if len(prev_rows) < min_stock_count:
+        raise KrxOpenApiError(
+            f"{prev_date}: previous-session universe too small "
+            f"({len(prev_rows)}/{min_stock_count})"
+        )
+
+    snapshot, cap_df = _frames(rows)
+    prev_snapshot, _ = _frames(prev_rows)
+
+    logger.info(
+        "[MARKET-DATA] source=KRX_OPENAPI date=%s stocks=%d prev_date=%s prev_stocks=%d",
+        trade_date,
+        len(snapshot),
+        prev_date,
+        len(prev_snapshot),
+    )
+
+    return MarketSnapshotBundle(
+        snapshot=snapshot,
+        prev_snapshot=prev_snapshot,
+        cap_df=cap_df,
+        prev_date=prev_date,
+        source="krx_openapi",
+    )
+
+
+def _previous_session(
+    trade_date: str,
+    auth_key: str,
+    request_get: Callable,
+    max_lookback_days: int,
+    request_kwargs: dict,
+) -> tuple[str, list[dict]]:
+    """Walk back day by day until a session with data appears.
+
+    The API has no calendar endpoint, and an empty response is how both weekends
+    and holidays present, so the previous session is found by asking rather than
+    by computing it — which also keeps this correct across holiday changes.
+    """
+    day = pd.Timestamp(trade_date)
+    for _ in range(max_lookback_days):
+        day -= pd.Timedelta(days=1)
+        candidate = day.strftime("%Y%m%d")
+        rows = _rows_for_date(candidate, auth_key, request_get, **request_kwargs)
+        if rows:
+            return candidate, rows
+
+    raise KrxOpenApiError(
+        f"no session with data in the {max_lookback_days} days before {trade_date}"
+    )

--- a/cores/krx_openapi_snapshot.py
+++ b/cores/krx_openapi_snapshot.py
@@ -154,13 +154,24 @@ def _rows_for_date(
     trade_date: str,
     auth_key: str,
     request_get: Callable,
-    **kwargs,
+    *,
+    timeout: float,
+    max_attempts: int,
+    retry_wait_sec: float,
 ) -> list[dict]:
     """Both markets for one date, keyed to stocks only."""
     rows: list[dict] = []
     for market in _ENDPOINTS:
         rows.extend(
-            _fetch_market(market, trade_date, auth_key, request_get, **kwargs)
+            _fetch_market(
+                market,
+                trade_date,
+                auth_key,
+                request_get,
+                timeout=timeout,
+                max_attempts=max_attempts,
+                retry_wait_sec=retry_wait_sec,
+            )
         )
 
     kept = [row for row in rows if _TICKER_RE.fullmatch(str(row.get("ISU_CD", "")))]
@@ -225,11 +236,14 @@ def fetch_krx_openapi_bundle(
         raise ValueError("trade_date must be YYYYMMDD")
 
     key = _auth_key(auth_key)
-    request_kwargs = dict(
-        timeout=timeout, max_attempts=max_attempts, retry_wait_sec=retry_wait_sec
+    rows = _rows_for_date(
+        trade_date,
+        key,
+        request_get,
+        timeout=timeout,
+        max_attempts=max_attempts,
+        retry_wait_sec=retry_wait_sec,
     )
-
-    rows = _rows_for_date(trade_date, key, request_get, **request_kwargs)
     if not rows:
         raise KrxOpenApiError(
             f"{trade_date}: no rows. Either not a trading day, or end-of-day data "
@@ -241,7 +255,13 @@ def fetch_krx_openapi_bundle(
         )
 
     prev_date, prev_rows = _previous_session(
-        trade_date, key, request_get, max_lookback_days, request_kwargs
+        trade_date,
+        key,
+        request_get,
+        max_lookback_days,
+        timeout=timeout,
+        max_attempts=max_attempts,
+        retry_wait_sec=retry_wait_sec,
     )
     if len(prev_rows) < min_stock_count:
         raise KrxOpenApiError(
@@ -274,7 +294,10 @@ def _previous_session(
     auth_key: str,
     request_get: Callable,
     max_lookback_days: int,
-    request_kwargs: dict,
+    *,
+    timeout: float,
+    max_attempts: int,
+    retry_wait_sec: float,
 ) -> tuple[str, list[dict]]:
     """Walk back day by day until a session with data appears.
 
@@ -286,7 +309,14 @@ def _previous_session(
     for _ in range(max_lookback_days):
         day -= pd.Timedelta(days=1)
         candidate = day.strftime("%Y%m%d")
-        rows = _rows_for_date(candidate, auth_key, request_get, **request_kwargs)
+        rows = _rows_for_date(
+            candidate,
+            auth_key,
+            request_get,
+            timeout=timeout,
+            max_attempts=max_attempts,
+            retry_wait_sec=retry_wait_sec,
+        )
         if rows:
             return candidate, rows
 

--- a/tests/test_krx_openapi_snapshot.py
+++ b/tests/test_krx_openapi_snapshot.py
@@ -1,0 +1,178 @@
+"""Offline tests for the KRX OPEN API snapshot source.
+
+Every test drives a fake ``request_get`` so the suite never touches the network
+and never spends the API quota. The live behaviour these mirror was measured on
+2026-08-04 against the real service: 2,686 six-digit codes for 2026-08-03,
+previous session 2026-07-31, and an empty payload for the current session.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from cores.krx_openapi_snapshot import (  # noqa: E402
+    KrxOpenApiError,
+    fetch_krx_openapi_bundle,
+)
+
+AUTH = "test-key"
+
+
+class _Response:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+def _row(code, date, *, close=1000, open_=990, high=1010, low=980,
+         volume=1000, amount=1_000_000, cap=600_000_000_000):
+    return {
+        "BAS_DD": date,
+        "ISU_CD": code,
+        "ISU_NM": f"종목{code}",
+        "MKT_NM": "KOSPI",
+        "SECT_TP_NM": "",
+        "TDD_CLSPRC": str(close),
+        "TDD_OPNPRC": str(open_),
+        "TDD_HGPRC": str(high),
+        "TDD_LWPRC": str(low),
+        "ACC_TRDVOL": str(volume),
+        "ACC_TRDVAL": str(amount),
+        "MKTCAP": str(cap),
+        "LIST_SHRS": "1000000",
+    }
+
+
+def _make_get(rows_by_date, *, status_by_date=None):
+    """Serve KOSPI rows per date; KOSDAQ always empty so counts stay readable."""
+    def _get(url, params=None, headers=None, timeout=None):
+        date = (params or {})["basDd"]
+        if status_by_date and date in status_by_date:
+            return _Response({}, status_code=status_by_date[date])
+        rows = rows_by_date.get(date, []) if url.endswith("stk_bydd_trd") else []
+        return _Response({"OutBlock_1": rows})
+    return _get
+
+
+def _universe(date, count, **kw):
+    return [_row(f"{i:06d}", date, **kw) for i in range(count)]
+
+
+def test_builds_bundle_and_finds_previous_session():
+    """A weekend gap is crossed by asking, not by computing a calendar."""
+    rows = {
+        "20260803": _universe("20260803", 2600, close=1100),
+        # 20260802 / 20260801 are a weekend: empty, as the real API returns.
+        "20260731": _universe("20260731", 2600, close=1000),
+    }
+    bundle = fetch_krx_openapi_bundle(
+        "20260803", auth_key=AUTH, request_get=_make_get(rows), min_stock_count=2500
+    )
+
+    assert bundle.source == "krx_openapi"
+    assert bundle.prev_date == "20260731"
+    assert bundle.snapshot.shape == (2600, 6)
+    assert bundle.prev_snapshot.shape == (2600, 6)
+    assert list(bundle.cap_df.columns) == ["시가총액"]
+    assert bundle.snapshot.index.equals(bundle.prev_snapshot.index)
+
+
+def test_columns_match_the_screening_contract():
+    """trigger_batch indexes these names directly; renaming one breaks it silently."""
+    rows = {
+        "20260803": _universe("20260803", 2600),
+        "20260731": _universe("20260731", 2600),
+    }
+    bundle = fetch_krx_openapi_bundle(
+        "20260803", auth_key=AUTH, request_get=_make_get(rows), min_stock_count=2500
+    )
+    assert list(bundle.snapshot.columns) == [
+        "Open", "High", "Low", "Close", "Volume", "Amount"
+    ]
+    row = bundle.snapshot.iloc[0]
+    assert (row["Open"], row["High"], row["Low"], row["Close"]) == (990, 1010, 980, 1000)
+
+
+def test_non_stock_codes_are_dropped():
+    """Warrants and the like carry non-numeric codes and must not enter the universe."""
+    rows = {
+        "20260803": _universe("20260803", 2600) + [_row("KR7005930", "20260803")],
+        "20260731": _universe("20260731", 2600),
+    }
+    bundle = fetch_krx_openapi_bundle(
+        "20260803", auth_key=AUTH, request_get=_make_get(rows), min_stock_count=2500
+    )
+    assert len(bundle.snapshot) == 2600
+    assert all(code.isdigit() and len(code) == 6 for code in bundle.snapshot.index)
+
+
+def test_current_session_is_refused_rather_than_returned_thin():
+    """The API serves no same-day data; an empty response must not become an empty frame."""
+    get = _make_get({"20260803": _universe("20260803", 2600)})
+    with pytest.raises(KrxOpenApiError, match="not published yet"):
+        fetch_krx_openapi_bundle("20260804", auth_key=AUTH, request_get=get)
+
+
+def test_short_universe_is_refused():
+    """A partial universe changes every trigger's normalisation, so it is an error."""
+    rows = {"20260803": _universe("20260803", 100)}
+    with pytest.raises(KrxOpenApiError, match="universe too small"):
+        fetch_krx_openapi_bundle(
+            "20260803", auth_key=AUTH, request_get=_make_get(rows), min_stock_count=2500
+        )
+
+
+def test_unauthorised_service_is_not_retried():
+    """401 means the service was never approved for this key; retrying cannot fix it."""
+    calls = []
+
+    def _get(url, params=None, headers=None, timeout=None):
+        calls.append(params["basDd"])
+        return _Response({}, status_code=401)
+
+    with pytest.raises(KrxOpenApiError, match="not authorised"):
+        fetch_krx_openapi_bundle("20260803", auth_key=AUTH, request_get=_get)
+    assert len(calls) == 1
+
+
+def test_missing_auth_key_is_explicit(monkeypatch):
+    monkeypatch.delenv("KRX_OPENAPI_AUTH_KEY", raising=False)
+    with pytest.raises(KrxOpenApiError, match="KRX_OPENAPI_AUTH_KEY"):
+        fetch_krx_openapi_bundle("20260803")
+
+
+def test_blank_numeric_field_becomes_nan_not_zero():
+    """A suspended issue reports an empty price; zero would pass filters it should fail."""
+    rows = {
+        "20260803": _universe("20260803", 2600) + [
+            {**_row("999999", "20260803"), "TDD_CLSPRC": ""}
+        ],
+        "20260731": _universe("20260731", 2600),
+    }
+    bundle = fetch_krx_openapi_bundle(
+        "20260803", auth_key=AUTH, request_get=_make_get(rows), min_stock_count=2500
+    )
+    assert pd.isna(bundle.snapshot.loc["999999", "Close"])
+
+
+def test_mismatched_date_in_payload_is_rejected():
+    """Serving a neighbouring session would silently shift every comparison by a day."""
+    rows = {"20260803": _universe("20260731", 2600)}
+    with pytest.raises(KrxOpenApiError, match="other dates"):
+        fetch_krx_openapi_bundle(
+            "20260803", auth_key=AUTH, request_get=_make_get(rows), min_stock_count=2500
+        )
+
+
+def test_bad_date_format_is_rejected():
+    with pytest.raises(ValueError, match="YYYYMMDD"):
+        fetch_krx_openapi_bundle("2026-08-03", auth_key=AUTH)

--- a/tools/probe_krx_openapi_availability.py
+++ b/tools/probe_krx_openapi_availability.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""When does the KRX OPEN API publish a session's data?
+
+The answer decides how the screening batch can use this source, and it cannot be
+reasoned out — the service documents no publication schedule. So this probe runs
+at fixed points through the trading day and records what is actually there.
+
+What the answer changes:
+
+- If session T-1 is available before 09:30, the morning batch can take
+  ``prev_snapshot`` and ``cap_df`` from the OPEN API and drop that part of the
+  KRX scraping path.
+- If session T appears shortly after the 15:30 close, the afternoon numbers that
+  go into published reports can come from the sanctioned source the same day.
+- If publication is late or irregular, the batch has to keep a second source and
+  the migration is partial rather than complete.
+
+One observation on 2026-08-04 23:44 KST is the starting point: session 2026-08-03
+was present, session 2026-08-04 was not. So the lag is at least overnight, and
+the open question is where between those two points it lands.
+
+Writes one JSON line per run to ``logs/krx_openapi_availability.jsonl`` so runs
+accumulate into a timeline rather than overwriting each other.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import requests
+
+KST = ZoneInfo("Asia/Seoul")
+BASE_URL = "https://data-dbg.krx.co.kr/svc/apis/sto"
+MARKETS = {"KOSPI": "stk_bydd_trd", "KOSDAQ": "ksq_bydd_trd"}
+DEFAULT_LOG = Path("logs/krx_openapi_availability.jsonl")
+
+
+def _auth_key() -> str:
+    key = os.getenv("KRX_OPENAPI_AUTH_KEY", "")
+    if not key:
+        # Only load dotenv when the variable is absent, so a deliberately
+        # exported key in the environment always wins.
+        try:
+            from dotenv import load_dotenv
+
+            load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+            key = os.getenv("KRX_OPENAPI_AUTH_KEY", "")
+        except ImportError:
+            pass
+    if not key:
+        sys.exit("KRX_OPENAPI_AUTH_KEY is not set")
+    return key
+
+
+def probe_date(date: str, key: str, timeout: float = 20.0) -> dict:
+    """Row counts per market for one session date."""
+    result: dict[str, object] = {"date": date}
+    total = 0
+    for market, path in MARKETS.items():
+        try:
+            response = requests.get(
+                f"{BASE_URL}/{path}",
+                params={"basDd": date},
+                headers={"AUTH_KEY": key},
+                timeout=timeout,
+            )
+            if response.status_code != 200:
+                result[market] = f"HTTP {response.status_code}"
+                continue
+            rows = response.json().get("OutBlock_1", [])
+            result[market] = len(rows)
+            total += len(rows)
+        except Exception as exc:  # noqa: BLE001 - a probe records failures, it does not raise
+            result[market] = f"{type(exc).__name__}: {exc}"
+    result["total"] = total
+    return result
+
+
+def recent_dates(now: datetime, back: int) -> list[str]:
+    return [(now - timedelta(days=n)).strftime("%Y%m%d") for n in range(back + 1)]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dates", nargs="*", help="YYYYMMDD; default: today and the 3 days before")
+    parser.add_argument("--back", type=int, default=3)
+    parser.add_argument("--log", type=Path, default=DEFAULT_LOG)
+    parser.add_argument("--label", default="", help="tag for this probe point, e.g. 'pre-open'")
+    args = parser.parse_args()
+
+    key = _auth_key()
+    now = datetime.now(KST)
+    dates = args.dates or recent_dates(now, args.back)
+
+    record = {
+        "probed_at": now.isoformat(timespec="seconds"),
+        "label": args.label,
+        "weekday": now.strftime("%a"),
+        "results": [probe_date(d, key) for d in dates],
+    }
+
+    args.log.parent.mkdir(parents=True, exist_ok=True)
+    with args.log.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    stamp = now.strftime("%m-%d %H:%M")
+    parts = []
+    for item in record["results"]:
+        total = item["total"]
+        parts.append(f"{item['date']}={total if total else '없음'}")
+    print(f"[{stamp} KST{' ' + args.label if args.label else ''}] " + "  ".join(parts))
+
+    # Say plainly whether the previous session is usable right now, because that
+    # is the single fact the morning batch design depends on.
+    today = now.strftime("%Y%m%d")
+    for item in record["results"]:
+        if item["date"] != today and item["total"]:
+            print(f"  → 가장 최근 조회 가능 세션: {item['date']} ({item['total']}건)")
+            break
+    else:
+        print("  → 조회 가능한 최근 세션 없음")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 왜

2026-08-04 KRX 가 db-server IP 를 차단하며 안내한 것은 "고쳐 쓰라"가 아니라 **공식 경로를 쓰라**였다. 이용약관 제10조 제2호가 자동화 수집을 금지하므로 스크래핑은 재시도 간격을 늘려도 해결되지 않는다 — 재탐지되면 다시 막힌다. 그 공식 경로가 `openapi.krx.co.kr` 이고, 이 PR 이 그 경로다.

## 인증키 발급 후 실호출로 확인한 것

**되는 것**
- 전종목이 한 번에. KOSPI 943 + KOSDAQ 1,820 중 6자리 코드만 남기면 **2,686 종목** — 8/4 장애 때 Naver 폴백이 받아낸 수와 정확히 일치. 유니버스가 안 바뀌므로 트리거 정규화도 안 흔들린다.
- **시가총액이 같은 응답에** 들어 있다. `cap_df` 2차 호출이 없어지고, 가격과 시총이 서로 다른 시점을 가리킬 수 없다.
- 값 정합성: 삼성전자 8/3 종가 239,500 / 시총 1,400조. 전일종가 대비 상한가가 정확히 **+30.00%** 로 재계산된다.
- 2,686종목 × 2일 = **6.8초**.
- 지수 일별시세도 승인됨 (KOSPI 51 / KOSDAQ 40 / KRX 40).

**안 되는 것 — 이게 설계를 결정한다**
- 🔴 **당일 데이터 없음.** 마감 후 8시간 34분(익일 00:04)에도 0건. → 장중 09:30·14:46 스크리닝의 `snapshot` 은 못 채운다. **전일·과거 전용.**
- 🔴 **기간 조회 없음.** `basDd` 단일 일자만 (`strtDd`/`endDd` 무시). N일 = N콜이라 차트용 시계열은 범위 지원 소스가 계속 맡는다.
- 🔴 **수급 없음.** 주식 카테고리는 일별매매정보 + 종목기본정보뿐. 투자자별 거래실적은 서비스 목록에 없다.

## 그래서 이 PR 은 배선하지 않는다

기존 경로를 대체하지 않고 **옆에 선다**. `trigger_batch` 에 지금 물리면 당일 스냅샷이 비어 배치가 죽는다. 배선은 장중 소스(KIS)가 정해진 뒤에 한다.

## 설계 결정 2개

**빈 응답을 빈 프레임으로 돌려주지 않는다.** 8/4 장애가 두 시간 걸린 이유가 "데이터 없음"과 "소스 죽음"이 구분되지 않아서였다. 유니버스가 기준 미달이거나 응답이 다른 날짜를 실어 오면 예외로 세운다. 401 은 재시도하지 않는다 — 키는 유효한데 서비스가 미승인인 것이라 반복해도 같다.

**전일 세션은 계산하지 않고 물어서 찾는다.** 휴장일과 주말이 똑같이 빈 응답으로 오고 API 에 달력이 없다. 공휴일이 바뀌어도 이 방식은 따라간다.

## 관측

공개 시각을 문서가 안 알려주고 이 답이 설계를 가른다(09:30 배치가 전일 세션을 쓸 수 있는가). `tools/probe_krx_openapi_availability.py` 가 평일 6시점에 돌며 JSONL 로 쌓는다.

## 검증

- 신규 오프라인 테스트 **10건 통과** — 전부 가짜 `request_get`. API 쿼터 안 쓰고 CI 에서 돈다.
- 기존 스냅샷·스크리닝·소스체인 테스트 **45건 회귀 없음**.
- 실호출 검증은 위 수치 그대로.

전환 설계 전문은 로컬 `tasks/plan-a-krx-exit-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)