### PR TITLE
fix(kakao): enable investor flow fallback for reports

### DIFF
--- a/kakao_bot/runtime/analysis_worker_main.py
+++ b/kakao_bot/runtime/analysis_worker_main.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import os
 import signal
-from collections.abc import Mapping
+from collections.abc import Mapping, MutableMapping
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -20,6 +20,8 @@ from kakao_bot.application.analysis_service import (
 from kakao_bot.ports.analysis import AnalysisPort
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_KAKAO_REPORT_DATA_SOURCES = "fdr,naver,krx"
 
 
 class AnalysisWorkerConfigurationError(ValueError):
@@ -180,10 +182,22 @@ def _report_public_base_url(environ: Mapping[str, str] | None = None) -> str | N
     )
 
 
+def _configure_report_data_sources(
+    environ: MutableMapping[str, str] | None = None,
+) -> str:
+    """Give Kakao reports a public recent-flow fallback without overriding ops."""
+
+    values = os.environ if environ is None else environ
+    return values.setdefault(
+        "PRISM_REPORT_DATA_SOURCES", DEFAULT_KAKAO_REPORT_DATA_SOURCES
+    )
+
+
 async def async_main() -> int:
     llm_runtime_started = False
     try:
         config = load_config()
+        _configure_report_data_sources()
         llm_runtime_started = await _start_llm_runtime()
     except AnalysisWorkerConfigurationError as exc:
         logger.error("%s", exc)

--- a/tests/test_kakao_analysis_worker.py
+++ b/tests/test_kakao_analysis_worker.py
@@ -10,6 +10,7 @@ from kakao_bot.domain.models import AnalysisJob, ApprovalStatus, OutboundDeliver
 from kakao_bot.ports.analysis import AnalysisOutcome
 from kakao_bot.runtime.analysis_worker_main import (
     AnalysisWorkerConfigurationError,
+    _configure_report_data_sources,
     _report_public_base_url,
     _start_llm_runtime,
     _stop_llm_runtime,
@@ -243,6 +244,19 @@ def test_report_public_base_url_keeps_legacy_env_compatibility():
         )
         == "https://legacy.example.test"
     )
+
+
+def test_kakao_reports_default_to_recent_investor_flow_fallback():
+    environ = {}
+
+    assert _configure_report_data_sources(environ) == "fdr,naver,krx"
+    assert environ["PRISM_REPORT_DATA_SOURCES"] == "fdr,naver,krx"
+
+
+def test_explicit_report_source_order_wins_over_kakao_default():
+    environ = {"PRISM_REPORT_DATA_SOURCES": "kis,fdr,krx"}
+
+    assert _configure_report_data_sources(environ) == "kis,fdr,krx"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
카톡 분석 워커에만 `fdr,naver,krx` 보고서 소스 기본값을 적용합니다. 운영자가 `PRISM_REPORT_DATA_SOURCES`를 명시하면 그대로 우선합니다.

검증: 관련 테스트 62개 및 Ruff 통과.