### PR TITLE
fix(batch): 배치 거래일 해석을 KRX 에서 떼어낸다 (KR 리포트 0건 장애)

### DIFF
--- a/check_market_day.py
+++ b/check_market_day.py
@@ -17,9 +17,14 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
-def is_market_day():
-    """Check if it's a Korean stock market trading day"""
-    today = date.today()
+def is_market_day(target_date=None):
+    """Check if a date is a Korean stock market trading day.
+
+    ``target_date`` defaults to today, which is how the scheduler and the
+    orchestrator call it. ``trigger_batch`` passes an explicit date so it can
+    walk backwards to the most recent session without reaching for KRX.
+    """
+    today = target_date or date.today()
 
     # Weekend check (5: Saturday, 6: Sunday)
     if today.weekday() >= 5:

--- a/tests/test_batch_trade_date_resolution.py
+++ b/tests/test_batch_trade_date_resolution.py
@@ -1,0 +1,155 @@
+"""배치 기준 거래일 해석은 KRX 가 죽어도 살아남아야 한다.
+
+2026-08-05 오후 KR 배치가 **리포트 0건**으로 끝났다. 실패 지점은 ``run_batch`` 의
+첫 데이터 호출이었다:
+
+    trigger_batch.py  trade_date = stock_api.get_nearest_business_day_in_a_week(...)
+    → krx_data_client → KRXBlockedError: KRX 접근이 차단된 상태입니다
+    → "No stocks selected. Terminating process."   (시작 64초 만에)
+
+차단은 전날 8/4 18:04 에 걸린 것이라 그 배치가 유발한 것도 아니었다.
+
+이 모듈의 다른 KRX 호출 6곳은 이미 보호돼 있었다 — 종목명 조회는 try/except 로
+코드 표시로 강등되고, 스냅샷·시총 조회는 ``load_market_snapshot_bundle`` 의 Naver
+폴백에 덮인다. **무방비였던 것은 이 한 줄뿐이고, 하필 가장 먼저 실행됐다.**
+
+그래서 검증의 핵심은 "KRX 가 예외를 던져도 거래일이 나오는가" 하나다.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+import trigger_batch  # noqa: E402
+
+
+class _KrxDown:
+    """KRX 를 부르면 무조건 터지게 만든다 (차단 상태 재현)."""
+
+    def __init__(self):
+        self.called = 0
+
+    def __call__(self, *args, **kwargs):
+        self.called += 1
+        raise RuntimeError("KRX 접근이 차단된 상태입니다. 198분 뒤(18:04)에 다시 시도하세요.")
+
+
+def _patch_krx(monkeypatch) -> _KrxDown:
+    down = _KrxDown()
+    monkeypatch.setattr(
+        trigger_batch.stock_api, "get_nearest_business_day_in_a_week", down
+    )
+    return down
+
+
+# --- 회귀의 핵심 -------------------------------------------------------------
+
+
+def test_resolves_trading_day_while_krx_is_blocked(monkeypatch):
+    """8/5 장애 재현 — KRX 가 터져도 거래일이 나와야 한다."""
+    _patch_krx(monkeypatch)
+
+    # 2026-08-05 는 수요일(평일).
+    assert trigger_batch._resolve_trade_date("20260805") == "20260805"
+
+
+def test_does_not_call_krx_on_a_normal_trading_day(monkeypatch):
+    """평상시엔 KRX 를 아예 안 부른다 — 스크래핑을 줄이는 것이 Plan A 의 목적이다."""
+    down = _patch_krx(monkeypatch)
+
+    trigger_batch._resolve_trade_date("20260805")
+
+    assert down.called == 0
+
+
+def test_walks_back_to_friday_from_a_weekend(monkeypatch):
+    """휴장일이면 직전 개장일로 물러난다."""
+    _patch_krx(monkeypatch)
+
+    # 2026-08-08 토요일 → 08-07 금요일
+    assert trigger_batch._resolve_trade_date("20260808") == "20260807"
+    # 2026-08-09 일요일 → 08-07 금요일
+    assert trigger_batch._resolve_trade_date("20260809") == "20260807"
+
+
+def test_walks_back_over_a_public_holiday(monkeypatch):
+    """법정공휴일도 건너뛴다 (2026-08-15 광복절, 토요일이라 08-14 금요일이 답)."""
+    _patch_krx(monkeypatch)
+
+    assert trigger_batch._resolve_trade_date("20260815") == "20260814"
+
+
+# --- 폴백 사슬 ---------------------------------------------------------------
+
+
+def test_falls_back_to_krx_when_the_local_calendar_is_unavailable(monkeypatch):
+    """달력을 못 읽으면 예전 동작(KRX)으로 물러난다 — 기능 후퇴가 아니다."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_calendar(name, *args, **kwargs):
+        if name == "check_market_day":
+            raise ImportError("no calendar here")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_calendar)
+    monkeypatch.setattr(
+        trigger_batch.stock_api,
+        "get_nearest_business_day_in_a_week",
+        lambda *a, **k: "20260804",
+    )
+
+    assert trigger_batch._resolve_trade_date("20260805") == "20260804"
+
+
+def test_returns_the_input_date_when_every_source_fails(monkeypatch):
+    """둘 다 죽어도 배치를 끝내지 않는다 — 예외를 올리면 8/5 와 같은 결과가 된다."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_calendar(name, *args, **kwargs):
+        if name == "check_market_day":
+            raise ImportError("no calendar here")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_calendar)
+    _patch_krx(monkeypatch)
+
+    assert trigger_batch._resolve_trade_date("20260805") == "20260805"
+
+
+def test_never_raises_so_the_batch_cannot_die_here(monkeypatch):
+    """이 함수는 어떤 경우에도 예외를 밖으로 내보내지 않는다."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _explode(name, *args, **kwargs):
+        if name == "check_market_day":
+            raise RuntimeError("boom")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _explode)
+    _patch_krx(monkeypatch)
+
+    assert trigger_batch._resolve_trade_date("20260805") == "20260805"
+
+
+# --- 달력 자체 ---------------------------------------------------------------
+
+
+def test_is_market_day_accepts_an_explicit_date():
+    """``is_market_day()`` 는 인자 없이도(스케줄러) 인자와 함께도(배치) 쓰인다."""
+    from check_market_day import is_market_day
+
+    assert is_market_day(datetime.date(2026, 8, 5)) is True  # 수요일
+    assert is_market_day(datetime.date(2026, 8, 8)) is False  # 토요일
+    assert is_market_day(datetime.date(2026, 8, 15)) is False  # 광복절
+    # 인자 없는 기존 호출 형태가 그대로 동작한다.
+    assert isinstance(is_market_day(), bool)

--- a/trigger_batch.py
+++ b/trigger_batch.py
@@ -1697,6 +1697,63 @@ def select_final_tickers(triggers: dict, trade_date: str = None, use_hybrid: boo
 
     return final_result
 
+# How far back to walk when today is not a trading session. A long weekend plus
+# a holiday stretch stays inside a week; beyond that something is wrong and we
+# should say so rather than silently screening month-old data.
+_TRADE_DATE_LOOKBACK_DAYS = 7
+
+
+def _resolve_trade_date(today_str: str) -> str:
+    """Resolve the batch reference trading date **without depending on KRX**.
+
+    This used to be a single ``stock_api.get_nearest_business_day_in_a_week()``
+    call — the batch's very first data call, with no fallback. When KRX blocked
+    the db-server IP, the 2026-08-05 afternoon batch died here 64 seconds in and
+    produced **zero KR reports**:
+
+        KRXBlockedError: KRX 접근이 차단된 상태입니다. 198분 뒤(18:04)에 ...
+        → "No stocks selected. Terminating process."
+
+    Every other KRX call in this module is already protected — the ticker-name
+    lookup degrades to bare codes, and the snapshot/market-cap calls sit behind
+    ``load_market_snapshot_bundle``'s Naver fallback. This one line was the only
+    unguarded one, and it ran first.
+
+    The orchestrator already decides whether to run at all via
+    ``check_market_day.is_market_day()``, which reads a local holiday calendar
+    and touches no network. Using that same calendar here is both consistent
+    with the gate that let the batch start and immune to KRX being unreachable.
+    KRX is kept only as a fallback for the case where the calendar is
+    unavailable, so it can no longer take the batch down on its own.
+    """
+    try:
+        from check_market_day import is_market_day
+
+        day = datetime.datetime.strptime(today_str, "%Y%m%d").date()
+        for _ in range(_TRADE_DATE_LOOKBACK_DAYS):
+            if is_market_day(day):
+                return day.strftime("%Y%m%d")
+            day -= datetime.timedelta(days=1)
+        logger.warning(
+            "No trading day found within %d days of %s; falling back to KRX",
+            _TRADE_DATE_LOOKBACK_DAYS,
+            today_str,
+        )
+    except Exception as exc:  # noqa: BLE001 - calendar must never end the batch
+        logger.warning("Local trading calendar unavailable (%s); falling back to KRX", exc)
+
+    try:
+        return stock_api.get_nearest_business_day_in_a_week(today_str, prev=True)
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "KRX trading-date lookup failed too (%s); using %s as-is. "
+            "Screening may run against a non-session date.",
+            exc,
+            today_str,
+        )
+        return today_str
+
+
 # --- Batch execution function ---
 def run_batch(trigger_time: str, log_level: str = "INFO", output_file: str = None, macro_context: dict = None):
     """
@@ -1710,7 +1767,7 @@ def run_batch(trigger_time: str, log_level: str = "INFO", output_file: str = Non
     logger.info(f"Log level: {log_level.upper()}")
 
     today_str = datetime.datetime.today().strftime("%Y%m%d")
-    trade_date = stock_api.get_nearest_business_day_in_a_week(today_str, prev=True)
+    trade_date = _resolve_trade_date(today_str)
     logger.info(f"Batch reference trading date: {trade_date}")
 
     market_data = load_market_snapshot_bundle(trade_date)


### PR DESCRIPTION
## 장애

**2026-08-05 오후 KR 배치가 시작 64초 만에 죽어 리포트가 0건이었다.**

```
14:46:05  파이프라인 시작 → 매크로 분석 성공 (regime=sideways, sectors=5)
14:47:09  trigger_batch 진입 즉시 예외
          KRXBlockedError: KRX 접근이 차단된 상태입니다. 198분 뒤(18:04)에 ...
          → "No stocks selected. Terminating process."
```

차단은 **전날 8/4 18:04 에 걸린 것**이라 이 배치가 유발한 것도 아니다.
그런데도 배치 전체가 끝났다.

## 원인

`run_batch` 의 **첫 데이터 호출**이 KRX 를 직접 부르는데 폴백이 없었다.

```python
trade_date = stock_api.get_nearest_business_day_in_a_week(today_str, prev=True)
```

이 모듈의 KRX 직접 호출은 **7곳인데 6곳은 이미 보호돼 있었다**:

| 호출 | 보호 |
|---|---|
| 종목명 조회 (`_get_ticker_name_map`) | try/except → 종목코드 표시로 강등 |
| 스냅샷·전일·시총 (4곳) | `load_market_snapshot_bundle` 의 Naver 폴백 |
| **배치 거래일 (`run_batch`)** | **없음 ← 이것 하나** |

무방비였던 것은 한 줄뿐이고 **하필 가장 먼저 실행됐다.**
`PRISM_MARKET_DATA_SOURCES=kis,fdr,krx` 로 KIS 를 1순위에 올려둔 것도 소용이
없었다 — 이 호출은 `cores.market_data` 소스 체인을 **아예 거치지 않는다.**

## 수정

오케스트레이터는 이미 `check_market_day.is_market_day()` 로 배치 실행 여부를
결정한다(`stock_analysis_orchestrator.py:1446`). `holidays` 패키지 기반의 **로컬
달력이라 네트워크가 필요 없다.**

배치를 시작시킨 그 판단과 같은 달력을 쓰는 것이 일관적이고, KRX 가 죽어도
영향이 없다. **KRX 는 달력을 못 읽는 경우의 폴백으로만 남긴다** — 더 이상
혼자서 배치를 죽일 수 없다.

폴백 사슬: `로컬 달력` → `KRX` → `입력 날짜 그대로(경고)`.
마지막 단계까지 두는 이유는, 여기서 예외를 올리면 8/5 와 똑같은 결과가 되기 때문이다.

`is_market_day()` 에 날짜 인자를 추가했다(기본값 오늘). 스케줄러의 기존 무인자
호출은 그대로 동작하고, 배치는 명시 날짜로 직전 개장일까지 되짚는다.

## 검증

```
tests/test_batch_trade_date_resolution.py     8 passed
```

**수정 전 코드로 돌려 8건 전부 실패하는 것을 확인했다.**
핵심 케이스 둘:
- `test_resolves_trading_day_while_krx_is_blocked` — 8/5 장애 그대로 재현
- `test_never_raises_so_the_batch_cannot_die_here` — 어떤 경우에도 예외를 안 낸다

부수 확인: `test_does_not_call_krx_on_a_normal_trading_day` — 평상시엔 KRX 를
아예 부르지 않는다. 스크래핑을 줄이는 것이 Plan A 의 목적이고, 재차단을 막는
직접적인 효과가 있다.

기존 스크리닝 테스트 무손상 (스크립트형이라 직접 실행):

```
tests/test_issue_289_screening.py        59 passed
tests/test_sideways_downtrend_gate.py    12 passed
```

전체 스위트 회귀 대조 (수집 불가 파일 5개 제외):

```
오늘 기준선   24 failed, 1615 passed
현재          24 failed, 1641 passed
```

늘어난 26건은 PR #526(12) + #527(6) + 이 PR(8) 이고 실패 개수는 동일하다.

## 남은 것

- ⚠️ **이 수정은 재차단을 막지 못한다.** `trigger_batch` 는 여전히 스냅샷·시총·
  MA20 을 KRX 로 긁는다(Naver 폴백이 있어 죽지는 않는다). KRX 안내문대로
  재탐지 시 차단이 재적용된다. 근본 해결은 Plan A 8~10 단계다.
- `check_market_day.py` 의 2026 특별휴일 목록이 비어 있다(`pass`). 임시공휴일이
  생기면 갱신이 필요하다 — **다만 이는 기존 조건이다.** 오케스트레이터가 이미
  같은 달력으로 실행을 결정하므로 이 PR 이 새로 만드는 위험은 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)