### PR TITLE
fix(kakao): 도움말과 일일 한도 안내 개선

### DIFF
--- a/kakao_bot/application/command_service.py
+++ b/kakao_bot/application/command_service.py
@@ -30,8 +30,14 @@ DEFAULT_USER_DAILY_LIMIT = 5
 DEFAULT_ROOM_DAILY_LIMIT = 20
 
 _UNAPPROVED = "이 채팅방은 아직 승인되지 않았습니다. 관리자에게 승인을 요청해주세요."
-_USER_LIMIT = "오늘 요청 한도를 모두 사용했습니다. 내일 다시 이용해주세요."
-_ROOM_LIMIT = "이 채팅방의 오늘 요청 한도를 모두 사용했습니다."
+_USER_LIMIT = (
+    "사용자별 일일 요청 한도 {limit}회를 모두 사용했습니다.\n"
+    "리포트·평가·질문 합산, 최근 24시간 기준입니다."
+)
+_ROOM_LIMIT = (
+    "이 채팅방의 일일 요청 한도 {limit}회를 모두 사용했습니다.\n"
+    "모든 사용자의 리포트·평가·질문 합산, 최근 24시간 기준입니다."
+)
 _NEED_TICKER = "종목을 함께 알려주세요. 예: 리포트 삼성전자"
 _NEED_QUESTION = "궁금한 내용을 함께 적어주세요. 예: 질문 오늘 코스피 왜 빠졌어?"
 _NEED_AVG_PRICE = (
@@ -62,11 +68,19 @@ _HELP_LINES = {
         " · 삼성전자 — 종목 이름만 보내면 분석 리포트\n"
         " · AAPL — 미국 종목은 티커로"
     ),
-    CommandKind.EVALUATE: " · 평가 삼성전자 70000 6 — 내 평단가 기준으로 평가",
+    CommandKind.EVALUATE: (
+        " · 평가 삼성전자 70000 6 — 내 평단가 기준으로 평가\n"
+        "   70000은 평단가, 뒤의 6은 보유기간(월)"
+    ),
     CommandKind.ASK: " · 오늘 시장 어때? — 그냥 물어보면 답변",
 }
 
-_HELP_FOOTER = "\n\n저를 멘션해서 편하게 말 걸어주세요. 명령어를 외울 필요 없어요."
+_HELP_FOOTER = (
+    "\n\n📌 일일 요청 한도(최근 24시간)"
+    f"\n · 리포트·평가·질문 합산 사용자당 {DEFAULT_USER_DAILY_LIMIT}회"
+    f"\n · 채팅방 전체 {DEFAULT_ROOM_DAILY_LIMIT}회"
+    "\n\n저를 멘션해서 편하게 말 걸어주세요. 명령어를 외울 필요 없어요."
+)
 
 
 def leads_somewhere(utterance: str) -> bool:
@@ -344,7 +358,7 @@ class CommandService:
         if used_by_user >= self._limits.user_daily:
             return CommandOutcome(
                 kind=CommandOutcomeKind.REJECTED,
-                message=_USER_LIMIT,
+                message=_USER_LIMIT.format(limit=self._limits.user_daily),
             )
 
         used_by_room = self._repository.count_analysis_jobs_since(
@@ -355,6 +369,6 @@ class CommandService:
         if used_by_room >= self._limits.room_daily:
             return CommandOutcome(
                 kind=CommandOutcomeKind.REJECTED,
-                message=_ROOM_LIMIT,
+                message=_ROOM_LIMIT.format(limit=self._limits.room_daily),
             )
         return None

--- a/kakao_bot/runtime/gateway_main.py
+++ b/kakao_bot/runtime/gateway_main.py
@@ -37,11 +37,17 @@ DEFAULT_LOCK_PATH = Path("/tmp/prism-kakao-gateway.lock")
 REGISTERED_COMMAND_UTTERANCES = [
     {
         "buttonName": "리포트",
-        "description": "국내 종목 분석 리포트를 생성합니다.",
+        "description": (
+            "한 칸 띄우고 국내 종목명 또는 미국 티커를 입력하세요. "
+            "예: 리포트 삼성전자 / 리포트 AAPL"
+        ),
     },
     {
         "buttonName": "평가",
-        "description": "보유 종목을 평단가 기준으로 평가합니다.",
+        "description": (
+            "한 칸 띄우고 종목명·평단가·보유기간(월)을 입력하세요. "
+            "예: 평가 삼성전자 70000 6"
+        ),
     },
     {"buttonName": "도움말", "description": None},
 ]

--- a/tests/test_kakao_command_service.py
+++ b/tests/test_kakao_command_service.py
@@ -15,6 +15,7 @@ from kakao_bot.application.command_service import (
     CommandLimits,
     CommandOutcomeKind,
     CommandService,
+    help_text,
 )
 from kakao_bot.domain.models import ApprovalStatus, InboundMessage
 from kakao_bot.ports.analysis import ResolvedTicker, TickerResolution
@@ -158,6 +159,7 @@ def test_user_daily_limit_blocks_further_requests(repository):
 
     assert blocked.kind is CommandOutcomeKind.REJECTED
     assert "한도" in blocked.message
+    assert "2회" in blocked.message
     assert len(repository.list_analysis_jobs()) == 2
 
 
@@ -188,6 +190,17 @@ def test_room_limit_counts_across_users(repository):
 
     assert blocked.kind is CommandOutcomeKind.REJECTED
     assert "채팅방" in blocked.message
+    assert "2회" in blocked.message
+
+
+def test_help_explains_evaluation_period_and_shared_daily_limits():
+    text = help_text()
+
+    assert "70000은 평단가" in text
+    assert "뒤의 6은 보유기간(월)" in text
+    assert "리포트·평가·질문 합산" in text
+    assert "사용자당 5회" in text
+    assert "채팅방 전체 20회" in text
 
 
 def test_help_is_answered_without_touching_the_room_gate(tmp_path):

--- a/tests/test_kakao_gateway.py
+++ b/tests/test_kakao_gateway.py
@@ -522,3 +522,10 @@ async def test_gateway_syncs_only_currently_supported_command_menu(tmp_path):
     assert client.utterances == REGISTERED_COMMAND_UTTERANCES
     labels = [item["buttonName"] for item in client.utterances]
     assert labels == ["리포트", "평가", "도움말"]
+    report_tip = client.utterances[0]["description"]
+    assert "한 칸 띄우고" in report_tip
+    assert "리포트 삼성전자" in report_tip
+    assert "리포트 AAPL" in report_tip
+    evaluation_tip = client.utterances[1]["description"]
+    assert "보유기간(월)" in evaluation_tip
+    assert "평가 삼성전자 70000 6" in evaluation_tip


### PR DESCRIPTION
## 변경 사항
- 평가 명령의 평단가와 보유기간(월) 입력 순서를 도움말에 명시
- 도움말에 사용자별 5회, 채팅방별 20회 한도와 합산 대상을 안내
- 한도 도달 메시지에 실제 설정된 횟수를 표시
- 멘션 메뉴 리포트 팁에 국내 종목명과 미국 티커 입력 예시 추가
- 평가 메뉴 팁에도 보유기간 단위를 명시

## 검증
- `314 passed` (카카오봇 전체 테스트)
- Ruff 통과