### PR TITLE
fix(kakao): 종목 전망 검색 최신성과 출처 링크 강화

### DIFF
--- a/kakao_bot/adapters/prism/report_adapter.py
+++ b/kakao_bot/adapters/prism/report_adapter.py
@@ -56,13 +56,18 @@ _ASK_GROUNDING = (
     "\n\n반드시 웹을 검색하고 실제 뉴스/기사 페이지를 스크랩하여 각 주장에 출처를 밝혀라. "
     "너의 사전지식이 아니라 오늘 기준 최신 웹 데이터에 근거하라. "
     "질문 대상과 직접 관련된 기사가 하나라도 있으면 '최신 근거가 없다'고 답하지 마라. "
-    "관련 핵심 사실을 우선 제시하고, 가능하면 최소 2개 사실에 매체명과 발행일을 붙여라."
+    "관련 핵심 사실을 우선 제시하고, 가능하면 최소 2개 사실에 매체명과 발행일을 붙여라. "
+    "각 사실 뒤에는 근거가 된 검색 결과 번호를 [자료 n] 형식으로 표시하라. "
+    "현재가·등락률·실적·목표주가처럼 투자 판단에 영향을 주는 숫자는 검증된 시장 데이터가 "
+    "있거나 서로 독립된 최신 기사에서 같은 값이 확인될 때만 쓰고, 아니면 생략하라. "
+    "검증된 시장 데이터 블록이 없으면 정확한 현재가·장중 고저가·당일 등락률은 절대 쓰지 마라."
 )
 
 _STOCK_RESEARCH_SUFFIX = re.compile(
     r"\s*(?:지금\s*)?"
     r"(?:사도\s*(?:될까|돼)|살까|매수(?:해도)?\s*(?:될까|괜찮을까)|"
-    r"주가\s*전망(?:은|이)?|전망(?:은|이)?\s*어때|어때)"
+    r"(?:최근\s*)?(?:주가\s*)?전망(?:은|이|을)?"
+    r"(?:\s*(?:알려\s*줘|말해\s*줘|분석해\s*줘|어때))?|어때)"
     r"[?？!！.\s]*$",
     re.IGNORECASE,
 )
@@ -274,9 +279,16 @@ async def _ask(question: str) -> str | None:
     # matches, and the expanded queries carry the actual research dimensions.
     search_opts = search_preset(
         "KR",
-        tbs="qdr:m",
+        tbs="qdr:d" if use_primary_sources else "qdr:m",
         allowlist=use_primary_sources,
     ) | await daily_facts("KR")
+    if use_primary_sources:
+        # Firecrawl's news vertical currently returns fresh but weakly related
+        # results for Korean stock queries. The web vertical finds the actual
+        # article pages and respects the primary-outlet allowlist; the shared
+        # temporal gate widens to a week/month only when today is genuinely quiet.
+        search_opts["sources"] = ["web"]
+        search_opts["include_source_links"] = True
     return await generate_firecrawl_search_response(queries, prompt, **search_opts)
 
 
@@ -293,8 +305,8 @@ def _ask_search_plan(question: str) -> tuple[list[str], bool]:
 
     return (
         [
-            f"{subject} 최신 뉴스 실적 전망 주가",
-            f"{subject} 실적 공시 외국인 기관 수급 리스크",
+            f"{subject} 오늘 최신 뉴스 주가 실적 전망",
+            f"{subject} 증권사 목표주가 실적 공시 외국인 기관 수급",
         ],
         True,
     )

--- a/report_generator.py
+++ b/report_generator.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 from datetime import date, datetime
@@ -12,6 +13,7 @@ from pathlib import Path
 from typing import Optional
 
 import markdown
+
 from cores.agents.report_agent import ReportAgent as Agent
 from cores.llm.agent_bridge import ensure_openai_agents_configured
 from cores.llm.backends.openai_agents_backend import OpenAIAgentsBackend
@@ -611,8 +613,6 @@ if __name__ == "__main__":
         import traceback
         logger.error(traceback.format_exc())
         return f"보고서 생성 중 오류가 발생했습니다: {str(e)}"
-
-import re
 
 def clean_model_response(response):
     # 마지막 평가 문장 패턴
@@ -1261,6 +1261,7 @@ async def generate_journal_conversation_response(
 
 MAX_ARTICLE_CHARS = 3000
 MAX_CONTEXT_CHARS = 60000
+_EVIDENCE_REFERENCE = re.compile(r"\[자료\s*(\d+)\]")
 
 
 def _build_search_context(items: list) -> str:
@@ -1273,7 +1274,7 @@ def _build_search_context(items: list) -> str:
     """
     chunks: list[str] = []
     total = 0
-    for item in items:
+    for index, item in enumerate(items, start=1):
         body = (item.get("body") or "").strip() or (item.get("snippet") or "").strip()
         if not body:
             continue
@@ -1286,7 +1287,7 @@ def _build_search_context(items: list) -> str:
             # instead of letting it read as current material.
             published += " ⚠️ 신선도 미검증 — 최근 일로 서술 금지"
         chunk = (
-            f"[{item.get('title') or '제목 없음'}]\n"
+            f"[자료 {index}] {item.get('title') or '제목 없음'}\n"
             f"발행일: {published} | 출처유형: {tag}\n"
             f"URL: {item.get('url')}\n{body}\n\n"
         )
@@ -1297,6 +1298,30 @@ def _build_search_context(items: list) -> str:
 
     logger.info(f"Search context built: {len(chunks)} articles, {total} chars")
     return "".join(chunks)
+
+
+def _append_source_links(response: str, items: list, *, fallback_limit: int = 3) -> str:
+    """Attach clickable article URLs matching the evidence numbers in the answer."""
+
+    referenced = []
+    for raw in _EVIDENCE_REFERENCE.findall(response):
+        index = int(raw)
+        if 1 <= index <= len(items) and index not in referenced:
+            referenced.append(index)
+    if not referenced:
+        referenced = list(range(1, min(len(items), fallback_limit) + 1))
+
+    selected = [(index, items[index - 1]) for index in referenced]
+    selected = [(index, item) for index, item in selected if item.get("url")]
+    if not selected or all(item["url"] in response for _, item in selected):
+        return response
+
+    lines = ["🔗 출처"]
+    for index, item in selected:
+        title = " ".join((item.get("title") or "기사").split())[:70]
+        published = item.get("date") or "발행일 미상"
+        lines.extend((f"{index}. {title} ({published})", item["url"]))
+    return response.rstrip() + "\n\n" + "\n".join(lines)
 
 
 async def generate_firecrawl_search_response(
@@ -1311,6 +1336,7 @@ async def generate_firecrawl_search_response(
     exclude_domains: Optional[list] = None,
     grounded_facts: str = "",
     period_label: str = "",
+    include_source_links: bool = False,
 ) -> Optional[str]:
     """
     Firecrawl /search plus shared LLM analysis.
@@ -1326,14 +1352,15 @@ async def generate_firecrawl_search_response(
         grounded_facts: Authoritative numbers fetched from a primary data source.
                         These override anything found on the web.
         period_label: Explicit period the report covers, e.g. "2026-07-20 ~ 2026-07-24"
+        include_source_links: Append clickable URLs for evidence referenced by the model.
 
     Returns:
         str: Generated analysis, or None on error
     """
     try:
-        from firecrawl_client import firecrawl_search_multi
         from cores.search_presets import widen_tbs
         from cores.temporal_gate import apply_temporal_gate
+        from firecrawl_client import firecrawl_search_multi
 
         queries = [search_query] if isinstance(search_query, str) else list(search_query)
 
@@ -1437,7 +1464,10 @@ async def generate_firecrawl_search_response(
         )
         logger.info(f"Firecrawl search analysis response: {len(response)} chars")
 
-        return clean_model_response(response)
+        cleaned = clean_model_response(response)
+        if include_source_links:
+            cleaned = _append_source_links(cleaned, items)
+        return cleaned
 
     except Exception as e:
         logger.error(f"generate_firecrawl_search_response failed: {e}")

--- a/tests/test_kakao_ask.py
+++ b/tests/test_kakao_ask.py
@@ -294,6 +294,17 @@ def test_stock_investment_question_expands_into_research_queries():
     assert all("사도 될까" not in query for query in queries)
 
 
+def test_recent_stock_outlook_question_uses_the_stock_research_plan():
+    from kakao_bot.adapters.prism.report_adapter import _ask_search_plan
+
+    queries, use_primary_sources = _ask_search_plan("삼성전자 최근 전망 알려줘")
+
+    assert use_primary_sources is True
+    assert len(queries) == 2
+    assert all("삼성전자" in query for query in queries)
+    assert all("알려줘" not in query for query in queries)
+
+
 def test_general_question_keeps_the_users_original_search_query():
     from kakao_bot.adapters.prism.report_adapter import _ask_search_plan
 
@@ -323,8 +334,50 @@ async def test_stock_question_requires_dated_source_evidence(monkeypatch):
     assert answer.startswith("연합뉴스")
     assert isinstance(captured["query"], list)
     assert captured["kwargs"].get("include_domains")
+    assert captured["kwargs"]["tbs"] == "qdr:d"
+    assert captured["kwargs"]["sources"] == ["web"]
+    assert captured["kwargs"]["include_source_links"] is True
     assert "매체명과 발행일" in captured["prompt"]
     assert "근거가 없다" in captured["prompt"]
+    assert "현재가·등락률·실적" in captured["prompt"]
+    assert "현재가·장중 고저가·당일 등락률은 절대" in captured["prompt"]
+    assert "[자료 n]" in captured["prompt"]
+
+
+def test_source_links_follow_the_evidence_numbers_used_by_the_answer():
+    from report_generator import _append_source_links
+
+    items = [
+        {
+            "title": "첫 번째 기사",
+            "date": "2026-08-06",
+            "url": "https://news.example/one",
+        },
+        {
+            "title": "두 번째 기사",
+            "date": "2026-08-06",
+            "url": "https://news.example/two",
+        },
+    ]
+
+    answer = _append_source_links("전망이 개선됐습니다. [자료 2]", items)
+
+    assert "https://news.example/two" in answer
+    assert "https://news.example/one" not in answer
+
+
+def test_source_links_fall_back_to_the_newest_three_when_model_omits_numbers():
+    from report_generator import _append_source_links
+
+    items = [
+        {"title": f"기사 {index}", "date": "2026-08-06", "url": f"https://n/{index}"}
+        for index in range(1, 5)
+    ]
+
+    answer = _append_source_links("출처 번호 없는 답변", items)
+
+    assert all(f"https://n/{index}" in answer for index in range(1, 4))
+    assert "https://n/4" not in answer
 
 
 def test_answer_works_when_called_the_way_the_worker_calls_it(monkeypatch):


### PR DESCRIPTION
## 문제
- `삼성전자 최근 전망 알려줘`가 종목 질문으로 감지되지 않아 원문 문장 1개만 월간 검색
- 오래된 기사와 관련도 낮은 news 결과가 섞임
- 최종 답변에 실제 기사 URL이 보장되지 않음
- 기사 속 목표가/합산 수치를 현재가나 분기 실적으로 오인할 수 있음

## 변경
- 최근 전망 질문도 종목 검색 플랜으로 감지
- 종목 질문은 주요 언론사 web 기사 + 최근 1일 우선, 결과 없을 때만 주/월 확장
- 검색 자료 번호와 실제 URL을 매칭해 출처 링크 자동 첨부
- 검증 데이터가 없으면 현재가·장중 고저가·당일 등락률 사용 금지
- 중요 숫자는 검증 데이터 또는 독립된 최신 2개 근거가 있을 때만 허용

## 검증
- 카카오봇 및 계약 테스트 319개 통과
- 신규 ASK 테스트 26개 통과
- Ruff 신규 import/undefined 오류 없음
- 운영 Firecrawl 실측으로 최신 1일 기사 검색 확인