### PR TITLE
fix: 리포트 캐시를 KST 날짜 단위로 제한

### DIFF
--- a/report_generator.py
+++ b/report_generator.py
@@ -11,6 +11,7 @@ import sys
 from datetime import date, datetime
 from pathlib import Path
 from typing import Optional
+from zoneinfo import ZoneInfo
 
 import markdown
 
@@ -34,6 +35,16 @@ _telegram_backend = None
 
 _FAILED_REPORT_MARKERS = ("analysis failed", "분석 실패")
 _MAX_CACHEABLE_FAILURE_MARKERS = 2
+_KST = ZoneInfo("Asia/Seoul")
+
+
+def _now_kst() -> datetime:
+    return datetime.now(_KST)
+
+
+def _is_current_kst_day(path: Path) -> bool:
+    modified_at = datetime.fromtimestamp(path.stat().st_mtime, tz=_KST)
+    return modified_at.date() == _now_kst().date()
 
 
 def _is_cacheable_report(content: str) -> bool:
@@ -112,9 +123,8 @@ def get_cached_us_report(ticker: str) -> tuple:
     # Sort by latest
     latest_file = max(report_files, key=lambda p: p.stat().st_mtime)
 
-    # Check if file was created within 24 hours
-    file_age = datetime.now() - datetime.fromtimestamp(latest_file.stat().st_mtime)
-    if file_age.days >= 1:  # Don't use files older than 24 hours as cache
+    # Cache is valid only for the same KST calendar date.
+    if not _is_current_kst_day(latest_file):
         return False, "", None, None
 
     # Check if corresponding PDF file exists
@@ -354,9 +364,8 @@ def get_cached_report(stock_code: str) -> tuple:
     # Sort by latest
     latest_file = max(report_files, key=lambda p: p.stat().st_mtime)
 
-    # Check if file was created within 24 hours
-    file_age = datetime.now() - datetime.fromtimestamp(latest_file.stat().st_mtime)
-    if file_age.days >= 1:  # Don't use files older than 24 hours as cache
+    # Cache is valid only for the same KST calendar date.
+    if not _is_current_kst_day(latest_file):
         return False, "", None, None
 
     # Check if corresponding PDF file exists

--- a/tests/test_report_cache_quality.py
+++ b/tests/test_report_cache_quality.py
@@ -1,6 +1,13 @@
+import os
+from datetime import datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
+import pytest
 import report_generator
+
+
+KST = ZoneInfo("Asia/Seoul")
 
 
 def _configure_cache_dirs(monkeypatch, tmp_path: Path) -> tuple[Path, Path]:
@@ -11,6 +18,75 @@ def _configure_cache_dirs(monkeypatch, tmp_path: Path) -> tuple[Path, Path]:
     monkeypatch.setattr(report_generator, "REPORTS_DIR", reports)
     monkeypatch.setattr(report_generator, "PDF_REPORTS_DIR", pdf_reports)
     return reports, pdf_reports
+
+
+def _configure_us_cache_dirs(monkeypatch, tmp_path: Path) -> tuple[Path, Path]:
+    reports = tmp_path / "us_reports"
+    pdf_reports = tmp_path / "us_pdf_reports"
+    reports.mkdir()
+    pdf_reports.mkdir()
+    monkeypatch.setattr(report_generator, "US_REPORTS_DIR", reports)
+    monkeypatch.setattr(report_generator, "US_PDF_REPORTS_DIR", pdf_reports)
+    return reports, pdf_reports
+
+
+@pytest.mark.parametrize("market", ["kr", "us"])
+def test_cache_expires_at_kst_calendar_day_boundary(monkeypatch, tmp_path, market):
+    if market == "kr":
+        reports, pdf_reports = _configure_cache_dirs(monkeypatch, tmp_path)
+        markdown_path = reports / "035720_카카오_20260806_analysis.md"
+        pdf_path = pdf_reports / "035720_카카오_20260806_analysis.pdf"
+        get_cached = lambda: report_generator.get_cached_report("035720")
+    else:
+        reports, pdf_reports = _configure_us_cache_dirs(monkeypatch, tmp_path)
+        markdown_path = reports / "IONQ_IonQ_20260806_analysis.md"
+        pdf_path = pdf_reports / "IONQ_IonQ_20260806_analysis.pdf"
+        get_cached = lambda: report_generator.get_cached_us_report("IONQ")
+
+    markdown_path.write_text("# 정상 분석 보고서", encoding="utf-8")
+    pdf_path.write_bytes(b"pdf")
+    created_at = datetime(2026, 8, 6, 23, 55, tzinfo=KST)
+    os.utime(markdown_path, (created_at.timestamp(), created_at.timestamp()))
+    monkeypatch.setattr(
+        report_generator,
+        "_now_kst",
+        lambda: datetime(2026, 8, 7, 0, 5, tzinfo=KST),
+    )
+
+    assert get_cached() == (False, "", None, None)
+
+
+@pytest.mark.parametrize("market", ["kr", "us"])
+def test_cache_remains_valid_through_same_kst_calendar_day(
+    monkeypatch, tmp_path, market
+):
+    if market == "kr":
+        reports, pdf_reports = _configure_cache_dirs(monkeypatch, tmp_path)
+        markdown_path = reports / "035720_카카오_20260807_analysis.md"
+        pdf_path = pdf_reports / "035720_카카오_20260807_analysis.pdf"
+        get_cached = lambda: report_generator.get_cached_report("035720")
+    else:
+        reports, pdf_reports = _configure_us_cache_dirs(monkeypatch, tmp_path)
+        markdown_path = reports / "IONQ_IonQ_20260807_analysis.md"
+        pdf_path = pdf_reports / "IONQ_IonQ_20260807_analysis.pdf"
+        get_cached = lambda: report_generator.get_cached_us_report("IONQ")
+
+    markdown_path.write_text("# 정상 분석 보고서", encoding="utf-8")
+    pdf_path.write_bytes(b"pdf")
+    created_at = datetime(2026, 8, 7, 0, 1, tzinfo=KST)
+    os.utime(markdown_path, (created_at.timestamp(), created_at.timestamp()))
+    monkeypatch.setattr(
+        report_generator,
+        "_now_kst",
+        lambda: datetime(2026, 8, 7, 23, 59, tzinfo=KST),
+    )
+
+    is_cached, content, cached_markdown, cached_pdf = get_cached()
+
+    assert is_cached is True
+    assert content == "# 정상 분석 보고서"
+    assert cached_markdown == markdown_path
+    assert cached_pdf == pdf_path
 
 
 def test_failed_report_is_not_reused_as_cache(monkeypatch, tmp_path):


### PR DESCRIPTION
## 변경 사항
- KR/US 리포트 캐시의 rolling 24시간 판정을 제거
- 파일 수정 시각과 현재 시각의 Asia/Seoul 달력 날짜가 같을 때만 캐시 재사용
- 자정 직후 만료 및 같은 날짜 종일 유지 경계 테스트 추가

## 검증
- `.venv/bin/python -m pytest -q tests/test_report_cache_quality.py tests/test_kakao_analysis_worker.py tests/test_telegram_report_routing.py` (27 passed)
- `.venv/bin/python -m py_compile report_generator.py`
- `git diff --check`