### PR TITLE
fix(kakao): 종목 질문을 최신 근거 중심으로 검색

### DIFF
--- a/kakao_bot/adapters/prism/report_adapter.py
+++ b/kakao_bot/adapters/prism/report_adapter.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import threading
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from datetime import datetime
@@ -53,7 +54,17 @@ _ASK_ANSWER_BUDGET = 1_200
 
 _ASK_GROUNDING = (
     "\n\n반드시 웹을 검색하고 실제 뉴스/기사 페이지를 스크랩하여 각 주장에 출처를 밝혀라. "
-    "너의 사전지식이 아니라 오늘 기준 최신 웹 데이터에 근거하라."
+    "너의 사전지식이 아니라 오늘 기준 최신 웹 데이터에 근거하라. "
+    "질문 대상과 직접 관련된 기사가 하나라도 있으면 '최신 근거가 없다'고 답하지 마라. "
+    "관련 핵심 사실을 우선 제시하고, 가능하면 최소 2개 사실에 매체명과 발행일을 붙여라."
+)
+
+_STOCK_RESEARCH_SUFFIX = re.compile(
+    r"\s*(?:지금\s*)?"
+    r"(?:사도\s*(?:될까|돼)|살까|매수(?:해도)?\s*(?:될까|괜찮을까)|"
+    r"주가\s*전망(?:은|이)?|전망(?:은|이)?\s*어때|어때)"
+    r"[?？!！.\s]*$",
+    re.IGNORECASE,
 )
 
 
@@ -256,7 +267,34 @@ async def _ask(question: str) -> str | None:
         f"{_ASK_ANSWER_BUDGET}자 이내. 표와 마크다운 문법은 쓰지 마라."
     ) + _ASK_GROUNDING
 
-    # Free-form: the subject is unpredictable, so a KR-press allowlist would
-    # drop legitimate sources. Keep recency and the news channel, drop the list.
-    search_opts = search_preset("KR", tbs="qdr:m", allowlist=False) | await daily_facts("KR")
-    return await generate_firecrawl_search_response(question, prompt, **search_opts)
+    queries, use_primary_sources = _ask_search_plan(question)
+    # General free-form questions stay unrestricted because their subject is
+    # unpredictable. A detected stock question is different: primary business
+    # outlets are much safer than social posts and generic "지금 사도 될까"
+    # matches, and the expanded queries carry the actual research dimensions.
+    search_opts = search_preset(
+        "KR",
+        tbs="qdr:m",
+        allowlist=use_primary_sources,
+    ) | await daily_facts("KR")
+    return await generate_firecrawl_search_response(queries, prompt, **search_opts)
+
+
+def _ask_search_plan(question: str) -> tuple[list[str], bool]:
+    """Turn a conversational stock question into evidence-oriented queries."""
+
+    match = _STOCK_RESEARCH_SUFFIX.search(question.strip())
+    if not match:
+        return [question], False
+
+    subject = question[: match.start()].strip()
+    if not subject or len(subject) > 40:
+        return [question], False
+
+    return (
+        [
+            f"{subject} 최신 뉴스 실적 전망 주가",
+            f"{subject} 실적 공시 외국인 기관 수급 리스크",
+        ],
+        True,
+    )

--- a/tests/test_kakao_ask.py
+++ b/tests/test_kakao_ask.py
@@ -279,6 +279,52 @@ def test_a_report_job_is_unaffected_by_the_ask_branch(repository):
 # --------------------------------------------------------------------------
 
 
+def test_stock_investment_question_expands_into_research_queries():
+    from kakao_bot.adapters.prism.report_adapter import _ask_search_plan
+
+    queries, use_primary_sources = _ask_search_plan("카카오 지금 사도 될까?")
+
+    assert use_primary_sources is True
+    assert len(queries) == 2
+    assert all("카카오" in query for query in queries)
+    assert any("실적" in query and "전망" in query for query in queries)
+    assert any("공시" in query and "수급" in query for query in queries)
+    assert all("사도 될까" not in query for query in queries)
+
+
+def test_general_question_keeps_the_users_original_search_query():
+    from kakao_bot.adapters.prism.report_adapter import _ask_search_plan
+
+    assert _ask_search_plan(QUESTION) == ([QUESTION], False)
+
+
+@pytest.mark.asyncio
+async def test_stock_question_requires_dated_source_evidence(monkeypatch):
+    import cores.market_facts_cache as mfc
+    import report_generator as rg
+    from kakao_bot.adapters.prism.report_adapter import _ask
+
+    captured = {}
+
+    async def facts(market):
+        return {}
+
+    async def search(query, prompt, **kwargs):
+        captured.update(query=query, prompt=prompt, kwargs=kwargs)
+        return "연합뉴스(7/29)에 따르면 AI 수익화가 관건입니다."
+
+    monkeypatch.setattr(mfc, "daily_facts", facts)
+    monkeypatch.setattr(rg, "generate_firecrawl_search_response", search)
+
+    answer = await _ask("카카오 지금 사도 될까?")
+
+    assert answer.startswith("연합뉴스")
+    assert isinstance(captured["query"], list)
+    assert captured["kwargs"].get("include_domains")
+    assert "매체명과 발행일" in captured["prompt"]
+    assert "근거가 없다" in captured["prompt"]
+
+
 def test_answer_works_when_called_the_way_the_worker_calls_it(monkeypatch):
     """`run_once` is always reached through `asyncio.to_thread`.
 


### PR DESCRIPTION
## 원인
- Firecrawl은 정상 작동했으나 `카카오 지금 사도 될까?`를 그대로 검색
- `지금 사도 될까`가 강하게 매칭돼 SK스퀘어·스페이스X·부동산 등 무관한 결과 유입
- 관련 근거가 희박해 모델이 판단 유보 폴백을 생성

## 변경
- 종목 매수·전망 질문에서 종목명을 분리
- 실적·전망·주가 및 공시·수급·리스크 검색어로 확장
- 종목 질문은 국내 1차 경제매체 allowlist 적용
- 관련 기사가 있으면 매체명·발행일·핵심 사실을 답변에 명시하도록 프롬프트 강화
- 일반 시장 질문은 기존 자유 검색 유지

## 실측
- 연합뉴스 7/29, 연합인포맥스 8/4, 연합뉴스 7/8 카카오 관련 기사 회수

## 검증
- 카카오 테스트 313 passed
- Ruff, compileall, git diff --check 통과