### PR TITLE
refactor(mcp): 리포트 경로에서 펀더멘털 도구를 뺀다 (WiseReport 가 이미 담당)

### DIFF
--- a/cores/market_data/mcp_server.py
+++ b/cores/market_data/mcp_server.py
@@ -91,7 +91,6 @@ _load_repo_env()
 from cores.market_data import (  # noqa: E402
     get_index_ohlcv_by_date,
     get_market_cap_by_date,
-    get_market_fundamental_by_date,
     get_market_ohlcv_by_date,
     get_market_ticker_name,
     get_market_trading_volume_by_date,
@@ -214,29 +213,20 @@ def get_stock_market_cap(
     )
 
 
-@mcp.tool()
-def get_stock_fundamental(
-    fromdate: Union[str, int],
-    todate: Union[str, int],
-    ticker: Union[str, int],
-) -> Dict[str, Any]:
-    """Retrieves fundamental data (PER/PBR/Dividend Yield) for a specific stock.
-
-    Args:
-        fromdate (str): Start date for retrieval (YYYYMMDD)
-        todate   (str): End date for retrieval (YYYYMMDD)
-        ticker   (str): Stock ticker symbol
-
-    Returns:
-        Dict with date keys containing fundamental data.
-    """
-    return _guard(
-        f"{validate_ticker(ticker)} 펀더멘털(PER/PBR)",
-        get_market_fundamental_by_date,
-        validate_date(fromdate),
-        validate_date(todate),
-        validate_ticker(ticker),
-    )
+# 펀더멘털(PER/PBR) 도구는 의도적으로 노출하지 않는다.
+#
+# 리포트의 펀더멘털은 아래쪽 `기업 현황`·`기업 개요` 섹션이 WiseReport 크롤링
+# (`cores/agents/company_info_agents.py`)으로 이미 채운다. 그쪽이 훨씬 넓다 —
+# EPS·BPS·PER·PBR·PCR·EV/EBITDA·배당수익률·배당성향의 현재값과 과거 3개년,
+# **Fwd 12M 컨센서스**, 업종 평균 PER 대비 할인/할증까지 준다.
+#
+# 여기서 줄 수 있는 것은 PER/PBR/배당수익률의 과거 시계열뿐이고, KRX 수치 자체가
+# 정확하지 않다는 관측도 있었다(Rocky, 2026-08-05). 좁고 덜 정확한 두 번째 출처를
+# 함께 노출하면 LLM 이 어느 쪽을 쓸지 갈리고, 두 값이 어긋나면 리포트가 모순된다.
+#
+# 체인의 `get_market_fundamental_by_date` 자체는 남아 있다 —
+# `trigger_contrarian_value`(스크리닝 PER 필터)와 `cores/stock_chart.py` 가 쓴다.
+# 노출을 끊는 것은 **리포트 경로**뿐이다.
 
 
 @mcp.tool()

--- a/tests/test_market_data_mcp_server.py
+++ b/tests/test_market_data_mcp_server.py
@@ -175,11 +175,21 @@ def test_exposes_the_same_tool_names_the_prompts_reference():
     for name in (
         "get_stock_ohlcv",
         "get_stock_market_cap",
-        "get_stock_fundamental",
         "get_stock_trading_volume",
         "get_index_ohlcv",
     ):
         assert callable(getattr(srv, name)), name
+
+
+def test_does_not_expose_a_fundamental_tool():
+    """펀더멘털은 WiseReport 섹션이 담당한다 — 두 번째 출처를 노출하지 않는다.
+
+    `cores/agents/company_info_agents.py` 가 EPS·BPS·PER·PBR·PCR·EV/EBITDA·
+    배당수익률·배당성향의 현재값과 과거 3개년, Fwd 12M 컨센서스, 업종 평균 대비
+    할인/할증까지 준다. 여기서 줄 수 있는 것은 PER/PBR 과거 시계열뿐이고 KRX
+    수치의 정확도 문제도 관측됐다. 둘 다 노출하면 값이 어긋날 때 리포트가 모순된다.
+    """
+    assert not hasattr(srv, "get_stock_fundamental")
 
 
 def test_server_name_matches_the_configured_mcp_server():


### PR DESCRIPTION
## 왜

Rocky 지적(2026-08-05): **리포트의 펀더멘털은 KRX 에서 받던 게 정확하지도 않았고,
아래쪽 `기업 현황`·`기업 개요` 섹션이 WiseReport 크롤링으로 이미 채우고 있다.**

확인해보니 맞다. `cores/agents/company_info_agents.py` 가 훨씬 넓다:

| | MCP 펀더멘털 도구 | WiseReport 섹션 |
|---|---|---|
| 지표 | PER · PBR · 배당수익률 | EPS · BPS · PER · PBR · PCR · EV/EBITDA · 배당수익률 · 배당성향 |
| 기간 | 과거 시계열 | 현재값 + 과거 3개년 + **Fwd 12M 컨센서스** |
| 비교 | 없음 | **업종 평균 PER 대비 할인/할증**, Forward PER 밸류에이션 |
| 재무비율 | 없음 | ROE · ROA · 부채비율 · 자본유보율 |
| 정확도 | KRX 수치 부정확 관측 | — |

**좁고 덜 정확한 두 번째 출처를 함께 노출하면** LLM 이 어느 쪽을 쓸지 갈리고,
두 값이 어긋나면 리포트가 스스로 모순된다.

## 안전한 이유

프롬프트 어디에서도 이 도구를 **이름으로 지목하지 않는다.** LLM 이 `list_tools`
로 발견하는 구조라 노출을 끊으면 아예 시도하지 않는다. (`report_generator` 의
프롬프트는 `get_stock_ohlcv`, `get_stock_trading_volume` 만 언급한다.)

체인의 `get_market_fundamental_by_date` **자체는 남긴다** —
`trigger_contrarian_value` 의 PER 필터와 `cores/stock_chart.py` 가 쓴다.
끊는 것은 **리포트 경로뿐**이다.

## 검증

```
노출 도구 6 → 5 (E2E 로 목록 확인)
TOOLS: ['get_index_ohlcv', 'get_stock_market_cap', 'get_stock_ohlcv',
        'get_stock_trading_volume', 'get_ticker_name']

tests/test_market_data_mcp_server.py   18 passed (1건 신규)
회귀 대조   24 failed, 1675 passed  →  24 failed, 1676 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)