### PR TITLE
feat(mcp): 리포트 데이터 경로를 KRX 스크래핑에서 소스 체인으로 옮긴다

### DIFF
--- a/cores/llm/mcp_servers.yaml
+++ b/cores/llm/mcp_servers.yaml
@@ -12,15 +12,34 @@ servers:
     - firecrawl-mcp
     env:
       FIRECRAWL_API_KEY: ${FIRECRAWL_API_KEY}
+  # 2026-08-05: kospi_kosdaq_stock_server(PyPI) 에서 리포 내 서버로 교체했다.
+  #
+  # 그 패키지는 KRX Data Marketplace 를 카카오 로그인으로 스크래핑한다. KRX 가
+  # db-server IP 를 막자 리포트의 이동평균·RSI·MACD·볼린저·지지저항·수급이 통째로
+  # "산출 불가"로 나갔다. 차트는 멀쩡했는데 cores/stock_chart.py 는 소스 체인을
+  # 타고 리포트 텍스트만 이 MCP 경로를 탔기 때문이다.
+  #
+  # 새 서버는 cores.market_data 체인 위에서 돈다. 도구 이름·인자·반환 형태와
+  # **서버 이름까지 동일**하므로 report_generator 의 프롬프트는 바뀌지 않는다.
+  # KRX 자격증명(KAKAO_ID/KAKAO_PW)이 더 이상 필요 없다.
+  #
+  # command: 이 서버는 리포 코드를 import 하므로 **리포 의존성이 설치된 인터프리터**
+  # 여야 한다. 맨 `python3` 는 호스트마다 다른 것을 가리킨다 — 맥미니에서는
+  # Homebrew 3.14 라서 `mcp` 조차 없다. 오케스트레이터를 띄우는 것과 같은 파이썬을
+  # PRISM_MCP_PYTHON 으로 지정한다.
   kospi_kosdaq:
-    command: python3
+    command: ${PRISM_MCP_PYTHON:-python3}
     args:
     - -m
-    - kospi_kosdaq_stock_server
+    - cores.market_data.mcp_server
     env:
-      KAKAO_ID: ${KAKAO_ID}
-      KAKAO_PW: ${KAKAO_PW}
-      KRX_LOGIN_METHOD: ${KRX_LOGIN_METHOD}
+      # 레지스트리가 env 를 명시적으로 넘기므로 리포 루트를 직접 준다.
+      # 기본값 '.' 는 자식의 cwd(오케스트레이터가 리포 루트에서 실행)를 가리킨다.
+      PYTHONPATH: ${PRISM_REPO_ROOT:-.}
+      # 리포트에 실리는 수치는 순서를 따로 둘 수 있다(미설정 시 일반 체인 순서).
+      # 치환기가 중첩 ${A:-${B}} 를 못 다루므로 여기서는 그대로 넘기고,
+      # 우선순위 결정은 서버가 한다.
+      PRISM_REPORT_DATA_SOURCES: ${PRISM_REPORT_DATA_SOURCES:-}
   perplexity:
     # Published from github.com/modelcontextprotocol/servers by Perplexity
     # (maintainer james.liounis@perplexity.ai). Fetching it removes the need to

--- a/cores/market_data/mcp_server.py
+++ b/cores/market_data/mcp_server.py
@@ -1,0 +1,320 @@
+"""리포트 에이전트용 MCP 서버 — 소스 체인 위에서 돈다.
+
+## 왜 만들었나
+
+리포트 생성 에이전트는 `kospi_kosdaq` MCP 서버(PyPI `kospi-kosdaq-stock-server`)로
+시세·수급을 받는다. 그 서버는 **KRX Data Marketplace 를 카카오 로그인으로 스크래핑**
+한다(`KAKAO_ID`/`KAKAO_PW`). pykrx 폴백도 결국 같은 KRX 다.
+
+2026-08-05 KRX 가 db-server IP 를 막자 리포트에서 **기술적 지표가 통째로 비었다**:
+
+    5·20·60·120일 이동평균   산출 불가
+    RSI(14일)                산출 불가
+    MACD / 시그널선          산출 불가
+    볼린저밴드(20일)         산출 불가
+    지지선·저항선            산출 불가
+    투자자별 순매수 수량     확인 불가
+
+차트는 정상으로 그려졌다. `cores/stock_chart.py` 는 체인을 타는데 **리포트 텍스트만
+이 MCP 경로를 타기 때문**이다. 스크리닝 쪽 KRX 호출을 42→4회로 줄여놓고도 정작
+상품인 리포트는 그대로였다.
+
+## 무엇이 다른가
+
+도구 이름·인자·반환 형태를 기존 서버와 **동일하게** 맞췄다. 서버 이름도
+`kospi_kosdaq` 그대로 쓰므로 `report_generator` 의 프롬프트는 한 글자도 안 바뀐다.
+바뀌는 것은 데이터가 어디서 오느냐뿐이다:
+
+    기존   KRX Data Marketplace 스크래핑 (카카오 로그인)
+    지금   cores.market_data 체인 (기본 kis -> fdr -> krx)
+
+`PRISM_MARKET_DATA_SOURCES` 로 순서를 바꾼다. KRX 자격증명이 필요 없다.
+
+## 실패를 숨기지 않는다
+
+체인이 전 소스 소진 시 빈 프레임을 주므로, 여기서는 그것을 `{"error": ...}` 로
+바꿔 돌려준다. 빈 dict 를 그냥 주면 LLM 이 "데이터가 없다"와 "0 이다"를 구분하지
+못한다 — 2026-08-05 의 MA200 건이 정확히 그 실패 모드였다(없는 줄을 '언급할 가치
+없음'으로 읽고 스스로 지어냈다).
+
+실행:
+
+    python -m cores.market_data.mcp_server
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Any, Dict, Union
+
+from mcp.server.fastmcp import FastMCP
+
+# 이 파일은 MCP 서버로 **별도 프로세스에서** 실행된다. 리포 루트가 sys.path 에
+# 없으면 cores 를 못 찾는다.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+# MCP 자식 프로세스가 부모의 환경을 온전히 물려받는다는 보장이 없다(레지스트리가
+# env 블록을 명시적으로 넘긴다). KIS 자격증명이 없으면 체인이 조용히 KIS 를 건너뛰고
+# 다음 소스로 내려가므로, 여기서 직접 .env 를 읽어 그 실패 모드를 없앤다.
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv(os.path.join(_REPO_ROOT, ".env"))
+except Exception:  # noqa: BLE001 - 없으면 상속된 환경으로 진행한다
+    pass
+
+from cores.market_data import (  # noqa: E402
+    get_index_ohlcv_by_date,
+    get_market_cap_by_date,
+    get_market_fundamental_by_date,
+    get_market_ohlcv_by_date,
+    get_market_ticker_name,
+    get_market_trading_volume_by_date,
+)
+
+logging.basicConfig(level=logging.INFO, stream=sys.stderr)
+logger = logging.getLogger("market_data_mcp")
+
+mcp = FastMCP("kospi_kosdaq")
+
+
+# --- 입력 정규화 (기존 서버와 동일 규칙) -------------------------------------
+
+
+def validate_date(date_str: Union[str, int]) -> str:
+    """YYYYMMDD 8자리로 정규화한다. LLM 이 정수나 하이픈을 섞어 보낸다."""
+    text = str(date_str).strip().replace("-", "").replace("/", "")
+    if len(text) != 8 or not text.isdigit():
+        raise ValueError(f"date must be YYYYMMDD, got {date_str!r}")
+    return text
+
+
+def validate_ticker(ticker_str: Union[str, int]) -> str:
+    """6자리 종목코드로 정규화한다. 정수로 오면 앞의 0 이 날아가 있다."""
+    text = str(ticker_str).strip()
+    if text.isdigit():
+        return text.zfill(6)
+    return text
+
+
+def _frame_to_dated_dict(df, reverse: bool = True) -> Dict[str, Any]:
+    """DataFrame 을 날짜 키 dict 로 바꾼다 (기존 서버의 출력 형태)."""
+    if df is None or df.empty:
+        return {}
+
+    formatted = {}
+    for key, row in df.to_dict(orient="index").items():
+        label = key.strftime("%Y-%m-%d") if hasattr(key, "strftime") else str(key)
+        formatted[label] = row
+
+    return dict(sorted(formatted.items(), reverse=reverse))
+
+
+def _answer(df, what: str) -> Dict[str, Any]:
+    """빈 결과를 침묵이 아니라 명시적 오류로 돌려준다.
+
+    LLM 에게 빈 dict 는 '없다'가 아니라 '언급할 가치 없다'로 읽힌다. 그러면
+    스스로 채운다 — 2026-08-05 MA200 건이 그랬다. 그래서 사유를 문장으로 준다.
+    """
+    payload = _frame_to_dated_dict(df)
+    if payload:
+        return payload
+    return {
+        "error": (
+            f"{what} 데이터를 어떤 소스에서도 받지 못했습니다. "
+            f"이 값이 0 이라는 뜻이 아니라 조회 불가라는 뜻이며, "
+            f"추정치로 서술하지 마십시오."
+        )
+    }
+
+
+def _guard(what: str, fn, *args, **kwargs) -> Dict[str, Any]:
+    try:
+        return _answer(fn(*args, **kwargs), what)
+    except Exception as exc:  # noqa: BLE001 - MCP 도구는 예외를 못 넘긴다
+        logger.error("%s failed: %s", what, exc)
+        return {"error": f"{what} 조회 실패: {exc}"}
+
+
+# --- MCP Tools ---------------------------------------------------------------
+
+
+@mcp.tool()
+def get_stock_ohlcv(
+    fromdate: Union[str, int],
+    todate: Union[str, int],
+    ticker: Union[str, int],
+    adjusted: bool = True,
+) -> Dict[str, Any]:
+    """Retrieves OHLCV (Open/High/Low/Close/Volume) data for a specific stock.
+
+    Args:
+        fromdate (str): Start date for retrieval (YYYYMMDD)
+        todate   (str): End date for retrieval (YYYYMMDD)
+        ticker   (str): Stock ticker symbol
+        adjusted (bool, optional): Whether to use adjusted prices. Defaults to True.
+
+    Returns:
+        Dict with date keys containing OHLCV data.
+    """
+    return _guard(
+        f"{validate_ticker(ticker)} OHLCV",
+        get_market_ohlcv_by_date,
+        validate_date(fromdate),
+        validate_date(todate),
+        validate_ticker(ticker),
+        adjusted=adjusted,
+    )
+
+
+@mcp.tool()
+def get_stock_market_cap(
+    fromdate: Union[str, int],
+    todate: Union[str, int],
+    ticker: Union[str, int],
+) -> Dict[str, Any]:
+    """Retrieves market capitalization data for a specific stock.
+
+    Args:
+        fromdate (str): Start date for retrieval (YYYYMMDD)
+        todate   (str): End date for retrieval (YYYYMMDD)
+        ticker   (str): Stock ticker symbol
+
+    Returns:
+        Dict with date keys containing market cap data.
+    """
+    return _guard(
+        f"{validate_ticker(ticker)} 시가총액",
+        get_market_cap_by_date,
+        validate_date(fromdate),
+        validate_date(todate),
+        validate_ticker(ticker),
+    )
+
+
+@mcp.tool()
+def get_stock_fundamental(
+    fromdate: Union[str, int],
+    todate: Union[str, int],
+    ticker: Union[str, int],
+) -> Dict[str, Any]:
+    """Retrieves fundamental data (PER/PBR/Dividend Yield) for a specific stock.
+
+    Args:
+        fromdate (str): Start date for retrieval (YYYYMMDD)
+        todate   (str): End date for retrieval (YYYYMMDD)
+        ticker   (str): Stock ticker symbol
+
+    Returns:
+        Dict with date keys containing fundamental data.
+    """
+    return _guard(
+        f"{validate_ticker(ticker)} 펀더멘털(PER/PBR)",
+        get_market_fundamental_by_date,
+        validate_date(fromdate),
+        validate_date(todate),
+        validate_ticker(ticker),
+    )
+
+
+@mcp.tool()
+def get_stock_trading_volume(
+    fromdate: Union[str, int],
+    todate: Union[str, int],
+    ticker: Union[str, int],
+    detail: bool = False,
+) -> Dict[str, Any]:
+    """Retrieves trading volume by investor type for a specific stock.
+
+    Args:
+        fromdate (str): Start date for retrieval (YYYYMMDD)
+        todate   (str): End date for retrieval (YYYYMMDD)
+        ticker   (str): Stock ticker symbol
+        detail   (bool, optional): Unused; kept for call compatibility.
+
+    Returns:
+        Dict with date keys containing investor-type net buying data.
+    """
+    return _guard(
+        f"{validate_ticker(ticker)} 투자자별 수급",
+        get_market_trading_volume_by_date,
+        validate_date(fromdate),
+        validate_date(todate),
+        validate_ticker(ticker),
+    )
+
+
+@mcp.tool()
+def get_index_ohlcv(
+    fromdate: Union[str, int],
+    todate: Union[str, int],
+    ticker: Union[str, int],
+    freq: str = "d",
+) -> Dict[str, Any]:
+    """Retrieves OHLCV data for a specific index.
+
+    Args:
+        fromdate (str): Start date for retrieval (YYYYMMDD)
+        todate   (str): End date for retrieval (YYYYMMDD)
+        ticker   (str): Index code (e.g. 1001 KOSPI, 2001 KOSDAQ)
+        freq     (str, optional): Unused; daily only.
+
+    Returns:
+        Dict with date keys containing index OHLCV data.
+    """
+    return _guard(
+        f"지수 {ticker} OHLCV",
+        get_index_ohlcv_by_date,
+        validate_date(fromdate),
+        validate_date(todate),
+        str(ticker).strip(),
+    )
+
+
+@mcp.tool()
+def get_ticker_name(ticker: Union[str, int]) -> Dict[str, Any]:
+    """Resolves a ticker symbol to its company name.
+
+    Args:
+        ticker (str): Stock ticker symbol
+
+    Returns:
+        Dict with `ticker` and `name`.
+    """
+    code = validate_ticker(ticker)
+    try:
+        name = get_market_ticker_name(code)
+    except Exception as exc:  # noqa: BLE001
+        return {"error": f"{code} 종목명 조회 실패: {exc}"}
+    # 체인은 답할 소스가 없으면 티커를 그대로 돌려준다. 그걸 이름으로 속이지 않는다.
+    if name == code:
+        return {"error": f"{code} 종목명을 어떤 소스에서도 받지 못했습니다."}
+    return {"ticker": code, "name": name}
+
+
+def apply_report_source_order() -> str:
+    """리포트 전용 소스 순서가 지정돼 있으면 그것을 쓴다.
+
+    리포트에 실리는 수치는 배포되므로 스크리닝과 다른 소스를 쓰고 싶을 수 있다
+    (설계서 §3). 그래서 ``PRISM_REPORT_DATA_SOURCES`` 를 별도로 둔다. 비어 있으면
+    일반 체인 순서(``PRISM_MARKET_DATA_SOURCES``)를 그대로 따른다.
+
+    YAML 치환기가 중첩 ``${A:-${B}}`` 를 못 다뤄서 우선순위 판단을 여기서 한다.
+    """
+    override = (os.getenv("PRISM_REPORT_DATA_SOURCES") or "").strip()
+    if override:
+        os.environ["PRISM_MARKET_DATA_SOURCES"] = override
+    return os.getenv("PRISM_MARKET_DATA_SOURCES", "krx,fdr (chain default)")
+
+
+def main() -> None:
+    logger.info("market data MCP server starting (sources=%s)", apply_report_source_order())
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/cores/market_data/mcp_server.py
+++ b/cores/market_data/mcp_server.py
@@ -57,15 +57,36 @@ _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__f
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
-# MCP 자식 프로세스가 부모의 환경을 온전히 물려받는다는 보장이 없다(레지스트리가
-# env 블록을 명시적으로 넘긴다). KIS 자격증명이 없으면 체인이 조용히 KIS 를 건너뛰고
-# 다음 소스로 내려가므로, 여기서 직접 .env 를 읽어 그 실패 모드를 없앤다.
-try:
-    from dotenv import load_dotenv
+logging.basicConfig(level=logging.INFO, stream=sys.stderr)
+logger = logging.getLogger("market_data_mcp")
 
-    load_dotenv(os.path.join(_REPO_ROOT, ".env"))
-except Exception:  # noqa: BLE001 - 없으면 상속된 환경으로 진행한다
-    pass
+
+def _load_repo_env() -> None:
+    """리포의 ``.env`` 를 읽어 KIS 자격증명을 확보한다.
+
+    MCP 자식 프로세스가 부모의 환경을 온전히 물려받는다는 보장이 없다 —
+    레지스트리가 env 블록을 명시적으로 넘긴다. 자격증명이 없으면 체인이 **조용히**
+    KIS 를 건너뛰고 다음 소스로 내려간다. 그 조용함이 문제라서, 실패하면 반드시
+    말하게 둔다(삼키고 pass 하면 8/4 장애를 숨긴 것과 같은 모양이 된다).
+    """
+    try:
+        from dotenv import load_dotenv
+    except ImportError:
+        logger.warning("python-dotenv 없음 — 상속된 환경변수만 사용한다")
+        return
+
+    env_path = os.path.join(_REPO_ROOT, ".env")
+    if not os.path.exists(env_path):
+        logger.warning("%s 없음 — 상속된 환경변수만 사용한다", env_path)
+        return
+
+    try:
+        load_dotenv(env_path)
+    except OSError as exc:
+        logger.warning("%s 읽기 실패(%s) — 상속된 환경변수만 사용한다", env_path, exc)
+
+
+_load_repo_env()
 
 from cores.market_data import (  # noqa: E402
     get_index_ohlcv_by_date,
@@ -75,9 +96,6 @@ from cores.market_data import (  # noqa: E402
     get_market_ticker_name,
     get_market_trading_volume_by_date,
 )
-
-logging.basicConfig(level=logging.INFO, stream=sys.stderr)
-logger = logging.getLogger("market_data_mcp")
 
 mcp = FastMCP("kospi_kosdaq")
 

--- a/tests/test_market_data_mcp_server.py
+++ b/tests/test_market_data_mcp_server.py
@@ -1,0 +1,187 @@
+"""리포트용 MCP 서버는 체인 위에서 돌고, 없는 데이터를 침묵으로 넘기지 않는다.
+
+2026-08-05 리포트에서 기술적 지표가 통째로 "산출 불가"로 나갔다. 원인은 리포트
+에이전트가 쓰는 `kospi_kosdaq` MCP 서버가 KRX 를 카카오 로그인으로 스크래핑하는
+PyPI 패키지였고, KRX 가 IP 를 막았기 때문이다. 차트는 멀쩡했다 —
+`cores/stock_chart.py` 는 소스 체인을 타는데 리포트 텍스트만 이 경로를 탔다.
+
+이 서버는 같은 도구 계약을 유지한 채 `cores.market_data` 체인 위에서 돈다.
+서버 이름까지 같아서 `report_generator` 의 프롬프트는 바뀌지 않는다.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+pytest.importorskip("mcp")
+
+from cores.market_data import mcp_server as srv  # noqa: E402
+
+
+def _ohlcv(rows: int = 3) -> pd.DataFrame:
+    idx = pd.to_datetime(["2026-08-03", "2026-08-04", "2026-08-05"][:rows])
+    return pd.DataFrame(
+        {"Open": [1, 2, 3][:rows], "Close": [2, 3, 4][:rows]}, index=idx
+    )
+
+
+# --- 입력 정규화 -------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [("20260805", "20260805"), (20260805, "20260805"), ("2026-08-05", "20260805")],
+)
+def test_validate_date_normalizes(raw, expected):
+    assert srv.validate_date(raw) == expected
+
+
+def test_validate_date_rejects_garbage():
+    with pytest.raises(ValueError):
+        srv.validate_date("august")
+
+
+def test_validate_ticker_zero_fills():
+    """LLM 이 정수로 보내면 앞의 0 이 날아간다 — 9150 은 009150 이다."""
+    assert srv.validate_ticker(9150) == "009150"
+    assert srv.validate_ticker("009150") == "009150"
+
+
+# --- 체인 경유 ---------------------------------------------------------------
+
+
+def test_ohlcv_reads_through_the_chain(monkeypatch):
+    seen = {}
+
+    def _chain(start, end, ticker, adjusted=True):
+        seen["args"] = (start, end, ticker, adjusted)
+        return _ohlcv()
+
+    monkeypatch.setattr(srv, "get_market_ohlcv_by_date", _chain)
+
+    result = srv.get_stock_ohlcv("2026-07-01", 20260805, 9150)
+
+    assert seen["args"] == ("20260701", "20260805", "009150", True)
+    assert "2026-08-05" in result
+
+
+def test_ohlcv_is_sorted_newest_first():
+    """기존 서버와 같은 정렬 — 프롬프트가 '최근' 을 앞에서 읽는다."""
+    frame = _ohlcv()
+    assert list(srv._frame_to_dated_dict(frame)) == [
+        "2026-08-05",
+        "2026-08-04",
+        "2026-08-03",
+    ]
+
+
+def test_trading_volume_reads_through_the_chain(monkeypatch):
+    called = {}
+
+    def _chain(start, end, ticker):
+        called["ticker"] = ticker
+        return _ohlcv()
+
+    monkeypatch.setattr(srv, "get_market_trading_volume_by_date", _chain)
+
+    assert "error" not in srv.get_stock_trading_volume("20260701", "20260805", "005930")
+    assert called["ticker"] == "005930"
+
+
+def test_index_ohlcv_keeps_the_index_code_unpadded(monkeypatch):
+    """지수 코드는 종목코드가 아니다 — 1001 을 001001 로 만들면 안 된다."""
+    seen = {}
+
+    def _chain(start, end, index_ticker):
+        seen["code"] = index_ticker
+        return _ohlcv()
+
+    monkeypatch.setattr(srv, "get_index_ohlcv_by_date", _chain)
+
+    srv.get_index_ohlcv("20260701", "20260805", 1001)
+
+    assert seen["code"] == "1001"
+
+
+# --- 없는 데이터를 침묵으로 넘기지 않는다 -------------------------------------
+
+
+def test_empty_result_becomes_an_explicit_error(monkeypatch):
+    """빈 dict 를 주면 LLM 이 '없다'와 '0 이다'를 구분 못 한다.
+
+    2026-08-05 MA200 건이 정확히 그 실패 모드였다 — 없는 줄을 '언급할 가치 없음'
+    으로 읽고 스스로 지어냈다.
+    """
+    monkeypatch.setattr(
+        srv, "get_market_ohlcv_by_date", lambda *a, **k: pd.DataFrame()
+    )
+
+    result = srv.get_stock_ohlcv("20260701", "20260805", "005930")
+
+    assert "error" in result
+    assert "추정치로 서술하지 마십시오" in result["error"]
+
+
+def test_chain_exception_is_reported_not_raised(monkeypatch):
+    """MCP 도구는 예외를 밖으로 못 넘긴다 — 오류 문자열로 돌려준다."""
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("chain exploded")
+
+    monkeypatch.setattr(srv, "get_market_ohlcv_by_date", _boom)
+
+    result = srv.get_stock_ohlcv("20260701", "20260805", "005930")
+
+    assert "error" in result and "chain exploded" in result["error"]
+
+
+def test_ticker_name_does_not_pass_off_the_code_as_a_name(monkeypatch):
+    """체인은 답할 소스가 없으면 티커를 그대로 준다. 그걸 이름이라 하지 않는다."""
+    monkeypatch.setattr(srv, "get_market_ticker_name", lambda t: t)
+
+    assert "error" in srv.get_ticker_name("009150")
+
+
+def test_ticker_name_returns_the_resolved_name(monkeypatch):
+    monkeypatch.setattr(srv, "get_market_ticker_name", lambda t: "삼성전기")
+
+    assert srv.get_ticker_name("009150") == {"ticker": "009150", "name": "삼성전기"}
+
+
+# --- 리포트 전용 소스 순서 ---------------------------------------------------
+
+
+def test_report_source_override_wins(monkeypatch):
+    monkeypatch.setenv("PRISM_MARKET_DATA_SOURCES", "kis,fdr,krx")
+    monkeypatch.setenv("PRISM_REPORT_DATA_SOURCES", "krx,fdr")
+
+    assert srv.apply_report_source_order() == "krx,fdr"
+    assert srv.os.environ["PRISM_MARKET_DATA_SOURCES"] == "krx,fdr"
+
+
+def test_falls_back_to_the_general_chain_order(monkeypatch):
+    monkeypatch.setenv("PRISM_MARKET_DATA_SOURCES", "kis,fdr,krx")
+    monkeypatch.setenv("PRISM_REPORT_DATA_SOURCES", "")
+
+    assert srv.apply_report_source_order() == "kis,fdr,krx"
+
+
+# --- 도구 계약 유지 -----------------------------------------------------------
+
+
+def test_exposes_the_same_tool_names_the_prompts_reference():
+    """report_generator 프롬프트가 이름으로 지목하는 도구들이다."""
+    for name in (
+        "get_stock_ohlcv",
+        "get_stock_market_cap",
+        "get_stock_fundamental",
+        "get_stock_trading_volume",
+        "get_index_ohlcv",
+    ):
+        assert callable(getattr(srv, name)), name
+
+
+def test_server_name_matches_the_configured_mcp_server():
+    """서버 이름이 바뀌면 report_generator 의 server_names 를 전부 고쳐야 한다."""
+    assert srv.mcp.name == "kospi_kosdaq"


### PR DESCRIPTION
## 문제

2026-08-05 리포트에서 **기술적 지표가 통째로 비었다.**

```
5·20·60·120일 이동평균                산출 불가
RSI(14일) / MACD / 볼린저 / 지지저항   산출 불가
투자자별 순매수 수량                   확인 불가
```

**차트는 정상으로 그려졌다.** `cores/stock_chart.py` 는 소스 체인을 타는데
**리포트 텍스트만 `kospi_kosdaq` MCP 경로**를 탔기 때문이다.

그 서버(PyPI `kospi-kosdaq-stock-server`)는 KRX Data Marketplace 를 **카카오
로그인으로 스크래핑**한다. pykrx 폴백도 결국 같은 KRX 다. KRX 가 IP 를 막자 전멸했다.

오늘 스크리닝 쪽 KRX 호출은 42→4회로 줄였는데 **정작 상품인 리포트는 그대로였다.**

## 무엇을 했나

`cores/market_data/mcp_server.py` 를 추가하고 `mcp_servers.yaml` 의 `kospi_kosdaq`
를 여기로 돌린다.

**도구 이름·인자·반환 형태와 서버 이름까지 동일**하므로 `report_generator` 의
프롬프트와 `server_names` 는 한 글자도 안 바뀐다. 바뀌는 것은 데이터 출처뿐이다.

| | 기존 | 지금 |
|---|---|---|
| 출처 | KRX Data Marketplace 스크래핑 | `cores.market_data` 체인 |
| 자격증명 | `KAKAO_ID` / `KAKAO_PW` | **불필요** |
| 순서 조절 | 없음 | `PRISM_MARKET_DATA_SOURCES` |

KRX 자격증명이 필요 없어져 env 에서 걷어냈다.

## 없는 데이터를 침묵으로 넘기지 않는다

체인은 전 소스 소진 시 빈 프레임을 준다. 그걸 그대로 빈 dict 로 주면 LLM 이
**"없다"와 "0 이다"를 구분하지 못한다.** 2026-08-05 MA200 건이 정확히 그 실패
모드였다 — 없는 줄을 '언급할 가치 없음'으로 읽고 스스로 지어냈다.

그래서 사유를 문장으로 담아 돌려준다:

```
"... 데이터를 어떤 소스에서도 받지 못했습니다. 이 값이 0 이라는 뜻이 아니라
 조회 불가라는 뜻이며, 추정치로 서술하지 마십시오."
```

`get_ticker_name` 도 같은 원칙이다 — 체인이 티커를 그대로 돌려주면 그걸 이름인
척하지 않고 오류로 알린다.

## 인터프리터

`command: ${PRISM_MCP_PYTHON:-python3}`.

이 서버는 리포 코드를 import 하므로 **리포 의존성이 설치된 파이썬**이어야 하는데
맨 `python3` 는 호스트마다 다른 것을 가리킨다.

- **db-server**: `python3` = pyenv shim 3.11.11, `mcp`·`pandas` 보유 → **설정 없이 동작**
- **맥미니**: Homebrew 3.14 라 `mcp` 조차 없음 → `PRISM_MCP_PYTHON` 필요
  (기존 서버도 같은 이유로 로컬에서는 뜨지 않았다 — 새로 생긴 제약이 아니다)

리포트 전용 소스 순서는 `PRISM_REPORT_DATA_SOURCES` 로 따로 줄 수 있다. YAML
치환기가 중첩 `${A:-${B}}` 를 못 다뤄서 우선순위 판단은 서버가 한다.

## 검증

**MCP 클라이언트로 실제 기동해 왕복 확인했다** (설정 파싱 → 프로세스 spawn →
`list_tools` → `get_stock_ohlcv` 호출):

```
"2026-08-04": {
  "Open": 244500, "High": 244500, "Low": 228000, "Close": 240000,
  "Volume": 29433821, "Amount": 6922844531100, "MarketCap": 1403106865920000
}
```

기존 서버와 같은 컬럼 구성이다.

```
tests/test_market_data_mcp_server.py     17 passed  (신규)
회귀 대조   24 failed, 1658 passed  →  24 failed, 1675 passed
```

⚠️ **로컬에서는 KIS 인증이 403** 이라 위 응답은 체인의 FDR 이 답한 것이다.
db-server 에서 KIS 가 실제로 이 능력들을 서빙하는지는 배포 전 별도 확인한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)