### PR TITLE
fix(kakao): 채팅방 전체 요청 한도 기본 비활성화

### DIFF
--- a/kakao_bot/application/command_service.py
+++ b/kakao_bot/application/command_service.py
@@ -27,7 +27,6 @@ from kakao_bot.ports.repositories import KakaoRepository
 logger = logging.getLogger(__name__)
 
 DEFAULT_USER_DAILY_LIMIT = 5
-DEFAULT_ROOM_DAILY_LIMIT = 20
 
 _UNAPPROVED = "이 채팅방은 아직 승인되지 않았습니다. 관리자에게 승인을 요청해주세요."
 _USER_LIMIT = (
@@ -78,7 +77,6 @@ _HELP_LINES = {
 _HELP_FOOTER = (
     "\n\n📌 일일 요청 한도(최근 24시간)"
     f"\n · 리포트·평가·질문 합산 사용자당 {DEFAULT_USER_DAILY_LIMIT}회"
-    f"\n · 채팅방 전체 {DEFAULT_ROOM_DAILY_LIMIT}회"
     "\n\n저를 멘션해서 편하게 말 걸어주세요. 명령어를 외울 필요 없어요."
 )
 
@@ -143,7 +141,7 @@ class CommandOutcome:
 @dataclass(frozen=True)
 class CommandLimits:
     user_daily: int = DEFAULT_USER_DAILY_LIMIT
-    room_daily: int = DEFAULT_ROOM_DAILY_LIMIT
+    room_daily: int | None = None
 
 
 class CommandService:
@@ -360,6 +358,9 @@ class CommandService:
                 kind=CommandOutcomeKind.REJECTED,
                 message=_USER_LIMIT.format(limit=self._limits.user_daily),
             )
+
+        if self._limits.room_daily is None:
+            return None
 
         used_by_room = self._repository.count_analysis_jobs_since(
             room_id=message.room_id,

--- a/tests/test_kakao_command_service.py
+++ b/tests/test_kakao_command_service.py
@@ -193,6 +193,17 @@ def test_room_limit_counts_across_users(repository):
     assert "2회" in blocked.message
 
 
+def test_room_limit_is_disabled_by_default(repository):
+    service = CommandService(repository, FakeResolver())
+
+    outcomes = [
+        service.handle(message("리포트 삼성전자", user_id=f"user-{index}"), now=NOW)
+        for index in range(21)
+    ]
+
+    assert all(outcome.kind is CommandOutcomeKind.ACCEPTED for outcome in outcomes)
+
+
 def test_help_explains_evaluation_period_and_shared_daily_limits():
     text = help_text()
 
@@ -200,7 +211,7 @@ def test_help_explains_evaluation_period_and_shared_daily_limits():
     assert "뒤의 6은 보유기간(월)" in text
     assert "리포트·평가·질문 합산" in text
     assert "사용자당 5회" in text
-    assert "채팅방 전체 20회" in text
+    assert "채팅방 전체" not in text
 
 
 def test_help_is_answered_without_touching_the_room_gate(tmp_path):


### PR DESCRIPTION
## 변경 사항
- 사용자별 최근 24시간 5회 한도는 유지
- 채팅방 전체 한도는 기본적으로 비활성화
- 운영자가 명시적으로 설정한 경우에만 방 한도 적용
- 도움말에서 방 전체 한도 안내 제거

## 검증
- 카카오봇 전체 테스트 315개 통과
- Ruff 통과