### PR TITLE
feat(kakao): use Luna high for formal reports

### DIFF
--- a/kakao_bot/runtime/analysis_worker_main.py
+++ b/kakao_bot/runtime/analysis_worker_main.py
@@ -22,6 +22,8 @@ from kakao_bot.ports.analysis import AnalysisPort
 logger = logging.getLogger(__name__)
 
 DEFAULT_KAKAO_REPORT_DATA_SOURCES = "fdr,naver,krx"
+DEFAULT_KAKAO_REPORT_MODEL = "gpt-5.6-luna"
+DEFAULT_KAKAO_REPORT_EFFORT = "high"
 
 
 class AnalysisWorkerConfigurationError(ValueError):
@@ -200,11 +202,23 @@ def _configure_report_data_sources(
     )
 
 
+def _configure_report_model(
+    environ: MutableMapping[str, str] | None = None,
+) -> tuple[str, str]:
+    """Default Kakao's formal report subprocesses to Luna with high reasoning."""
+
+    values = os.environ if environ is None else environ
+    model = values.setdefault("REPORT_MODEL", DEFAULT_KAKAO_REPORT_MODEL)
+    effort = values.setdefault("REPORT_EFFORT", DEFAULT_KAKAO_REPORT_EFFORT)
+    return model, effort
+
+
 async def async_main() -> int:
     llm_runtime_started = False
     try:
         config = load_config()
         _configure_report_data_sources()
+        _configure_report_model()
         llm_runtime_started = await _start_llm_runtime()
     except AnalysisWorkerConfigurationError as exc:
         logger.error("%s", exc)

--- a/tests/test_kakao_analysis_worker.py
+++ b/tests/test_kakao_analysis_worker.py
@@ -11,6 +11,7 @@ from kakao_bot.ports.analysis import AnalysisOutcome
 from kakao_bot.runtime.analysis_worker_main import (
     AnalysisWorkerConfigurationError,
     _configure_report_data_sources,
+    _configure_report_model,
     _report_public_base_url,
     _start_llm_runtime,
     _stop_llm_runtime,
@@ -263,6 +264,20 @@ def test_legacy_report_source_order_gains_recent_flow_fallback():
     environ = {"PRISM_REPORT_DATA_SOURCES": "fdr,krx"}
 
     assert _configure_report_data_sources(environ) == "fdr,naver,krx"
+
+
+def test_kakao_reports_default_to_luna_with_high_reasoning():
+    environ = {}
+
+    assert _configure_report_model(environ) == ("gpt-5.6-luna", "high")
+    assert environ["REPORT_MODEL"] == "gpt-5.6-luna"
+    assert environ["REPORT_EFFORT"] == "high"
+
+
+def test_explicit_report_model_configuration_wins_over_kakao_default():
+    environ = {"REPORT_MODEL": "custom-model", "REPORT_EFFORT": "medium"}
+
+    assert _configure_report_model(environ) == ("custom-model", "medium")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 변경 사항
- 카카오 정식 리포트 생성 기본 모델을 `gpt-5.6-luna`로 설정
- 추론 강도를 `high`로 설정
- 운영 환경에서 명시한 `REPORT_MODEL`/`REPORT_EFFORT`는 우선 유지
- 일반 질문·평가·메인 오케스트레이터에는 영향 없음

## 검증
- `20 passed`
- Ruff 통과
- `git diff --check` 통과