### PR TITLE
feat(market-data): KIS 를 시세·수급 소스로 붙인다

### DIFF
--- a/cores/market_data/__init__.py
+++ b/cores/market_data/__init__.py
@@ -26,6 +26,7 @@ import os
 import pandas as pd
 
 from cores.market_data.fdr_source import FdrSource
+from cores.market_data.kis_source import KisSource
 from cores.market_data.krx_source import KrxSource
 from cores.market_data.source import (
     MarketDataSource,
@@ -38,6 +39,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "FdrSource",
+    "KisSource",
     "KrxSource",
     "MarketDataSource",
     "SourceChain",
@@ -54,7 +56,11 @@ __all__ = [
     "set_default_chain",
 ]
 
-_BUILDERS = {"krx": KrxSource, "fdr": FdrSource}
+_BUILDERS = {"krx": KrxSource, "fdr": FdrSource, "kis": KisSource}
+# KIS is registered but not in the default order. It is the route we intend to
+# migrate to, and putting it first is a decision to make with measurements
+# rather than at import time — `PRISM_MARKET_DATA_SOURCES=kis,fdr,krx` promotes
+# it without a code change.
 _DEFAULT_ORDER = "krx,fdr"
 
 _chain: SourceChain | None = None

--- a/cores/market_data/kis_source.py
+++ b/cores/market_data/kis_source.py
@@ -1,0 +1,296 @@
+"""한국투자증권 Open API as a market data source.
+
+The contracted route. KRX restricted the server's IP on 2026-08-04 for automated
+bulk collection, and the fix is not gentler scraping — it is asking a provider we
+have an agreement with. KIS is that provider, and it is the only one here besides
+KRX that publishes investor flows.
+
+Two things shape this adapter:
+
+**It borrows the trading client rather than authenticating on its own.** KIS
+issues one token per app key, and `kis_auth` keeps global environment state that
+`changeTREnv` mutates under `get_trading_env_lock()`. A second auth path on the
+same host would fight the live trading loops for that state and could force a
+token re-issue underneath them. `DomesticStockTrading(auto_trading=False)`
+already resolves the account, reuses the cached token and takes the lock on every
+request, so this reuses it. The flag is false because nothing here places orders.
+
+**The daily chart endpoint caps how many rows one call returns.** A year-long
+request comes back truncated with no error, which would quietly chart a shorter
+period than asked for. So ranges are walked backwards in windows until the
+requested start is reached, rather than trusting a single call.
+
+Imports of the trading package are deferred: it reads `trading/config/kis_devlp.yaml`
+at import time and would make this module — and the whole source chain — fail to
+load on a host without KIS credentials.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+import pandas as pd
+
+from cores.market_data.schema import has_ohlcv, normalize
+from cores.market_data.source import Unavailable, Unsupported
+
+logger = logging.getLogger(__name__)
+
+_MARKET_DOMESTIC = "J"
+_MARKET_INDEX = "U"
+
+_DAILY_CHART = "/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice"
+_DAILY_CHART_TR = "FHKST03010100"
+
+_INDEX_CHART = "/uapi/domestic-stock/v1/quotations/inquire-daily-indexchartprice"
+_INDEX_CHART_TR = "FHKUP03500100"
+
+_INVESTOR_DAILY = "/uapi/domestic-stock/v1/quotations/investor-trade-by-stock-daily"
+_INVESTOR_DAILY_TR = "FHPTJ04160001"
+
+# KIS names every price field the same way across these endpoints.
+_PRICE_COLUMNS = {
+    "stck_oprc": "Open",
+    "stck_hgpr": "High",
+    "stck_lwpr": "Low",
+    "stck_clpr": "Close",
+    "acml_vol": "Volume",
+    "acml_tr_pbmn": "Amount",
+}
+
+# KRX index codes to KIS 업종코드. These collide in a way that fails silently:
+# prism (and pykrx) call KOSPI `1001`, but KIS calls KOSDAQ `1001`. Passing the
+# code straight through returned 737.35 for a KOSPI request on 2026-08-03, when
+# KOSPI closed at 6257.45 — a plausible number for the wrong index, which is the
+# worst kind of wrong. Verified by live call: KIS 0001=KOSPI, 1001=KOSDAQ,
+# 2001=KOSPI200.
+_INDEX_CODES = {
+    "1001": "0001",  # KOSPI
+    "2001": "1001",  # KOSDAQ
+}
+
+_INDEX_COLUMNS = {
+    "bstp_nmix_oprc": "Open",
+    "bstp_nmix_hgpr": "High",
+    "bstp_nmix_lwpr": "Low",
+    "bstp_nmix_prpr": "Close",
+    "acml_vol": "Volume",
+    "acml_tr_pbmn": "Amount",
+}
+
+# Downstream code (cores/stock_chart.py:1142) indexes investor flows by these
+# Korean names, so the adapter speaks them rather than making the chart change.
+_FLOW_COLUMNS = {
+    "orgn_ntby_qty": "기관합계",
+    "frgn_ntby_qty": "외국인합계",
+    "prsn_ntby_qty": "개인",
+    "etc_corp_ntby_vol": "기타법인",
+}
+
+_DATE_FIELD = "stck_bsop_date"
+
+# How many windows a single range may take before we stop asking. A daily chart
+# call returns on the order of 100 rows, so this covers several years without
+# looping forever against an endpoint that has stopped moving backwards.
+_MAX_WINDOWS = 40
+
+
+class KisSource:
+    name = "kis"
+
+    def __init__(self) -> None:
+        self._client = None
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------ client
+
+    def _trading(self):
+        """The shared, already-authenticated trading client.
+
+        Built once and reused: construction resolves the account and calls
+        `ka.auth()`, and doing that per request would be both slow and a way to
+        churn the token the trading loops depend on.
+        """
+        if self._client is None:
+            with self._lock:
+                if self._client is None:
+                    try:
+                        from trading.domestic_stock_trading import DomesticStockTrading
+
+                        self._client = DomesticStockTrading(auto_trading=False)
+                    except Exception as exc:  # missing config, auth failure, import
+                        raise Unavailable(f"KIS client unavailable: {exc}") from exc
+        return self._client
+
+    def _fetch(self, api_url: str, tr_id: str, params: dict) -> object:
+        try:
+            response = self._trading()._request(api_url, tr_id, params)
+        except Unavailable:
+            raise
+        except Exception as exc:  # transport, auth, rate limit — all "not now"
+            raise Unavailable(f"KIS {tr_id} failed: {exc}") from exc
+
+        if not response or not response.isOK():
+            detail = ""
+            try:
+                detail = response.getErrorMessage()
+            except Exception:  # noqa: BLE001 - the error body is best-effort
+                pass
+            raise Unavailable(f"KIS {tr_id} rejected the request: {detail}")
+        return response.getBody()
+
+    # ------------------------------------------------------------------ frames
+
+    @staticmethod
+    def _to_frame(rows: list[dict], columns: dict[str, str], what: str) -> pd.DataFrame:
+        """Rows to a date-indexed, numeric frame in the shared schema."""
+        if not rows:
+            raise Unavailable(f"KIS returned no rows for {what}")
+
+        frame = pd.DataFrame(rows)
+        if _DATE_FIELD not in frame.columns:
+            raise Unavailable(f"KIS {what} response has no {_DATE_FIELD}")
+
+        present = {src: dst for src, dst in columns.items() if src in frame.columns}
+        if not present:
+            raise Unavailable(f"KIS {what} response has none of the expected fields")
+
+        out = frame[[_DATE_FIELD, *present]].rename(columns=present)
+        out.index = pd.to_datetime(out.pop(_DATE_FIELD), format="%Y%m%d")
+        # Every value arrives as a string; a blank one is missing, not zero.
+        out = out.apply(pd.to_numeric, errors="coerce")
+        return normalize(out[~out.index.duplicated(keep="first")])
+
+    def _walk_range(
+        self, start: str, end: str, fetch_window
+    ) -> list[dict]:
+        """Collect rows for [start, end], one window at a time.
+
+        The endpoint truncates long ranges silently. Rather than assume a row
+        limit, this keeps asking for what is still missing and stops when a
+        window returns nothing new — so it stays correct if the cap changes.
+        """
+        collected: dict[str, dict] = {}
+        cursor = end
+
+        for _ in range(_MAX_WINDOWS):
+            rows = fetch_window(start, cursor)
+            fresh = {
+                str(row[_DATE_FIELD]): row
+                for row in rows
+                if row.get(_DATE_FIELD) and str(row[_DATE_FIELD]) not in collected
+            }
+            if not fresh:
+                break
+            collected.update(fresh)
+
+            earliest = min(fresh)
+            if earliest <= start:
+                break
+            # Step one day back from the earliest row we have, so the next
+            # window ends where this one began without re-fetching it.
+            cursor = (pd.Timestamp(earliest) - pd.Timedelta(days=1)).strftime("%Y%m%d")
+            if cursor < start:
+                break
+
+        return [collected[key] for key in sorted(collected)]
+
+    # -------------------------------------------------------------- capabilities
+
+    def price_history(
+        self, ticker: str, start: str, end: str, *, adjusted: bool = True
+    ) -> pd.DataFrame:
+        def window(window_start: str, window_end: str) -> list[dict]:
+            body = self._fetch(
+                _DAILY_CHART,
+                _DAILY_CHART_TR,
+                {
+                    "FID_COND_MRKT_DIV_CODE": _MARKET_DOMESTIC,
+                    "FID_INPUT_ISCD": ticker,
+                    "FID_INPUT_DATE_1": window_start,
+                    "FID_INPUT_DATE_2": window_end,
+                    "FID_PERIOD_DIV_CODE": "D",
+                    # 0 is 수정주가 — split- and issuance-adjusted, which is what
+                    # every indicator downstream assumes.
+                    "FID_ORG_ADJ_PRC": "0" if adjusted else "1",
+                },
+            )
+            return list(getattr(body, "output2", None) or [])
+
+        rows = self._walk_range(start, end, window)
+        frame = self._to_frame(rows, _PRICE_COLUMNS, f"ohlcv {ticker}")
+        if not has_ohlcv(frame):
+            raise Unavailable(f"KIS ohlcv {ticker} missing OHLCV columns")
+        return frame
+
+    def index_history(self, index_code: str, start: str, end: str) -> pd.DataFrame:
+        kis_code = _INDEX_CODES.get(str(index_code))
+        if kis_code is None:
+            # Guessing would return a real number for a different index.
+            raise Unsupported(f"no KIS 업종코드 mapped for index {index_code}")
+
+        def window(window_start: str, window_end: str) -> list[dict]:
+            body = self._fetch(
+                _INDEX_CHART,
+                _INDEX_CHART_TR,
+                {
+                    "FID_COND_MRKT_DIV_CODE": _MARKET_INDEX,
+                    "FID_INPUT_ISCD": kis_code,
+                    "FID_INPUT_DATE_1": window_start,
+                    "FID_INPUT_DATE_2": window_end,
+                    "FID_PERIOD_DIV_CODE": "D",
+                },
+            )
+            return list(getattr(body, "output2", None) or [])
+
+        rows = self._walk_range(start, end, window)
+        return self._to_frame(rows, _INDEX_COLUMNS, f"index {index_code}")
+
+    def investor_flows(self, ticker: str, start: str, end: str) -> pd.DataFrame:
+        """Net buying by investor type — the gap KRX alone used to fill.
+
+        `FID_INPUT_DATE_1` is an as-of date, not a range start: the endpoint
+        answers with roughly 30 sessions ending there. Passing the caller's
+        `start` therefore returns the month *before* the range and none of it —
+        a request for 07-28..08-03 came back 06-22..07-28 in testing. So the
+        cursor is the end date, and longer ranges are walked back like prices.
+        """
+        def window(window_start: str, window_end: str) -> list[dict]:
+            body = self._fetch(
+                _INVESTOR_DAILY,
+                _INVESTOR_DAILY_TR,
+                {
+                    "FID_COND_MRKT_DIV_CODE": _MARKET_DOMESTIC,
+                    "FID_INPUT_ISCD": ticker,
+                    "FID_INPUT_DATE_1": window_end,
+                    "FID_ORG_ADJ_PRC": "0",
+                    "FID_ETC_CLS_CODE": "",
+                },
+            )
+            return list(getattr(body, "output2", None) or [])
+
+        rows = self._walk_range(start, end, window)
+        frame = self._to_frame(rows, _FLOW_COLUMNS, f"flows {ticker}")
+        return frame[
+            (frame.index >= pd.Timestamp(start)) & (frame.index <= pd.Timestamp(end))
+        ]
+
+    def market_cap_history(self, ticker: str, start: str, end: str) -> pd.DataFrame:
+        # The chart endpoint carries 시가총액 only in output1, as one current
+        # value — there is no series. Reconstructing it from a constant share
+        # count is what FdrSource already does, and doing it here too would just
+        # hide which source the approximation came from.
+        raise Unsupported("KIS publishes market cap as a current value, not a series")
+
+    def fundamentals(self, ticker: str, start: str, end: str) -> pd.DataFrame:
+        # PER/PBR/EPS/BPS come from inquire-price as today's snapshot only.
+        raise Unsupported("KIS publishes PER/PBR as current values, not a series")
+
+    def ticker_name(self, ticker: str) -> str:
+        # inquire-price carries no company name. The nearest fields are the
+        # market and the sector, and `get_current_price` maps `stock_name` to
+        # `rprs_mrkt_kor_name` — so asking it for 005930 answers "KOSPI200",
+        # not "삼성전자". Returning that would label every chart with a market
+        # name, so this is declared missing and the chain falls through.
+        raise Unsupported("KIS inquire-price does not return a company name")

--- a/cores/market_data/kis_source.py
+++ b/cores/market_data/kis_source.py
@@ -132,13 +132,26 @@ class KisSource:
             raise Unavailable(f"KIS {tr_id} failed: {exc}") from exc
 
         if not response or not response.isOK():
-            detail = ""
-            try:
-                detail = response.getErrorMessage()
-            except Exception:  # noqa: BLE001 - the error body is best-effort
-                pass
-            raise Unavailable(f"KIS {tr_id} rejected the request: {detail}")
+            raise Unavailable(
+                f"KIS {tr_id} rejected the request: {self._error_detail(response)}"
+            )
         return response.getBody()
+
+    @staticmethod
+    def _error_detail(response) -> str:
+        """KIS's reason for refusing, or why we could not read one.
+
+        Reported rather than swallowed: the difference between a rate limit and
+        a bad ticker is the whole diagnosis, and a rejection that says nothing
+        is what turned the 2026-08-04 outage into a two-hour hunt.
+        """
+        getter = getattr(response, "getErrorMessage", None)
+        if getter is None:
+            return "no error message on the response"
+        try:
+            return str(getter() or "").strip() or "empty error message"
+        except Exception as exc:  # noqa: BLE001 - never mask the original failure
+            return f"error message unreadable ({type(exc).__name__}: {exc})"
 
     # ------------------------------------------------------------------ frames
 

--- a/tests/test_kis_source.py
+++ b/tests/test_kis_source.py
@@ -237,3 +237,24 @@ def test_module_imports_without_kis_credentials():
     assert "kis" in module._BUILDERS
     # Registered but not default: existing behaviour is unchanged until promoted.
     assert module._DEFAULT_ORDER == "krx,fdr"
+
+
+def test_rejection_reports_why_even_when_the_error_body_is_broken():
+    """A rejection that says nothing is what makes an outage take hours."""
+    class _Broken(_Response):
+        def getErrorMessage(self):  # noqa: N802
+            raise RuntimeError("body parse failed")
+
+    class _BrokenClient(_FakeClient):
+        def _request(self, api_url, tr_id, params):
+            self.calls.append(params)
+            return _Broken([], ok=False)
+
+    with pytest.raises(Unavailable, match="unreadable"):
+        _source(_BrokenClient()).price_history("005930", "20260803", "20260803")
+
+
+def test_rejection_includes_the_kis_reason():
+    client = _FakeClient(ok=False, error="초당 거래건수를 초과하였습니다")
+    with pytest.raises(Unavailable, match="초당 거래건수"):
+        _source(client).price_history("005930", "20260803", "20260803")

--- a/tests/test_kis_source.py
+++ b/tests/test_kis_source.py
@@ -1,0 +1,239 @@
+"""Offline tests for the KIS market data source.
+
+A fake trading client stands in for `DomesticStockTrading`, so nothing here
+authenticates, spends KIS quota, or touches the token file the live trading
+loops share.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from cores.market_data.kis_source import KisSource  # noqa: E402
+from cores.market_data.source import Unavailable, Unsupported  # noqa: E402
+
+
+class _Body:
+    def __init__(self, output2):
+        self.output2 = output2
+
+
+class _Response:
+    def __init__(self, output2, ok=True, error=""):
+        self._body = _Body(output2)
+        self._ok = ok
+        self._error = error
+
+    def isOK(self):  # noqa: N802 - mirrors the KIS SDK
+        return self._ok
+
+    def getBody(self):  # noqa: N802
+        return self._body
+
+    def getErrorMessage(self):  # noqa: N802
+        return self._error
+
+
+class _FakeClient:
+    """Replays canned windows and records what was asked for."""
+
+    def __init__(self, windows=None, ok=True, error="", name="삼성전자"):
+        self.windows = windows if windows is not None else []
+        self.calls: list[dict] = []
+        self._ok = ok
+        self._error = error
+        self._name = name
+
+    def _request(self, api_url, tr_id, params):
+        self.calls.append(params)
+        if not self._ok:
+            return _Response([], ok=False, error=self._error)
+        index = min(len(self.calls) - 1, len(self.windows) - 1) if self.windows else 0
+        rows = self.windows[index] if self.windows else []
+        return _Response(rows)
+
+    def get_current_price(self, ticker):
+        return {"stock_name": self._name}
+
+
+def _price_row(date, close=1000):
+    return {
+        "stck_bsop_date": date,
+        "stck_oprc": str(close - 10),
+        "stck_hgpr": str(close + 10),
+        "stck_lwpr": str(close - 20),
+        "stck_clpr": str(close),
+        "acml_vol": "12345",
+        "acml_tr_pbmn": "678900",
+    }
+
+
+def _source(client):
+    source = KisSource()
+    source._client = client
+    return source
+
+
+def test_price_history_maps_to_the_shared_schema():
+    client = _FakeClient([[_price_row("20260803", 1000), _price_row("20260731", 990)]])
+    frame = _source(client).price_history("005930", "20260731", "20260803")
+
+    assert list(frame.columns) == ["Open", "High", "Low", "Close", "Volume", "Amount"]
+    assert isinstance(frame.index, pd.DatetimeIndex)
+    assert frame.index.is_monotonic_increasing
+    assert frame.loc["2026-08-03", "Close"] == 1000
+    assert frame.loc["2026-08-03", "Open"] == 990
+
+
+def test_long_range_is_walked_rather_than_truncated():
+    """The endpoint caps rows per call; a single call would silently short the range."""
+    client = _FakeClient(
+        [
+            [_price_row("20260803"), _price_row("20260802")],  # first window
+            [_price_row("20260801"), _price_row("20260731")],  # second, older
+            [],                                                 # nothing left
+        ]
+    )
+    frame = _source(client).price_history("005930", "20260731", "20260803")
+
+    assert len(frame) == 4
+    assert str(frame.index.min().date()) == "2026-07-31"
+    assert len(client.calls) >= 2, "a truncated first window must be followed up"
+
+
+def test_walk_stops_when_a_window_returns_nothing_new():
+    """A source stuck on the same rows must not loop forever."""
+    same = [_price_row("20260803")]
+    client = _FakeClient([same, same, same])
+    frame = _source(client).price_history("005930", "20200101", "20260803")
+
+    assert len(frame) == 1
+    assert len(client.calls) <= 3
+
+
+def test_investor_flows_uses_the_column_names_the_chart_indexes():
+    rows = [
+        {
+            "stck_bsop_date": "20260803",
+            "orgn_ntby_qty": "1000",
+            "frgn_ntby_qty": "-2000",
+            "prsn_ntby_qty": "500",
+            "etc_corp_ntby_vol": "12",
+        }
+    ]
+    frame = _source(_FakeClient([rows])).investor_flows("005930", "20260801", "20260803")
+
+    assert set(frame.columns) == {"기관합계", "외국인합계", "개인", "기타법인"}
+    assert frame.loc["2026-08-03", "외국인합계"] == -2000
+
+
+def _flow_row(date, qty="1"):
+    return {"stck_bsop_date": date, "orgn_ntby_qty": qty, "frgn_ntby_qty": qty,
+            "prsn_ntby_qty": qty, "etc_corp_ntby_vol": qty}
+
+
+def test_investor_flows_trims_to_the_requested_range():
+    """The endpoint answers with a fixed window around the as-of date, so rows
+    outside what was asked for arrive and must not leak through."""
+    rows = [_flow_row("20260731"), _flow_row("20260803"), _flow_row("20260804")]
+    frame = _source(_FakeClient([rows])).investor_flows("005930", "20260801", "20260803")
+    assert str(frame.index.max().date()) == "2026-08-03"
+    assert str(frame.index.min().date()) == "2026-08-03"
+
+
+def test_investor_flows_asks_as_of_the_end_date():
+    """FID_INPUT_DATE_1 is an as-of date, not a range start. Sending `start`
+    returned 06-22..07-28 for a 07-28..08-03 request — the month before."""
+    client = _FakeClient([[_flow_row("20260803")]])
+    _source(client).investor_flows("005930", "20260728", "20260803")
+    assert client.calls[0]["FID_INPUT_DATE_1"] == "20260803"
+
+
+def _index_row():
+    return {
+        "stck_bsop_date": "20260803",
+        "bstp_nmix_oprc": "6358.27",
+        "bstp_nmix_hgpr": "6393.00",
+        "bstp_nmix_lwpr": "6230.35",
+        "bstp_nmix_prpr": "6257.45",
+        "acml_vol": "1000",
+        "acml_tr_pbmn": "2000",
+    }
+
+
+def test_index_history_reads_the_index_field_names():
+    client = _FakeClient([[_index_row()]])
+    frame = _source(client).index_history("1001", "20260803", "20260803")
+    assert frame.loc["2026-08-03", "Close"] == pytest.approx(6257.45)
+
+
+def test_index_codes_are_translated_not_passed_through():
+    """KRX calls KOSPI 1001; KIS calls KOSDAQ 1001. Passing it through returns
+    a real number for the wrong index — verified live: 737.35 vs 6257.45."""
+    client = _FakeClient([[_index_row()]])
+    _source(client).index_history("1001", "20260803", "20260803")
+    assert client.calls[0]["FID_INPUT_ISCD"] == "0001", "KOSPI must become 0001"
+
+    client = _FakeClient([[_index_row()]])
+    _source(client).index_history("2001", "20260803", "20260803")
+    assert client.calls[0]["FID_INPUT_ISCD"] == "1001", "KOSDAQ must become 1001"
+
+
+def test_unmapped_index_is_unsupported_rather_than_guessed():
+    with pytest.raises(Unsupported, match="업종코드"):
+        _source(_FakeClient()).index_history("9999", "20260803", "20260803")
+
+
+def test_empty_response_is_unavailable_not_an_empty_frame():
+    """An empty frame renders as a blank chart; the caller must be told instead."""
+    with pytest.raises(Unavailable, match="no rows"):
+        _source(_FakeClient([[]])).price_history("005930", "20260801", "20260803")
+
+
+def test_rejected_request_is_unavailable():
+    client = _FakeClient(ok=False, error="초당 거래건수를 초과하였습니다")
+    with pytest.raises(Unavailable, match="rejected"):
+        _source(client).price_history("005930", "20260801", "20260803")
+
+
+def test_blank_value_is_nan_not_zero():
+    rows = [{**_price_row("20260803"), "stck_clpr": ""}]
+    frame = _source(_FakeClient([rows])).price_history("005930", "20260803", "20260803")
+    assert pd.isna(frame.loc["2026-08-03", "Close"])
+
+
+@pytest.mark.parametrize("capability", ["market_cap_history", "fundamentals"])
+def test_series_only_capabilities_are_declared_unsupported(capability):
+    """Unsupported, not faked: the chain should fall through to a source that has it."""
+    source = _source(_FakeClient())
+    with pytest.raises(Unsupported):
+        getattr(source, capability)("005930", "20260801", "20260803")
+
+
+def test_ticker_name_is_unsupported_rather_than_the_market_name():
+    """`get_current_price` maps stock_name to rprs_mrkt_kor_name, so 005930
+    answers "KOSPI200". Charts would be labelled with a market, not a company."""
+    with pytest.raises(Unsupported, match="company name"):
+        _source(_FakeClient()).ticker_name("005930")
+
+
+def test_adjusted_flag_is_passed_through():
+    client = _FakeClient([[_price_row("20260803")]])
+    _source(client).price_history("005930", "20260803", "20260803", adjusted=False)
+    assert client.calls[0]["FID_ORG_ADJ_PRC"] == "1"
+
+    client = _FakeClient([[_price_row("20260803")]])
+    _source(client).price_history("005930", "20260803", "20260803", adjusted=True)
+    assert client.calls[0]["FID_ORG_ADJ_PRC"] == "0"
+
+
+def test_module_imports_without_kis_credentials():
+    """The chain must load on hosts that have no trading config at all."""
+    import importlib
+
+    module = importlib.import_module("cores.market_data")
+    assert "kis" in module._BUILDERS
+    # Registered but not default: existing behaviour is unchanged until promoted.
+    assert module._DEFAULT_ORDER == "krx,fdr"


### PR DESCRIPTION
## 왜

KRX 가 못 주는 것을 KIS 가 준다. 특히 **수급** — 지금까지 "대체 소스 없음"으로 `market_data/__init__.py:141` 에서 KRX 직결 패스스루로 남아 있던 능력이다. `investor-trade-by-stock-daily` 가 OHLCV 와 투자자별 순매수를 한 번에 준다.

기본 순서는 `krx,fdr` 그대로다. **이 PR 은 기존 동작을 바꾸지 않는다.** 등록만 해두고 `PRISM_MARKET_DATA_SOURCES=kis,fdr,krx` 로 승격하는 건 실측을 보고 정한다.

## 토큰 안전성 — 별도 인증 경로를 만들지 않았다

KIS 는 앱키당 토큰 하나고, `kis_auth` 의 전역 환경을 `changeTREnv` 가 `get_trading_env_lock()` 아래서 바꾼다. **같은 호스트(db-server)에서 자동매매 loop_a/loop_c 가 돈다.** 두 번째 인증 경로는 그 전역 상태를 놓고 다투고 토큰을 밑에서 갈아치울 수 있다.

그래서 `DomesticStockTrading(auto_trading=False)` 를 그대로 빌려 쓴다. 실측 확인:
```
✅ Valid token found (expires: 2026-08-05 09:00:04)
✅ Using existing valid token
```
재발급 없음.

## 실호출이 잡아낸 결함 3건 — 오프라인 테스트로는 하나도 못 잡았다

**1. 🔴 지수코드가 조용히 다른 지수를 준다**
prism·pykrx 는 KOSPI 를 `1001` 이라 부르는데 **KIS 는 `1001` 이 KOSDAQ 이다.** 그대로 넘기면 8/3 코스피 요청에 `737.35` 가 온다 — 정답은 `6257.45`. 예외도 안 나고 그럴듯한 숫자라 가장 나쁜 종류의 오류다. `1001→0001`, `2001→1001` 로 옮기고 미매핑 코드는 Unsupported.

**2. 🔴 수급이 요청 구간을 안 지킨다**
`FID_INPUT_DATE_1` 은 구간 시작이 아니라 **기준일**이고 거기서 과거로 약 30세션을 준다. start 를 넣으면 `07-28~08-03` 요청에 `06-22~07-28` 이 온다 — 요청 구간이 통째로 빠진다. 커서를 end 로 바꿨다.

**3. 🔴 `ticker_name` 이 시장명을 반환한다**
`get_current_price` 가 stock_name 을 `rprs_mrkt_kor_name` 에 매핑해서 005930 을 물으면 **"KOSPI200"** 이 나온다. inquire-price 에 종목명 필드가 아예 없다. 차트 라벨이 전부 시장명이 될 뻔했다. Unsupported 로 선언해 체인이 넘어가게 했다.

## 그 밖

- 일별차트가 긴 구간을 말없이 자른다. 행 수 상한을 가정하지 않고 못 받은 구간을 계속 되물어 채운다 — 상한이 바뀌어도 따라간다. 1년 요청에 244행(거래일 수 일치).
- 시가총액·펀더멘털은 Unsupported. KIS 는 현재값만 주고 시계열이 없다. 상수 주식수 재구성은 FdrSource 가 이미 `approximate` 표시까지 붙여 하고 있고, 여기서 또 하면 어느 소스의 근사인지 알 수 없어진다.

## 검증

실호출 (db-server, 매매 크론 비가동 시간대):
```
삼성전자 8/3  KIS      O=248000 H=249500 L=238000 C=239500 V=27825493
              KRX OPEN O=248000 H=249500 L=238000 C=239500 V=27825493   ← 완전일치
지수  KRX 1001 → 6257.45 (코스피)    KRX 2001 → 737.35 (코스닥)
수급  07-28~08-03 5행 / 60일 구간 44행
```
서로 독립된 두 정식 소스가 같은 값을 낸다.

- 오프라인 테스트 **17건** (가짜 클라이언트 — 인증·쿼터·토큰 안 건드림)
- 기존 소스체인·스냅샷·스크리닝 포함 **72건 회귀 없음**

🤖 Generated with [Claude Code](https://claude.com/claude-code)