### PR TITLE
fix: reduce DB afternoon batch latency

### DIFF
--- a/stock_analysis_orchestrator.py
+++ b/stock_analysis_orchestrator.py
@@ -54,6 +54,21 @@ PDF_REPORTS_DIR.mkdir(exist_ok=True)
 (TELEGRAM_MSGS_DIR / "sent").mkdir(exist_ok=True)
 
 
+def _batch_report_parallel_limit(job_count: int, environ=None) -> int:
+    """Return a safe report-level concurrency for scheduled batch runs."""
+    if job_count <= 0:
+        return 1
+
+    environ = os.environ if environ is None else environ
+    raw_limit = environ.get("PRISM_BATCH_REPORT_MAX_CONCURRENCY", "3")
+    try:
+        configured = int(raw_limit)
+    except (TypeError, ValueError):
+        configured = 3
+
+    return min(job_count, max(1, configured))
+
+
 class StockAnalysisOrchestrator:
     """Stock Analysis and Telegram Transmission Orchestrator"""
 
@@ -1243,8 +1258,7 @@ class StockAnalysisOrchestrator:
 
     async def generate_reports(self, tickers, mode, timeout: int = None, language: str = "ko", macro_context: dict = None) -> list:
         """
-        Generate reports serially for all stocks.
-        Process one stock at a time to prevent OpenAI rate limit issues.
+        Generate reports concurrently with a bounded report-level limit.
 
         Args:
             tickers: List of stocks to analyze
@@ -1256,12 +1270,14 @@ class StockAnalysisOrchestrator:
             list: List of successful report paths
         """
 
-        logger.info(f"Starting report generation for {len(tickers)} stocks (serial processing)")
+        concurrency = _batch_report_parallel_limit(len(tickers))
+        logger.info(
+            f"Starting report generation for {len(tickers)} stocks "
+            f"(bounded parallelism={concurrency})"
+        )
+        semaphore = asyncio.Semaphore(concurrency)
 
-        successful_reports = []
-
-        # Process each stock sequentially
-        for idx, ticker_info in enumerate(tickers, 1):
+        async def generate_one(idx, ticker_info):
             # If ticker_info is a dict
             if isinstance(ticker_info, dict):
                 ticker = ticker_info.get('code')
@@ -1281,22 +1297,22 @@ class StockAnalysisOrchestrator:
                 # Import function directly from main.py
                 from cores.main import analyze_stock
 
-                # Use await directly since already in async environment
-                logger.info(f"[{idx}/{len(tickers)}] Starting analyze_stock function call")
-                report = await analyze_stock(
-                    company_code=ticker,
-                    company_name=company_name,
-                    reference_date=reference_date,
-                    language=language,
-                    macro_context=macro_context
-                )
+                async with semaphore:
+                    logger.info(f"[{idx}/{len(tickers)}] Starting analyze_stock function call")
+                    report = await analyze_stock(
+                        company_code=ticker,
+                        company_name=company_name,
+                        reference_date=reference_date,
+                        language=language,
+                        macro_context=macro_context
+                    )
 
                 # Save result
                 if report and len(report.strip()) > 0:
                     with open(output_file, "w", encoding="utf-8") as f:
                         f.write(report)
                     logger.info(f"[{idx}/{len(tickers)}] Report generation complete: {company_name}({ticker}) - {len(report)} characters")
-                    successful_reports.append(output_file)
+                    return output_file
                 else:
                     logger.error(f"[{idx}/{len(tickers)}] Report generation failed: {company_name}({ticker}) - empty content")
 
@@ -1305,7 +1321,12 @@ class StockAnalysisOrchestrator:
                 import traceback
                 logger.error(traceback.format_exc())
 
+            return None
 
+        results = await asyncio.gather(
+            *(generate_one(idx, ticker_info) for idx, ticker_info in enumerate(tickers, 1))
+        )
+        successful_reports = [report_path for report_path in results if report_path]
         logger.info(f"Report generation complete: {len(successful_reports)}/{len(tickers)} successful")
 
         return successful_reports

--- a/tests/test_batch_report_parallelism.py
+++ b/tests/test_batch_report_parallelism.py
@@ -1,0 +1,63 @@
+import asyncio
+import sys
+from types import ModuleType
+
+import stock_analysis_orchestrator as orchestrator_module
+from stock_analysis_orchestrator import (
+    StockAnalysisOrchestrator,
+    _batch_report_parallel_limit,
+)
+
+
+def test_batch_report_parallel_limit_defaults_to_three():
+    assert _batch_report_parallel_limit(5, {}) == 3
+    assert _batch_report_parallel_limit(2, {}) == 2
+
+
+def test_batch_report_parallel_limit_honors_and_sanitizes_environment():
+    key = "PRISM_BATCH_REPORT_MAX_CONCURRENCY"
+
+    assert _batch_report_parallel_limit(5, {key: "2"}) == 2
+    assert _batch_report_parallel_limit(5, {key: "0"}) == 1
+    assert _batch_report_parallel_limit(5, {key: "99"}) == 5
+    assert _batch_report_parallel_limit(5, {key: "invalid"}) == 3
+
+
+def test_generate_reports_runs_with_bounded_parallelism_and_keeps_input_order(
+    monkeypatch, tmp_path
+):
+    active = 0
+    max_active = 0
+
+    async def fake_analyze_stock(company_code, **_kwargs):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep({"001": 0.03, "002": 0.02, "003": 0.01}[company_code])
+        active -= 1
+        return f"report-{company_code}"
+
+    fake_cores_main = ModuleType("cores.main")
+    fake_cores_main.analyze_stock = fake_analyze_stock
+    monkeypatch.setitem(sys.modules, "cores.main", fake_cores_main)
+    monkeypatch.setattr(orchestrator_module, "REPORTS_DIR", tmp_path)
+    monkeypatch.setenv("PRISM_BATCH_REPORT_MAX_CONCURRENCY", "2")
+
+    orchestrator = StockAnalysisOrchestrator.__new__(StockAnalysisOrchestrator)
+    reports = asyncio.run(
+        orchestrator.generate_reports(
+            [
+                {"code": "001", "name": "첫째"},
+                {"code": "002", "name": "둘째"},
+                {"code": "003", "name": "셋째"},
+            ],
+            "afternoon",
+        )
+    )
+
+    assert max_active == 2
+    assert [path.split("/")[-1].split("_")[0] for path in reports] == [
+        "001",
+        "002",
+        "003",
+    ]


### PR DESCRIPTION
## 변경 사항
- KR 정규 배치의 종목별 보고서 생성을 최대 3개 제한 병렬로 전환
- `PRISM_BATCH_REPORT_MAX_CONCURRENCY`로 운영 병렬도 조정 가능
- 실패 격리와 입력 순서 보존 회귀 테스트 추가

## 원인
8월 6일 오후 배치는 3개 보고서를 직렬 생성하느라 35분 38초가 소요되어 카카오 캠페인이 배치 시작 44분 뒤에 발송됐습니다.

## 검증
- `pytest -q tests/test_batch_report_parallelism.py tests/test_batch_campaign_publisher.py` (18 passed)
- `python3 -m py_compile stock_analysis_orchestrator.py`
- `git diff --check`