### PR TITLE
fix: 외부 time MCP 의존성 제거

### DIFF
--- a/cores/llm/mcp_servers.yaml
+++ b/cores/llm/mcp_servers.yaml
@@ -61,9 +61,14 @@ servers:
     - --db-path
     - ../stock_tracking_db.sqlite
   time:
-    command: uvx
+    # The external mcp-server-time package broke against newer mcp releases
+    # (McpError -> MCPError). Keep this deterministic and in-repo instead.
+    command: ${PRISM_MCP_PYTHON:-python3}
     args:
-    - mcp-server-time
+    - -m
+    - cores.llm.time_mcp_server
+    env:
+      PYTHONPATH: ${PRISM_REPO_ROOT:-.}
   deepsearch:
     command: npx
     args:

--- a/cores/llm/time_mcp_server.py
+++ b/cores/llm/time_mcp_server.py
@@ -1,0 +1,72 @@
+"""Small in-repo MCP time server with no external package bootstrap.
+
+The published ``mcp-server-time`` package currently imports ``McpError`` from
+an API that newer ``mcp`` releases renamed.  Starting it through ``uvx`` then
+closes the connection before an agent can call ``get_current_time``.  Keeping
+the two tiny time operations here removes that runtime compatibility surface.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("time")
+
+
+def _timezone(name: str) -> ZoneInfo:
+    normalized = str(name or "").strip()
+    if not normalized:
+        raise ValueError("timezone is required")
+    try:
+        return ZoneInfo(normalized)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError(f"unknown timezone: {normalized}") from exc
+
+
+@mcp.tool()
+def get_current_time(timezone: str) -> dict[str, object]:
+    """Return the current ISO-8601 time in an IANA timezone."""
+    zone = _timezone(timezone)
+    current = datetime.now(zone)
+    return {
+        "timezone": timezone,
+        "datetime": current.isoformat(),
+        "is_dst": bool(current.dst()),
+    }
+
+
+@mcp.tool()
+def convert_time(
+    source_timezone: str,
+    time: str,
+    target_timezone: str,
+) -> dict[str, object]:
+    """Convert an ISO-8601 local datetime between IANA timezones."""
+    source_zone = _timezone(source_timezone)
+    target_zone = _timezone(target_timezone)
+    try:
+        parsed = datetime.fromisoformat(str(time).strip())
+    except ValueError as exc:
+        raise ValueError(f"time must be ISO-8601, got {time!r}") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=source_zone)
+    else:
+        parsed = parsed.astimezone(source_zone)
+    converted = parsed.astimezone(target_zone)
+    return {
+        "source_timezone": source_timezone,
+        "source_datetime": parsed.isoformat(),
+        "target_timezone": target_timezone,
+        "target_datetime": converted.isoformat(),
+    }
+
+
+def main() -> None:
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_time_mcp_server.py
+++ b/tests/test_time_mcp_server.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from cores.llm.config_loader import load_mcp_registry
+from cores.llm.time_mcp_server import convert_time, get_current_time
+
+
+def test_get_current_time_uses_requested_timezone():
+    result = get_current_time("Asia/Seoul")
+
+    parsed = datetime.fromisoformat(result["datetime"])
+    assert result["timezone"] == "Asia/Seoul"
+    assert parsed.utcoffset().total_seconds() == 9 * 60 * 60
+    assert result["is_dst"] is False
+
+
+def test_convert_time_preserves_instant():
+    result = convert_time(
+        "Asia/Seoul",
+        "2026-08-06T01:00:00",
+        "UTC",
+    )
+
+    source = datetime.fromisoformat(result["source_datetime"])
+    target = datetime.fromisoformat(result["target_datetime"])
+    assert source.timestamp() == target.timestamp()
+    assert target.isoformat() == "2026-08-05T16:00:00+00:00"
+
+
+def test_unknown_timezone_is_rejected():
+    with pytest.raises(ValueError, match="unknown timezone"):
+        get_current_time("Mars/Olympus")
+
+
+def test_registry_uses_configured_python_for_time_server(monkeypatch):
+    monkeypatch.setenv("PRISM_MCP_PYTHON", "/opt/prism/venv/bin/python")
+    monkeypatch.setenv("PRISM_REPO_ROOT", "/opt/prism/repo")
+
+    spec = load_mcp_registry().get("time")
+
+    assert spec.command == "/opt/prism/venv/bin/python"
+    assert spec.args == ("-m", "cores.llm.time_mcp_server")
+    assert spec.env == {"PYTHONPATH": "/opt/prism/repo"}


### PR DESCRIPTION
## 원인

- 카카오 `/평가` agent가 사용하는 외부 `mcp-server-time` 패키지가 최신 `mcp`에서 이름이 바뀐 예외(`McpError` → `MCPError`)를 import해 시작 즉시 종료됐습니다.
- `uvx` 런타임 설치 여부와 외부 패키지 버전에 따라 동일 기능이 다시 깨질 수 있었습니다.

## 변경 내용

- `get_current_time`, `convert_time`을 제공하는 작은 in-repo time MCP를 추가했습니다.
- MCP registry의 `time` 서버를 외부 `uvx mcp-server-time`에서 현재 venv Python으로 실행되는 내부 모듈로 교체했습니다.
- IANA timezone 검증과 변환, registry 환경 치환 테스트를 추가했습니다.

## 검증

- 카카오·LLM 설정 관련 테스트 364개 통과
- Ruff, compileall, diff check 통과
