### PR TITLE
feat(kakao): bound parallel report generation

### DIFF
--- a/cores/analysis.py
+++ b/cores/analysis.py
@@ -1,5 +1,6 @@
 import os
 import asyncio
+from collections.abc import Mapping
 from datetime import datetime
 from dotenv import load_dotenv
 
@@ -40,6 +41,22 @@ from cores.utils import clean_markdown
 
 # Market analysis cache storage (global variable)
 _market_analysis_cache = {}
+
+
+def _report_parallel_limit(
+    section_count: int,
+    environ: Mapping[str, str] | None = None,
+) -> int:
+    """Resolve an optional bound while preserving legacy full parallelism."""
+
+    values = os.environ if environ is None else environ
+    raw_limit = values.get("PRISM_PARALLEL_REPORT_MAX_CONCURRENCY")
+    if raw_limit is None:
+        return section_count
+    try:
+        return min(section_count, max(1, int(raw_limit)))
+    except ValueError:
+        return section_count
 
 async def analyze_stock(company_code: str = "000660", company_name: str = "SK하이닉스", reference_date: str = None, language: str = "ko", macro_context: dict = None):
     """
@@ -96,9 +113,15 @@ async def analyze_stock(company_code: str = "000660", company_name: str = "SK하
         if parallel_enabled:
             # Parallel execution mode
             # Keep independent section loggers; the backend owns MCP server lifecycles.
-            logger.info(f"Running analysis in PARALLEL mode for {company_name}...")
+            parallel_limit = _report_parallel_limit(len(base_sections))
+            parallel_semaphore = asyncio.Semaphore(parallel_limit)
+            logger.info(
+                "Running analysis in PARALLEL mode for %s (max concurrency=%d)...",
+                company_name,
+                parallel_limit,
+            )
 
-            async def process_section(section):
+            async def process_section_unbounded(section):
                 """Process a single section with its own logger context."""
                 if section not in agents:
                     return section, None
@@ -125,6 +148,10 @@ async def analyze_stock(company_code: str = "000660", company_name: str = "SK하
                     except Exception as e:
                         section_logger.error(f"Final failure processing {section}: {e}")
                         return section, f"Analysis failed: {section}"
+
+            async def process_section(section):
+                async with parallel_semaphore:
+                    return await process_section_unbounded(section)
 
             # Execute all sections in parallel (each with its own logger context).
             results = await asyncio.gather(*[process_section(section) for section in base_sections])

--- a/kakao_bot/runtime/analysis_worker_main.py
+++ b/kakao_bot/runtime/analysis_worker_main.py
@@ -23,7 +23,8 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_KAKAO_REPORT_DATA_SOURCES = "fdr,naver,krx"
 DEFAULT_KAKAO_REPORT_MODEL = "gpt-5.6-luna"
-DEFAULT_KAKAO_REPORT_EFFORT = "high"
+DEFAULT_KAKAO_REPORT_EFFORT = "medium"
+DEFAULT_KAKAO_REPORT_MAX_CONCURRENCY = "3"
 
 
 class AnalysisWorkerConfigurationError(ValueError):
@@ -205,12 +206,26 @@ def _configure_report_data_sources(
 def _configure_report_model(
     environ: MutableMapping[str, str] | None = None,
 ) -> tuple[str, str]:
-    """Default Kakao's formal report subprocesses to Luna with high reasoning."""
+    """Default Kakao's formal report subprocesses to Luna with medium reasoning."""
 
     values = os.environ if environ is None else environ
     model = values.setdefault("REPORT_MODEL", DEFAULT_KAKAO_REPORT_MODEL)
     effort = values.setdefault("REPORT_EFFORT", DEFAULT_KAKAO_REPORT_EFFORT)
     return model, effort
+
+
+def _configure_report_parallelism(
+    environ: MutableMapping[str, str] | None = None,
+) -> tuple[str, str]:
+    """Enable bounded parallel base-section generation for Kakao reports."""
+
+    values = os.environ if environ is None else environ
+    enabled = values.setdefault("PRISM_PARALLEL_REPORT", "true")
+    max_concurrency = values.setdefault(
+        "PRISM_PARALLEL_REPORT_MAX_CONCURRENCY",
+        DEFAULT_KAKAO_REPORT_MAX_CONCURRENCY,
+    )
+    return enabled, max_concurrency
 
 
 async def async_main() -> int:
@@ -219,6 +234,7 @@ async def async_main() -> int:
         config = load_config()
         _configure_report_data_sources()
         _configure_report_model()
+        _configure_report_parallelism()
         llm_runtime_started = await _start_llm_runtime()
     except AnalysisWorkerConfigurationError as exc:
         logger.error("%s", exc)

--- a/tests/test_kakao_analysis_worker.py
+++ b/tests/test_kakao_analysis_worker.py
@@ -12,6 +12,7 @@ from kakao_bot.runtime.analysis_worker_main import (
     AnalysisWorkerConfigurationError,
     _configure_report_data_sources,
     _configure_report_model,
+    _configure_report_parallelism,
     _report_public_base_url,
     _start_llm_runtime,
     _stop_llm_runtime,
@@ -266,18 +267,35 @@ def test_legacy_report_source_order_gains_recent_flow_fallback():
     assert _configure_report_data_sources(environ) == "fdr,naver,krx"
 
 
-def test_kakao_reports_default_to_luna_with_high_reasoning():
+def test_kakao_reports_default_to_luna_with_medium_reasoning():
     environ = {}
 
-    assert _configure_report_model(environ) == ("gpt-5.6-luna", "high")
+    assert _configure_report_model(environ) == ("gpt-5.6-luna", "medium")
     assert environ["REPORT_MODEL"] == "gpt-5.6-luna"
-    assert environ["REPORT_EFFORT"] == "high"
+    assert environ["REPORT_EFFORT"] == "medium"
 
 
 def test_explicit_report_model_configuration_wins_over_kakao_default():
     environ = {"REPORT_MODEL": "custom-model", "REPORT_EFFORT": "medium"}
 
     assert _configure_report_model(environ) == ("custom-model", "medium")
+
+
+def test_kakao_reports_default_to_three_way_parallelism():
+    environ = {}
+
+    assert _configure_report_parallelism(environ) == ("true", "3")
+    assert environ["PRISM_PARALLEL_REPORT"] == "true"
+    assert environ["PRISM_PARALLEL_REPORT_MAX_CONCURRENCY"] == "3"
+
+
+def test_explicit_report_parallelism_wins_over_kakao_default():
+    environ = {
+        "PRISM_PARALLEL_REPORT": "false",
+        "PRISM_PARALLEL_REPORT_MAX_CONCURRENCY": "2",
+    }
+
+    assert _configure_report_parallelism(environ) == ("false", "2")
 
 
 @pytest.mark.asyncio

--- a/tests/test_report_parallelism.py
+++ b/tests/test_report_parallelism.py
@@ -1,0 +1,22 @@
+from cores.analysis import _report_parallel_limit
+
+
+def test_parallel_report_limit_defaults_to_all_sections():
+    assert _report_parallel_limit(6, {}) == 6
+
+
+def test_parallel_report_limit_honors_configured_bound():
+    environ = {"PRISM_PARALLEL_REPORT_MAX_CONCURRENCY": "3"}
+
+    assert _report_parallel_limit(6, environ) == 3
+
+
+def test_parallel_report_limit_is_clamped_to_safe_range():
+    assert _report_parallel_limit(6, {"PRISM_PARALLEL_REPORT_MAX_CONCURRENCY": "0"}) == 1
+    assert _report_parallel_limit(6, {"PRISM_PARALLEL_REPORT_MAX_CONCURRENCY": "20"}) == 6
+
+
+def test_invalid_parallel_report_limit_preserves_legacy_behavior():
+    environ = {"PRISM_PARALLEL_REPORT_MAX_CONCURRENCY": "invalid"}
+
+    assert _report_parallel_limit(6, environ) == 6


### PR DESCRIPTION
## 변경 사항
- 카카오 정식 리포트를 `gpt-5.6-luna` + `medium`으로 조정
- 카카오 기본 분석 섹션을 최대 3개씩 병렬 실행
- 기존 전역 병렬 모드는 설정이 없으면 종전처럼 전체 병렬 유지
- 운영자가 명시한 모델·추론·병렬 설정은 우선 유지
- 투자전략과 최종 요약은 기존처럼 순차 실행

## 배경
현대차 리포트에서 6개 기본 섹션 순차 실행이 약 12분 40초를 차지했고 전체 생성은 약 14분이었습니다.

## 검증
- 관련 테스트 26개 통과
- 변경 파일 Ruff 통과
- core E9/F 검사 통과
- py_compile 통과
- git diff --check 통과