### PR TITLE
fix(kakao): parse report requests and reject failed cache

### DIFF
--- a/kakao_bot/application/command_parser.py
+++ b/kakao_bot/application/command_parser.py
@@ -29,6 +29,17 @@ _NUMERIC = re.compile(r"^\d+(?:[.,]\d+)?$")
 # Marks that make a token part of a sentence rather than a name on its own.
 _SENTENCE_MARK = re.compile(r"[?？!！.,、。]")
 _PERIOD = re.compile(r"^(\d+)\s*(?:개월|달|months?|m)?$", re.IGNORECASE)
+_REPORT_REQUEST_SUFFIXES = frozenset(
+    {
+        "써줘",
+        "작성해줘",
+        "만들어줘",
+        "해주세요",
+        "해줘",
+        "부탁해",
+        "부탁해요",
+    }
+)
 
 
 class CommandKind(Enum):
@@ -134,12 +145,24 @@ def parse_command(utterance: str) -> ParsedCommand:
     if kind is CommandKind.EVALUATE:
         return _parse_evaluate(market, rest)
 
+    if kind is CommandKind.REPORT:
+        rest = _strip_report_request_suffixes(rest)
+
     query = " ".join(rest).strip() or None
     return ParsedCommand(
         kind=kind,
         query=query,
         market=market or _infer_market(query),
     )
+
+
+def _strip_report_request_suffixes(tokens: list[str]) -> list[str]:
+    """Drop polite request words that are not part of a stock name."""
+
+    result = list(tokens)
+    while result and result[-1].strip().lower() in _REPORT_REQUEST_SUFFIXES:
+        result.pop()
+    return result
 
 
 def _take_keyword(

--- a/report_generator.py
+++ b/report_generator.py
@@ -32,6 +32,17 @@ TELEGRAM_ANALYSIS_EFFORT = os.environ.get(
 
 _telegram_backend = None
 
+_FAILED_REPORT_MARKERS = ("analysis failed", "분석 실패")
+_MAX_CACHEABLE_FAILURE_MARKERS = 2
+
+
+def _is_cacheable_report(content: str) -> bool:
+    """Reject generated artifacts whose analysis mostly failed."""
+
+    normalized = content.casefold()
+    failure_count = sum(normalized.count(marker) for marker in _FAILED_REPORT_MARKERS)
+    return bool(content.strip()) and failure_count <= _MAX_CACHEABLE_FAILURE_MARKERS
+
 
 def _get_telegram_backend():
     """Lazily configure the shared SDK backend for Telegram analysis calls."""
@@ -114,6 +125,10 @@ def get_cached_us_report(ticker: str) -> tuple:
 
     with open(latest_file, "r", encoding="utf-8") as f:
         content = f.read()
+
+    if not _is_cacheable_report(content):
+        logger.warning("Ignoring failed cached US report: %s", latest_file)
+        return False, "", None, None
 
     # Generate PDF if it doesn't exist
     if not pdf_file:
@@ -352,6 +367,10 @@ def get_cached_report(stock_code: str) -> tuple:
 
     with open(latest_file, "r", encoding="utf-8") as f:
         content = f.read()
+
+    if not _is_cacheable_report(content):
+        logger.warning("Ignoring failed cached report: %s", latest_file)
+        return False, "", None, None
 
     # Generate PDF if it doesn't exist
     if not pdf_file:

--- a/tests/test_kakao_command_parser.py
+++ b/tests/test_kakao_command_parser.py
@@ -32,6 +32,21 @@ def test_report_parses_regardless_of_word_order_or_mention(utterance):
     assert command.market is None, "한글 종목명의 시장은 resolver가 정한다"
 
 
+@pytest.mark.parametrize(
+    "utterance",
+    [
+        "@프리즘인사이트테스트 카카오 리포트 써줘",
+        "카카오 리포트 작성해줘",
+        "리포트 카카오 만들어줘",
+    ],
+)
+def test_report_request_suffix_is_not_part_of_stock_name(utterance):
+    command = parse_command(utterance)
+
+    assert command.kind is CommandKind.REPORT
+    assert command.query == "카카오"
+
+
 def test_six_digit_code_is_recognized_as_kr():
     command = parse_command("리포트 005930")
 

--- a/tests/test_report_cache_quality.py
+++ b/tests/test_report_cache_quality.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import report_generator
+
+
+def _configure_cache_dirs(monkeypatch, tmp_path: Path) -> tuple[Path, Path]:
+    reports = tmp_path / "reports"
+    pdf_reports = tmp_path / "pdf_reports"
+    reports.mkdir()
+    pdf_reports.mkdir()
+    monkeypatch.setattr(report_generator, "REPORTS_DIR", reports)
+    monkeypatch.setattr(report_generator, "PDF_REPORTS_DIR", pdf_reports)
+    return reports, pdf_reports
+
+
+def test_failed_report_is_not_reused_as_cache(monkeypatch, tmp_path):
+    reports, pdf_reports = _configure_cache_dirs(monkeypatch, tmp_path)
+    (reports / "035720_카카오_20260806_analysis.md").write_text(
+        "# 카카오 분석 보고서\n"
+        "Analysis failed: price_volume_analysis\n"
+        "Analysis failed: company_status\n"
+        "Analysis failed: news_analysis",
+        encoding="utf-8",
+    )
+    (pdf_reports / "035720_카카오_20260806_analysis.pdf").write_bytes(b"bad")
+
+    assert report_generator.get_cached_report("035720") == (
+        False,
+        "",
+        None,
+        None,
+    )
+
+
+def test_successful_report_remains_cacheable(monkeypatch, tmp_path):
+    reports, pdf_reports = _configure_cache_dirs(monkeypatch, tmp_path)
+    markdown_path = reports / "035720_카카오_20260806_analysis.md"
+    pdf_path = pdf_reports / "035720_카카오_20260806_analysis.pdf"
+    markdown_path.write_text("# 카카오 분석 보고서\n\n정상 분석 내용", encoding="utf-8")
+    pdf_path.write_bytes(b"pdf")
+
+    is_cached, content, cached_markdown, cached_pdf = (
+        report_generator.get_cached_report("035720")
+    )
+
+    assert is_cached is True
+    assert content == "# 카카오 분석 보고서\n\n정상 분석 내용"
+    assert cached_markdown == markdown_path
+    assert cached_pdf == pdf_path


### PR DESCRIPTION
## 원인
1. `카카오 리포트 써줘`에서 `써줘`까지 종목명으로 전달됨
2. 모든 분석 섹션이 실패한 과거 리포트가 24시간 캐시로 재사용됨

## 변경 사항
- 리포트 요청형 접미사(`써줘`, `작성해줘`, `만들어줘` 등) 제거
- 실패 마커가 3개 이상인 국내·미국 리포트는 캐시에서 제외
- 실패 캐시 발견 시 신규 리포트 생성

## 검증
- 관련 테스트 67개 통과
- 변경 파서·테스트 Ruff 통과
- 레거시 report_generator E9/F 검사 통과
- py_compile 및 git diff --check 통과