### PR TITLE
fix(kakao): upgrade legacy report source order

### DIFF
--- a/kakao_bot/runtime/analysis_worker_main.py
+++ b/kakao_bot/runtime/analysis_worker_main.py
@@ -185,9 +185,16 @@ def _report_public_base_url(environ: Mapping[str, str] | None = None) -> str | N
 def _configure_report_data_sources(
     environ: MutableMapping[str, str] | None = None,
 ) -> str:
-    """Give Kakao reports a public recent-flow fallback without overriding ops."""
+    """Give Kakao reports a public recent-flow fallback without overriding ops.
+
+    ``fdr,krx`` was deployed as an outage-era fallback before the public recent
+    flow source existed. Upgrade only that exact legacy value; a deliberately
+    configured order such as ``kis,fdr,krx`` remains untouched.
+    """
 
     values = os.environ if environ is None else environ
+    if values.get("PRISM_REPORT_DATA_SOURCES") == "fdr,krx":
+        values["PRISM_REPORT_DATA_SOURCES"] = DEFAULT_KAKAO_REPORT_DATA_SOURCES
     return values.setdefault(
         "PRISM_REPORT_DATA_SOURCES", DEFAULT_KAKAO_REPORT_DATA_SOURCES
     )

--- a/tests/test_kakao_analysis_worker.py
+++ b/tests/test_kakao_analysis_worker.py
@@ -259,6 +259,12 @@ def test_explicit_report_source_order_wins_over_kakao_default():
     assert _configure_report_data_sources(environ) == "kis,fdr,krx"
 
 
+def test_legacy_report_source_order_gains_recent_flow_fallback():
+    environ = {"PRISM_REPORT_DATA_SOURCES": "fdr,krx"}
+
+    assert _configure_report_data_sources(environ) == "fdr,naver,krx"
+
+
 @pytest.mark.asyncio
 async def test_chatgpt_oauth_worker_starts_and_stops_proxy(monkeypatch):
     from cores import chatgpt_proxy


### PR DESCRIPTION
운영의 레거시 `fdr,krx` 설정에 Naver 최근 수급 폴백을 자동 삽입합니다. 다른 명시적 순서는 유지합니다.

검증: 카카오 워커 테스트 15개 및 Ruff 통과.