### PR TITLE
fix(kakao): 평가 결과 가독성과 말줄임 손실 개선

### DIFF
--- a/kakao_bot/adapters/kakao/report_renderer.py
+++ b/kakao_bot/adapters/kakao/report_renderer.py
@@ -41,6 +41,7 @@ _BLANK_RUN = re.compile(r"\n{3,}")
 # Kakao renders plain text, so list structure has to survive as a character.
 _BULLET = re.compile(r"^[ \t]*[-*+][ \t]+", re.MULTILINE)
 _TRAILING_SPACES = re.compile(r"[ \t]+$", re.MULTILINE)
+_SINGLE_LINE_BREAK = re.compile(r"(?<!\n)\n(?!\n)")
 
 # Reports open with an executive summary. Lifting it beats truncating from the
 # top, which cuts off mid-sentence inside the first technical section and reads
@@ -118,14 +119,24 @@ def _evaluate_result(payload: Mapping[str, object]) -> dict[str, object]:
     ticker = _required_text(payload, "ticker")
     company_name = _required_text(payload, "company_name")
     verdict = payload.get("verdict")
-    body = _condense(verdict if isinstance(verdict, str) else "")
+    body = _clean_text(verdict if isinstance(verdict, str) else "")
     if not body:
         return _evaluate_failed(payload)
+    body = _SINGLE_LINE_BREAK.sub("\n\n", body)
 
     header = f"🧮 {company_name} ({ticker}) 평가{_position_suffix(payload)}"
+    body_parts = _split_text(
+        body,
+        first_limit=MAX_SIMPLE_TEXT_LENGTH - len(header) - 2,
+        continuation_limit=MAX_SIMPLE_TEXT_LENGTH,
+    )
+    text_outputs = [
+        simple_text_output(f"{header}\n\n{body_parts[0]}"),
+        *[simple_text_output(part) for part in body_parts[1:]],
+    ]
     return skill_response(
         [
-            simple_text_output(f"{header}\n\n{body}"[:MAX_SIMPLE_TEXT_LENGTH]),
+            *text_outputs,
             _next_actions(ticker, company_name),
         ]
     )
@@ -293,15 +304,60 @@ def _next_actions(
 def _condense(summary: str) -> str:
     """Flatten report markdown into something a chat bubble can hold."""
 
-    if not summary.strip():
-        return ""
-    text = _BULLET.sub("· ", _executive_summary(summary))
-    text = _MARKDOWN_NOISE.sub("", text)
-    text = _TRAILING_SPACES.sub("", text)
-    text = _BLANK_RUN.sub("\n\n", text).strip()
+    text = _clean_text(summary)
     if len(text) <= _SUMMARY_BUDGET:
         return text
     return text[: _SUMMARY_BUDGET - 1].rstrip() + "…"
+
+
+def _clean_text(text: str) -> str:
+    """Remove Markdown noise without discarding any content."""
+
+    if not text.strip():
+        return ""
+    cleaned = _BULLET.sub("· ", _executive_summary(text))
+    cleaned = _MARKDOWN_NOISE.sub("", cleaned)
+    cleaned = _TRAILING_SPACES.sub("", cleaned)
+    return _BLANK_RUN.sub("\n\n", cleaned).strip()
+
+
+def _split_text(
+    text: str,
+    *,
+    first_limit: int,
+    continuation_limit: int,
+) -> list[str]:
+    """Fit text into two bubbles, preferring paragraph and sentence ends."""
+
+    if len(text) <= first_limit:
+        return [text]
+
+    split_at, resume_at = _natural_split(text, first_limit)
+    first = text[:split_at].rstrip()
+    remainder = text[resume_at:].lstrip()
+    if len(remainder) <= continuation_limit:
+        return [first, remainder]
+
+    final_limit = continuation_limit - 1
+    final_at, _ = _natural_split(remainder, final_limit)
+    second = remainder[:final_at].rstrip() + "…"
+    return [first, second]
+
+
+def _natural_split(text: str, limit: int) -> tuple[int, int]:
+    """Return cut/resume offsets at the latest useful boundary."""
+
+    window = text[: limit + 1]
+    candidates: list[tuple[int, int]] = []
+    for match in re.finditer(r"\n{2,}", window):
+        candidates.append((match.start(), match.end()))
+    for match in re.finditer(r"(?<=[.!?。！？])(?:[ \t]+|\n+)", window):
+        candidates.append((match.start(), match.end()))
+
+    useful = [candidate for candidate in candidates if candidate[0] >= limit // 2]
+    if useful:
+        return max(useful, key=lambda candidate: candidate[0])
+    return limit, limit
 
 
 def _executive_summary(summary: str) -> str:

--- a/tests/test_kakao_evaluate.py
+++ b/tests/test_kakao_evaluate.py
@@ -379,3 +379,42 @@ class TestRendering:
         )
 
         assert len(self.text_of(response)) <= 1000
+
+    def test_a_long_verdict_uses_two_bubbles_without_losing_the_conclusion(self):
+        verdict = (
+            "첫 번째 판단 문장입니다. " * 80
+            + "\n마지막 결론: 추가매수보다 반등 확인이 먼저입니다."
+        )
+
+        response = render_delivery(
+            delivery("evaluate_result", self.payload(verdict=verdict))
+        )
+
+        outputs = response["template"]["outputs"]
+        texts = [output["simpleText"]["text"] for output in outputs[:2]]
+        assert len(outputs) == 3
+        assert all(len(text) <= 1000 for text in texts)
+        assert "마지막 결론" in texts[1]
+        assert not texts[0].endswith("…")
+
+    def test_a_long_verdict_splits_at_a_sentence_boundary(self):
+        verdict = "가" * 900 + ". " + "다음 문장은 두 번째 말풍선에 있어야 합니다. " * 4
+
+        response = render_delivery(
+            delivery("evaluate_result", self.payload(verdict=verdict))
+        )
+
+        outputs = response["template"]["outputs"]
+        first = outputs[0]["simpleText"]["text"]
+        second = outputs[1]["simpleText"]["text"]
+        assert first.endswith(".")
+        assert second.startswith("다음 문장은")
+
+    def test_evaluation_paragraphs_get_visible_spacing(self):
+        verdict = "현재 손익을 확인했어.\n추세 전환은 아직 일러.\n한 줄 평: 기다리자."
+
+        response = render_delivery(
+            delivery("evaluate_result", self.payload(verdict=verdict))
+        )
+
+        assert "확인했어.\n\n추세 전환" in self.text_of(response)


### PR DESCRIPTION
## 문제
- 평가 결과를 약 880자에서 먼저 잘라 마지막 결론이 `…`으로 유실됨
- 단일 줄바꿈만 유지돼 카카오 말풍선에서 문단 구분이 약함

## 변경
- 평가 결과는 최대 두 개의 SimpleText 말풍선을 사용
- 문단 또는 문장 경계에서 우선 분할
- 평가문 단락 사이에 빈 줄을 추가
- 2,000자 초과 시에만 최종 말풍선에서 안전하게 축약
- 후속 행동 카드를 포함해 카카오 최대 출력 3개 준수

## 검증
- 제보된 카카오 평가문 전체 보존: 헤더 포함 942자, 말줄임 없음
- 카카오 테스트 310 passed
- Ruff, compileall, git diff --check 통과