### PR TITLE
feat(telegram): use Luna high for formal reports

### DIFF
--- a/utils/restart_telegram_bot.sh
+++ b/utils/restart_telegram_bot.sh
@@ -32,6 +32,12 @@ ENTRY="telegram_ai_bot.py"
 LOG="${APP_DIR}/telegram_bot.log"
 PY="${PY:-python3}"
 
+# The bot imports report generation modules before loading its .env file, so
+# formal-report model defaults must exist in the process environment at launch.
+# Explicit operator overrides still win.
+export REPORT_MODEL="${REPORT_MODEL:-gpt-5.6-luna}"
+export REPORT_EFFORT="${REPORT_EFFORT:-high}"
+
 # pyenv python 이 ENTRY 를 직접 실행하는 프로세스만 매칭한다.
 # `-bash -c ... nohup python3 telegram_ai_bot.py ...` 형태의 래퍼 셸까지
 # 잡으면 애먼 것을 죽이게 되므로 정규식을 실행 이미지에 고정한다.


### PR DESCRIPTION
## 변경 사항
- Telegram AI Bot 기동 시 정식 리포트 모델을 `gpt-5.6-luna`로 기본 설정
- 추론 강도를 `high`로 기본 설정
- 명시적인 운영 환경변수는 계속 우선

## 배경
봇이 `.env` 로드 전에 리포트 모듈을 import하므로 재기동 스크립트에서 환경변수를 선주입합니다.

## 검증
- `bash -n` 통과
- Telegram 리포트 테스트 2개 통과
- `git diff --check` 통과