### PR TITLE
fix(kakao): 복합 출처 표기의 기사 URL 매칭 수정

### DIFF
--- a/report_generator.py
+++ b/report_generator.py
@@ -1261,7 +1261,7 @@ async def generate_journal_conversation_response(
 
 MAX_ARTICLE_CHARS = 3000
 MAX_CONTEXT_CHARS = 60000
-_EVIDENCE_REFERENCE = re.compile(r"\[자료\s*(\d+)\]")
+_EVIDENCE_REFERENCE = re.compile(r"\[[^\]]*?자료\s*(\d+)[^\]]*\]")
 
 
 def _build_search_context(items: list) -> str:

--- a/tests/test_kakao_ask.py
+++ b/tests/test_kakao_ask.py
@@ -375,7 +375,10 @@ def test_source_links_follow_the_evidence_numbers_used_by_the_answer():
         },
     ]
 
-    answer = _append_source_links("전망이 개선됐습니다. [자료 2]", items)
+    answer = _append_source_links(
+        "전망이 개선됐습니다. [서울경제·8월 6일, 자료 2]",
+        items,
+    )
 
     assert "https://news.example/two" in answer
     assert "https://news.example/one" not in answer


### PR DESCRIPTION
## 문제
모델이 `[매체명·날짜, 자료 6]` 형식으로 인용하면 자료 번호를 감지하지 못해 최신 3개 URL로 대체됨.

## 변경
괄호 안에 매체명·날짜가 함께 있어도 `자료 n` 번호를 추출해 정확한 기사 URL을 첨부.

## 검증
- ASK 테스트 29개 통과
- Ruff import/undefined 검사 통과