### PR TITLE
fix(kakao): restore report PDF links

### DIFF
--- a/kakao_bot/runtime/analysis_worker_main.py
+++ b/kakao_bot/runtime/analysis_worker_main.py
@@ -166,8 +166,17 @@ def _analysis_service(
         max_attempts=config.max_attempts,
         # Unset means no public endpoint exists yet, in which case no link is
         # minted and the card ships summary-only rather than a dead button.
-        public_base_url=os.getenv("KAKAO_PUBLIC_BASE_URL"),
+        public_base_url=_report_public_base_url(),
         link_ttl_hours=int(os.getenv("KAKAO_REPORT_LINK_TTL_HOURS", "72")),
+    )
+
+
+def _report_public_base_url(environ: Mapping[str, str] | None = None) -> str | None:
+    """Resolve the deployed PDF-link setting with legacy compatibility."""
+
+    values = os.environ if environ is None else environ
+    return values.get("KAKAO_BOT_PUBLIC_BASE_URL") or values.get(
+        "KAKAO_PUBLIC_BASE_URL"
     )
 
 

--- a/tests/test_kakao_analysis_worker.py
+++ b/tests/test_kakao_analysis_worker.py
@@ -10,6 +10,7 @@ from kakao_bot.domain.models import AnalysisJob, ApprovalStatus, OutboundDeliver
 from kakao_bot.ports.analysis import AnalysisOutcome
 from kakao_bot.runtime.analysis_worker_main import (
     AnalysisWorkerConfigurationError,
+    _report_public_base_url,
     _start_llm_runtime,
     _stop_llm_runtime,
 )
@@ -224,6 +225,24 @@ def test_batch_size_is_respected(tmp_path):
         assert result.completed == 2
         assert len(analysis.calls) == 2
         assert len(repository.list_outbox()) == 2
+
+
+def test_report_public_base_url_uses_deployed_env_name():
+    assert (
+        _report_public_base_url(
+            {"KAKAO_BOT_PUBLIC_BASE_URL": "https://analysis.example.test"}
+        )
+        == "https://analysis.example.test"
+    )
+
+
+def test_report_public_base_url_keeps_legacy_env_compatibility():
+    assert (
+        _report_public_base_url(
+            {"KAKAO_PUBLIC_BASE_URL": "https://legacy.example.test"}
+        )
+        == "https://legacy.example.test"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 원인
운영 환경은 `KAKAO_BOT_PUBLIC_BASE_URL`을 설정하지만 분석 워커는 `KAKAO_PUBLIC_BASE_URL`만 읽어 PDF 링크가 생성되지 않았습니다.

## 변경
- 운영 환경변수 이름을 우선 사용
- 기존 이름도 하위 호환
- 두 설정 경로 회귀 테스트 추가

## 검증
- `30 passed`
- Ruff 통과