### PR TITLE
refactor(market-data): get_multi_day_ohlcv 를 소스 체인으로 돌린다 (KRX 42→4회)

### DIFF
--- a/cores/market_data/krx_source.py
+++ b/cores/market_data/krx_source.py
@@ -46,7 +46,10 @@ def _throttle() -> None:
     with _THROTTLE_LOCK:
         wait = min_gap - (time.monotonic() - _LAST_CALL[0])
         if wait > 0:
-            time.sleep(wait + random.uniform(0.0, 0.2))
+            # Jitter spreads request timing so concurrent workers do not line up
+            # on the same instant. Nothing here is a secret or a token, so an
+            # unpredictable-to-an-attacker value would buy nothing (B311).
+            time.sleep(wait + random.uniform(0.0, 0.2))  # nosec B311
         _LAST_CALL[0] = time.monotonic()
 
 

--- a/cores/market_data/krx_source.py
+++ b/cores/market_data/krx_source.py
@@ -13,10 +13,41 @@ credentials, which defeats the point of having alternatives.
 
 from __future__ import annotations
 
+import os
+import random
+import threading
+import time
+
 import pandas as pd
 
 from cores.market_data.schema import has_ohlcv, normalize
 from cores.market_data.source import Unavailable
+
+# Minimum spacing between consecutive KRX requests, plus jitter.
+#
+# This lived in ``trigger_batch.get_multi_day_ohlcv`` and therefore protected
+# exactly one call site; every other path into KRX — including everything routed
+# through this chain — hit the service back to back. Bursts are what produce the
+# read-timeouts, and sustained bursts are what KRX calls "비정상 대량 조회".
+# Spacing belongs to the source, not to one caller.
+#
+# ``KRX_MIN_GAP_SEC=0`` disables it.
+_THROTTLE_LOCK = threading.Lock()
+_LAST_CALL = [0.0]
+
+
+def _throttle() -> None:
+    try:
+        min_gap = float(os.getenv("KRX_MIN_GAP_SEC", "0.4"))
+    except (TypeError, ValueError):
+        min_gap = 0.4
+    if min_gap <= 0:
+        return
+    with _THROTTLE_LOCK:
+        wait = min_gap - (time.monotonic() - _LAST_CALL[0])
+        if wait > 0:
+            time.sleep(wait + random.uniform(0.0, 0.2))
+        _LAST_CALL[0] = time.monotonic()
 
 
 class KrxSource:
@@ -26,6 +57,7 @@ class KrxSource:
     def _client():
         import krx_data_client
 
+        _throttle()
         return krx_data_client
 
     @staticmethod

--- a/tests/test_multi_day_ohlcv_via_chain.py
+++ b/tests/test_multi_day_ohlcv_via_chain.py
@@ -1,0 +1,173 @@
+"""``get_multi_day_ohlcv`` 는 소스 체인을 거쳐야 한다.
+
+2026-08-05 장애 재현 실행에서 KRX 시도 42회 중 **39회가 이 함수**였다. 배치에서
+가장 뜨거운 KRX 경로인데 `krx_data_client` 를 직접 불러서, `PRISM_MARKET_DATA_SOURCES`
+로 KIS 를 1순위에 올려도 이 경로만은 그대로 KRX 를 때렸다. 체인 순서가 무의미했던
+것이고, 그게 호스트가 차단되는 이유이자 Plan A 가 없애려는 대상이다.
+
+스로틀도 같이 옮겼다. `trigger_batch` 에 있을 때는 이 함수 한 군데만 보호했고
+체인을 타는 나머지 KRX 호출은 전부 무방비였다. 간격 유지는 호출자가 아니라
+**소스**의 책임이다.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+import trigger_batch  # noqa: E402
+
+
+def _frame(rows: int = 30) -> pd.DataFrame:
+    idx = pd.date_range("2026-07-01", periods=rows, freq="D")
+    return pd.DataFrame(
+        {
+            "Open": range(rows),
+            "High": range(rows),
+            "Low": range(rows),
+            "Close": range(rows),
+            "Volume": range(rows),
+        },
+        index=idx,
+    )
+
+
+def test_reads_through_the_source_chain(monkeypatch):
+    """체인 함수가 불려야 한다 — krx_data_client 직결이 아니다."""
+    import cores.market_data as market_data
+
+    seen = {}
+
+    def _chain(start, end, ticker, adjusted=True):
+        seen["args"] = (start, end, ticker)
+        return _frame()
+
+    monkeypatch.setattr(market_data, "get_market_ohlcv_by_date", _chain)
+
+    result = trigger_batch.get_multi_day_ohlcv("005930", "20260731", days=10)
+
+    assert seen["args"][2] == "005930"
+    assert seen["args"][1] == "20260731"
+    assert len(result) == 10  # tail(days)
+
+
+def test_does_not_call_krx_data_client_directly(monkeypatch):
+    """KIS 가 답하면 KRX 는 아예 안 불린다 — 이게 이 변경의 목적이다."""
+    import cores.market_data as market_data
+    import krx_data_client
+
+    def _must_not_be_called(*args, **kwargs):
+        raise AssertionError("krx_data_client 를 직접 불렀다")
+
+    monkeypatch.setattr(
+        krx_data_client, "get_market_ohlcv_by_date", _must_not_be_called
+    )
+    monkeypatch.setattr(
+        market_data, "get_market_ohlcv_by_date", lambda *a, **k: _frame()
+    )
+
+    assert not trigger_batch.get_multi_day_ohlcv("005930", "20260731", days=5).empty
+
+
+def test_falls_back_to_fdr_when_every_source_is_exhausted(monkeypatch):
+    """체인은 소진 시 예외가 아니라 빈 프레임을 준다. 그때만 FDR 재시도다."""
+    import cores.market_data as market_data
+
+    monkeypatch.setattr(
+        market_data, "get_market_ohlcv_by_date", lambda *a, **k: pd.DataFrame()
+    )
+
+    fdr_stub = pytest.importorskip("FinanceDataReader")
+    monkeypatch.setattr(fdr_stub, "DataReader", lambda *a, **k: _frame())
+
+    result = trigger_batch.get_multi_day_ohlcv("005930", "20260731", days=7)
+
+    assert len(result) == 7
+
+
+def test_returns_empty_frame_when_chain_and_fdr_both_fail(monkeypatch):
+    """MA20 게이트가 0 을 '모름 → 통과'로 읽으므로 예외를 올리면 안 된다."""
+    import cores.market_data as market_data
+
+    monkeypatch.setattr(
+        market_data, "get_market_ohlcv_by_date", lambda *a, **k: pd.DataFrame()
+    )
+    fdr_stub = pytest.importorskip("FinanceDataReader")
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("FDR down")
+
+    monkeypatch.setattr(fdr_stub, "DataReader", _boom)
+
+    assert trigger_batch.get_multi_day_ohlcv("005930", "20260731").empty
+
+
+def test_chain_exception_does_not_propagate(monkeypatch):
+    """체인이 터져도 배치를 죽이지 않는다."""
+    import cores.market_data as market_data
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("chain exploded")
+
+    monkeypatch.setattr(market_data, "get_market_ohlcv_by_date", _boom)
+    fdr_stub = pytest.importorskip("FinanceDataReader")
+    monkeypatch.setattr(fdr_stub, "DataReader", lambda *a, **k: _frame())
+
+    assert not trigger_batch.get_multi_day_ohlcv("005930", "20260731", days=3).empty
+
+
+# --- 스로틀이 소스로 옮겨갔다 ------------------------------------------------
+
+
+def test_throttle_now_lives_in_the_krx_source():
+    """호출자가 아니라 소스가 간격을 지킨다."""
+    from cores.market_data import krx_source
+
+    assert hasattr(krx_source, "_throttle")
+    # trigger_batch 에는 더 이상 없다.
+    assert not hasattr(trigger_batch, "_krx_throttle")
+
+
+def test_krx_source_throttles_before_handing_out_the_client(monkeypatch):
+    """``_client()`` 를 얻을 때마다 간격이 적용된다."""
+    from cores.market_data import krx_source
+
+    calls = []
+    monkeypatch.setattr(krx_source, "_throttle", lambda: calls.append(1))
+
+    krx_source.KrxSource._client()
+    krx_source.KrxSource._client()
+
+    assert len(calls) == 2
+
+
+def test_throttle_can_be_disabled_by_env(monkeypatch):
+    """KRX_MIN_GAP_SEC=0 이면 대기가 없다 (테스트·백필용)."""
+    from cores.market_data import krx_source
+
+    monkeypatch.setenv("KRX_MIN_GAP_SEC", "0")
+
+    slept = []
+    monkeypatch.setattr(krx_source.time, "sleep", lambda s: slept.append(s))
+
+    krx_source._throttle()
+    krx_source._throttle()
+
+    assert slept == []
+
+
+def test_throttle_survives_a_garbage_env_value(monkeypatch):
+    """잘못된 값이 스로틀을 끄거나 터뜨리지 않는다 — 기본값으로 돌아간다."""
+    from cores.market_data import krx_source
+
+    monkeypatch.setenv("KRX_MIN_GAP_SEC", "not-a-number")
+    monkeypatch.setattr(krx_source, "_LAST_CALL", [0.0])
+
+    slept = []
+    monkeypatch.setattr(krx_source.time, "sleep", lambda s: slept.append(s))
+    monkeypatch.setattr(krx_source.time, "monotonic", lambda: 0.0)
+
+    krx_source._throttle()
+
+    assert slept and slept[0] >= 0.4

--- a/trigger_batch.py
+++ b/trigger_batch.py
@@ -174,32 +174,13 @@ def get_previous_snapshot(trade_date: str) -> (pd.DataFrame, str):
 
     return df, prev_date
 
-import time as _time
-import random as _random
-import threading as _threading
-
 # --- KRX request throttle ---------------------------------------------------
-# data.krx.co.kr는 IP 차단(403/RST)이 아니라 버스트 요청·장마감 트래픽에 응답이
-# 느려져 Read timeout을 낸다. 요청 사이 최소 간격 + 지터로 연타를 눌러 timeout
-# 빈도를 낮춘다. env로 조절 — KRX_MIN_GAP_SEC=0 이면 스로틀 비활성(기본 0.4s).
-_KRX_THROTTLE_LOCK = _threading.Lock()
-_KRX_LAST_CALL = [0.0]
-
-
-def _krx_throttle() -> None:
-    """Enforce a minimum spacing (+jitter) between consecutive KRX requests."""
-    try:
-        min_gap = float(os.getenv("KRX_MIN_GAP_SEC", "0.4"))
-    except (TypeError, ValueError):
-        min_gap = 0.4
-    if min_gap <= 0:
-        return
-    with _KRX_THROTTLE_LOCK:
-        elapsed = _time.monotonic() - _KRX_LAST_CALL[0]
-        wait = min_gap - elapsed
-        if wait > 0:
-            _time.sleep(wait + _random.uniform(0.0, 0.2))
-        _KRX_LAST_CALL[0] = _time.monotonic()
+# 여기 있던 _krx_throttle 은 cores/market_data/krx_source.py 로 옮겼다.
+# data.krx.co.kr 는 버스트 요청·장마감 트래픽에 응답이 느려져 Read timeout 을
+# 내고, 지속되면 "비정상 대량 조회"로 IP 가 차단된다. 간격 유지는 호출자 한 곳이
+# 아니라 **소스**의 책임이다 — 이 파일에 두었을 때는 get_multi_day_ohlcv 한
+# 군데만 보호했고 체인을 타는 나머지 KRX 호출은 전부 무방비였다.
+# 조절은 그대로 KRX_MIN_GAP_SEC (기본 0.4s, 0 이면 비활성).
 
 
 def get_multi_day_ohlcv(ticker: str, end_date: str, days: int = 10) -> pd.DataFrame:
@@ -215,28 +196,44 @@ def get_multi_day_ohlcv(ticker: str, end_date: str, days: int = 10) -> pd.DataFr
         DataFrame with columns: Open, High, Low, Close, Volume, Amount
         Index: Date
     """
-    from krx_data_client import get_market_ohlcv_by_date
+    # Routed through the source chain (default kis -> fdr -> krx) rather than
+    # calling krx_data_client directly.
+    #
+    # This is the hottest KRX path in the batch: the 2026-08-05 outage run made
+    # 42 KRX attempts and **39 of them came from here**. Going direct meant the
+    # chain order was irrelevant — KIS could be first and this still hammered
+    # KRX, which is both what gets the host restricted and what Plan A exists to
+    # remove.
+    #
+    # The chain returns an empty frame when every source is exhausted (it does
+    # not raise), so the FDR retry below now only runs after kis/fdr/krx have all
+    # declined. It is kept because it calls FinanceDataReader differently from
+    # the chain's FDR source, so it is a genuine second chance rather than a
+    # repeat of the same request.
+    from cores.market_data import get_market_ohlcv_by_date
 
     # Calculate sufficient past date from end date (with margin for business days)
     end_dt = datetime.datetime.strptime(end_date, '%Y%m%d')
     start_dt = end_dt - datetime.timedelta(days=days * 2)  # 2x margin for business days
     start_date = start_dt.strftime('%Y%m%d')
 
-    krx_failed = False
+    chain_failed = False
     try:
-        _krx_throttle()  # 버스트 스로틀: KRX 연타 방지로 read-timeout 빈도↓
         df = get_market_ohlcv_by_date(start_date, end_date, ticker)
         if df.empty:
-            logger.warning(f"No {days}-day data for {ticker} from KRX; attempting FinanceDataReader fallback.")
-            krx_failed = True
+            logger.warning(
+                f"No {days}-day data for {ticker} from any source; "
+                f"attempting FinanceDataReader fallback."
+            )
+            chain_failed = True
         else:
             # Select only recent N days
             return df.tail(days)
     except Exception as e:
-        logger.warning(f"KRX query failed for {ticker}: {e}; attempting FinanceDataReader fallback.")
-        krx_failed = True
+        logger.warning(f"Market data chain failed for {ticker}: {e}; attempting FinanceDataReader fallback.")
+        chain_failed = True
 
-    if krx_failed:
+    if chain_failed:
         try:
             import FinanceDataReader as fdr
             fdr_start = start_dt.strftime('%Y-%m-%d')


### PR DESCRIPTION
## 왜

배치에서 **가장 뜨거운 KRX 경로**다. 8/5 장애 재현 실행에서 KRX 시도 42회 중
**39회가 이 함수**였다.

`krx_data_client` 를 직접 부르고 있어서 `PRISM_MARKET_DATA_SOURCES` 로 KIS 를
1순위에 올려도 **이 경로만은 그대로 KRX 를 때렸다.** 체인 순서가 무의미했던
것이고, 그게 호스트가 차단되는 이유이자 Plan A 가 없애려는 대상이다.

8/5 오후 장애 때 배운 것과 같은 구조다 — 체인을 우회하는 직접 호출이 남아 있으면
체인 전환은 그만큼 헛돈다.

## 실측 (KRX 차단 주입, 오후 배치 완주)

```
기본 순서  krx,fdr       KRX 시도 43회  → 3종목 선정
서버 순서  kis,fdr,krx   KRX 시도  4회  → 3종목 선정
```

**39회가 KIS 로 흡수됐다.** 산출은 동일하다 — 같은 3종목, 같은 가격, 같은 종목명:

```
- 삼성전기 (009150)  시가 1,351,000 → 종가 1,356,000  양봉
- 풍산 (103140)      시가    71,500 → 종가    80,700  양봉
- 대한항공 (003490)  시가    26,800 → 종가    26,900  양봉
```

남은 4회의 정체도 드러났다 — **스냅샷 번들 3회**(설계서 §8 8단계)와
**종목명 대량 조회 1회**. 다음 착수점이 이걸로 특정된다.

## 무엇을 바꿨나

`cores.market_data.get_market_ohlcv_by_date` 로 교체했다. **시그니처가 동일해
호출부 변경은 없다.**

체인은 소진 시 예외가 아니라 **빈 프레임**을 주므로, 기존 FDR 재시도는 이제
kis/fdr/krx 가 전부 거절한 뒤에만 돈다. 체인의 FDR 소스와 호출 방식이 달라
(직접 `fdr.DataReader` vs 소스 래퍼) 같은 요청의 반복이 아니라 **진짜 두 번째
기회**이므로 남겨뒀다.

## 스로틀을 소스로 옮겼다

`_krx_throttle` 이 `trigger_batch` 에 있어서 **`get_multi_day_ohlcv` 한 군데만**
보호했다. 체인을 타는 나머지 KRX 호출은 전부 무방비였다.

KRX 는 버스트에 read timeout 을 내고, 지속되면 "비정상 대량 조회"로 IP 를 막는다.
간격 유지는 호출자가 아니라 **소스**의 책임이므로 `krx_source._throttle` 로 옮겼다.
이제 어느 경로로 들어오든 KRX 는 간격을 지킨다.

부수 효과로 **KIS 가 답할 때 불필요한 0.4초 대기가 사라진다** — 종목당 0.4초면
배치에서 15초가 넘는다.

`KRX_MIN_GAP_SEC` 는 그대로 동작한다(기본 0.4s, `0` 이면 비활성).

## 검증

```
tests/test_multi_day_ohlcv_via_chain.py     9 passed  (신규)
```

수정 전 코드로 돌려 **6건이 실패**하는 것을 확인했다.

```
회귀 대조   24 failed, 1649 passed  →  24 failed, 1658 passed
스크립트형  test_issue_289_screening 59 / test_sideways_downtrend_gate 12
            / test_price_query_retry 9   전부 무손상
E2E         tools/verify_batch_survives_krx_outage.py 양쪽 순서로 완주
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)