### PR TITLE
fix(triggers): 매수 트리거가 음봉을 뽑지 않게 한다 (KR·US 4곳)

### DIFF
--- a/prism-us/us_trigger_batch.py
+++ b/prism-us/us_trigger_batch.py
@@ -726,6 +726,7 @@ def trigger_afternoon_volume_surge_flat(trade_date: str, snapshot: pd.DataFrame,
 
     # Sideways determination (change within +-5%)
     snap["IsSideways"] = (snap["DailyChange"].abs() <= 5)
+    snap["IsRising"] = snap["Close"] > snap["Open"]
 
     # Additional filter: Volume increase >= 50%
     snap = snap[snap["VolumeIncreaseRate"] >= 50]
@@ -740,8 +741,11 @@ def trigger_afternoon_volume_surge_flat(trade_date: str, snapshot: pd.DataFrame,
     # Primary filter: Top N by composite score
     candidates = scored.head(top_n)
 
-    # Secondary filter: Sideways stocks only
-    result = candidates[candidates["IsSideways"]].copy()
+    # Secondary filter: Sideways stocks only, and only on a bullish candle.
+    # A volume surge that closes below its own open is distribution, not the
+    # accumulation base this trigger is meant to find — IsSideways alone (|move| <= 5%)
+    # cannot tell the two apart.
+    result = candidates[candidates["IsSideways"] & candidates["IsRising"]].copy()
 
     if result.empty:
         logger.debug("trigger_afternoon_volume_surge_flat: No sideways stocks")

--- a/tests/test_trigger_bearish_candle_exclusion.py
+++ b/tests/test_trigger_bearish_candle_exclusion.py
@@ -1,0 +1,251 @@
+"""매수 트리거는 음봉 종목을 뽑지 않는다 (KR·US).
+
+Rocky 보고(2026-08-05): 스크리닝 결과에 음봉이 계속 섞여 나온다.
+
+전수 확인 결과 8개 트리거 중 네 자리에 ``Close > Open`` 검사가 없었다:
+
+| 트리거 | KR | US |
+|---|---|---|
+| volume_surge / gap_up / value_to_cap / closing_strength / contrarian | ✅ | ✅ |
+| daily_rise_top | ❌ **없었다** | ✅ 있었다 |
+| macro_sector_leader | ❌ **없었다** | ✅ 있었다 |
+| volume_surge_flat | ❌ **없었다** | ❌ **없었다** |
+
+KR 두 자리는 US 에 이미 있던 것이 KR 로만 이식되지 않은 비대칭이었다.
+
+각 트리거가 음봉을 통과시킨 경로가 서로 다르다는 점이 중요하다 — 한 곳만 고치면
+나머지가 남는다:
+
+- ``daily_rise_top``  : 전일 종가 대비 +3% 만 본다. 갭상승 후 종일 밀린 종목도 통과.
+- ``macro_sector_leader``: 시장 평균 대비 상대강도만 본다. 하락장에서는 음봉이어도
+  상대강도가 양수일 수 있다.
+- ``volume_surge_flat``: ``|전일대비| <= 5%`` 인 "횡보"만 본다. 거래량이 터지면서
+  시가 아래로 마감하는 것은 매집이 아니라 분산인데 이 조건으로는 구분이 안 된다.
+
+각 테스트는 음봉이 배제되는 것과 **같은 조건의 양봉은 여전히 뽑히는 것**을 함께
+확인한다. 후자가 없으면 "전부 걸러내서 통과"하는 가짜 통과를 못 잡는다.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+import trigger_batch  # noqa: E402
+
+KR_CAP_FLOOR = 500_000_000_000
+KR_AMOUNT = 50_000_000_000  # SCREENING_MIN_TRADE_VALUE(100억) 위
+US_AMOUNT = 500_000_000  # MIN_TRADING_VALUE($100M) 위
+
+
+def _run_us_scenario(script_body: str) -> str:
+    """US 트리거 시나리오를 **별도 프로세스**에서 돌리고 stdout 을 돌려준다.
+
+    ``prism-us/cores/`` 는 리포 루트의 ``cores/`` 를 가리는 **별도 패키지**다
+    (양쪽에 ``rs_rating`` 이 있고, ``us_surge_detector`` 는 prism-us 쪽에만 있다).
+    이 파일의 KR 테스트가 ``trigger_batch`` 를 import 하면서 루트 ``cores`` 가
+    ``sys.modules`` 에 박히므로, 같은 프로세스에서 ``us_trigger_batch`` 를 import
+    하면 ``ModuleNotFoundError: cores.us_surge_detector`` 가 난다.
+
+    ``us_trigger_batch`` 는 자기 import 시점에 ``prism-us`` 를 ``sys.path`` 맨 앞에
+    넣으므로, **깨끗한 프로세스**에서는 정상적으로 로드된다. 로직을 복사해 검사하면
+    실제 코드가 아니라 사본을 검증하게 되므로 프로세스를 나눈다.
+    """
+    completed = subprocess.run(
+        [sys.executable, "-c", script_body],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            f"US 시나리오 실패 (rc={completed.returncode})\n"
+            f"--- stdout ---\n{completed.stdout}\n--- stderr ---\n{completed.stderr}"
+        )
+    return completed.stdout
+
+
+def _frame(rows: dict[str, dict]) -> pd.DataFrame:
+    return pd.DataFrame.from_dict(rows, orient="index")
+
+
+# --- KR ---------------------------------------------------------------------
+
+
+def test_kr_daily_rise_top_excludes_bearish_candle():
+    """갭상승 후 밀린 음봉은 전일 대비 +3% 를 넘겨도 뽑히지 않는다."""
+    # BULL: 시가 100 → 종가 110 (양봉, 전일대비 +10%)
+    # BEAR: 시가 120 → 종가 105 (음봉, 전일대비 +5% — 갭상승 후 종일 밀렸다)
+    snapshot = _frame(
+        {
+            "BULL": {"Open": 100.0, "Close": 110.0, "Volume": 1_000_000, "Amount": KR_AMOUNT},
+            "BEAR": {"Open": 120.0, "Close": 105.0, "Volume": 1_000_000, "Amount": KR_AMOUNT},
+        }
+    )
+    prev = _frame(
+        {
+            "BULL": {"Open": 100.0, "Close": 100.0, "Volume": 1_000_000, "Amount": KR_AMOUNT},
+            "BEAR": {"Open": 100.0, "Close": 100.0, "Volume": 1_000_000, "Amount": KR_AMOUNT},
+        }
+    )
+    cap = pd.DataFrame({"시가총액": {"BULL": KR_CAP_FLOOR * 2, "BEAR": KR_CAP_FLOOR * 2}})
+
+    result = trigger_batch.trigger_afternoon_daily_rise_top("20260804", snapshot, prev, cap)
+
+    assert "BEAR" not in result.index
+    assert "BULL" in result.index
+
+
+def test_kr_volume_surge_flat_excludes_bearish_candle(monkeypatch):
+    """거래량이 터지면서 시가 아래로 마감한 횡보주는 매집이 아니다."""
+    # MA20 게이트는 이 테스트의 관심사가 아니다. 0 = 데이터 없음 → 통과.
+    monkeypatch.setattr(trigger_batch, "_compute_ma20", lambda *a, **k: 0.0)
+
+    # 둘 다 거래량 2배, 전일대비 절대값 5% 이내(횡보).
+    snapshot = _frame(
+        {
+            "BULL": {"Open": 99.0, "Close": 102.0, "Volume": 2_000_000, "Amount": KR_AMOUNT},
+            "BEAR": {"Open": 104.0, "Close": 98.0, "Volume": 2_000_000, "Amount": KR_AMOUNT},
+        }
+    )
+    prev = _frame(
+        {
+            "BULL": {"Open": 100.0, "Close": 100.0, "Volume": 1_000_000, "Amount": KR_AMOUNT},
+            "BEAR": {"Open": 100.0, "Close": 100.0, "Volume": 1_000_000, "Amount": KR_AMOUNT},
+        }
+    )
+    cap = pd.DataFrame({"시가총액": {"BULL": KR_CAP_FLOOR * 2, "BEAR": KR_CAP_FLOOR * 2}})
+
+    result = trigger_batch.trigger_afternoon_volume_surge_flat("20260804", snapshot, prev, cap)
+
+    assert "BEAR" not in result.index
+    assert "BULL" in result.index
+
+
+def test_kr_macro_sector_leader_excludes_bearish_candle():
+    """하락장에서 상대강도가 양수여도 음봉이면 그날의 주도주가 아니다."""
+    macro_context = {
+        "leading_sectors": [{"sector": "반도체", "confidence": 0.9}],
+        "sector_map": {"BULL": "반도체", "BEAR": "반도체"},
+    }
+    snapshot = _frame(
+        {
+            "BULL": {"Open": 99.0, "Close": 103.0, "Volume": 1_000_000, "Amount": KR_AMOUNT},
+            "BEAR": {"Open": 108.0, "Close": 101.0, "Volume": 1_000_000, "Amount": KR_AMOUNT},
+        }
+    )
+    prev = _frame(
+        {
+            "BULL": {"Open": 100.0, "Close": 100.0, "Volume": 1_000_000, "Amount": KR_AMOUNT},
+            "BEAR": {"Open": 100.0, "Close": 100.0, "Volume": 1_000_000, "Amount": KR_AMOUNT},
+        }
+    )
+    cap = pd.DataFrame({"시가총액": {"BULL": KR_CAP_FLOOR * 2, "BEAR": KR_CAP_FLOOR * 2}})
+
+    result = trigger_batch.trigger_macro_sector_leader(
+        "20260804", snapshot, prev, cap, macro_context=macro_context
+    )
+
+    # BEAR 는 전일대비 +1% 로 상대강도가 양수지만 음봉이라 빠진다.
+    assert "BEAR" not in result.index
+    assert "BULL" in result.index
+
+
+def test_kr_macro_sector_leader_returns_empty_when_every_leader_is_bearish():
+    """전부 음봉이면 빈 결과다 — 억지로 하나 뽑지 않는다."""
+    macro_context = {
+        "leading_sectors": [{"sector": "반도체", "confidence": 0.9}],
+        "sector_map": {"BEAR1": "반도체", "BEAR2": "반도체"},
+    }
+    snapshot = _frame(
+        {
+            "BEAR1": {"Open": 108.0, "Close": 101.0, "Volume": 1_000_000, "Amount": KR_AMOUNT},
+            "BEAR2": {"Open": 110.0, "Close": 102.0, "Volume": 1_000_000, "Amount": KR_AMOUNT},
+        }
+    )
+    prev = _frame(
+        {
+            "BEAR1": {"Open": 100.0, "Close": 100.0, "Volume": 1_000_000, "Amount": KR_AMOUNT},
+            "BEAR2": {"Open": 100.0, "Close": 100.0, "Volume": 1_000_000, "Amount": KR_AMOUNT},
+        }
+    )
+    cap = pd.DataFrame({"시가총액": {"BEAR1": KR_CAP_FLOOR * 2, "BEAR2": KR_CAP_FLOOR * 2}})
+
+    result = trigger_batch.trigger_macro_sector_leader(
+        "20260804", snapshot, prev, cap, macro_context=macro_context
+    )
+
+    assert result.empty
+
+
+# --- US ---------------------------------------------------------------------
+
+
+_US_SCENARIO = f"""
+import sys
+sys.path.insert(0, {str(REPO_ROOT / "prism-us")!r})
+
+import pandas as pd
+import us_trigger_batch as us
+
+# MA20 게이트는 이 시나리오의 관심사가 아니다. 0 = 데이터 없음 → 통과.
+us._compute_ma20 = lambda *a, **k: 0.0
+
+A = {US_AMOUNT}
+snapshot = pd.DataFrame.from_dict({{
+    "BULL": {{"Open": 99.0, "Close": 102.0, "Volume": 2_000_000, "Amount": A}},
+    "BEAR": {{"Open": 104.0, "Close": 98.0, "Volume": 2_000_000, "Amount": A}},
+}}, orient="index")
+prev = pd.DataFrame.from_dict({{
+    "BULL": {{"Open": 100.0, "Close": 100.0, "Volume": 1_000_000, "Amount": A}},
+    "BEAR": {{"Open": 100.0, "Close": 100.0, "Volume": 1_000_000, "Amount": A}},
+}}, orient="index")
+
+result = us.trigger_afternoon_volume_surge_flat("20260804", snapshot, prev, None)
+print("SELECTED=" + ",".join(str(t) for t in result.index))
+"""
+
+
+def test_us_volume_surge_flat_excludes_bearish_candle():
+    """US 횡보 트리거에도 같은 구멍이 있었다 — KR 과 함께 막는다."""
+    stdout = _run_us_scenario(_US_SCENARIO)
+
+    selected_line = next(
+        line for line in stdout.splitlines() if line.startswith("SELECTED=")
+    )
+    selected = [t for t in selected_line.removeprefix("SELECTED=").split(",") if t]
+
+    assert "BEAR" not in selected
+    assert "BULL" in selected
+
+
+# --- 이미 막혀 있던 자리 (회귀 방지) -----------------------------------------
+
+
+def test_kr_volume_surge_still_excludes_bearish_candle():
+    """이번 변경이 기존에 동작하던 음봉 배제를 건드리지 않았는지 확인한다."""
+    snapshot = _frame(
+        {
+            "BULL": {"Open": 99.0, "Close": 105.0, "Volume": 2_000_000, "Amount": KR_AMOUNT},
+            "BEAR": {"Open": 108.0, "Close": 104.0, "Volume": 2_000_000, "Amount": KR_AMOUNT},
+        }
+    )
+    prev = _frame(
+        {
+            "BULL": {"Open": 100.0, "Close": 100.0, "Volume": 1_000_000, "Amount": KR_AMOUNT},
+            "BEAR": {"Open": 100.0, "Close": 100.0, "Volume": 1_000_000, "Amount": KR_AMOUNT},
+        }
+    )
+    cap = pd.DataFrame({"시가총액": {"BULL": KR_CAP_FLOOR * 2, "BEAR": KR_CAP_FLOOR * 2}})
+
+    result = trigger_batch.trigger_morning_volume_surge("20260804", snapshot, prev, cap)
+
+    assert "BEAR" not in result.index

--- a/trigger_batch.py
+++ b/trigger_batch.py
@@ -965,9 +965,15 @@ def trigger_afternoon_daily_rise_top(trade_date: str, snapshot: pd.DataFrame, pr
     # Calculate two types of change rates
     snap["intraday_change_rate"] = (snap["Close"] / snap["Open"] - 1) * 100  # Current vs opening price
     snap["prev_day_change_rate"] = ((snap["Close"] - prev["Close"]) / prev["Close"]) * 100  # Same as brokerage app
+    snap["is_rising"] = snap["Close"] > snap["Open"]
 
     # Change rate filter: 3% or more, 20% or less (v1.16.6: surge stocks can enter)
-    snap = snap[(snap["prev_day_change_rate"] >= 3.0) & (snap["prev_day_change_rate"] <= 15.0)]
+    # Bullish candle required — prev_day_change_rate alone measures the move from
+    # yesterday's close, so a stock that gapped up and then sold off all day still
+    # clears +3% while printing a bearish candle. Mirrors us_trigger_batch.py.
+    snap = snap[(snap["prev_day_change_rate"] >= 3.0)
+                & (snap["prev_day_change_rate"] <= 15.0)
+                & snap["is_rising"]]
 
     if snap.empty:
         logger.debug("trigger_afternoon_daily_rise_top: No stocks meeting criteria")
@@ -1096,6 +1102,7 @@ def trigger_afternoon_volume_surge_flat(trade_date: str, snapshot: pd.DataFrame,
 
     # Determine sideways stocks (change rate within ±5%) - v1.16.6: Changed to previous day change rate basis
     snap["is_sideways"] = (snap["prev_day_change_rate"].abs() <= 5)
+    snap["is_rising"] = snap["Close"] > snap["Open"]
 
     # Additional filter: Only stocks with 50% or more volume increase vs previous day
     snap = snap[snap["volume_increase_rate"] >= 50]
@@ -1110,8 +1117,11 @@ def trigger_afternoon_volume_surge_flat(trade_date: str, snapshot: pd.DataFrame,
     # Primary filtering: Top stocks by composite score
     candidates = scored.head(top_n)
 
-    # Secondary filtering: Select only sideways stocks
-    result = candidates[candidates["is_sideways"] == True].copy()
+    # Secondary filtering: Select only sideways stocks, and only on a bullish candle.
+    # A volume surge that closes below its own open is distribution, not the
+    # accumulation base this trigger is meant to find — is_sideways alone (|move| <= 5%)
+    # cannot tell the two apart.
+    result = candidates[candidates["is_sideways"] & candidates["is_rising"]].copy()
 
     if result.empty:
         logger.debug("trigger_afternoon_volume_surge_flat: No stocks meeting criteria")
@@ -1224,6 +1234,14 @@ def trigger_macro_sector_leader(trade_date: str, snapshot: pd.DataFrame,
     # Expose as prev_day_change_rate so the downstream dispatch (which only reads
     # prev_day_change_rate) reports the real change rate instead of 0.
     snap_filtered["prev_day_change_rate"] = snap_filtered["DailyChange"]
+
+    # Bullish candle required (Close > Open) — same rule the other triggers already apply.
+    # A "sector leader" that closes below its own open is not showing leadership today;
+    # relative strength alone can stay positive in a falling market.
+    snap_filtered = snap_filtered[snap_filtered["Close"] > snap_filtered["Open"]]
+    if snap_filtered.empty:
+        logger.debug("trigger_macro_sector_leader: No leaders with a bullish candle")
+        return pd.DataFrame()
 
     # Market average change for relative strength calculation
     market_avg_change = (


### PR DESCRIPTION
## 왜

Rocky 보고(2026-08-05): 스크리닝 결과에 **음봉이 계속 섞여 나온다.**

## 무엇이 문제였나

8개 트리거를 전수 확인한 결과 **네 자리**에 `Close > Open` 검사가 없었다.
KR 두 자리는 **US 에 이미 있던 것이 이식되지 않은 비대칭**이다 —
`us_trigger_batch.py` 에는 근거 주석까지 달려 있는데 KR 에는 아예 없었다.

| 트리거 | KR | US |
|---|---|---|
| volume_surge / gap_up / value_to_cap / closing_strength / contrarian | ✅ 있음 | ✅ 있음 |
| **daily_rise_top** | ❌ **없음 → 추가** | ✅ 있음 |
| **macro_sector_leader** | ❌ **없음 → 추가** | ✅ 있음 |
| **volume_surge_flat** | ❌ **없음 → 추가** | ❌ **없음 → 추가** |

**통과 경로가 셋 다 달랐다.** 한 곳만 고치면 나머지가 남는다:

- **`daily_rise_top`** — 전일 종가 대비 `+3%` 만 본다. **갭상승 후 종일 밀린
  종목**이 그대로 통과한다. 시가 대비는 어디서도 안 본다.
- **`macro_sector_leader`** — 시장 평균 대비 **상대강도**만 본다. 하락장에서는
  음봉이어도 상대강도가 양수일 수 있다.
- **`volume_surge_flat`** — `|전일대비| <= 5%` 인 "횡보"만 본다. 거래량이
  터지면서 시가 아래로 마감하는 것은 매집이 아니라 **분산**인데 이 조건으로는
  구분이 안 된다. (같은 이유로 이미 #289 후속의 MA20 하락추세 게이트가 붙어 있다.)

## 어떻게 고쳤나

**필터 위치는 US 구현과 각 트리거의 기존 구조를 그대로 따랐다.**
`normalize_and_score` 의 `(x-min)/(max-min)` 정규화가 **집합 전체에 의존**하므로,
같은 필터라도 점수 계산 앞에 두느냐 뒤에 두느냐가 산출을 바꾼다. 임의로 옮기지 않았다.

- `daily_rise_top` — 점수 계산 **앞**의 변화율 필터에 합류 (US:590 과 동일)
- `macro_sector_leader` — 정규화 **앞**, 섹터 매칭 뒤 (US:851 과 동일)
- `volume_surge_flat` — 점수 계산 **뒤**의 2차 필터에서 `is_sideways` 와 함께
  (해당 트리거가 원래 `is_sideways` 를 쓰던 자리)

## 검증

```
tests/test_trigger_bearish_candle_exclusion.py              6 passed
```

**수정 전 코드로 돌려 5건이 실제로 실패하는 것을 확인했다.** 나머지 1건은 원래
음봉을 걸렀던 트리거의 회귀 대조군이라 양쪽에서 통과한다 — "전부 걸러내서 통과"하는
가짜 통과를 막는 장치다.

기존 스크리닝 테스트 무손상 (스크립트형이라 직접 실행):

```
tests/test_sideways_downtrend_gate.py      12 passed   ← 이번에 고친 트리거
tests/test_issue_289_screening.py          59 passed
tests/test_agent_fit_score_constant_tripwire.py  13 passed
tests/test_price_query_retry.py             9 passed
```

전체 스위트 회귀 대조 (수집 불가 파일 5개 제외):

```
변경 전   24 failed, 1615 passed
변경 후   24 failed, 1621 passed   ← 늘어난 6건이 이 PR 의 새 테스트
```

실패 24건은 async 미지원·렌더링 등 **기존 문제**이며 개수가 동일하다.

## 알아둘 것

- **CI 는 이 테스트를 돌리지 않는다.** `ci.yml` 은 지정된 8개 묶음만 돌고, 게다가
  pandas 를 설치하지 않아 트리거 테스트는 `importorskip` 으로 건너뛴다. 위 검증은
  전부 로컬 실측이다. 트리거 테스트를 CI 로 끌어올리려면 pandas·numpy·dotenv 에
  더해 `krx_data_client` 까지 필요한데, 그건 Plan A 가 **걷어내는 중**인 의존이라
  별도 판단이 필요하다.
- US 테스트는 **별도 프로세스**로 돈다. `prism-us/cores/` 가 리포 루트 `cores/` 를
  가리는 별도 패키지(양쪽에 `rs_rating` 이 있고 `us_surge_detector` 는 prism-us
  쪽에만 있다)라 한 프로세스에서 KR·US 트리거를 같이 import 할 수 없다. `ci.yml`
  이 fill-chaser 를 분리해 돌리는 것과 같은 이유다.
- ⚠️ **매매 로직 변경이다.** 하네스 PRD 의 오닐 검토자가 물려야 할 사안인데 그
  검토자는 아직 미구현(PRD 만 있음)이다. 특히 `volume_surge_flat` 은 "횡보 중
  거래량 증가"를 찾는 트리거라 양봉 조건으로 후보가 눈에 띄게 줄 수 있다.
  **배포 후 첫 배치에서 이 트리거의 산출 건수를 확인할 것.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)