### PR TITLE
fix(kakao): 말풍선 분할 시 출처 항목 단위 보존

### DIFF
--- a/report_generator.py
+++ b/report_generator.py
@@ -1321,14 +1321,16 @@ def _append_source_links(response: str, items: list, *, fallback_limit: int = 3)
     if not selected or all(item["url"] in visible_response for _, item in selected):
         return visible_response
 
-    lines = ["🔗 출처"]
+    source_blocks = ["🔗 출처"]
     for display_index, (_, item) in enumerate(selected, start=1):
         title = " ".join((item.get("title") or "기사").split())[:55]
         raw_date = str(item.get("date") or "")
         matched_date = re.search(r"\d{4}-\d{2}-\d{2}", raw_date)
         published = matched_date.group(0) if matched_date else "발행일 미상"
-        lines.extend((f"{display_index}. {title} ({published})", item["url"]))
-    return visible_response + "\n\n" + "\n".join(lines)
+        source_blocks.append(
+            f"{display_index}. {title} ({published})\n{item['url']}"
+        )
+    return visible_response + "\n\n" + "\n\n".join(source_blocks)
 
 
 async def generate_firecrawl_search_response(

--- a/tests/test_kakao_ask.py
+++ b/tests/test_kakao_ask.py
@@ -440,6 +440,7 @@ def test_source_links_limit_referenced_articles_and_compact_the_dates():
     assert all(f"https://news.example/{index}" in answer for index in range(1, 4))
     assert "https://news.example/4" not in answer
     assert "2026-08-06T" not in answer
+    assert "https://news.example/2\n\n3. 기사 3" in answer
 
 
 def test_intraday_facts_calculate_the_candle_and_low_rebound():


### PR DESCRIPTION
## 변경
- 출처 제목과 URL을 하나의 문단 블록으로 구성
- 말풍선 분할 시 `3.`과 기사 제목이 떨어지지 않도록 문단 경계 제공

## 검증
- ASK 테스트 33개 통과
- Ruff import/undefined 검사 통과