### PR TITLE
fix(market-data): restore recent investor flows without KRX login

### DIFF
--- a/cores/market_data/__init__.py
+++ b/cores/market_data/__init__.py
@@ -28,6 +28,7 @@ import pandas as pd
 from cores.market_data.fdr_source import FdrSource
 from cores.market_data.kis_source import KisSource
 from cores.market_data.krx_source import KrxSource
+from cores.market_data.naver_source import NaverSource
 from cores.market_data.source import (
     MarketDataSource,
     SourceChain,
@@ -42,6 +43,7 @@ __all__ = [
     "KisSource",
     "KrxSource",
     "MarketDataSource",
+    "NaverSource",
     "SourceChain",
     "Unavailable",
     "Unsupported",
@@ -56,7 +58,12 @@ __all__ = [
     "set_default_chain",
 ]
 
-_BUILDERS = {"krx": KrxSource, "fdr": FdrSource, "kis": KisSource}
+_BUILDERS = {
+    "krx": KrxSource,
+    "fdr": FdrSource,
+    "kis": KisSource,
+    "naver": NaverSource,
+}
 # KIS is registered but not in the default order. It is the route we intend to
 # migrate to, and putting it first is a decision to make with measurements
 # rather than at import time — `PRISM_MARKET_DATA_SOURCES=kis,fdr,krx` promotes

--- a/cores/market_data/naver_source.py
+++ b/cores/market_data/naver_source.py
@@ -1,0 +1,104 @@
+"""Recent investor flows from Naver Finance's public stock trend endpoint.
+
+This is a narrow resilience adapter, not a general market-data source. The
+endpoint exposes only the latest ten sessions, but that is enough to keep a
+same-day report honest about recent foreign, institutional, and individual net
+buying when authenticated KRX is unavailable and KIS is closed until 15:40.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pandas as pd
+import requests
+
+from cores.market_data.schema import normalize
+from cores.market_data.source import Unavailable, Unsupported
+
+_TREND_URL = "https://m.stock.naver.com/api/stock/{ticker}/trend"
+_HEADERS = {
+    "User-Agent": "Mozilla/5.0",
+    "Referer": "https://m.stock.naver.com/",
+}
+_COLUMNS = {
+    "organPureBuyQuant": "기관합계",
+    "foreignerPureBuyQuant": "외국인합계",
+    "individualPureBuyQuant": "개인",
+}
+
+
+class NaverSource:
+    name = "naver"
+
+    def __init__(self, *, request_get: Callable = requests.get) -> None:
+        self._request_get = request_get
+
+    def investor_flows(self, ticker: str, start: str, end: str) -> pd.DataFrame:
+        try:
+            response = self._request_get(
+                _TREND_URL.format(ticker=ticker),
+                headers=_HEADERS,
+                timeout=10,
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except Exception as exc:
+            raise Unavailable(f"Naver trend request failed: {exc}") from exc
+
+        if not isinstance(payload, list) or not payload:
+            raise Unavailable("Naver trend returned no rows")
+
+        records = []
+        for row in payload:
+            if not isinstance(row, dict):
+                continue
+            date = str(row.get("bizdate") or "")
+            if len(date) != 8 or not date.isdigit():
+                continue
+            try:
+                record = {"Date": date}
+                record.update(
+                    {
+                        target: _signed_int(row.get(source))
+                        for source, target in _COLUMNS.items()
+                    }
+                )
+            except (TypeError, ValueError):
+                continue
+            records.append(record)
+
+        if not records:
+            raise Unavailable("Naver trend rows failed schema validation")
+
+        frame = pd.DataFrame.from_records(records).set_index("Date")
+        frame = normalize(frame)
+        frame = frame[
+            (frame.index >= pd.Timestamp(start)) & (frame.index <= pd.Timestamp(end))
+        ]
+        if frame.empty:
+            raise Unavailable(f"Naver trend has no rows in {start}..{end}")
+        frame.attrs["coverage"] = "latest_10_sessions"
+        return frame
+
+    def price_history(self, ticker: str, start: str, end: str, *, adjusted: bool = True):
+        raise Unsupported("Naver trend source only publishes recent investor flows")
+
+    def index_history(self, index_code: str, start: str, end: str):
+        raise Unsupported("Naver trend source only publishes recent investor flows")
+
+    def market_cap_history(self, ticker: str, start: str, end: str):
+        raise Unsupported("Naver trend source only publishes recent investor flows")
+
+    def fundamentals(self, ticker: str, start: str, end: str):
+        raise Unsupported("Naver trend source only publishes recent investor flows")
+
+    def ticker_name(self, ticker: str):
+        raise Unsupported("Naver trend source only publishes recent investor flows")
+
+
+def _signed_int(value: object) -> int:
+    if not isinstance(value, (str, int)):
+        raise TypeError("investor flow is not numeric")
+    return int(str(value).replace(",", "").replace("+", "").strip())
+

--- a/tests/test_market_data_sources.py
+++ b/tests/test_market_data_sources.py
@@ -184,6 +184,12 @@ class TestConfiguredOrder:
 
         assert default_chain().names == ["fdr"]
 
+    def test_naver_can_be_configured_as_an_investor_flow_fallback(self, monkeypatch):
+        monkeypatch.setenv("PRISM_MARKET_DATA_SOURCES", "fdr,naver,krx")
+        set_default_chain(None)
+
+        assert default_chain().names == ["fdr", "naver", "krx"]
+
     def test_an_unknown_name_is_ignored_rather_than_fatal(self, monkeypatch):
         monkeypatch.setenv("PRISM_MARKET_DATA_SOURCES", "nonsense,fdr")
         set_default_chain(None)

--- a/tests/test_naver_investor_source.py
+++ b/tests/test_naver_investor_source.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import pytest
+
+from cores.market_data.naver_source import NaverSource
+from cores.market_data.source import Unavailable, Unsupported
+
+
+class FakeResponse:
+    def __init__(self, payload, *, status_error: Exception | None = None):
+        self._payload = payload
+        self._status_error = status_error
+
+    def raise_for_status(self):
+        if self._status_error:
+            raise self._status_error
+
+    def json(self):
+        return self._payload
+
+
+def _rows():
+    return [
+        {
+            "itemCode": "005930",
+            "bizdate": "20260805",
+            "foreignerPureBuyQuant": "+2,298,577",
+            "organPureBuyQuant": "-2,078,706",
+            "individualPureBuyQuant": "-222,721",
+        },
+        {
+            "itemCode": "005930",
+            "bizdate": "20260804",
+            "foreignerPureBuyQuant": "+850,527",
+            "organPureBuyQuant": "-3,924,513",
+            "individualPureBuyQuant": "+2,927,753",
+        },
+    ]
+
+
+def test_naver_investor_flows_match_shared_schema_and_sort_dates():
+    calls = []
+
+    def get(url, **kwargs):
+        calls.append((url, kwargs))
+        return FakeResponse(_rows())
+
+    frame = NaverSource(request_get=get).investor_flows(
+        "005930", "20260801", "20260805"
+    )
+
+    assert list(frame.columns) == ["기관합계", "외국인합계", "개인"]
+    assert list(frame.index.strftime("%Y%m%d")) == ["20260804", "20260805"]
+    assert frame.loc["2026-08-05", "외국인합계"] == 2_298_577
+    assert frame.loc["2026-08-05", "기관합계"] == -2_078_706
+    assert calls[0][0].endswith("/api/stock/005930/trend")
+    assert calls[0][1]["timeout"] == 10
+
+
+def test_naver_investor_flows_respect_requested_range():
+    source = NaverSource(request_get=lambda *args, **kwargs: FakeResponse(_rows()))
+
+    frame = source.investor_flows("005930", "20260805", "20260805")
+
+    assert list(frame.index.strftime("%Y%m%d")) == ["20260805"]
+
+
+@pytest.mark.parametrize("payload", [[], {}, [{"bizdate": "bad"}]])
+def test_naver_investor_flows_reject_unusable_payload(payload):
+    source = NaverSource(request_get=lambda *args, **kwargs: FakeResponse(payload))
+
+    with pytest.raises(Unavailable):
+        source.investor_flows("005930", "20260801", "20260805")
+
+
+def test_naver_source_declares_unimplemented_capabilities():
+    source = NaverSource(request_get=lambda *args, **kwargs: FakeResponse(_rows()))
+
+    with pytest.raises(Unsupported):
+        source.price_history("005930", "20260801", "20260805")
+    with pytest.raises(Unsupported):
+        source.index_history("1001", "20260801", "20260805")
+


### PR DESCRIPTION
## 원인
카톡 보고서 백엔드는 KRX 로그인 자격정보가 없고 KIS 수급 API는 장중 15:40 이전 조회를 거부해 투자자별 거래동향이 비었습니다.

## 변경
- Naver 종목 trend API 기반 최근 10거래일 수급 폴백 추가
- 기관·외국인·개인 순매수량을 공통 스키마로 정규화
- 날짜 범위·응답 스키마 검증 및 소스 체인 설정 지원

## 검증
- 시장데이터 테스트 48개 통과
- Ruff 통과
- 삼성전자 2026-08-05 수치가 KRX 결과와 일치