### PR TITLE
fix(kakao): 오늘 장중 종목 변동 원인 답변 강화

### DIFF
--- a/kakao_bot/adapters/prism/report_adapter.py
+++ b/kakao_bot/adapters/prism/report_adapter.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import re
 import threading
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from datetime import datetime
+from functools import lru_cache
 
 from kakao_bot.ports.analysis import AnalysisOutcome
 from prism_core.report_service import generate_report
@@ -63,12 +65,25 @@ _ASK_GROUNDING = (
     "검증된 시장 데이터 블록이 없으면 정확한 현재가·장중 고저가·당일 등락률은 절대 쓰지 마라."
 )
 
+_INTRADAY_GROUNDING = (
+    "\n\n오늘 장중 움직임의 원인은 오늘자 직접 관련 기사로 확인된 내용만 단정하라. "
+    "과거 유사 사례로 오늘 원인을 단정하지 마라. 직접 보도가 부족하면 검증된 일봉 형태와 "
+    "가능한 요인을 구분하고, 확인되지 않은 원인은 명확히 미확정이라고 밝혀라."
+)
+
 _STOCK_RESEARCH_SUFFIX = re.compile(
     r"\s*(?:지금\s*)?"
     r"(?:사도\s*(?:될까|돼)|살까|매수(?:해도)?\s*(?:될까|괜찮을까)|"
     r"(?:최근\s*)?(?:주가\s*)?전망(?:은|이|을)?"
     r"(?:\s*(?:알려\s*줘|말해\s*줘|분석해\s*줘|어때))?|어때)"
     r"[?？!！.\s]*$",
+    re.IGNORECASE,
+)
+
+_INTRADAY_EVENT_QUESTION = re.compile(
+    r"^(?P<subject>[A-Za-z0-9가-힣&().-]{2,30})\s+"
+    r"(?=.*(?:오늘|장중|일봉|급락|급등|하한가|상한가))"
+    r".*(?:왜|이유|원인|무슨\s*일)",
     re.IGNORECASE,
 )
 
@@ -265,23 +280,36 @@ async def _ask(question: str) -> str | None:
     # Local time on purpose: this is the date the user and the market are
     # living in, not a timestamp to be compared across zones.
     today = datetime.now().strftime("%Y년 %m월 %d일")  # noqa: DTZ005
+    subject, is_intraday = _stock_question(question)
     prompt = (
         f"오늘은 {today}입니다. 다음 투자 관련 질문에 대해 최신 정보를 기반으로 답변해줘:\n\n"
         f"{question}\n\n"
         f"한국어로, 카카오톡 메시지 형태로 이모지 포함하여 작성. "
         f"{_ASK_ANSWER_BUDGET}자 이내. 표와 마크다운 문법은 쓰지 마라."
-    ) + _ASK_GROUNDING
+    ) + _ASK_GROUNDING + (_INTRADAY_GROUNDING if is_intraday else "")
 
     queries, use_primary_sources = _ask_search_plan(question)
     # General free-form questions stay unrestricted because their subject is
     # unpredictable. A detected stock question is different: primary business
     # outlets are much safer than social posts and generic "지금 사도 될까"
     # matches, and the expanded queries carry the actual research dimensions.
+    market_facts = await daily_facts("KR")
     search_opts = search_preset(
         "KR",
         tbs="qdr:d" if use_primary_sources else "qdr:m",
         allowlist=use_primary_sources,
-    ) | await daily_facts("KR")
+    ) | market_facts
+    if subject:
+        stock_facts = await _stock_session_facts(subject)
+        if stock_facts:
+            existing = search_opts.get("grounded_facts", "").strip()
+            search_opts["grounded_facts"] = "\n\n".join(
+                part for part in (existing, stock_facts) if part
+            )
+            if is_intraday:
+                search_opts["period_label"] = (
+                    f"{datetime.now():%Y-%m-%d} 당일 장중"  # noqa: DTZ005
+                )
     if use_primary_sources:
         # Firecrawl's news vertical currently returns fresh but weakly related
         # results for Korean stock queries. The web vertical finds the actual
@@ -295,13 +323,18 @@ async def _ask(question: str) -> str | None:
 def _ask_search_plan(question: str) -> tuple[list[str], bool]:
     """Turn a conversational stock question into evidence-oriented queries."""
 
-    match = _STOCK_RESEARCH_SUFFIX.search(question.strip())
-    if not match:
+    subject, is_intraday = _stock_question(question)
+    if not subject:
         return [question], False
 
-    subject = question[: match.start()].strip()
-    if not subject or len(subject) > 40:
-        return [question], False
+    if is_intraday:
+        return (
+            [
+                f"{subject} 오늘 장중 급락 반등 이유",
+                f"{subject} 오늘 주가 하락 수급 차익실현 매도 원인",
+            ],
+            True,
+        )
 
     return (
         [
@@ -310,3 +343,104 @@ def _ask_search_plan(question: str) -> tuple[list[str], bool]:
         ],
         True,
     )
+
+
+def _stock_question(question: str) -> tuple[str | None, bool]:
+    """Return a validated stock subject and whether the question is intraday."""
+
+    text = question.strip()
+    event = _INTRADAY_EVENT_QUESTION.search(text)
+    if event:
+        subject = event.group("subject").strip()
+        if _resolve_kr_stock(subject):
+            return subject, True
+
+    match = _STOCK_RESEARCH_SUFFIX.search(text)
+    if not match:
+        return None, False
+    subject = text[: match.start()].strip()
+    if not subject or len(subject) > 40 or not _resolve_kr_stock(subject):
+        return None, False
+    return subject, False
+
+
+@lru_cache(maxsize=256)
+def _resolve_kr_stock(subject: str) -> tuple[str, str] | None:
+    """Resolve an exact KR company name without spending a network request."""
+
+    from kakao_bot.adapters.prism.ticker_adapter import PrismTickerResolver
+
+    resolver = PrismTickerResolver(os.getenv("KAKAO_STOCK_MAP_PATH", "stock_map.json"))
+    resolution = resolver.resolve(subject, market="kr")
+    if not resolution.succeeded or resolution.ticker is None:
+        return None
+    return resolution.ticker.ticker, resolution.ticker.company_name
+
+
+def _format_stock_session_facts(
+    company_name: str,
+    ticker: str,
+    current: dict,
+    previous: dict,
+    *,
+    observed_at: str,
+) -> str:
+    """Render authoritative intraday OHLCV without asking the model to calculate."""
+
+    previous_close = int(previous["Close"])
+    close = int(current["Close"])
+    low = int(current["Low"])
+    change_pct = (close / previous_close - 1) * 100
+    rebound_pct = (close / low - 1) * 100
+    return (
+        "[검증된 종목 당일 일봉 데이터]\n"
+        f"종목: {company_name} ({ticker})\n"
+        f"조회 시각: {observed_at}\n"
+        f"전일 종가: {previous_close:,}원\n"
+        f"시가: {int(current['Open']):,}원\n"
+        f"장중 고가: {int(current['High']):,}원\n"
+        f"장중 저가: {low:,}원\n"
+        f"현재가: {close:,}원\n"
+        f"전일 대비: {change_pct:+.2f}%\n"
+        f"저가 대비 반등: {rebound_pct:+.2f}%\n"
+        f"거래량: {int(current['Volume']):,}주\n"
+        "출처: 네이버 금융 일봉 데이터\n"
+        "주의: 당일 장중 값이며 정규장 종가가 아닙니다."
+    )
+
+
+async def _stock_session_facts(subject: str) -> str:
+    """Fetch one stock's current daily candle through the existing safe fallback."""
+
+    resolved = _resolve_kr_stock(subject)
+    if resolved is None:
+        return ""
+    ticker, company_name = resolved
+
+    def fetch() -> str:
+        import requests
+
+        from cores.naver_market_snapshot import _fetch_daily_pair
+
+        trade_date = datetime.now().strftime("%Y%m%d")  # noqa: DTZ005
+        current, previous = _fetch_daily_pair(
+            requests.get,
+            ticker,
+            trade_date,
+            timeout=10,
+            max_attempts=2,
+            retry_wait_sec=0.2,
+        )
+        return _format_stock_session_facts(
+            company_name,
+            ticker,
+            current,
+            previous,
+            observed_at=datetime.now().strftime("%Y-%m-%d %H:%M KST"),  # noqa: DTZ005
+        )
+
+    try:
+        return await asyncio.wait_for(asyncio.to_thread(fetch), timeout=25)
+    except Exception as exc:  # noqa: BLE001 - retrieval fails soft
+        logger.warning("Intraday facts unavailable for %s: %s", subject, exc)
+        return ""

--- a/tests/test_kakao_ask.py
+++ b/tests/test_kakao_ask.py
@@ -305,6 +305,21 @@ def test_recent_stock_outlook_question_uses_the_stock_research_plan():
     assert all("알려줘" not in query for query in queries)
 
 
+def test_intraday_stock_move_question_uses_today_cause_queries():
+    from kakao_bot.adapters.prism.report_adapter import _ask_search_plan
+
+    queries, use_primary_sources = _ask_search_plan(
+        "SK하이닉스 오늘 거의 하한가까지 갔다가 올라온 이유는 뭐야"
+    )
+
+    assert use_primary_sources is True
+    assert len(queries) == 2
+    assert all("SK하이닉스" in query for query in queries)
+    assert any("장중 급락 반등 이유" in query for query in queries)
+    assert any("수급" in query and "원인" in query for query in queries)
+    assert all("뭐야" not in query for query in queries)
+
+
 def test_general_question_keeps_the_users_original_search_query():
     from kakao_bot.adapters.prism.report_adapter import _ask_search_plan
 
@@ -378,6 +393,61 @@ def test_source_links_fall_back_to_the_newest_three_when_model_omits_numbers():
 
     assert all(f"https://n/{index}" in answer for index in range(1, 4))
     assert "https://n/4" not in answer
+
+
+def test_intraday_facts_calculate_the_candle_and_low_rebound():
+    from kakao_bot.adapters.prism.report_adapter import _format_stock_session_facts
+
+    facts = _format_stock_session_facts(
+        "SK하이닉스",
+        "000660",
+        {"Open": 1_600_000, "High": 1_606_000, "Low": 1_505_000, "Close": 1_522_000, "Volume": 2_259_466},
+        {"Close": 1_668_000, "Date": "20260805"},
+        observed_at="2026-08-06 11:20 KST",
+    )
+
+    assert "전일 종가: 1,668,000원" in facts
+    assert "장중 저가: 1,505,000원" in facts
+    assert "현재가: 1,522,000원" in facts
+    assert "전일 대비: -8.75%" in facts
+    assert "저가 대비 반등: +1.13%" in facts
+    assert "당일 장중 값" in facts
+
+
+@pytest.mark.asyncio
+async def test_intraday_question_adds_stock_facts_and_forbids_old_cause_inference(
+    monkeypatch,
+):
+    import cores.market_facts_cache as mfc
+    import kakao_bot.adapters.prism.report_adapter as adapter
+    import report_generator as rg
+
+    captured = {}
+
+    async def facts(market):
+        return {}
+
+    async def stock_facts(subject):
+        assert subject == "SK하이닉스"
+        return "[검증된 종목 당일 일봉 데이터]\n현재가: 1,522,000원"
+
+    async def search(query, prompt, **kwargs):
+        captured.update(query=query, prompt=prompt, kwargs=kwargs)
+        return "오늘자 수급 기사에 따르면 차익실현 매물이 나왔습니다."
+
+    monkeypatch.setattr(mfc, "daily_facts", facts)
+    monkeypatch.setattr(adapter, "_stock_session_facts", stock_facts)
+    monkeypatch.setattr(rg, "generate_firecrawl_search_response", search)
+
+    answer = await adapter._ask(
+        "SK하이닉스 오늘 거의 하한가까지 갔다가 올라온 이유는 뭐야"
+    )
+
+    assert answer.startswith("오늘자")
+    assert "현재가: 1,522,000원" in captured["kwargs"]["grounded_facts"]
+    assert captured["kwargs"]["period_label"].endswith("당일 장중")
+    assert "과거 유사 사례로 오늘 원인을 단정하지 마라" in captured["prompt"]
+    assert "오늘자 직접 관련 기사" in captured["prompt"]
 
 
 def test_answer_works_when_called_the_way_the_worker_calls_it(monkeypatch):


### PR DESCRIPTION
## 문제
- `SK하이닉스 오늘 ... 이유`가 일반 질문으로 분류되어 월간 과거 기사 사용
- KRX 세션 조회 실패 시 종목 당일 일봉 데이터가 비어 있음
- 과거 유사 사례로 오늘 장중 원인을 단정

## 변경
- 오늘/장중/일봉/급락/급등/상·하한가 + 왜/이유/원인 질문을 종목 이벤트로 감지
- 종목명은 로컬 종목맵으로 검증해 일반 시장 질문 오탐 방지
- 오늘 원인 중심 Firecrawl 쿼리 2개 생성
- 기존 네이버 일봉 안전 경로로 전일 종가·시고저현재·거래량·저가 대비 반등률 제공
- 오늘자 직접 관련 기사만 원인 단정에 사용, 과거 유사 사례 추론 금지

## 검증
- 카톡봇 및 계약 테스트 322개 통과
- ASK 테스트 29개 통과
- Ruff 통과
- 운영 Firecrawl 실측: 오늘자 직접 관련 기사 10건 확인