### PR TITLE
fix(kakao): 분석 대기시간 안내 개선

### DIFF
--- a/kakao_bot/application/command_service.py
+++ b/kakao_bot/application/command_service.py
@@ -274,12 +274,14 @@ class CommandService:
         if is_evaluate:
             ack = (
                 f"🧮 {resolved.company_name} ({resolved.ticker}) 평가를 시작했습니다.\n"
-                "완료되면 이 방으로 결과를 보내드릴게요."
+                "보통 1~2분 정도 걸립니다.\n"
+                "중간 표시가 없어도 정상 처리 중이며, 완료되면 이 방으로 보내드릴게요."
             )
         else:
             ack = (
                 f"📊 {resolved.company_name} ({resolved.ticker}) 분석을 시작했습니다.\n"
-                "완료되면 이 방으로 결과를 보내드릴게요."
+                "보통 2~5분 정도 걸립니다.\n"
+                "중간 표시가 없어도 정상 처리 중이며, 완료되면 이 방으로 보내드릴게요."
             )
 
         return CommandOutcome(
@@ -321,7 +323,8 @@ class CommandService:
             kind=CommandOutcomeKind.ACCEPTED,
             message=(
                 "🔍 질문을 확인했습니다. 최신 정보를 찾아볼게요.\n"
-                "완료되면 이 방으로 답변을 보내드릴게요."
+                "보통 1분 안팎으로 걸립니다.\n"
+                "중간 표시가 없어도 정상 처리 중이며, 완료되면 이 방으로 보내드릴게요."
             ),
             job_id=job.job_id,
         )

--- a/tests/test_kakao_ask.py
+++ b/tests/test_kakao_ask.py
@@ -181,6 +181,8 @@ def test_ask_enqueues_without_touching_the_resolver(repository):
 
     assert outcome.kind is CommandOutcomeKind.ACCEPTED
     assert resolver.calls == []
+    assert "1분" in outcome.message
+    assert "중간 표시가 없어도" in outcome.message
 
     [claimed] = repository.claim_analysis_jobs(now=NOW, lease_seconds=900, limit=1)
     assert claimed.kind == "ask"

--- a/tests/test_kakao_command_service.py
+++ b/tests/test_kakao_command_service.py
@@ -10,12 +10,12 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
+from kakao_bot.adapters.persistence.sqlite import SQLiteKakaoRepository
 from kakao_bot.application.command_service import (
     CommandLimits,
     CommandOutcomeKind,
     CommandService,
 )
-from kakao_bot.adapters.persistence.sqlite import SQLiteKakaoRepository
 from kakao_bot.domain.models import ApprovalStatus, InboundMessage
 from kakao_bot.ports.analysis import ResolvedTicker, TickerResolution
 
@@ -71,6 +71,8 @@ def test_report_command_enqueues_a_job_and_acknowledges(repository, service):
     assert outcome.ticker == "005930"
     assert outcome.company_name == "삼성전자"
     assert "삼성전자" in outcome.message
+    assert "2~5분" in outcome.message
+    assert "중간 표시가 없어도" in outcome.message
 
     [job] = repository.list_analysis_jobs()
     assert job["room_id"] == ROOM

--- a/tests/test_kakao_evaluate.py
+++ b/tests/test_kakao_evaluate.py
@@ -181,6 +181,8 @@ class TestEnqueue:
         assert job["ticker"] == "005930"
         assert job["payload"]["avg_price"] == 70000.0
         assert job["payload"]["period_months"] == 6
+        assert "1~2분" in outcome.message
+        assert "중간 표시가 없어도" in outcome.message
 
     def test_the_tone_travels_with_the_job(self, repository, service):
         service.handle(message("평가 삼성전자 70000 6 취한 친구처럼"), now=NOW)


### PR DESCRIPTION
## 문제
- 접수 후 결과까지 1분 이상 중간 메시지가 없어 멈춘 것처럼 보임

## 변경
- 평가: 보통 1~2분
- 질문: 보통 1분 안팎
- 리포트: 보통 2~5분
- 모든 접수 메시지에 `중간 표시가 없어도 정상 처리 중` 안내 추가

## 검증
- 관련 회귀 테스트 3 passed
- 전체 카카오 테스트 313 passed
- Ruff, compileall, git diff --check 통과