### PR TITLE
fix: OpenAI SDK 호환 버전 고정

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,10 @@ python-dateutil~=2.9.0.post0
 email-validator
 # openai bumped from <2.0.0: openai-agents requires >=2.9; verified mcp-agent 0.2.6
 # runs on openai 2.x (2026-06-19 coexistence test). See tasks/mcp_agent_removal_prd.md.
-openai>=2.9,<3
+# openai 2.52.0 made InputTokensDetails.cache_write_tokens required, while
+# openai-agents 0.7.0 still constructs it with cached_tokens only. Keep the
+# pair on the production-verified version until agents supports that schema.
+openai==2.43.0
 openai-agents==0.7.0
 anthropic~=0.64.0
 markdown>=3.3.0


### PR DESCRIPTION
## 원인

- `openai-agents==0.7.0`은 `InputTokensDetails(cached_tokens=0)` 형태를 사용합니다.
- 제한 없이 설치된 `openai 2.52.0`에서는 `cache_write_tokens`가 필수가 되어, agent 실행 전 Pydantic validation error가 발생했습니다.

## 변경 내용

- 운영 및 로컬에서 검증된 `openai==2.43.0`으로 정확히 고정했습니다.
- `openai-agents`가 새 schema를 지원할 때 함께 업그레이드할 수 있도록 이유를 주석으로 남겼습니다.

## 검증

- `pip check` 통과
- 카카오·LLM 관련 테스트 364개 통과
