### PR TITLE
fix: 카카오 분석 worker OAuth 초기화

### DIFF
--- a/kakao_bot/runtime/analysis_worker_main.py
+++ b/kakao_bot/runtime/analysis_worker_main.py
@@ -68,6 +68,38 @@ def load_config(
     )
 
 
+async def _start_llm_runtime(
+    environ: Mapping[str, str] | None = None,
+) -> bool:
+    """Start the OAuth proxy before the worker creates any LLM clients.
+
+    The batch orchestrators already own this lifecycle, but the standalone
+    Kakao analysis worker did not.  In ``chatgpt_oauth`` mode that left the
+    worker without ``OPENAI_BASE_URL`` or ``OPENAI_API_KEY`` and every report,
+    ask, and evaluation job failed only after it had been accepted from chat.
+    """
+    values = os.environ if environ is None else environ
+    if values.get("PRISM_OPENAI_AUTH_MODE", "").strip() != "chatgpt_oauth":
+        return False
+
+    from cores.chatgpt_proxy import inject_env, start_proxy
+
+    inject_env()
+    if not await start_proxy():
+        raise AnalysisWorkerConfigurationError(
+            "ChatGPT OAuth proxy could not start; analysis worker will not accept jobs"
+        )
+    return True
+
+
+async def _stop_llm_runtime(started: bool) -> None:
+    if not started:
+        return
+    from cores.chatgpt_proxy import stop_proxy
+
+    await stop_proxy()
+
+
 async def run_analysis_worker_once(
     config: AnalysisWorkerRuntimeConfig,
     *,
@@ -140,8 +172,10 @@ def _analysis_service(
 
 
 async def async_main() -> int:
+    llm_runtime_started = False
     try:
         config = load_config()
+        llm_runtime_started = await _start_llm_runtime()
     except AnalysisWorkerConfigurationError as exc:
         logger.error("%s", exc)
         return 2
@@ -160,6 +194,7 @@ async def async_main() -> int:
     finally:
         for sig in installed_signals:
             loop.remove_signal_handler(sig)
+        await _stop_llm_runtime(llm_runtime_started)
 
 
 def main() -> int:

--- a/tests/test_kakao_analysis_worker.py
+++ b/tests/test_kakao_analysis_worker.py
@@ -2,10 +2,17 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from kakao_bot.adapters.persistence.sqlite import SQLiteKakaoRepository
 from kakao_bot.application.analysis_service import AnalysisService
 from kakao_bot.domain.models import AnalysisJob, ApprovalStatus, OutboundDelivery
 from kakao_bot.ports.analysis import AnalysisOutcome
+from kakao_bot.runtime.analysis_worker_main import (
+    AnalysisWorkerConfigurationError,
+    _start_llm_runtime,
+    _stop_llm_runtime,
+)
 
 NOW = datetime(2026, 7, 23, 5, 0, tzinfo=timezone.utc)
 
@@ -217,3 +224,61 @@ def test_batch_size_is_respected(tmp_path):
         assert result.completed == 2
         assert len(analysis.calls) == 2
         assert len(repository.list_outbox()) == 2
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_oauth_worker_starts_and_stops_proxy(monkeypatch):
+    from cores import chatgpt_proxy
+
+    calls = []
+
+    def fake_inject_env():
+        calls.append("inject")
+
+    async def fake_start_proxy():
+        calls.append("start")
+        return True
+
+    async def fake_stop_proxy():
+        calls.append("stop")
+
+    monkeypatch.setattr(chatgpt_proxy, "inject_env", fake_inject_env)
+    monkeypatch.setattr(chatgpt_proxy, "start_proxy", fake_start_proxy)
+    monkeypatch.setattr(chatgpt_proxy, "stop_proxy", fake_stop_proxy)
+
+    started = await _start_llm_runtime(
+        {"PRISM_OPENAI_AUTH_MODE": "chatgpt_oauth"}
+    )
+    await _stop_llm_runtime(started)
+
+    assert started is True
+    assert calls == ["inject", "start", "stop"]
+
+
+@pytest.mark.asyncio
+async def test_non_oauth_worker_does_not_start_proxy(monkeypatch):
+    from cores import chatgpt_proxy
+
+    async def unexpected_start():
+        raise AssertionError("proxy should not start")
+
+    monkeypatch.setattr(chatgpt_proxy, "start_proxy", unexpected_start)
+
+    assert await _start_llm_runtime({"PRISM_OPENAI_AUTH_MODE": "api_key"}) is False
+
+
+@pytest.mark.asyncio
+async def test_oauth_proxy_start_failure_stops_worker(monkeypatch):
+    from cores import chatgpt_proxy
+
+    monkeypatch.setattr(chatgpt_proxy, "inject_env", lambda: None)
+
+    async def failed_start():
+        return False
+
+    monkeypatch.setattr(chatgpt_proxy, "start_proxy", failed_start)
+
+    with pytest.raises(AnalysisWorkerConfigurationError, match="could not start"):
+        await _start_llm_runtime(
+            {"PRISM_OPENAI_AUTH_MODE": "chatgpt_oauth"}
+        )


### PR DESCRIPTION
## 원인

- 카카오 분석 worker는 메인 orchestrator와 달리 ChatGPT OAuth proxy를 시작하지 않았습니다.
- 운영 환경에 `OPENAI_BASE_URL`과 `OPENAI_API_KEY`가 없어 `/report`, `/평가`, `/ask` 작업이 수락된 뒤 실패했습니다.

## 변경 내용

- `PRISM_OPENAI_AUTH_MODE=chatgpt_oauth`일 때 분석 worker가 OAuth proxy를 시작하고 환경을 주입합니다.
- proxy 초기화가 실패하면 작업을 수락하지 않고 worker 시작 단계에서 명확히 중단합니다.
- worker 종료 시 proxy를 정상 종료합니다.
- OAuth 시작·미사용·실패 경로 회귀 테스트를 추가했습니다.

## 검증

- `tests/test_kakao_analysis_worker.py`: 10 passed
- 전체 `tests/test_kakao_*.py`: 304 passed
- Ruff 및 compileall 통과

## 운영 조사 결과

- 2026-08-05 20:15 KST 실패는 OpenAI 인증 환경 누락으로 확인했습니다.
- orchestrator 캠페인은 db-server 큐에 9건 생성됐지만 전달 cron 부재로 모두 `PENDING`입니다.
- 배포 후 서버 설정과 캠페인 전달 cron은 별도 운영 조치로 복구합니다.
