### PR TITLE
fix(trend-facts): 200일선을 주거나, 없다고 말하거나

### DIFF
--- a/cores/agents/trading_agents.py
+++ b/cores/agents/trading_agents.py
@@ -99,6 +99,10 @@ def create_trading_scenario_agent(language: str = "ko", sector_names: list = Non
         - (T2) The 20-day MA is sloping down AND close is ≥5% below the 20-day MA — a sharp early breakdown
         Use the provided '개별 추세 팩트 / Individual Trend Facts' input and report section '1-1 Price'
         (if facts absent, judge conservatively from the report).
+        **Only cite a moving average that appears in the facts block.** If a line is marked
+        데이터 없음, or is not listed at all, do not assert where price sits relative to it and do not
+        call it support or resistance — say the data is unavailable instead. A market index's
+        200-day MA is the index's, never the stock's.
         **Exception (entry allowed)** only when the stock reclaims/breaks above the declining MA with
         volume, confirming a trend change. "It looks like it will bounce soon" is NOT an exception.
         State the trend basis in rejection_reason (No Entry) or rationale (exception entry).

--- a/prism-us/cores/agents/trading_agents.py
+++ b/prism-us/cores/agents/trading_agents.py
@@ -427,6 +427,10 @@ trend matches any below → **No Entry**:
 - (T2) The 20-day MA is sloping down AND close is ≥5% below the 20-day MA — a sharp early breakdown
 Use the provided '개별 추세 팩트 / Individual Trend Facts' input and report section '1-1 Price'
 (if facts absent, judge conservatively from the report).
+**Only cite a moving average that appears in the facts block.** If a line is marked 데이터 없음,
+or is not listed at all, do not assert where price sits relative to it and do not call it support
+or resistance — say the data is unavailable instead. A market index's 200-day MA is the index's,
+never the stock's.
 **Exception (entry allowed)** only when the stock reclaims/breaks above the declining MA with
 volume, confirming a trend change. "It looks like it will bounce soon" is NOT an exception.
 State the trend basis in rejection_reason (No Entry) or rationale (exception entry).

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -907,8 +907,13 @@ class USStockTrackingAgent:
 
             client = get_us_data_client()
 
-            # ~6 months of daily bars: enough for MA60 + 60-session RS window (fail-open if short).
-            df = client.get_ohlcv(ticker, period="6mo")
+            # 2 years of daily bars. It was 6mo (~124 sessions), which cannot
+            # produce a 200-day average at all — so the facts block had no MA200
+            # line and the agent filled the silence itself. On 2026-08-04 a PLTR
+            # skip cited "200일선 저항" while the close sat 6.6% *above* its
+            # 200-day. O'Neil's own criterion is price above the 200-day, so this
+            # was not a minor detail. (fail-open if short.)
+            df = client.get_ohlcv(ticker, period="2y")
             if df is None or len(df) < 25 or 'close' not in df.columns:
                 logger.warning(f"[TrendFacts] {ticker} insufficient OHLCV rows; skipping")
                 return ""
@@ -919,6 +924,7 @@ class USStockTrackingAgent:
             ma20_s = close_s.rolling(window=20).mean()
             ma50_s = close_s.rolling(window=50).mean()
             ma60_s = close_s.rolling(window=60).mean()
+            ma200_s = close_s.rolling(window=200).mean()
 
             def _val(s):
                 try:
@@ -943,9 +949,11 @@ class USStockTrackingAgent:
             ma20 = _val(ma20_s)
             ma50 = _val(ma50_s)
             ma60 = _val(ma60_s)
+            ma200 = _val(ma200_s)
             ma20_up = _slope_up(ma20_s)
             ma50_up = _slope_up(ma50_s)
             ma60_up = _slope_up(ma60_s)
+            ma200_up = _slope_up(ma200_s)
 
             # 50일선 우선, 없으면 60일선 fallback (T1용)
             ma_mid = ma50 if ma50 is not None else ma60
@@ -998,12 +1006,32 @@ class USStockTrackingAgent:
             def _fmt(v, suffix=""):
                 return f"{v:+.1f}{suffix}" if v is not None else "n/a"
 
+            def _ma200_line():
+                """State the 200-day, or state plainly that there isn't one.
+
+                Omitting it is what caused the invention this fixes: the agent is
+                told to reason from this block, and a missing line reads as
+                "unmentioned" rather than "unknown". Recent IPOs will always land
+                here, so the absence has to say so out loud.
+                """
+                if ma200 is None:
+                    return (
+                        f"- vs MA200: **데이터 없음** — 확보 {len(close_s)}거래일로 "
+                        "200일 이동평균을 계산할 수 없습니다. "
+                        "200일선을 근거로 서술하지 마십시오."
+                    )
+                return (
+                    f"- vs MA200: {_above(close, ma200)} "
+                    f"({_fmt(_pct(close, ma200), '%')}), MA200 기울기: {_dir(ma200_up)}"
+                )
+
             lines = [
                 "### 📉 개별 추세 팩트 (추세 게이트용 · as-of 오늘)",
                 f"- 종가: {close:,.2f}",
                 f"- vs MA20: {_above(close, ma20)} ({_fmt(_pct(close, ma20), '%')}), MA20 기울기: {_dir(ma20_up)}",
                 f"- vs MA50: {_above(close, ma50)} ({_fmt(_pct(close, ma50), '%')}), MA50 기울기: {_dir(ma50_up)}",
                 f"- vs MA60: {_above(close, ma60)} ({_fmt(_pct(close, ma60), '%')}), MA60 기울기: {_dir(ma60_up)}",
+                _ma200_line(),
                 f"- RS(60일, 종목-S&P500): {_fmt(rs, '%p')} (종목 {_fmt(stock_ret, '%')} / 지수 {_fmt(idx_ret, '%')})",
                 f"- T1_hit(종가<{ma_mid_label}, 오닐 10주선 이탈): {t1_hit} / "
                 f"T2_hit(MA20 하락 and 종가 MA20 대비 -5%↓): {t2_hit}",

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -561,7 +561,13 @@ class StockTrackingAgent:
             )
 
             end_dt = datetime.now()
-            start_dt = end_dt - timedelta(days=120)
+            # 400 calendar days ≈ 270 sessions: enough for MA200 with room to spare.
+            # It was 120 days (~82 sessions), which cannot produce a 200-day average
+            # at all — so the facts block simply had no MA200 line, and the agent
+            # filled the silence itself. On 2026-08-04 a PLTR skip cited "200일선
+            # 저항" while the close sat 6.6% *above* its 200-day. O'Neil's own
+            # criterion is price above the 200-day, so this was not a minor detail.
+            start_dt = end_dt - timedelta(days=400)
             end = end_dt.strftime("%Y%m%d")
             start = start_dt.strftime("%Y%m%d")
 
@@ -576,6 +582,7 @@ class StockTrackingAgent:
             ma20_s = close_s.rolling(window=20).mean()
             ma50_s = close_s.rolling(window=50).mean()
             ma60_s = close_s.rolling(window=60).mean()
+            ma200_s = close_s.rolling(window=200).mean()
 
             def _val(s):
                 try:
@@ -600,9 +607,11 @@ class StockTrackingAgent:
             ma20 = _val(ma20_s)
             ma50 = _val(ma50_s)
             ma60 = _val(ma60_s)
+            ma200 = _val(ma200_s)
             ma20_up = _slope_up(ma20_s)
             ma50_up = _slope_up(ma50_s)
             ma60_up = _slope_up(ma60_s)
+            ma200_up = _slope_up(ma200_s)
 
             # 50일선 우선, 없으면 60일선 fallback (T1용)
             ma_mid = ma50 if ma50 is not None else ma60
@@ -660,12 +669,32 @@ class StockTrackingAgent:
             def _fmt(v, suffix=""):
                 return f"{v:+.1f}{suffix}" if v is not None else "n/a"
 
+            def _ma200_line():
+                """State the 200-day, or state plainly that there isn't one.
+
+                Omitting it is what caused the invention this fixes: the agent is
+                told to reason from this block, and a missing line reads as
+                "unmentioned" rather than "unknown". Newly listed names will
+                always land here, so the absence has to say so out loud.
+                """
+                if ma200 is None:
+                    return (
+                        f"- vs MA200: **데이터 없음** — 확보 {len(close_s)}거래일로 "
+                        "200일 이동평균을 계산할 수 없습니다. "
+                        "200일선을 근거로 서술하지 마십시오."
+                    )
+                return (
+                    f"- vs MA200: {_above(close, ma200)} "
+                    f"({_fmt(_pct(close, ma200), '%')}), MA200 기울기: {_dir(ma200_up)}"
+                )
+
             lines = [
                 "### 📉 개별 추세 팩트 (추세 게이트용 · as-of 오늘)",
                 f"- 종가: {close:,.0f}",
                 f"- vs MA20: {_above(close, ma20)} ({_fmt(_pct(close, ma20), '%')}), MA20 기울기: {_dir(ma20_up)}",
                 f"- vs MA50: {_above(close, ma50)} ({_fmt(_pct(close, ma50), '%')}), MA50 기울기: {_dir(ma50_up)}",
                 f"- vs MA60: {_above(close, ma60)} ({_fmt(_pct(close, ma60), '%')}), MA60 기울기: {_dir(ma60_up)}",
+                _ma200_line(),
                 f"- RS(60일, 종목-지수): {_fmt(rs, '%p')} (종목 {_fmt(stock_ret, '%')} / 지수 {_fmt(idx_ret, '%')})",
                 f"- T1_hit(종가<{ma_mid_label}, 오닐 10주선 이탈): {t1_hit} / "
                 f"T2_hit(MA20 하락 and 종가 MA20 대비 -5%↓): {t2_hit}",

--- a/tests/test_trend_facts_ma200.py
+++ b/tests/test_trend_facts_ma200.py
@@ -1,0 +1,180 @@
+"""The 200-day MA must be stated, or its absence must be stated.
+
+2026-08-04, US afternoon batch, PLTR skip: "다만 하락 중인 50·60일선과 200일선 저항이
+남아 있고". The 50- and 60-day parts were right. The 200-day part was invented, and
+backwards — PLTR closed at 162.66 against a 200-day of 152.54, i.e. 6.6% *above* it.
+
+The cause was not a wrong number. It was a missing one. `_get_trend_facts` fetched
+6 months (US) / 120 days (KR) of bars, which cannot produce a 200-day average, so the
+facts block simply had no MA200 line. The agent is instructed to reason from that
+block, and a line that is absent reads as "not worth mentioning" rather than
+"unknown" — so it filled the gap, plausibly and wrongly. The market context in the
+same prompt does carry a 200-day, but the index's, which is a tempting thing to
+borrow.
+
+Price above the 200-day is one of O'Neil's own criteria, so this is not decoration.
+These tests hold the two halves of the fix: the window is long enough to compute it,
+and when it still cannot be computed the block says so out loud.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+for _n in [
+    "mcp_agent",
+    "mcp_agent.app",
+    "mcp_agent.workflows",
+    "mcp_agent.workflows.llm",
+    "mcp_agent.workflows.llm.augmented_llm",
+    "cores.llm",
+    "cores.llm.openai_responses_llm",
+    "cores.agents.trading_agents",
+    "Crypto",
+    "Crypto.Cipher",
+    "Crypto.Cipher.AES",
+    "Crypto.Util",
+    "Crypto.Util.Padding",
+    "trading.kis_auth",
+    "seaborn",
+    "cores.stock_chart",
+]:
+    sys.modules.setdefault(_n, MagicMock())
+
+
+def _bars(n: int, start: float = 100.0, step: float = 0.5) -> pd.DataFrame:
+    """Steadily rising closes — enough structure for a rising 200-day."""
+    dates = pd.date_range("2025-01-01", periods=n, freq="B")
+    close = [start + i * step for i in range(n)]
+    return pd.DataFrame(
+        {
+            "Close": close,
+            "Open": [c - 1 for c in close],
+            "High": [c + 1 for c in close],
+            "Low": [c - 2 for c in close],
+            "Volume": [1_000_000] * n,
+        },
+        index=dates,
+    )
+
+
+def _kr_agent(tmp_path, name):
+    from stock_tracking_agent import StockTrackingAgent
+
+    return StockTrackingAgent(db_path=str(tmp_path / f"{name}.sqlite"))
+
+
+def _configure_kr(frame):
+    sc = sys.modules["cores.stock_chart"]
+    sc.get_market_ohlcv_by_date.reset_mock()
+    sc.get_market_ohlcv_by_date.return_value = frame
+    sc.get_index_ohlcv_by_date.return_value = None
+    sc._detect_index_ticker.return_value = "^KS11"
+    return sc
+
+
+def _kr_facts(tmp_path, name, frame):
+    _configure_kr(frame)
+    agent = _kr_agent(tmp_path, name)
+    with patch("cores.regime_policy.get_market_pulse_detail", return_value=None):
+        return agent._get_trend_facts("005930")
+
+
+# --------------------------------------------------------------------------- KR
+
+def test_kr_states_the_200_day_when_it_can_be_computed(tmp_path):
+    facts = _kr_facts(tmp_path, "kr_present", _bars(260))
+
+    assert "MA200" in facts, f"200-day missing from the facts block:\n{facts}"
+    ma200_line = next(l for l in facts.splitlines() if "MA200" in l)
+    # Rising series: the last close is above its own 200-day, and the average rises.
+    assert "위" in ma200_line, ma200_line
+    assert "상승" in ma200_line, ma200_line
+
+
+def test_kr_says_so_when_the_200_day_cannot_be_computed(tmp_path):
+    """Silence is what the agent filled in. Absence has to be explicit."""
+    facts = _kr_facts(tmp_path, "kr_absent", _bars(70))
+
+    assert "MA200" in facts, f"the absent 200-day still needs a line:\n{facts}"
+    ma200_line = next(l for l in facts.splitlines() if "MA200" in l)
+    assert "데이터 없음" in ma200_line, ma200_line
+    assert "서술하지" in ma200_line, (
+        f"the block must tell the agent not to narrate it:\n{ma200_line}"
+    )
+
+
+def test_kr_requests_enough_history_for_a_200_day(tmp_path):
+    """120 calendar days (~82 sessions) can never yield a 200-day average."""
+    sc = _configure_kr(_bars(260))
+    agent = _kr_agent(tmp_path, "kr_window")
+    with patch("cores.regime_policy.get_market_pulse_detail", return_value=None):
+        agent._get_trend_facts("005930")
+
+    start, end = sc.get_market_ohlcv_by_date.call_args[0][:2]
+    span_days = (pd.Timestamp(end) - pd.Timestamp(start)).days
+    assert span_days >= 400, (
+        f"requested only {span_days} calendar days; a 200-session average needs ~280+"
+    )
+
+
+def test_kr_keeps_the_shorter_averages(tmp_path):
+    """The fix adds a line; it must not disturb the ones the gate already uses."""
+    facts = _kr_facts(tmp_path, "kr_others", _bars(260))
+    for label in ("MA20", "MA50", "MA60", "T1_hit", "T2_hit"):
+        assert label in facts, f"{label} disappeared from the facts block:\n{facts}"
+
+
+# --------------------------------------------------------------------------- US
+
+def test_us_requests_two_years_of_bars():
+    """`period="6mo"` yielded ~124 sessions — short of 200 by construction.
+
+    Scoped to the ticker's own bars: the S&P 500 fetch a few lines below still
+    asks for 6mo, and rightly so — it only feeds a 60-session relative-strength
+    comparison and needs no 200-day.
+    """
+    source = (PROJECT_ROOT / "prism-us" / "us_stock_tracking_agent.py").read_text()
+    assert 'client.get_ohlcv(ticker, period="6mo")' not in source, (
+        "6mo cannot produce a 200-day average; the PLTR invention started here"
+    )
+    assert 'client.get_ohlcv(ticker, period="2y")' in source, (
+        "expected the trend-facts fetch to ask for 2y of the ticker's own bars"
+    )
+
+
+def test_us_facts_block_carries_the_200_day():
+    source = (PROJECT_ROOT / "prism-us" / "us_stock_tracking_agent.py").read_text()
+    assert "ma200_s = close_s.rolling(window=200).mean()" in source
+    assert "_ma200_line()" in source, "the MA200 line must be in the emitted block"
+    assert "데이터 없음" in source, "absence must be stated, not left silent"
+
+
+# ------------------------------------------------------------------- prompt guard
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "cores/agents/trading_agents.py",
+        "prism-us/cores/agents/trading_agents.py",
+    ],
+)
+def test_prompt_forbids_citing_absent_moving_averages(path):
+    """Belt and braces: a newly listed name will still have no 200-day."""
+    # The prompts are wrapped prose, so line breaks fall in different places in
+    # each file. Compare on collapsed whitespace rather than on the wrapping.
+    source = " ".join((PROJECT_ROOT / path).read_text().split())
+    assert "Only cite a moving average that appears in the facts block" in source, (
+        f"{path} does not forbid citing averages that were never provided"
+    )
+    assert "index's 200-day MA is the index's" in source, (
+        f"{path} does not warn against borrowing the index's 200-day for the stock"
+    )


### PR DESCRIPTION
## 무슨 일이 있었나

2026-08-04 US 오후 배치, PLTR 매수보류 메시지:

> 다만 하락 중인 50·60일선과 **200일선 저항**이 남아 있고, 업종 평균의 6.2배인 P/E 및 10% 밖의 차트 지지선이 지금의 일괄 진입을 배제합니다.

50·60일선은 맞다(실측 20거래일 −2.27% / −2.62%). **200일선은 지어낸 것이고 방향까지 반대다** — 종가 `162.66` vs MA200 `152.54`, 저항이 아니라 **6.6% 위**였다.

## 원인 — 틀린 숫자가 아니라 없는 숫자

`_get_trend_facts` 가 받는 구간이 200일 이동평균을 계산할 수 없는 길이였다.

```
US  period="6mo"              → 124 거래일 → MA200 = NaN
KR  timedelta(days=120)       →  82 거래일 → MA200 = NaN
```

그래서 팩트 블록에 `vs MA20 / MA50 / MA60` 만 있고 **MA200 줄이 아예 없었다.**

프롬프트는 에이전트에게 *"이 블록으로 판정하라"* 고 지시한다. 그런데 **없는 줄은 "모른다"가 아니라 "언급할 가치가 없다"로 읽힌다.** 그래서 스스로 채웠고, 그럴듯하게 틀렸다.

거기에 같은 프롬프트의 시장 컨텍스트에는 200일선이 있다 — `sp500_200d_ma`, **지수의** 것이다. 빌려다 쓰기 딱 좋은 자리에 있었다.

주가가 200일선 위인지는 **오닐의 핵심 기준**이라 장식이 아니다. 그리고 이건 PLTR 하나가 아니라 **KR·US 모든 매수 판정**에 해당했다.

## 수정

**1. 실제로 계산되게 한다**
```
US  period="6mo"        → "2y"          (501 거래일)
KR  timedelta(days=120) → days=400      (~270 거래일)
```
※ `us_stock_tracking_agent.py:977` 의 S&P 500 `6mo` 는 **그대로 둔다.** 60거래일 RS 비교용이라 200일이 필요없다.

**2. 계산 불가일 때 침묵하지 않는다**
```
- vs MA200: **데이터 없음** — 확보 N거래일로 200일 이동평균을 계산할 수 없습니다.
  200일선을 근거로 서술하지 마십시오.
```
신규 상장주는 앞으로도 계산이 안 된다. 구간만 늘리는 건 반쪽이고, **없다는 사실 자체를 말해야** 재발하지 않는다.

**3. 프롬프트 가드 (KR·US)**
팩트 블록에 없는 이평선은 인용 금지, 지수의 200일선은 지수의 것이지 종목의 것이 아님.

## 검증

PLTR 8/4 기준 수정 후 산출:
```
- vs MA200: 위 (+6.6%), MA200 기울기: 하락
```

**200일선이 하락 중인 건 사실**이므로 에이전트의 우려 자체엔 근거가 있었다. 위치를 반대로 말한 것이 문제였고, 이제 정확한 사실을 받는다.

참고로 이번 **Skip 결정 자체는 타당해 보인다** — 20일선 대비 +25%, 하루 +29.45% 급등 직후라 "지지선이 10% 밖"이 훨씬 강한 근거다. 결정이 아니라 **근거 서술**이 틀렸다. 다만 근거가 틀리면 사용자가 검증할 수 없고, 반대 방향으로 틀릴 때는 결정도 틀린다.

- 신규 테스트 **8건** (KR 동작 4 + US·프롬프트 정책 4)
- 기존 #448 회귀 테스트 **8건** 통과, 소스체인·스냅샷 포함 **68건** 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)