### PR TITLE
fix(telegram): switch report conversations by market

### DIFF
--- a/telegram_ai_bot.py
+++ b/telegram_ai_bot.py
@@ -783,11 +783,16 @@ class TelegramAIBot:
         report_conv_handler = ConversationHandler(
             entry_points=[
                 CommandHandler("report", self.handle_report_start),
-                MessageHandler(filters.Regex(r'^/report(@\w+)?$'), self.handle_report_start)
+                MessageHandler(filters.Regex(r'^/report(@\w+)?$'), self.handle_report_start),
+                CommandHandler("us_report", self.handle_us_report_start),
+                MessageHandler(filters.Regex(r'^/us_report(@\w+)?$'), self.handle_us_report_start),
             ],
             states={
                 REPORT_CHOOSING_TICKER: [
                     MessageHandler(filters.TEXT & ~filters.COMMAND, self.handle_report_ticker_input)
+                ],
+                US_REPORT_CHOOSING_TICKER: [
+                    MessageHandler(filters.TEXT & ~filters.COMMAND, self.handle_us_report_ticker_input)
                 ]
             },
             fallbacks=[
@@ -796,6 +801,7 @@ class TelegramAIBot:
             per_chat=False,
             per_user=True,
             conversation_timeout=300,
+            allow_reentry=True,
         )
         self.application.add_handler(report_conv_handler)
 
@@ -894,26 +900,6 @@ class TelegramAIBot:
             conversation_timeout=300,
         )
         self.application.add_handler(us_evaluate_handler)
-
-        # US report conversation handler (/us_report)
-        us_report_handler = ConversationHandler(
-            entry_points=[
-                CommandHandler("us_report", self.handle_us_report_start),
-                MessageHandler(filters.Regex(r'^/us_report(@\w+)?$'), self.handle_us_report_start)
-            ],
-            states={
-                US_REPORT_CHOOSING_TICKER: [
-                    MessageHandler(filters.TEXT & ~filters.COMMAND, self.handle_us_report_ticker_input)
-                ]
-            },
-            fallbacks=[
-                CommandHandler("cancel", self.handle_cancel)
-            ],
-            per_chat=False,
-            per_user=True,
-            conversation_timeout=300,
-        )
-        self.application.add_handler(us_report_handler)
 
         # ==========================================================================
         # Journal (investment diary) conversation handler (/journal)
@@ -1676,6 +1662,18 @@ class TelegramAIBot:
         stock_code, stock_name, error_message = await self.get_stock_code(user_input)
 
         if error_message:
+            # A previous /report conversation can remain active when the user
+            # switches to /us_report. Because the domestic handler is
+            # registered first, it would otherwise consume the next plain-text
+            # ticker. Route an unmistakable US ticker through the existing US
+            # report path instead of rejecting it as an unknown Korean stock.
+            if re.fullmatch(r"[A-Za-z]{1,5}", user_input):
+                logger.info(
+                    "Routing US ticker from domestic report state: %s",
+                    user_input.upper(),
+                )
+                return await self.handle_us_report_ticker_input(update, context)
+
             # Notify user of error and request re-input
             await update.message.reply_text(error_message)
             return REPORT_CHOOSING_TICKER

--- a/tests/test_telegram_report_routing.py
+++ b/tests/test_telegram_report_routing.py
@@ -1,0 +1,67 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram.ext import CommandHandler, ConversationHandler
+
+from telegram_ai_bot import TelegramAIBot
+
+
+class RecordingApplication:
+    def __init__(self):
+        self.handlers = []
+
+    def add_handler(self, handler, group=0):
+        self.handlers.append((group, handler))
+
+    def add_error_handler(self, callback):
+        self.error_handler = callback
+
+
+def test_report_commands_share_one_reentrant_conversation_handler():
+    bot = object.__new__(TelegramAIBot)
+    bot.application = RecordingApplication()
+
+    bot.setup_handlers()
+
+    report_conversations = []
+    for _, handler in bot.application.handlers:
+        if not isinstance(handler, ConversationHandler):
+            continue
+        commands = {
+            command
+            for entry_point in handler.entry_points
+            if isinstance(entry_point, CommandHandler)
+            for command in entry_point.commands
+        }
+        if commands & {"report", "us_report"}:
+            report_conversations.append((handler, commands))
+
+    assert len(report_conversations) == 1
+    handler, commands = report_conversations[0]
+    assert {"report", "us_report"} <= commands
+    assert handler.allow_reentry is True
+
+
+@pytest.mark.asyncio
+async def test_domestic_report_state_routes_us_ticker_to_us_report_handler():
+    bot = object.__new__(TelegramAIBot)
+    bot.get_stock_code = AsyncMock(
+        return_value=(None, None, "국내 종목을 찾을 수 없습니다.")
+    )
+    bot.handle_us_report_ticker_input = AsyncMock(
+        return_value=ConversationHandler.END
+    )
+    update = SimpleNamespace(
+        message=SimpleNamespace(text="IONQ", reply_text=AsyncMock()),
+        effective_user=SimpleNamespace(id=123),
+        effective_chat=SimpleNamespace(id=456),
+    )
+
+    result = await TelegramAIBot.handle_report_ticker_input(
+        bot, update, SimpleNamespace()
+    )
+
+    assert result == ConversationHandler.END
+    bot.handle_us_report_ticker_input.assert_awaited_once()
+    update.message.reply_text.assert_not_awaited()


### PR DESCRIPTION
## 원인
`/report` 상태가 남은 채 `/us_report`를 시작하면 두 ConversationHandler가 동시에 텍스트 입력을 기다렸고, 먼저 등록된 국내 핸들러가 `IONQ`를 가로챘습니다.

## 변경 사항
- `/report`와 `/us_report`를 하나의 재진입 가능한 ConversationHandler로 통합
- 명령 전환 시 시장별 입력 상태를 즉시 교체
- 국내 상태로 영문 티커가 들어온 경우 기존 미국 리포트 처리기로 자동 라우팅

## 검증
- 관련 테스트 4개 통과
- 새 테스트 파일 Ruff 통과
- `telegram_ai_bot.py` py_compile 통과
- `git diff --check` 통과