### PR TITLE
fix(kakao): 종목 별칭·자유 어순 인식과 출처 URL 보존

### DIFF
--- a/kakao_bot/adapters/kakao/report_renderer.py
+++ b/kakao_bot/adapters/kakao/report_renderer.py
@@ -174,15 +174,23 @@ def _ask_result(payload: Mapping[str, object]) -> dict[str, object]:
     """
 
     answer = payload.get("answer")
-    body = _condense(answer if isinstance(answer, str) else "")
+    body = _clean_text(answer if isinstance(answer, str) else "")
     if not body:
         return _ask_failed(payload)
 
     header = f"💬 {_echo_question(payload)}"
-    text = f"{header}\n\n{body}"
+    body_parts = _split_text(
+        body,
+        first_limit=MAX_SIMPLE_TEXT_LENGTH - len(header) - 2,
+        continuation_limit=MAX_SIMPLE_TEXT_LENGTH,
+    )
+    text_outputs = [
+        simple_text_output(f"{header}\n\n{body_parts[0]}"),
+        *[simple_text_output(part) for part in body_parts[1:]],
+    ]
     return skill_response(
         [
-            simple_text_output(text[:MAX_SIMPLE_TEXT_LENGTH]),
+            *text_outputs,
             _ask_actions(),
         ]
     )

--- a/kakao_bot/adapters/prism/report_adapter.py
+++ b/kakao_bot/adapters/prism/report_adapter.py
@@ -8,6 +8,7 @@ or its file layout.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import re
@@ -81,11 +82,15 @@ _STOCK_RESEARCH_SUFFIX = re.compile(
 )
 
 _INTRADAY_EVENT_QUESTION = re.compile(
-    r"^(?P<subject>[A-Za-z0-9가-힣&().-]{2,30})\s+"
     r"(?=.*(?:오늘|장중|일봉|급락|급등|하한가|상한가))"
-    r".*(?:왜|이유|원인|무슨\s*일)",
+    r"(?=.*(?:왜|이유|원인|무슨\s*일)).*",
     re.IGNORECASE,
 )
+
+_STOCK_ALIASES = {
+    "하이닉스": "SK하이닉스",
+    "삼전": "삼성전자",
+}
 
 
 class PrismReportAdapter:
@@ -351,30 +356,77 @@ def _stock_question(question: str) -> tuple[str | None, bool]:
     text = question.strip()
     event = _INTRADAY_EVENT_QUESTION.search(text)
     if event:
-        subject = event.group("subject").strip()
-        if _resolve_kr_stock(subject):
+        subject = _find_kr_stock_mention(text)
+        if subject:
             return subject, True
 
     match = _STOCK_RESEARCH_SUFFIX.search(text)
     if not match:
         return None, False
-    subject = text[: match.start()].strip()
-    if not subject or len(subject) > 40 or not _resolve_kr_stock(subject):
+    prefix = text[: match.start()].strip()
+    subject = _find_kr_stock_mention(prefix)
+    if not subject or len(subject) > 40:
         return None, False
     return subject, False
 
 
+@lru_cache(maxsize=8)
+def _load_kr_stock_maps(path: str) -> tuple[dict[str, str], dict[str, str]]:
+    try:
+        with open(path, encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Stock map unavailable for ask detection: %s", exc)
+        return {}, {}
+    return (
+        payload.get("name_to_code", {}) or {},
+        payload.get("code_to_name", {}) or {},
+    )
+
+
+def _stock_map_path() -> str:
+    return os.getenv("KAKAO_STOCK_MAP_PATH", "stock_map.json")
+
+
 @lru_cache(maxsize=256)
 def _resolve_kr_stock(subject: str) -> tuple[str, str] | None:
-    """Resolve an exact KR company name without spending a network request."""
+    """Resolve only exact names, explicit aliases, or six-digit codes."""
 
-    from kakao_bot.adapters.prism.ticker_adapter import PrismTickerResolver
+    name_to_code, code_to_name = _load_kr_stock_maps(_stock_map_path())
+    candidate = _STOCK_ALIASES.get(subject.strip(), subject.strip())
+    if re.fullmatch(r"\d{6}", candidate):
+        name = code_to_name.get(candidate)
+        return (candidate, name) if name else None
+    code = name_to_code.get(candidate)
+    return (code, candidate) if code else None
 
-    resolver = PrismTickerResolver(os.getenv("KAKAO_STOCK_MAP_PATH", "stock_map.json"))
-    resolution = resolver.resolve(subject, market="kr")
-    if not resolution.succeeded or resolution.ticker is None:
-        return None
-    return resolution.ticker.ticker, resolution.ticker.company_name
+
+@lru_cache(maxsize=8)
+def _searchable_stock_names(path: str) -> tuple[tuple[str, str], ...]:
+    name_to_code, _ = _load_kr_stock_maps(path)
+    return tuple(
+        sorted(
+            ((name.casefold(), name) for name in name_to_code if len(name) >= 2),
+            key=lambda pair: len(pair[0]),
+            reverse=True,
+        )
+    )
+
+
+def _find_kr_stock_mention(text: str) -> str | None:
+    """Find a real stock name anywhere in a conversational question."""
+
+    folded = text.casefold()
+    for alias, canonical in sorted(
+        _STOCK_ALIASES.items(), key=lambda pair: len(pair[0]), reverse=True
+    ):
+        if alias.casefold() in folded:
+            return canonical
+
+    for folded_name, canonical in _searchable_stock_names(_stock_map_path()):
+        if folded_name in folded:
+            return canonical
+    return None
 
 
 def _format_stock_session_facts(

--- a/tests/test_kakao_ask.py
+++ b/tests/test_kakao_ask.py
@@ -320,6 +320,25 @@ def test_intraday_stock_move_question_uses_today_cause_queries():
     assert all("뭐야" not in query for query in queries)
 
 
+def test_intraday_stock_alias_is_found_after_the_time_word():
+    from kakao_bot.adapters.prism.report_adapter import _ask_search_plan
+
+    queries, use_primary_sources = _ask_search_plan(
+        "오늘 하이닉스 거의 하한가까지 갔다 올라왔는데 왜그래?"
+    )
+
+    assert use_primary_sources is True
+    assert all("SK하이닉스" in query for query in queries)
+    assert all(not query.startswith("오늘 오늘") for query in queries)
+
+
+def test_common_time_word_is_never_resolved_as_a_partial_stock_name():
+    from kakao_bot.adapters.prism.report_adapter import _resolve_kr_stock
+
+    assert _resolve_kr_stock("오늘") is None
+    assert _resolve_kr_stock("하이닉스") == ("000660", "SK하이닉스")
+
+
 def test_general_question_keeps_the_users_original_search_query():
     from kakao_bot.adapters.prism.report_adapter import _ask_search_plan
 
@@ -538,12 +557,31 @@ def test_ask_result_strips_markdown_the_bubble_cannot_show():
     assert "· 외국인 순매도" in text
 
 
-def test_a_long_answer_is_cut_to_fit_the_bubble():
+def test_a_long_answer_is_split_to_fit_two_bubbles():
     response = render_delivery(
         delivery("ask_result", {"question": QUESTION, "answer": "가" * 5_000})
     )
 
-    assert len(_first_text(response)) <= 1_000
+    text_outputs = response["template"]["outputs"][:-1]
+    assert len(text_outputs) == 2
+    assert all(len(output["simpleText"]["text"]) <= 1_000 for output in text_outputs)
+
+
+def test_ask_source_url_survives_when_answer_crosses_the_first_bubble_limit():
+    url = "https://www.example.com/news/2026/08/06/complete-article-url"
+    answer = "가" * 850 + f"\n\n🔗 출처\n1. 오늘 기사 (2026-08-06)\n{url}"
+
+    response = render_delivery(
+        delivery("ask_result", {"question": QUESTION, "answer": answer})
+    )
+
+    rendered = "\n".join(
+        output["simpleText"]["text"]
+        for output in response["template"]["outputs"]
+        if "simpleText" in output
+    )
+    assert url in rendered
+    assert not rendered.endswith("…")
 
 
 def test_an_empty_answer_falls_back_to_the_failure_card():


### PR DESCRIPTION
## 문제
- `오늘 하이닉스 ...`에서 첫 단어 `오늘`을 종목 후보로 잡고 부분일치로 `오늘이엔엠`에 오인 매칭
- 검색 쿼리가 `오늘 오늘 장중 ...`으로 생성되어 SK하이닉스 당일 데이터 누락
- ASK 답변을 단일 1,000자 말풍선으로 잘라 뒤쪽 기사 URL이 훼손

## 변경
- 종목 감지에서 부분일치 제거: 정확 종목명·6자리 코드·명시적 별칭만 허용
- 문장 어디에 있든 종목명을 찾는 자유 어순 지원
- `하이닉스 → SK하이닉스`, `삼전 → 삼성전자` 별칭 지원
- ASK 답변을 최대 두 말풍선으로 자연 분할해 출처 URL 전체 보존

## 검증
- 카톡봇 전체 테스트 325개 통과
- 별칭·렌더링 대상 테스트 45개 통과
- Ruff 통과