### PR TITLE
feat(screening): use KIS multi-quote market snapshot

### DIFF
--- a/cores/kis_market_snapshot.py
+++ b/cores/kis_market_snapshot.py
@@ -1,0 +1,185 @@
+"""Intraday all-stock snapshot from KIS's 30-stock quote endpoint."""
+
+from __future__ import annotations
+
+from io import BytesIO
+import time
+from typing import Iterable
+import zipfile
+
+import pandas as pd
+import requests
+
+from cores.naver_market_snapshot import MarketSnapshotBundle
+
+
+_URL = "/uapi/domestic-stock/v1/quotations/intstock-multprice"
+_TR_ID = "FHKST11300006"
+_CHUNK_SIZE = 30
+_KOSPI_WIDTHS = [
+    2, 1, 4, 4, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 9, 5, 5, 1, 1,
+    1, 2, 1, 1, 1, 2, 2, 2, 3, 1, 3, 12, 12, 8, 15, 21,
+    2, 7, 1, 1, 1, 1, 1, 9, 9, 9, 5, 9, 8, 9, 3, 1, 1, 1,
+]
+_KOSDAQ_WIDTHS = [
+    2, 1, 4, 4, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 9, 5, 5, 1, 1, 1, 2, 1, 1, 1,
+    2, 2, 2, 3, 1, 3, 12, 12, 8, 15, 21, 2, 7, 1, 1, 1,
+    1, 9, 9, 9, 5, 9, 8, 9, 3, 1, 1, 1,
+]
+_MASTER_SPECS = (
+    ("https://new.real.download.dws.co.kr/common/master/kospi_code.mst.zip", _KOSPI_WIDTHS, 12),
+    ("https://new.real.download.dws.co.kr/common/master/kosdaq_code.mst.zip", _KOSDAQ_WIDTHS, 8),
+)
+_COLUMNS = {
+    "inter2_oprc": "Open",
+    "inter2_hgpr": "High",
+    "inter2_lwpr": "Low",
+    "inter2_prpr": "Close",
+    "acml_vol": "Volume",
+    "acml_tr_pbmn": "Amount",
+}
+
+
+class KisSnapshotError(RuntimeError):
+    """KIS could not return a complete, schema-valid intraday universe."""
+
+
+def fetch_kis_master_universe(
+    *, request_get=requests.get, timeout: float = 30.0, min_stock_count: int = 2500
+) -> dict[str, str]:
+    """Download today's official KIS KOSPI/KOSDAQ master and return stocks."""
+    universe: dict[str, str] = {}
+    try:
+        for url, widths, etp_index in _MASTER_SPECS:
+            response = request_get(url, timeout=timeout)
+            response.raise_for_status()
+            with zipfile.ZipFile(BytesIO(response.content)) as archive:
+                names = archive.namelist()
+                if not names:
+                    raise KisSnapshotError(f"KIS master archive is empty: {url}")
+                content = archive.read(names[0])
+            tail_size = sum(widths)
+            etp_offset = sum(widths[:etp_index])
+            etp_width = widths[etp_index]
+            for line in content.splitlines():
+                if len(line) < 61:
+                    continue
+                code = line[0:9].decode("euc-kr", errors="ignore").strip()
+                name = line[21:61].decode("euc-kr", errors="ignore").strip()
+                tail = line[-tail_size:]
+                etp = tail[etp_offset : etp_offset + etp_width].decode(
+                    "ascii", errors="ignore"
+                ).strip()
+                if len(code) == 6 and code.isdigit() and name and etp != "2":
+                    universe[code] = name
+    except KisSnapshotError:
+        raise
+    except Exception as exc:
+        raise KisSnapshotError(f"KIS master download failed: {exc}") from exc
+
+    if len(universe) < min_stock_count:
+        raise KisSnapshotError(
+            f"KIS master universe too small ({len(universe)}/{min_stock_count})"
+        )
+    return dict(sorted(universe.items()))
+
+
+def _trading_client():
+    from trading.domestic_stock_trading import DomesticStockTrading
+
+    return DomesticStockTrading(auto_trading=False)
+
+
+def _params(codes: list[str]) -> dict[str, str]:
+    params: dict[str, str] = {}
+    for position, code in enumerate(codes, 1):
+        params[f"FID_COND_MRKT_DIV_CODE_{position}"] = "J"
+        params[f"FID_INPUT_ISCD_{position}"] = code
+    return params
+
+
+def fetch_kis_intraday_snapshot(
+    tickers: Iterable[str],
+    *,
+    client=None,
+    min_stock_count: int = 2500,
+    max_attempts: int = 3,
+    retry_wait_sec: float = 1.0,
+    request_interval_sec: float = 0.1,
+) -> pd.DataFrame:
+    """Return a complete OHLCV/amount snapshot, 30 tickers per KIS call."""
+    codes = sorted({str(code).strip().zfill(6) for code in tickers})
+    if len(codes) < min_stock_count:
+        raise KisSnapshotError(
+            f"KIS requested universe too small ({len(codes)}/{min_stock_count})"
+        )
+
+    trading = client or _trading_client()
+    rows: dict[str, dict] = {}
+
+    for offset in range(0, len(codes), _CHUNK_SIZE):
+        chunk = codes[offset : offset + _CHUNK_SIZE]
+        last_reason = "no response"
+        for attempt in range(1, max_attempts + 1):
+            response = trading._request(_URL, _TR_ID, _params(chunk))
+            if response and response.isOK():
+                for row in list(getattr(response.getBody(), "output", None) or []):
+                    code = str(row.get("inter_shrn_iscd", "")).strip().zfill(6)
+                    if code:
+                        rows[code] = dict(row)
+                break
+            last_reason = (
+                str(response.getErrorMessage()) if response else "no response"
+            )
+            if attempt < max_attempts and retry_wait_sec:
+                time.sleep(retry_wait_sec * attempt)
+        else:
+            raise KisSnapshotError(
+                f"KIS multi-price chunk {offset // _CHUNK_SIZE + 1} failed: {last_reason}"
+            )
+        if request_interval_sec:
+            time.sleep(request_interval_sec)
+
+    missing = sorted(set(codes) - set(rows))
+    if missing:
+        raise KisSnapshotError(
+            f"KIS multi-price response missing {len(missing)} tickers; sample={missing[:10]}"
+        )
+
+    frame = pd.DataFrame.from_dict(rows, orient="index")
+    absent = set(_COLUMNS) - set(frame.columns)
+    if absent:
+        raise KisSnapshotError(f"KIS multi-price missing fields: {sorted(absent)}")
+
+    out = frame[list(_COLUMNS)].rename(columns=_COLUMNS)
+    out = out.apply(pd.to_numeric, errors="coerce").sort_index()
+    if out[list(_COLUMNS.values())].isna().all(axis=1).any():
+        raise KisSnapshotError("KIS multi-price returned rows with no numeric snapshot data")
+    return out
+
+
+def build_kis_openapi_snapshot_bundle(
+    trade_date: str,
+    *,
+    universe_fetcher=fetch_kis_master_universe,
+    snapshot_fetcher=fetch_kis_intraday_snapshot,
+    previous_fetcher=None,
+) -> MarketSnapshotBundle:
+    """Combine today's official KIS quotes with the previous OPEN API session."""
+    if previous_fetcher is None:
+        from cores.krx_openapi_snapshot import fetch_previous_krx_openapi_snapshot
+
+        previous_fetcher = fetch_previous_krx_openapi_snapshot
+
+    universe = universe_fetcher()
+    snapshot = snapshot_fetcher(universe.keys())
+    previous = previous_fetcher(trade_date)
+    return MarketSnapshotBundle(
+        snapshot=snapshot,
+        prev_snapshot=previous.snapshot,
+        cap_df=previous.cap_df,
+        prev_date=previous.trade_date,
+        source="kis+krx_openapi",
+    )

--- a/cores/krx_openapi_snapshot.py
+++ b/cores/krx_openapi_snapshot.py
@@ -32,6 +32,7 @@ import logging
 import os
 import re
 import time
+from dataclasses import dataclass
 from typing import Callable
 
 import pandas as pd
@@ -65,6 +66,46 @@ _FIELD_MAP = {
 
 class KrxOpenApiError(RuntimeError):
     """The OPEN API could not produce a usable snapshot."""
+
+
+@dataclass(frozen=True)
+class PreviousKrxOpenApiSnapshot:
+    snapshot: pd.DataFrame
+    cap_df: pd.DataFrame
+    trade_date: str
+
+
+def fetch_previous_krx_openapi_snapshot(
+    trade_date: str,
+    *,
+    auth_key: str | None = None,
+    request_get: Callable = requests.get,
+    min_stock_count: int = 2500,
+    timeout: float = 20.0,
+    max_attempts: int = 3,
+    retry_wait_sec: float = 0.5,
+    max_lookback_days: int = 10,
+) -> PreviousKrxOpenApiSnapshot:
+    """Return the latest published market snapshot strictly before trade_date."""
+    if not re.fullmatch(r"\d{8}", trade_date):
+        raise ValueError("trade_date must be YYYYMMDD")
+    key = _auth_key(auth_key)
+    previous_date, rows = _previous_session(
+        trade_date,
+        key,
+        request_get,
+        max_lookback_days,
+        timeout=timeout,
+        max_attempts=max_attempts,
+        retry_wait_sec=retry_wait_sec,
+    )
+    if len(rows) < min_stock_count:
+        raise KrxOpenApiError(
+            f"{previous_date}: previous-session universe too small "
+            f"({len(rows)}/{min_stock_count})"
+        )
+    snapshot, cap_df = _frames(rows)
+    return PreviousKrxOpenApiSnapshot(snapshot, cap_df, previous_date)
 
 
 def _auth_key(explicit: str | None) -> str:

--- a/tests/test_kis_market_snapshot.py
+++ b/tests/test_kis_market_snapshot.py
@@ -1,0 +1,189 @@
+"""Offline tests for the KIS 30-stock intraday snapshot endpoint."""
+
+from __future__ import annotations
+
+from io import BytesIO
+import zipfile
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from cores.kis_market_snapshot import (  # noqa: E402
+    build_kis_openapi_snapshot_bundle,
+    KisSnapshotError,
+    fetch_kis_master_universe,
+    fetch_kis_intraday_snapshot,
+)
+
+
+class _Body:
+    def __init__(self, output):
+        self.output = output
+
+
+class _Response:
+    def __init__(self, output, *, ok=True, error=""):
+        self._body = _Body(output)
+        self._ok = ok
+        self._error = error
+
+    def isOK(self):  # noqa: N802
+        return self._ok
+
+    def getBody(self):  # noqa: N802
+        return self._body
+
+    def getErrorMessage(self):  # noqa: N802
+        return self._error
+
+
+def _row(code, price=1000):
+    return {
+        "inter_shrn_iscd": code,
+        "inter_kor_isnm": f"종목{code}",
+        "inter2_oprc": str(price - 10),
+        "inter2_hgpr": str(price + 20),
+        "inter2_lwpr": str(price - 30),
+        "inter2_prpr": str(price),
+        "acml_vol": "12345",
+        "acml_tr_pbmn": "678900",
+        "inter2_prdy_clpr": str(price - 5),
+    }
+
+
+class _Client:
+    def __init__(self, *, drop=None, reject=False):
+        self.calls = []
+        self.drop = set(drop or [])
+        self.reject = reject
+
+    def _request(self, api_url, tr_id, params):
+        self.calls.append((api_url, tr_id, params))
+        if self.reject:
+            return _Response([], ok=False, error="EGW00201")
+        codes = [
+            params[f"FID_INPUT_ISCD_{i}"]
+            for i in range(1, 31)
+            if f"FID_INPUT_ISCD_{i}" in params
+        ]
+        return _Response([_row(code) for code in codes if code not in self.drop])
+
+
+def test_chunks_thirty_tickers_and_maps_screening_columns():
+    tickers = [f"{i:06d}" for i in range(61)]
+    client = _Client()
+
+    frame = fetch_kis_intraday_snapshot(
+        tickers, client=client, min_stock_count=1, retry_wait_sec=0, request_interval_sec=0
+    )
+
+    assert len(client.calls) == 3
+    assert len(frame) == 61
+    assert list(frame.columns) == ["Open", "High", "Low", "Close", "Volume", "Amount"]
+    assert frame.loc["000000", "Close"] == 1000
+    assert client.calls[0][1] == "FHKST11300006"
+
+
+def test_missing_ticker_is_rejected_instead_of_returning_a_thin_universe():
+    client = _Client(drop={"000031"})
+    with pytest.raises(KisSnapshotError, match="missing 1 tickers"):
+        fetch_kis_intraday_snapshot(
+            [f"{i:06d}" for i in range(40)],
+            client=client,
+            min_stock_count=1,
+            retry_wait_sec=0,
+            request_interval_sec=0,
+        )
+
+
+def test_rejected_chunk_retries_then_raises_with_kis_reason():
+    client = _Client(reject=True)
+    with pytest.raises(KisSnapshotError, match="EGW00201"):
+        fetch_kis_intraday_snapshot(
+            ["005930"], client=client, min_stock_count=1,
+            max_attempts=2, retry_wait_sec=0, request_interval_sec=0,
+        )
+    assert len(client.calls) == 2
+
+
+def test_small_requested_universe_is_refused_by_default():
+    with pytest.raises(KisSnapshotError, match="universe too small"):
+        fetch_kis_intraday_snapshot(["005930"], client=_Client(), request_interval_sec=0)
+
+
+class _DownloadResponse:
+    def __init__(self, content):
+        self.content = content
+
+    def raise_for_status(self):
+        return None
+
+
+def _master_zip(lines):
+    payload = b"\n".join(lines) + b"\n"
+    buffer = BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("market_code.mst", payload)
+    return buffer.getvalue()
+
+
+def _master_line(code, name, *, etp=False):
+    # Official KIS fixed-width prefix: short code 9, standard code 12, name 40.
+    tail = bytearray(b" " * 227)
+    if etp:
+        tail[22:23] = b"2"  # KOSPI ETP 상품구분코드
+    return f"{code:<9}{'KR7' + code:<12}{name:<40}".encode("euc-kr") + bytes(tail)
+
+
+def test_master_universe_combines_markets_and_drops_non_numeric_codes():
+    payloads = [
+        _master_zip([
+            _master_line("005930", "삼성전자"),
+            _master_line("069500", "KODEX 200", etp=True),
+            _master_line("Q123456", "ETN"),
+        ]),
+        _master_zip([_master_line("247540", "에코프로비엠")]),
+    ]
+
+    def get(_url, timeout=None):
+        return _DownloadResponse(payloads.pop(0))
+
+    universe = fetch_kis_master_universe(request_get=get, min_stock_count=1)
+
+    assert universe == {"005930": "삼성전자", "247540": "에코프로비엠"}
+
+
+def test_master_universe_refuses_partial_download():
+    payload = _master_zip([_master_line("005930", "삼성전자")])
+    with pytest.raises(KisSnapshotError, match="universe too small"):
+        fetch_kis_master_universe(
+            request_get=lambda *_args, **_kwargs: _DownloadResponse(payload)
+        )
+
+
+def test_builds_current_kis_and_previous_openapi_bundle():
+    current = pd.DataFrame(
+        {"Open": [10], "High": [12], "Low": [9], "Close": [11],
+         "Volume": [100], "Amount": [1100]}, index=["005930"]
+    )
+    previous = current.copy()
+    cap = pd.DataFrame({"시가총액": [1_000_000]}, index=["005930"])
+
+    class _Previous:
+        snapshot = previous
+        cap_df = cap
+        trade_date = "20260804"
+
+    bundle = build_kis_openapi_snapshot_bundle(
+        "20260805",
+        universe_fetcher=lambda: {"005930": "삼성전자"},
+        snapshot_fetcher=lambda codes: current,
+        previous_fetcher=lambda _date: _Previous(),
+    )
+
+    assert bundle.source == "kis+krx_openapi"
+    assert bundle.snapshot is current
+    assert bundle.prev_snapshot is previous
+    assert bundle.cap_df is cap
+    assert bundle.prev_date == "20260804"

--- a/tests/test_krx_openapi_snapshot.py
+++ b/tests/test_krx_openapi_snapshot.py
@@ -15,6 +15,7 @@ pd = pytest.importorskip("pandas")
 from cores.krx_openapi_snapshot import (  # noqa: E402
     KrxOpenApiError,
     fetch_krx_openapi_bundle,
+    fetch_previous_krx_openapi_snapshot,
 )
 
 AUTH = "test-key"
@@ -176,3 +177,18 @@ def test_mismatched_date_in_payload_is_rejected():
 def test_bad_date_format_is_rejected():
     with pytest.raises(ValueError, match="YYYYMMDD"):
         fetch_krx_openapi_bundle("2026-08-03", auth_key=AUTH)
+
+
+def test_previous_snapshot_works_when_current_session_is_not_published():
+    rows = {
+        "20260804": _universe("20260804", 2600, close=1100),
+        "20260803": _universe("20260803", 2600, close=1000),
+    }
+    previous = fetch_previous_krx_openapi_snapshot(
+        "20260805", auth_key=AUTH, request_get=_make_get(rows), min_stock_count=2500
+    )
+
+    assert previous.trade_date == "20260804"
+    assert previous.snapshot.shape == (2600, 6)
+    assert previous.snapshot.iloc[0]["Close"] == 1100
+    assert list(previous.cap_df.columns) == ["시가총액"]

--- a/tests/test_naver_market_snapshot.py
+++ b/tests/test_naver_market_snapshot.py
@@ -221,15 +221,15 @@ def test_daily_parser_never_resolves_external_xml_entities():
         _parse_daily_xml(malicious, TRADE_DATE)
 
 
-def test_trigger_batch_uses_naver_bundle_after_krx_failure(monkeypatch):
+def test_trigger_batch_uses_naver_bundle_after_kis_openapi_failure(monkeypatch):
     import trigger_batch
 
     fake_get = _FixtureGet()
     naver_bundle = _fetch(fake_get)
     monkeypatch.setattr(
         trigger_batch,
-        "get_snapshot",
-        lambda _date: (_ for _ in ()).throw(RuntimeError("KRX down")),
+        "build_kis_openapi_snapshot_bundle",
+        lambda _date: (_ for _ in ()).throw(RuntimeError("KIS down")),
     )
     monkeypatch.setattr(
         trigger_batch,
@@ -243,7 +243,7 @@ def test_trigger_batch_uses_naver_bundle_after_krx_failure(monkeypatch):
     assert result.source == "naver"
 
 
-def test_trigger_batch_keeps_krx_as_primary(monkeypatch):
+def test_trigger_batch_uses_kis_openapi_as_primary(monkeypatch):
     import trigger_batch
 
     snapshot = pd.DataFrame(
@@ -259,13 +259,8 @@ def test_trigger_batch_keeps_krx_as_primary(monkeypatch):
     )
     previous = snapshot.copy()
     cap = pd.DataFrame({"시가총액": [1_000_000]}, index=["005930"])
-    monkeypatch.setattr(trigger_batch, "get_snapshot", lambda _date: snapshot)
-    monkeypatch.setattr(
-        trigger_batch,
-        "get_previous_snapshot",
-        lambda _date: (previous, "20260721"),
-    )
-    monkeypatch.setattr(trigger_batch, "get_market_cap_df", lambda _date: cap)
+    primary = MarketSnapshotBundle(snapshot, previous, cap, "20260721", "kis+krx_openapi")
+    monkeypatch.setattr(trigger_batch, "build_kis_openapi_snapshot_bundle", lambda _date: primary)
     monkeypatch.setattr(
         trigger_batch,
         "fetch_naver_snapshot_bundle",
@@ -274,7 +269,7 @@ def test_trigger_batch_keeps_krx_as_primary(monkeypatch):
 
     result = trigger_batch.load_market_snapshot_bundle(TRADE_DATE)
 
-    assert result.source == "krx"
+    assert result.source == "kis+krx_openapi"
     assert result.snapshot is snapshot
     assert result.prev_snapshot is previous
     assert result.cap_df is cap
@@ -285,8 +280,8 @@ def test_trigger_batch_raises_typed_error_when_both_sources_fail(monkeypatch):
 
     monkeypatch.setattr(
         trigger_batch,
-        "get_snapshot",
-        lambda _date: (_ for _ in ()).throw(RuntimeError("KRX down")),
+        "build_kis_openapi_snapshot_bundle",
+        lambda _date: (_ for _ in ()).throw(RuntimeError("KIS down")),
     )
     monkeypatch.setattr(
         trigger_batch,

--- a/trigger_batch.py
+++ b/trigger_batch.py
@@ -14,6 +14,7 @@ from cores.naver_market_snapshot import (
     MarketSnapshotBundle,
     fetch_naver_snapshot_bundle,
 )
+from cores.kis_market_snapshot import build_kis_openapi_snapshot_bundle
 from cores.rs_rating import oneil_weighted_return, percentile_ratings
 from krx_data_client import (
     _get_client,
@@ -276,33 +277,20 @@ def get_market_cap_df(trade_date: str, market: str = "ALL") -> pd.DataFrame:
 
 
 def load_market_snapshot_bundle(trade_date: str) -> MarketSnapshotBundle:
-    """Load current, previous, and market-cap data from one coherent source.
-
-    KRX is always primary.  If any market-wide KRX input fails, rebuild the
-    complete bundle from Naver rather than mixing sources with different
-    timestamps or universes.
-    """
+    """Load current KIS quotes plus previous OPEN API data, or Naver fallback."""
     try:
-        snapshot = get_snapshot(trade_date)
-        prev_snapshot, prev_date = get_previous_snapshot(trade_date)
-        cap_df = get_market_cap_df(trade_date)
+        bundle = build_kis_openapi_snapshot_bundle(trade_date)
         logger.info(
-            "[MARKET-DATA] source=KRX stocks=%d prev_date=%s cap_rows=%d",
-            len(snapshot),
-            prev_date,
-            len(cap_df),
+            "[MARKET-DATA] source=KIS+KRX_OPENAPI stocks=%d prev_date=%s cap_rows=%d",
+            len(bundle.snapshot),
+            bundle.prev_date,
+            len(bundle.cap_df),
         )
-        return MarketSnapshotBundle(
-            snapshot=snapshot,
-            prev_snapshot=prev_snapshot,
-            cap_df=cap_df,
-            prev_date=prev_date,
-            source="krx",
-        )
-    except Exception as krx_exc:
+        return bundle
+    except Exception as primary_exc:
         logger.warning(
-            "[MARKET-DATA] KRX bundle failed; switching to Naver fallback: %s",
-            krx_exc,
+            "[MARKET-DATA] KIS+OPENAPI bundle failed; switching to Naver fallback: %s",
+            primary_exc,
         )
         try:
             bundle = fetch_naver_snapshot_bundle(
@@ -311,13 +299,13 @@ def load_market_snapshot_bundle(trade_date: str) -> MarketSnapshotBundle:
             )
         except Exception as naver_exc:
             logger.error(
-                "[MARKET-DATA] both KRX and Naver snapshot sources failed: "
-                "krx=%s naver=%s",
-                krx_exc,
+                "[MARKET-DATA] both KIS+OPENAPI and Naver snapshot sources failed: "
+                "primary=%s naver=%s",
+                primary_exc,
                 naver_exc,
             )
             raise MarketSnapshotUnavailableError(
-                f"Market snapshot unavailable from KRX and Naver: {naver_exc}"
+                f"Market snapshot unavailable from KIS+OPENAPI and Naver: {naver_exc}"
             ) from naver_exc
 
         logger.warning(


### PR DESCRIPTION
## Summary
- build the intraday KR screening universe from official KIS KOSPI/KOSDAQ master files
- fetch all 2,687 current stocks through the official 30-stock multi-price endpoint
- combine KIS intraday OHLCV/amount with the previous KRX OPEN API snapshot and market cap
- preserve the complete Naver bundle as fallback

## Live evidence
- single-stock endpoint: 2,686 attempts took 983.88s, 23 EGW00201 errors
- multi-price endpoint: 2,686/2,686 rows in 24.625s, zero missing/failed rows
- current KIS master: 2,687 stocks after ETP filtering; includes new SPAC 469880, excludes ETF 069500

## Verification
- 69 related pytest tests passed
- py_compile passed
- ruff passed on new/directly modified modules and tests
- existing trigger_batch.py has pre-existing E402/E712/E741 findings outside this change