### PR TITLE
fix(kakao): 종료된 예측·순위 명령을 멘션 메뉴에서 제거

### DIFF
--- a/kakao_bot/adapters/kakao/rest_client.py
+++ b/kakao_bot/adapters/kakao/rest_client.py
@@ -19,11 +19,13 @@ from kakao_bot.domain.models import MessageSendErrorCode, MessageSendResult
 DEFAULT_BASE_URL = "https://kapi.kakao.com"
 SEND_MESSAGE_PATH = "/v1/bot/send_message"
 CALLBACK_PATH = "/v1/bot/callback"
+COMMANDS_UPDATE_PATH = "/v1/bot/commands/update"
 
 
 class RequestKind(str, Enum):
     SEND_MESSAGE = "send_message"
     CALLBACK = "callback"
+    COMMANDS_UPDATE = "commands_update"
 
 
 @dataclass(frozen=True)
@@ -150,6 +152,20 @@ class KakaoRequestBuilder:
             json_body={"skillResponse": dict(skill_response)},
         )
 
+    def update_commands(
+        self,
+        utterances: list[dict[str, object]],
+    ) -> KakaoHttpRequest:
+        if len(utterances) > 20:
+            raise ValueError("Kakao command menu accepts at most 20 utterances")
+        if any(not str(item.get("buttonName", "")).strip() for item in utterances):
+            raise ValueError("every command must have a non-empty buttonName")
+        return KakaoHttpRequest(
+            url=f"{self._base_url}{COMMANDS_UPDATE_PATH}",
+            headers=self._headers(),
+            json_body={"utterances": [dict(item) for item in utterances]},
+        )
+
     def _headers(self) -> dict[str, str]:
         return {
             "Authorization": self._authorization,
@@ -197,6 +213,7 @@ class KakaoRestClient:
         self._retry_policies = {
             RequestKind.SEND_MESSAGE: EndpointRetryPolicy(max_attempts),
             RequestKind.CALLBACK: EndpointRetryPolicy(callback_max_attempts),
+            RequestKind.COMMANDS_UPDATE: EndpointRetryPolicy(max_attempts),
         }
         self._base_retry_delay = base_retry_delay
         self._max_retry_delay = max_retry_delay
@@ -218,6 +235,16 @@ class KakaoRestClient:
     ) -> MessageSendResult:
         request = self._request_builder.callback(callback_token, skill_response)
         return await self._post_with_retry(request, kind=RequestKind.CALLBACK)
+
+    async def update_commands(
+        self,
+        utterances: list[dict[str, object]],
+    ) -> MessageSendResult:
+        request = self._request_builder.update_commands(utterances)
+        return await self._post_with_retry(
+            request,
+            kind=RequestKind.COMMANDS_UPDATE,
+        )
 
     async def _post_with_retry(
         self,

--- a/kakao_bot/runtime/gateway_main.py
+++ b/kakao_bot/runtime/gateway_main.py
@@ -22,6 +22,7 @@ from kakao_bot.adapters.kakao.gateway_inbound_handler import (
     GatewayDispatchHandler,
 )
 from kakao_bot.adapters.kakao.gateway_protocol import GatewayDispatch
+from kakao_bot.adapters.kakao.rest_client import KakaoRestClient
 from kakao_bot.adapters.persistence.sqlite import (
     SQLiteGatewayStateStore,
     SQLiteKakaoRepository,
@@ -32,6 +33,18 @@ from kakao_bot.ports.gateway_state import GatewayStatePort
 logger = logging.getLogger(__name__)
 
 DEFAULT_LOCK_PATH = Path("/tmp/prism-kakao-gateway.lock")
+
+REGISTERED_COMMAND_UTTERANCES = [
+    {
+        "buttonName": "리포트",
+        "description": "국내 종목 분석 리포트를 생성합니다.",
+    },
+    {
+        "buttonName": "평가",
+        "description": "보유 종목을 평단가 기준으로 평가합니다.",
+    },
+    {"buttonName": "도움말", "description": None},
+]
 
 
 class GatewayConfigurationError(ValueError):
@@ -66,6 +79,29 @@ def load_config(
 
 
 EventHandler = Callable[[GatewayDispatch], Awaitable[None]]
+
+
+async def sync_command_menu(
+    config: GatewayRuntimeConfig,
+    *,
+    client: KakaoRestClient | None = None,
+) -> bool:
+    """Replace Kakao's persistent mention menu with supported commands."""
+
+    resolved_client = client or KakaoRestClient(config.token)
+    result = await resolved_client.update_commands(REGISTERED_COMMAND_UTTERANCES)
+    if not result.success:
+        logger.warning(
+            "Kakao command menu sync failed: status=%s code=%s",
+            result.status_code,
+            result.error_code,
+        )
+        return False
+    logger.info(
+        "Kakao command menu synced (%d commands)",
+        len(REGISTERED_COMMAND_UTTERANCES),
+    )
+    return True
 
 
 def _is_enabled(name: str, *, default: bool = True) -> bool:
@@ -186,6 +222,7 @@ async def async_main() -> int:
     except GatewayConfigurationError as exc:
         logger.error("%s", exc)
         return 2
+    await sync_command_menu(config)
     return await run_gateway(config)
 
 

--- a/tests/test_kakao_gateway.py
+++ b/tests/test_kakao_gateway.py
@@ -31,8 +31,14 @@ from kakao_bot.adapters.kakao.gateway_protocol import (
     SendCommand,
     classify_close,
 )
+from kakao_bot.domain.models import MessageSendResult
 from kakao_bot.ports.gateway_state import GatewayState
-from kakao_bot.runtime.gateway_main import GatewayRuntimeConfig, load_config
+from kakao_bot.runtime.gateway_main import (
+    REGISTERED_COMMAND_UTTERANCES,
+    GatewayRuntimeConfig,
+    load_config,
+    sync_command_menu,
+)
 
 TOKEN = "never-log-this-bot-token"
 
@@ -493,3 +499,26 @@ def test_runtime_config_reads_token_without_exposing_it_in_repr(tmp_path):
         database_path=tmp_path / "kakao.sqlite",
     )
     assert TOKEN not in repr(config)
+
+
+@pytest.mark.asyncio
+async def test_gateway_syncs_only_currently_supported_command_menu(tmp_path):
+    class FakeClient:
+        def __init__(self):
+            self.utterances = None
+
+        async def update_commands(self, utterances):
+            self.utterances = utterances
+            return MessageSendResult(success=True, status_code=200)
+
+    client = FakeClient()
+    config = GatewayRuntimeConfig(
+        token=TOKEN,
+        lock_path=tmp_path / "gateway.lock",
+        database_path=tmp_path / "kakao.sqlite",
+    )
+
+    assert await sync_command_menu(config, client=client) is True
+    assert client.utterances == REGISTERED_COMMAND_UTTERANCES
+    labels = [item["buttonName"] for item in client.utterances]
+    assert labels == ["리포트", "평가", "도움말"]

--- a/tests/test_kakao_rest_client.py
+++ b/tests/test_kakao_rest_client.py
@@ -9,6 +9,7 @@ import pytest
 
 from kakao_bot.adapters.kakao.rest_client import (
     CALLBACK_PATH,
+    COMMANDS_UPDATE_PATH,
     SEND_MESSAGE_PATH,
     KakaoHttpRequest,
     KakaoHttpResponse,
@@ -70,6 +71,45 @@ def test_request_builder_isolates_unverified_rest_envelopes():
     assert callback.headers["Authorization"] == "KakaoAK secret-token"
     assert callback.headers["X-Bot-Callback-Token"] == "callback-token"
     assert callback.json_body == {"skillResponse": skill}
+
+
+def test_command_menu_request_contains_only_supported_commands():
+    builder = KakaoRequestBuilder(
+        "secret-token",
+        base_url="https://example.test/",
+    )
+
+    request = builder.update_commands(
+        [
+            {"buttonName": "리포트", "description": "종목 분석"},
+            {"buttonName": "평가", "description": "보유 종목 평가"},
+            {"buttonName": "도움말", "description": None},
+        ]
+    )
+
+    assert request.url == f"https://example.test{COMMANDS_UPDATE_PATH}"
+    assert request.json_body == {
+        "utterances": [
+            {"buttonName": "리포트", "description": "종목 분석"},
+            {"buttonName": "평가", "description": "보유 종목 평가"},
+            {"buttonName": "도움말", "description": None},
+        ]
+    }
+    rendered = repr(request.json_body)
+    assert "예측" not in rendered
+    assert "순위" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_update_commands_posts_the_complete_replacement_menu():
+    transport = FakeTransport(response(200, body={"utterances": []}))
+    client = KakaoRestClient("token", transport=transport)
+    utterances = [{"buttonName": "도움말", "description": None}]
+
+    result = await client.update_commands(utterances)
+
+    assert result.success is True
+    assert transport.requests[0].json_body == {"utterances": utterances}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 변경 사항
- 카카오 등록 명령 메뉴를 리포트·평가·도움말 3개로 제한
- `/v1/bot/commands/update` 클라이언트 지원 추가
- Gateway 시작 시 현재 지원 명령으로 메뉴 자동 동기화
- 동기화 실패는 Gateway 수신을 막지 않도록 fail-open 처리

## 운영 조치
- 실계정 API에 동일 목록 적용 완료 (HTTP 200)
- 응답에서 예측·순위가 제외된 3개 항목 확인

## 검증
- `pytest tests/test_kakao_*.py`: 307 passed
- Ruff, compileall, git diff --check 통과