### PR TITLE
fix(batch): KRX 가 죽어도 종목명이 코드로 강등되지 않게 한다

### DIFF
--- a/tests/test_ticker_name_without_krx.py
+++ b/tests/test_ticker_name_without_krx.py
@@ -1,0 +1,126 @@
+"""KRX 가 죽어도 종목명이 종목코드로 강등되지 않아야 한다.
+
+2026-08-05 오후 시그널 얼럿이 **종목코드만** 달고 사용자에게 나갔다:
+
+    🚀 일중 상승률 상위주
+    · 009150 (009150)      ← "삼성전기 (009150)" 이어야 한다
+    · 103140 (103140)      ← 풍산
+    · 003490 (003490)      ← 대한항공
+
+원인은 ``_get_ticker_name_map()`` 의 KRX 대량 조회 **한 번**이다. 실패하면 빈
+dict 를 캐시하고, 그 뒤 모든 종목이 조용히 코드로 표시된다. 예외도 안 나고
+로그 한 줄(`ticker name lookup failed`)만 남는다 — 그날 로그에 정확히 2건 있었다.
+
+수정은 ``_get_display_ticker_name`` 이 ``cores.market_data`` 체인으로 물러나게
+한 것이다. FDR 소스가 KRX 상장목록 스냅샷에서 답하는데, 차단된 Data Marketplace
+세션과 무관하다.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+import trigger_batch  # noqa: E402
+
+
+def _blocked(*args, **kwargs):
+    raise RuntimeError("KRX 접근이 차단된 상태입니다. 198분 뒤(18:04)에 다시 시도하세요.")
+
+
+@pytest.fixture
+def krx_down(monkeypatch):
+    """KRX 대량 조회를 막는다.
+
+    ``trigger_batch`` 는 ``_get_client`` 를 모듈 최상단에서 직접 import 하므로
+    ``krx_data_client._get_client`` 를 막아도 소용없다. 이 모듈이 들고 있는
+    참조를 막아야 한다 — 처음 이 테스트를 짤 때 실제로 여기서 헛짚었다.
+    """
+    monkeypatch.setattr(trigger_batch, "_get_client", _blocked)
+    monkeypatch.setattr(trigger_batch.stock_api, "get_market_ticker_name", _blocked)
+    monkeypatch.setattr(trigger_batch, "_TICKER_NAME_CACHE", None)
+
+
+def test_bulk_lookup_degrades_to_empty_map_when_krx_is_blocked(krx_down):
+    """전제 확인 — 대량 조회는 여전히 빈 맵으로 강등된다."""
+    assert trigger_batch._get_ticker_name_map() == {}
+
+
+def test_falls_back_to_the_source_chain_for_the_name(krx_down, monkeypatch):
+    """빈 맵이어도 체인이 이름을 준다."""
+    import cores.market_data as market_data
+
+    monkeypatch.setattr(market_data, "get_market_ticker_name", lambda t: "삼성전기")
+
+    assert trigger_batch._get_display_ticker_name("009150", {}) == "삼성전기"
+
+
+def test_caches_the_resolved_name_into_the_map(monkeypatch):
+    """한 번 찾은 이름은 맵에 적재해 같은 실행에서 다시 조회하지 않는다."""
+    import cores.market_data as market_data
+
+    calls = []
+
+    def _counted(ticker):
+        calls.append(ticker)
+        return "삼성전기"
+
+    monkeypatch.setattr(market_data, "get_market_ticker_name", _counted)
+
+    name_map: dict[str, str] = {}
+    assert trigger_batch._get_display_ticker_name("009150", name_map) == "삼성전기"
+    assert trigger_batch._get_display_ticker_name("009150", name_map) == "삼성전기"
+
+    assert calls == ["009150"]
+    assert name_map["009150"] == "삼성전기"
+
+
+def test_prefers_the_bulk_map_when_krx_is_healthy(monkeypatch):
+    """KRX 가 살아 있으면 체인을 부르지 않는다 — 기존 경로가 우선이다."""
+    import cores.market_data as market_data
+
+    def _must_not_be_called(ticker):
+        raise AssertionError("bulk map 이 있는데 체인을 불렀다")
+
+    monkeypatch.setattr(market_data, "get_market_ticker_name", _must_not_be_called)
+
+    assert trigger_batch._get_display_ticker_name("009150", {"009150": "삼성전기"}) == "삼성전기"
+
+
+def test_falls_back_to_the_code_when_no_source_can_answer(monkeypatch):
+    """체인도 못 찾으면 종목코드다 — 라벨 때문에 배치를 죽이지 않는다.
+
+    ``cores.market_data.get_market_ticker_name`` 은 전 소스 소진 시 티커를 그대로
+    돌려준다. 그걸 '해결됐다'고 착각하면 안 된다.
+    """
+    import cores.market_data as market_data
+
+    monkeypatch.setattr(market_data, "get_market_ticker_name", lambda t: t)
+
+    assert trigger_batch._get_display_ticker_name("009150", {}) == "009150"
+
+
+def test_chain_failure_never_propagates(monkeypatch):
+    """체인이 터져도 예외가 밖으로 나가지 않는다."""
+    import cores.market_data as market_data
+
+    monkeypatch.setattr(market_data, "get_market_ticker_name", _blocked)
+
+    assert trigger_batch._get_display_ticker_name("009150", {}) == "009150"
+
+
+def test_normalizes_short_codes_before_lookup(monkeypatch):
+    """6자리 zero-fill 이 조회 전에 적용된다."""
+    import cores.market_data as market_data
+
+    seen = []
+
+    def _capture(ticker):
+        seen.append(ticker)
+        return "삼성전기"
+
+    monkeypatch.setattr(market_data, "get_market_ticker_name", _capture)
+
+    assert trigger_batch._get_display_ticker_name(9150, {}) == "삼성전기"
+    assert seen == ["009150"]

--- a/tests/test_trigger_batch_enhance_dataframe.py
+++ b/tests/test_trigger_batch_enhance_dataframe.py
@@ -23,6 +23,23 @@ def setup_function():
     t._TICKER_NAME_CACHE = None
 
 
+def _chain_cannot_answer(monkeypatch):
+    """소스 체인이 이름을 못 찾는 상태로 고정한다.
+
+    2026-08-05 부터 ``_get_display_ticker_name`` 은 KRX 대량 조회가 실패하면
+    ``cores.market_data`` 체인으로 물러난다(그전에는 곧바로 종목코드였고, 그래서
+    KRX 차단일에 시그널 얼럿이 "009150 (009150)" 으로 나갔다).
+
+    체인은 전 소스 소진 시 티커를 그대로 돌려주므로, 여기서 그 상태를 명시적으로
+    만든다. 이걸 안 걸면 테스트가 **실제 FDR 상장목록을 네트워크로 받아와** 결과가
+    실행 순서에 따라 달라진다 — 실제로 단독 실행 0.35초 / 다른 파일과 함께 18초에
+    결과가 갈렸다.
+    """
+    import cores.market_data as market_data
+
+    monkeypatch.setattr(market_data, "get_market_ticker_name", lambda ticker: ticker)
+
+
 def test_enhance_dataframe_fetches_ticker_names_in_one_batch(monkeypatch):
     calls = []
 
@@ -56,6 +73,7 @@ def test_enhance_dataframe_keeps_rows_when_name_lookup_times_out(monkeypatch):
             raise TimeoutError("KRX timeout")
 
     monkeypatch.setattr(t, "_get_client", lambda: TimeoutClient(), raising=False)
+    _chain_cannot_answer(monkeypatch)
 
     df = pd.DataFrame({"Close": [70000, 120000]}, index=["005930", "000660"])
 
@@ -78,6 +96,7 @@ def test_enhance_dataframe_caches_failed_lookup_for_process(monkeypatch):
             raise TimeoutError("KRX timeout")
 
     monkeypatch.setattr(t, "_get_client", lambda: TimeoutClient(), raising=False)
+    _chain_cannot_answer(monkeypatch)
 
     df = pd.DataFrame({"Close": [70000]}, index=["005930"])
 
@@ -89,12 +108,43 @@ def test_enhance_dataframe_caches_failed_lookup_for_process(monkeypatch):
     assert second["stock_name"].to_dict() == {"005930": "005930"}
 
 
+def test_enhance_dataframe_uses_the_chain_when_the_bulk_lookup_fails(monkeypatch):
+    """KRX 대량 조회가 죽어도 체인이 답하면 실제 종목명이 붙는다.
+
+    이것이 2026-08-05 얼럿 결함의 핵심이다. 위 두 테스트가 '실패하면 코드'를
+    검증하는데, 그것만 있으면 **체인이 답할 수 있는데도 코드로 나가는 상태**를
+    통과시킨다. 실제로 그렇게 사용자에게 나갔다.
+    """
+    import cores.market_data as market_data
+
+    class TimeoutClient:
+        def get_market_ticker_name(self, market="ALL"):
+            raise TimeoutError("KRX timeout")
+
+    monkeypatch.setattr(t, "_get_client", lambda: TimeoutClient(), raising=False)
+    monkeypatch.setattr(
+        market_data,
+        "get_market_ticker_name",
+        lambda ticker: {"009150": "삼성전기", "103140": "풍산"}.get(ticker, ticker),
+    )
+
+    df = pd.DataFrame({"Close": [1356000, 80700]}, index=["009150", "103140"])
+
+    result = t.enhance_dataframe(df)
+
+    assert result["stock_name"].to_dict() == {
+        "009150": "삼성전기",
+        "103140": "풍산",
+    }
+
+
 def test_enhance_dataframe_normalizes_numeric_ticker_index(monkeypatch):
     class FakeClient:
         def get_market_ticker_name(self, market="ALL"):
             return {"005930": "SAMSUNG"}
 
     monkeypatch.setattr(t, "_get_client", lambda: FakeClient(), raising=False)
+    _chain_cannot_answer(monkeypatch)
 
     df = pd.DataFrame({"Close": [70000, 120000]}, index=[5930, 660])
 

--- a/tools/verify_batch_survives_krx_outage.py
+++ b/tools/verify_batch_survives_krx_outage.py
@@ -78,16 +78,19 @@ def force_krx_outage() -> KrxCallCounter:
     ):
         setattr(trigger_batch.stock_api, attr, counter.fail(f"stock_api.{attr}"))
 
-    for attr in (
-        "get_market_ohlcv_by_date",
-        "get_market_fundamental_by_date",
-        "_get_client",
-    ):
+    for attr in ("get_market_ohlcv_by_date", "get_market_fundamental_by_date"):
         if hasattr(krx_data_client, attr):
             setattr(krx_data_client, attr, counter.fail(f"krx_data_client.{attr}"))
 
-    # 종목명 캐시는 조회 자체를 건너뛰게 둔다(빈 dict = 조회 완료).
-    trigger_batch._TICKER_NAME_CACHE = {}
+    # ``trigger_batch`` 는 ``_get_client`` 를 모듈 최상단에서 직접 import 한다.
+    # ``krx_data_client._get_client`` 만 막으면 이 참조가 그대로 살아 있다.
+    trigger_batch._get_client = counter.fail("trigger_batch._get_client")
+
+    # 종목명 캐시는 **비우지 않는다.** 초판은 여기에 빈 dict 를 심어 대량 조회를
+    # 건너뛰게 했는데, 그러면 "KRX 대량 조회 실패 → 전 종목이 코드로 강등" 경로가
+    # 아예 안 태워진다. 실제로 그 버그(2026-08-05 얼럿의 "009150 (009150)")를
+    # 이 하네스가 놓쳤다. None 으로 두어 조회를 시도시키고 실패하게 만든다.
+    trigger_batch._TICKER_NAME_CACHE = None
 
     return counter
 
@@ -150,6 +153,8 @@ def main() -> int:
 
     total = 0
     bearish: list[tuple[str, str, float, float]] = []
+    unnamed: list[str] = []
+    name_map = trigger_batch._get_ticker_name_map()
     print()
     print("최종 선정:")
     for trigger_type, df in result.items():
@@ -161,11 +166,23 @@ def main() -> int:
             open_px = float(row.get("Open", 0) or 0)
             close_px = float(row.get("Close", 0) or 0)
             candle = "양봉" if close_px > open_px else "🔴음봉"
-            print(f"      - {ticker}  시가 {open_px:,.0f} → 종가 {close_px:,.0f}  {candle}")
+            name = trigger_batch._get_display_ticker_name(ticker, name_map)
+            print(
+                f"      - {name} ({ticker})  "
+                f"시가 {open_px:,.0f} → 종가 {close_px:,.0f}  {candle}"
+            )
             if open_px > 0 and close_px <= open_px:
                 bearish.append((trigger_type, str(ticker), open_px, close_px))
+            # 이름이 코드 그대로면 사용자 얼럿에 "009150 (009150)" 이 나간다.
+            if name == trigger_batch._normalize_ticker_code(ticker):
+                unnamed.append(str(ticker))
 
     print()
+    if unnamed:
+        print("❌ 종목명이 코드로 강등됐다 — 얼럿에 그대로 나간다.")
+        print(f"   {', '.join(unnamed)}")
+        return 4
+
     if bearish:
         # PR #527 이 실데이터에서 안 먹었다는 뜻이다. 합성 테스트만으로는 못 잡는다.
         print("❌ 음봉이 선정됐다 — 매수 트리거 음봉 배제(PR #527)가 실데이터에서 안 먹었다.")

--- a/trigger_batch.py
+++ b/trigger_batch.py
@@ -69,8 +69,40 @@ def _get_ticker_name_map() -> dict[str, str]:
 
 
 def _get_display_ticker_name(ticker, name_map: dict[str, str]) -> str:
+    """Company name for display, falling back through the source chain.
+
+    The bulk lookup above is a single KRX call, so when KRX blocks the host it
+    returns an empty map and *every* name silently degrades to a bare code. That
+    reached users on 2026-08-05: the afternoon signal alert read "009150 (009150)"
+    instead of "삼성전기 (009150)".
+
+    ``cores.market_data`` resolves names through the configured chain, where the
+    FDR source answers from a KRX listing snapshot that has nothing to do with
+    the blocked Data Marketplace session. Only selected candidates are ever
+    rendered — a handful of tickers — and FDR caches the listing after the first
+    call, so this stays cheap.
+
+    Resolved names are written back into ``name_map`` (the process-wide cache),
+    so each ticker costs at most one lookup per run.
+    """
     ticker_code = _normalize_ticker_code(ticker)
-    return name_map.get(ticker_code, ticker_code)
+    name = name_map.get(ticker_code)
+    if name:
+        return name
+
+    try:
+        from cores.market_data import get_market_ticker_name
+
+        resolved = get_market_ticker_name(ticker_code)
+    except Exception as e:  # noqa: BLE001 - a label is never worth failing over
+        logger.debug(f"Ticker name chain lookup failed for {ticker_code}: {e}")
+        return ticker_code
+
+    # The chain returns the ticker itself when no source can answer.
+    if resolved and resolved != ticker_code:
+        name_map[ticker_code] = resolved
+        return resolved
+    return ticker_code
 
 
 # --- Data collection and caching functions ---


### PR DESCRIPTION
## 사용자에게 나간 결함

2026-08-05 오후 시그널 얼럿이 **종목코드만** 달고 나갔다.

```
🚀 일중 상승률 상위주
· 009150 (009150)      ← "삼성전기 (009150)" 이어야 한다
· 103140 (103140)      ← 풍산
· 003490 (003490)      ← 대한항공
```

## 원인

`_get_ticker_name_map()` 의 **KRX 대량 조회 한 번.** 실패하면 빈 dict 를 캐시하고,
그 뒤 모든 종목이 조용히 코드로 표시된다. 예외도 안 나고 로그 한 줄
(`ticker name lookup failed`)만 남는다 — 그날 로그에 정확히 2건 있었다.

KRX 차단 중이면 **반드시** 이렇게 된다. 즉 지금까지 KRX 가 막힐 때마다 얼럿과
리포트에 종목명이 없었다는 뜻이다.

## 수정

`_get_display_ticker_name` 이 `cores.market_data` 체인으로 물러난다. FDR 소스가
**KRX 상장목록 스냅샷**에서 답하는데, 차단된 Data Marketplace 세션과 무관하다.

렌더링 대상은 선정 종목 몇 개뿐이고 FDR 은 목록을 한 번 받아 캐시하므로 비용도
작다. 찾은 이름은 `name_map` 에 적재해 같은 실행에서 재조회하지 않는다.

**차단 주입 상태 실측** — 대량 조회 0건인데 전부 해결됐다:

```
bulk map size (KRX 차단): 0
  009150 -> 삼성전기
  103140 -> 풍산
  003490 -> 대한항공
  005930 -> 삼성전자
```

배치 하네스 실경로에서도 확인했다:

```
- 삼성전기 (009150)  시가 1,351,000 → 종가 1,356,000  양봉
- 풍산 (103140)      시가    71,500 → 종가    80,700  양봉
- 대한항공 (003490)  시가    26,800 → 종가    26,900  양봉
```

## 하네스의 구멍도 메웠다

`tools/verify_batch_survives_krx_outage.py`(PR #529)가 **이 버그를 놓쳤다.** 이유 둘:

1. `_TICKER_NAME_CACHE` 에 빈 dict 를 심어 대량 조회를 **건너뛰게** 했다. 그러면
   "조회 실패 → 전 종목 코드 강등" 경로가 아예 안 태워진다. `None` 으로 바꿔
   조회를 시도시키고 실패하게 만든다.
2. `krx_data_client._get_client` 만 막았는데 `trigger_batch` 는 `_get_client` 를
   **모듈 최상단에서 직접 import** 한다. 그 참조를 막아야 실제로 차단된다.
   (이 함정에 테스트를 짜면서 실제로 한 번 걸렸다 — 테스트 fixture 에 적어뒀다.)

이제 선정 종목의 이름이 코드 그대로면 **종료코드 4** 로 실패한다.

## 기존 테스트 3건 갱신

`test_trigger_batch_enhance_dataframe` 의 세 케이스는 **"대량 조회 실패 = 종목코드"
라는 옛 계약**을 검증하고 있었다. 그 계약을 의도적으로 바꿨으므로, 체인을 명시적으로
막는 헬퍼(`_chain_cannot_answer`)를 넣어 **원래 의도**(행 보존 · 대량조회 1회 ·
숫자 인덱스 정규화)는 유지하면서 갱신했다.

이 패치는 **결정성도 회복시킨다.** 갱신 전에는 이 테스트들이 실제 FDR 상장목록을
네트워크로 받아와 실행 순서에 따라 결과가 갈렸다 — 단독 0.35초 통과 /
다른 파일과 함께 18초 실패.

체인이 답할 수 있을 때 실제 이름이 붙는지 확인하는 케이스를 새로 넣었다. 그게
없으면 **"체인이 답할 수 있는데도 코드로 나가는 상태"** 를 그대로 통과시킨다 —
이번에 실제로 그렇게 나갔다.

## 검증

```
tests/test_ticker_name_without_krx.py                7 passed  (신규)
tests/test_trigger_batch_enhance_dataframe.py        5 passed  (1건 신규)
```

수정 전 코드로 돌려 새 계약 케이스 3건이 실패하는 것을 확인했다.

```
회귀 대조   24 failed, 1641 passed  →  24 failed, 1649 passed
스크립트형  test_issue_289_screening 59 passed / test_sideways_downtrend_gate 12 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)