### PR TITLE
feat: automate Kakao batch story delivery

### DIFF
--- a/kakao_bot/adapters/kakao/campaign_renderer.py
+++ b/kakao_bot/adapters/kakao/campaign_renderer.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 
-from kakao_bot.adapters.kakao.skill_response import MAX_SIMPLE_TEXT_LENGTH, simple_text
+from kakao_bot.adapters.kakao.skill_response import (
+    MAX_SIMPLE_TEXT_LENGTH,
+    list_card_output,
+    simple_text,
+    simple_text_output,
+    skill_response,
+)
 from kakao_bot.domain.models import ClaimedOutboundDelivery
 
 _MARKET_LABELS = {
@@ -24,6 +30,12 @@ def render_campaign_delivery(
         return _signal_campaign(delivery.payload)
     if delivery.message_type == "campaign_rest_notice":
         return _rest_notice(delivery.payload)
+    if delivery.message_type == "campaign_report":
+        return _report(delivery.payload)
+    if delivery.message_type == "campaign_decision":
+        return _story_text(delivery.payload, "🧭 프리즘봇 가상운용 판단")
+    if delivery.message_type == "campaign_portfolio":
+        return _story_text(delivery.payload, "📊 배치 종료 후 가격 기준 포트폴리오")
     raise ValueError(f"unsupported Kakao delivery type: {delivery.message_type}")
 
 
@@ -63,8 +75,7 @@ def _signal_campaign(payload: Mapping[str, object]) -> dict[str, object]:
     else:
         body = (
             f"🔔 {market[0]} {market[1]} {session} 프리즘 시그널\n"
-            f"📅 {trade_date} 포착된 관심종목\n\n"
-            + "\n\n".join(fallback_lines)
+            f"📅 {trade_date} 포착된 관심종목\n\n" + "\n\n".join(fallback_lines)
         )
 
     disclosure = (
@@ -91,6 +102,64 @@ def _rest_notice(payload: Mapping[str, object]) -> dict[str, object]:
             f"사유: {reason_text}"
         )
     )
+
+
+def _report(payload: Mapping[str, object]) -> dict[str, object]:
+    ticker = _required_text(payload, "ticker")
+    company_name = _required_text(payload, "company_name")
+    message = _required_text(payload, "message")
+    text = f"📄 {company_name} ({ticker}) 리포트\n\n{message}"
+    outputs: list[dict[str, object]] = [
+        simple_text_output(text[:MAX_SIMPLE_TEXT_LENGTH])
+    ]
+    pdf_url = payload.get("pdf_url")
+    if isinstance(pdf_url, str) and pdf_url.strip():
+        outputs.append(
+            list_card_output(
+                header_title="전체 리포트",
+                items=[
+                    {
+                        "title": f"{company_name} PDF 준비 완료",
+                        "description": "아래 버튼으로 만료 전 원문 리포트를 열어보세요",
+                    }
+                ],
+                buttons=[
+                    {
+                        "action": "webLink",
+                        "label": "📄 전체 리포트",
+                        "webLinkUrl": pdf_url.strip(),
+                    }
+                ],
+            )
+        )
+    return skill_response(outputs)
+
+
+def _story_text(payload: Mapping[str, object], heading: str) -> dict[str, object]:
+    message = _required_text(payload, "message")
+    # The source messages still say "실시간" for historical Telegram reasons.
+    # Kakao receives a post-batch snapshot, not a streaming quote surface.
+    if heading.startswith("📊"):
+        message = message.replace(
+            "실시간 포트폴리오", "배치 종료 후 가격 기준 포트폴리오"
+        )
+    body = f"{heading}\n\n{message}"
+    disclosure = "🤖 AI 모의운용 과정 공개이며 실제 매수·매도 권유가 아닙니다."
+    if "실제 매수" not in body and "실제 매매" not in body:
+        body = f"{body}\n\n{disclosure}"
+    chunks = []
+    remaining = body
+    while remaining and len(chunks) < 3:
+        chunk = remaining[:MAX_SIMPLE_TEXT_LENGTH]
+        if len(remaining) > MAX_SIMPLE_TEXT_LENGTH and "\n" in chunk:
+            split_at = chunk.rfind("\n")
+            if split_at >= MAX_SIMPLE_TEXT_LENGTH // 2:
+                chunk = chunk[:split_at]
+        chunks.append(chunk)
+        remaining = remaining[len(chunk) :].lstrip("\n")
+    if remaining:
+        chunks[-1] = chunks[-1][:-1].rstrip() + "…"
+    return skill_response([simple_text_output(chunk) for chunk in chunks])
 
 
 def _slot_labels(

--- a/kakao_bot/adapters/kakao/delivery_renderer.py
+++ b/kakao_bot/adapters/kakao/delivery_renderer.py
@@ -25,7 +25,15 @@ from kakao_bot.adapters.kakao.welcome_renderer import (
 )
 from kakao_bot.domain.models import ClaimedOutboundDelivery
 
-CAMPAIGN_TYPES = frozenset({"signal_campaign", "campaign_rest_notice"})
+CAMPAIGN_TYPES = frozenset(
+    {
+        "signal_campaign",
+        "campaign_rest_notice",
+        "campaign_report",
+        "campaign_decision",
+        "campaign_portfolio",
+    }
+)
 REPORT_TYPES = frozenset(
     {
         ANALYSIS_RESULT,

--- a/kakao_bot/adapters/local_campaign_consumer.py
+++ b/kakao_bot/adapters/local_campaign_consumer.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
 from kakao_bot.adapters.prism.batch_campaign_mapper import (
     BatchCampaignPayloadError,
+    is_batch_story_payload,
     map_batch_campaign_payload,
+    map_batch_story_payload,
 )
 from kakao_bot.application.batch_campaign_service import BatchCampaignService
+from kakao_bot.application.batch_story_service import BatchStoryService
 from kakao_bot.ports.repositories import KakaoRepository
 from messaging.local_campaign_queue import SQLiteBatchCampaignQueue
 
@@ -85,7 +89,16 @@ class LocalBatchCampaignConsumer:
                 stale_lease += int(not marked)
                 continue
             try:
-                campaign = map_batch_campaign_payload(entry.payload)
+                story = (
+                    map_batch_story_payload(entry.payload)
+                    if is_batch_story_payload(entry.payload)
+                    else None
+                )
+                campaign = (
+                    None
+                    if story is not None
+                    else map_batch_campaign_payload(entry.payload)
+                )
             except (BatchCampaignPayloadError, TypeError, ValueError) as exc:
                 marked = self._queue.mark_dead(
                     entry.queue_id,
@@ -99,7 +112,23 @@ class LocalBatchCampaignConsumer:
             repository: KakaoRepository | None = None
             try:
                 repository = self._repository_factory()
-                result = self._service_factory(repository).ingest_and_plan(campaign)
+                if story is not None:
+                    result = BatchStoryService(
+                        repository,
+                        public_base_url=(
+                            os.getenv("KAKAO_BOT_PUBLIC_BASE_URL")
+                            or os.getenv("KAKAO_PUBLIC_BASE_URL")
+                        ),
+                        link_ttl_hours=int(
+                            os.getenv("KAKAO_REPORT_LINK_TTL_HOURS", "72")
+                        ),
+                    ).ingest_and_plan(story)
+                    log_id = story.event_id
+                    campaign_created = None
+                else:
+                    result = self._service_factory(repository).ingest_and_plan(campaign)
+                    log_id = campaign.campaign_id
+                    campaign_created = result.campaign_created
                 marked = self._queue.acknowledge(
                     entry.queue_id,
                     lease_owner=self._lease_owner,
@@ -109,14 +138,14 @@ class LocalBatchCampaignConsumer:
                 stale_lease += int(not marked)
                 logger.info(
                     "Consumed local campaign %s (created=%s, deliveries=%s)",
-                    campaign.campaign_id,
-                    result.campaign_created,
+                    log_id,
+                    campaign_created,
                     result.deliveries_created,
                 )
             except Exception as exc:
                 logger.exception(
                     "Local campaign ingestion failed for %s",
-                    campaign.campaign_id,
+                    entry.campaign_id,
                 )
                 marked = self._queue.release(
                     entry.queue_id,

--- a/kakao_bot/adapters/prism/batch_campaign_mapper.py
+++ b/kakao_bot/adapters/prism/batch_campaign_mapper.py
@@ -8,6 +8,8 @@ from datetime import date, datetime, timezone
 
 from kakao_bot.domain.models import (
     BatchCampaign,
+    BatchStoryEvent,
+    BatchStoryKind,
     CampaignCandidate,
     CampaignStatus,
     Market,
@@ -15,9 +17,59 @@ from kakao_bot.domain.models import (
     Session,
 )
 
+_STORY_TYPES = {
+    "BATCH_CAMPAIGN_REPORT_READY": BatchStoryKind.REPORT,
+    "BATCH_CAMPAIGN_DECISION_READY": BatchStoryKind.DECISION,
+    "BATCH_CAMPAIGN_PORTFOLIO_SNAPSHOT": BatchStoryKind.PORTFOLIO,
+}
+
 
 class BatchCampaignPayloadError(ValueError):
     """Raised when a producer payload violates the batch campaign v1 contract."""
+
+
+def is_batch_story_payload(payload: Mapping[str, object]) -> bool:
+    return payload.get("event_type") in _STORY_TYPES
+
+
+def map_batch_story_payload(payload: Mapping[str, object]) -> BatchStoryEvent:
+    if not isinstance(payload, Mapping):
+        raise BatchCampaignPayloadError("payload must be a mapping")
+    if (
+        type(payload.get("schema_version")) is not int
+        or payload.get("schema_version") != 1
+    ):
+        raise BatchCampaignPayloadError("schema_version must be integer 1")
+    event_type = _required_string(payload, "event_type")
+    try:
+        kind = _STORY_TYPES[event_type]
+    except KeyError as exc:
+        raise BatchCampaignPayloadError(
+            f"unsupported batch story event_type: {event_type}"
+        ) from exc
+
+    market = _parse_enum(payload, "market", Market)
+    session = _parse_enum(payload, "session", Session)
+    regime = _parse_enum(payload, "regime", Regime)
+    common = {
+        "event_id": _required_string(payload, "event_id"),
+        "campaign_id": _required_string(payload, "campaign_id"),
+        "market": market,
+        "session": session,
+        "trade_date": _parse_trade_date(payload.get("trade_date")),
+        "regime": regime,
+        "kind": kind,
+        "message": _required_string(payload, "message"),
+        "created_at": _parse_occurred_at(payload.get("occurred_at")),
+    }
+    if kind is BatchStoryKind.REPORT:
+        return BatchStoryEvent(
+            **common,
+            ticker=_required_string(payload, "ticker"),
+            company_name=_required_string(payload, "company_name"),
+            artifact_path=_required_string(payload, "artifact_path"),
+        )
+    return BatchStoryEvent(**common)
 
 
 def map_batch_campaign_payload(payload: Mapping[str, object]) -> BatchCampaign:
@@ -44,9 +96,7 @@ def map_batch_campaign_payload(payload: Mapping[str, object]) -> BatchCampaign:
         CampaignStatus.COMPLETED,
         CampaignStatus.SKIPPED,
     ):
-        raise BatchCampaignPayloadError(
-            f"unsupported campaign status: {status_text}"
-        )
+        raise BatchCampaignPayloadError(f"unsupported campaign status: {status_text}")
 
     event_type = _required_string(payload, "event_type")
     expected_event_type = f"BATCH_CAMPAIGN_{status.value}"
@@ -105,9 +155,7 @@ def _optional_string(payload: Mapping[str, object], field: str) -> str | None:
     if value is None:
         return None
     if not isinstance(value, str) or not value.strip():
-        raise BatchCampaignPayloadError(
-            f"{field} must be a non-empty string or null"
-        )
+        raise BatchCampaignPayloadError(f"{field} must be a non-empty string or null")
     return value.strip()
 
 

--- a/kakao_bot/application/batch_story_service.py
+++ b/kakao_bot/application/batch_story_service.py
@@ -1,0 +1,85 @@
+"""Plan the post-screening report, decision, and portfolio story."""
+
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass
+from datetime import timedelta, timezone
+
+from kakao_bot.domain.models import BatchStoryEvent, BatchStoryKind, OutboundDelivery
+from kakao_bot.ports.repositories import KakaoRepository
+
+_TOKEN_BYTES = 24
+
+
+@dataclass(frozen=True)
+class BatchStoryPlanResult:
+    deliveries_created: int
+
+
+class BatchStoryService:
+    def __init__(
+        self,
+        repository: KakaoRepository,
+        *,
+        public_base_url: str | None = None,
+        link_ttl_hours: int = 72,
+        delivery_ttl_hours: int = 24,
+    ) -> None:
+        self._repository = repository
+        self._public_base_url = (public_base_url or "").rstrip("/")
+        self._link_ttl = timedelta(hours=link_ttl_hours)
+        self._delivery_ttl = timedelta(hours=delivery_ttl_hours)
+
+    def ingest_and_plan(self, event: BatchStoryEvent) -> BatchStoryPlanResult:
+        rooms = self._repository.list_delivery_targets(event.market, event.session)
+        created = 0
+        for room_id in rooms:
+            payload: dict[str, object] = {
+                "event_id": event.event_id,
+                "campaign_id": event.campaign_id,
+                "market": event.market.value,
+                "session": event.session.value,
+                "trade_date": event.trade_date.isoformat(),
+                "message": event.message,
+            }
+            message_type = {
+                BatchStoryKind.REPORT: "campaign_report",
+                BatchStoryKind.DECISION: "campaign_decision",
+                BatchStoryKind.PORTFOLIO: "campaign_portfolio",
+            }[event.kind]
+            if event.kind is BatchStoryKind.REPORT:
+                payload.update(
+                    {
+                        "ticker": event.ticker,
+                        "company_name": event.company_name,
+                        "pdf_url": self._mint_link(event, room_id),
+                    }
+                )
+            created += int(
+                self._repository.enqueue_outbound(
+                    OutboundDelivery(
+                        delivery_key=f"story:{event.event_id}:room:{room_id}",
+                        room_id=room_id,
+                        message_type=message_type,
+                        payload=payload,
+                        created_at=event.created_at,
+                        expires_at=event.created_at + self._delivery_ttl,
+                    )
+                )
+            )
+        return BatchStoryPlanResult(created)
+
+    def _mint_link(self, event: BatchStoryEvent, room_id: str) -> str | None:
+        if not self._public_base_url or not event.artifact_path:
+            return None
+        token = secrets.token_urlsafe(_TOKEN_BYTES)
+        now = event.created_at.astimezone(timezone.utc)
+        self._repository.create_report_link(
+            token,
+            artifact_path=event.artifact_path,
+            room_id=room_id,
+            now=now,
+            expires_at=now + self._link_ttl,
+        )
+        return f"{self._public_base_url}/kakao/reports/{token}"

--- a/kakao_bot/domain/models.py
+++ b/kakao_bot/domain/models.py
@@ -31,6 +31,12 @@ class CampaignStatus(str, Enum):
     SKIPPED = "SKIPPED"
 
 
+class BatchStoryKind(str, Enum):
+    REPORT = "REPORT"
+    DECISION = "DECISION"
+    PORTFOLIO = "PORTFOLIO"
+
+
 class ApprovalStatus(str, Enum):
     PENDING = "PENDING"
     APPROVED = "APPROVED"
@@ -98,6 +104,32 @@ class BatchCampaign:
                 raise ValueError("a skipped campaign requires skip_reason")
         elif self.skip_reason is not None:
             raise ValueError("skip_reason is only valid for skipped campaigns")
+
+
+@dataclass(frozen=True)
+class BatchStoryEvent:
+    event_id: str
+    campaign_id: str
+    market: Market
+    session: Session
+    trade_date: date
+    regime: Regime
+    kind: BatchStoryKind
+    message: str
+    ticker: str | None = None
+    company_name: str | None = None
+    artifact_path: str | None = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def __post_init__(self) -> None:
+        if not self.event_id.strip() or not self.campaign_id.strip():
+            raise ValueError("batch story ids must not be empty")
+        if not self.message.strip():
+            raise ValueError("batch story message must not be empty")
+        if self.kind is BatchStoryKind.REPORT and (
+            not self.ticker or not self.company_name or not self.artifact_path
+        ):
+            raise ValueError("report story requires stock and artifact fields")
 
 
 @dataclass(frozen=True)

--- a/messaging/__init__.py
+++ b/messaging/__init__.py
@@ -13,8 +13,14 @@ if TYPE_CHECKING:
     from messaging.batch_campaign_publisher import (
         BatchCampaignPublisher,
         build_batch_campaign_event,
+        build_batch_decision_event,
+        build_batch_portfolio_event,
+        build_batch_report_event,
         campaign_id_for,
         publish_batch_campaign_best_effort,
+        publish_batch_event_best_effort,
+        publish_batch_reports_best_effort,
+        publish_batch_tracking_story_best_effort,
     )
     from messaging.redis_signal_publisher import (
         SignalPublisher,
@@ -30,8 +36,14 @@ __all__ = [
     "publish_sell_signal",
     "BatchCampaignPublisher",
     "build_batch_campaign_event",
+    "build_batch_decision_event",
+    "build_batch_portfolio_event",
+    "build_batch_report_event",
     "campaign_id_for",
     "publish_batch_campaign_best_effort",
+    "publish_batch_event_best_effort",
+    "publish_batch_reports_best_effort",
+    "publish_batch_tracking_story_best_effort",
 ]
 
 _EXPORT_MODULES = {
@@ -41,8 +53,14 @@ _EXPORT_MODULES = {
     "publish_sell_signal": "messaging.redis_signal_publisher",
     "BatchCampaignPublisher": "messaging.batch_campaign_publisher",
     "build_batch_campaign_event": "messaging.batch_campaign_publisher",
+    "build_batch_decision_event": "messaging.batch_campaign_publisher",
+    "build_batch_portfolio_event": "messaging.batch_campaign_publisher",
+    "build_batch_report_event": "messaging.batch_campaign_publisher",
     "campaign_id_for": "messaging.batch_campaign_publisher",
     "publish_batch_campaign_best_effort": "messaging.batch_campaign_publisher",
+    "publish_batch_event_best_effort": "messaging.batch_campaign_publisher",
+    "publish_batch_reports_best_effort": "messaging.batch_campaign_publisher",
+    "publish_batch_tracking_story_best_effort": "messaging.batch_campaign_publisher",
 }
 
 

--- a/messaging/batch_campaign_publisher.py
+++ b/messaging/batch_campaign_publisher.py
@@ -26,6 +26,9 @@ _VALID_STATUSES = frozenset({COLLECTING, COMPLETED, SKIPPED})
 _VALID_MARKETS = frozenset({"KR", "US"})
 _VALID_SESSIONS = frozenset({"MORNING", "AFTERNOON"})
 _VALID_REGIMES = frozenset({"UNKNOWN", "UPTREND", "UNDER_PRESSURE", "CORRECTION"})
+REPORT_READY = "REPORT_READY"
+DECISION_READY = "DECISION_READY"
+PORTFOLIO_SNAPSHOT = "PORTFOLIO_SNAPSHOT"
 
 
 def _enum_value(value: Any) -> Any:
@@ -191,6 +194,134 @@ def build_batch_campaign_event(
     return event
 
 
+def _story_base(
+    *,
+    market: str,
+    session: str,
+    trade_date: Any,
+    regime: Optional[str],
+    stage: str,
+    occurred_at: Optional[datetime],
+) -> Dict[str, Any]:
+    normalized_market = str(_enum_value(market) or "").strip().upper()
+    normalized_session = str(_enum_value(session) or "").strip().upper()
+    normalized_regime = str(_enum_value(regime) or "UNKNOWN").strip().upper()
+    if normalized_market not in _VALID_MARKETS:
+        raise ValueError(f"unsupported market: {market}")
+    if normalized_session not in _VALID_SESSIONS:
+        raise ValueError(f"unsupported session: {session}")
+    if normalized_regime not in _VALID_REGIMES:
+        raise ValueError(f"unsupported campaign regime: {regime}")
+    normalized_date = _normalized_trade_date(trade_date)
+    campaign_id = campaign_id_for(
+        normalized_market, normalized_session, normalized_date
+    )
+    timestamp = occurred_at or datetime.now(timezone.utc)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "event_type": f"BATCH_CAMPAIGN_{stage}",
+        "campaign_id": campaign_id,
+        "market": normalized_market,
+        "session": normalized_session,
+        "trade_date": normalized_date,
+        "regime": normalized_regime,
+        "occurred_at": timestamp.astimezone(timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z"),
+    }
+
+
+def build_batch_report_event(
+    *,
+    market: str,
+    session: str,
+    trade_date: Any,
+    regime: Optional[str],
+    ticker: str,
+    company_name: str,
+    summary: str,
+    artifact_path: str | Path,
+    occurred_at: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    event = _story_base(
+        market=market,
+        session=session,
+        trade_date=trade_date,
+        regime=regime,
+        stage=REPORT_READY,
+        occurred_at=occurred_at,
+    )
+    normalized_ticker = str(ticker or "").strip().upper()
+    normalized_name = str(company_name or normalized_ticker).strip()
+    normalized_summary = str(summary or "").strip()
+    normalized_path = str(artifact_path or "").strip()
+    if not normalized_ticker or not normalized_name:
+        raise ValueError("report event requires ticker and company_name")
+    if not normalized_summary:
+        raise ValueError("report event requires summary")
+    if not normalized_path.lower().endswith(".pdf"):
+        raise ValueError("report event requires a PDF artifact_path")
+    event.update(
+        {
+            "event_id": f"{event['campaign_id']}:report:{normalized_ticker}",
+            "ticker": normalized_ticker,
+            "company_name": normalized_name,
+            "message": normalized_summary,
+            "artifact_path": normalized_path,
+        }
+    )
+    return event
+
+
+def _build_text_story_event(
+    *,
+    market: str,
+    session: str,
+    trade_date: Any,
+    regime: Optional[str],
+    stage: str,
+    suffix: str,
+    message: str,
+    occurred_at: Optional[datetime],
+) -> Dict[str, Any]:
+    event = _story_base(
+        market=market,
+        session=session,
+        trade_date=trade_date,
+        regime=regime,
+        stage=stage,
+        occurred_at=occurred_at,
+    )
+    normalized_message = str(message or "").strip()
+    if not normalized_message:
+        raise ValueError(f"{suffix} event requires message")
+    event["event_id"] = f"{event['campaign_id']}:{suffix}"
+    event["message"] = normalized_message
+    return event
+
+
+def build_batch_decision_event(
+    *, decision_key: str | None = None, **fields: Any
+) -> Dict[str, Any]:
+    event = _build_text_story_event(**fields, stage=DECISION_READY, suffix="decision")
+    if decision_key is not None:
+        normalized_key = str(decision_key).strip().lower()
+        if not normalized_key or not normalized_key.replace("-", "").isalnum():
+            raise ValueError(
+                "decision_key must contain only letters, numbers, or hyphens"
+            )
+        event["event_id"] = f"{event['campaign_id']}:decision:{normalized_key}"
+    return event
+
+
+def build_batch_portfolio_event(**fields: Any) -> Dict[str, Any]:
+    return _build_text_story_event(
+        **fields, stage=PORTFOLIO_SNAPSHOT, suffix="portfolio"
+    )
+
+
 class BatchCampaignPublisher:
     """Local queue publisher isolated from Kakao and trading-signal transports."""
 
@@ -272,3 +403,129 @@ async def publish_batch_campaign_best_effort(**event_fields: Any) -> Optional[st
     finally:
         if publisher is not None:
             await publisher.disconnect()
+
+
+async def publish_batch_event_best_effort(
+    event: Mapping[str, Any],
+) -> Optional[str]:
+    """Publish an already-built story event without affecting the batch."""
+    publisher: Optional[BatchCampaignPublisher] = None
+    try:
+        publisher = BatchCampaignPublisher()
+        await publisher.connect()
+        return await publisher.publish(event)
+    except Exception as exc:
+        logger.warning("Batch story hook failed (ignored): %s", exc)
+        return None
+    finally:
+        if publisher is not None:
+            await publisher.disconnect()
+
+
+async def publish_batch_reports_best_effort(
+    *,
+    market: str,
+    session: str,
+    trade_date: Any,
+    regime: Optional[str],
+    pdf_paths: Sequence[Any],
+    message_paths: Sequence[Any],
+) -> int:
+    """Publish only PDF reports that have a matching Telegram summary."""
+    summaries: dict[str, tuple[str, str]] = {}
+    for raw_path in message_paths:
+        path = Path(str(raw_path))
+        stem = path.stem.removesuffix("_telegram")
+        if "_" not in stem:
+            continue
+        ticker, company_name = stem.split("_", 1)
+        try:
+            message = path.read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            logger.warning("Could not read campaign summary %s: %s", path, exc)
+            continue
+        if message:
+            summaries[ticker.upper()] = (company_name, message)
+
+    published = 0
+    for raw_path in pdf_paths:
+        path = Path(str(raw_path))
+        parts = path.stem.split("_")
+        ticker = parts[0].upper() if parts else ""
+        matched = summaries.get(ticker)
+        if matched is None or not path.is_file():
+            logger.warning("Skipping Kakao report without complete artifacts: %s", path)
+            continue
+        company_name, message = matched
+        try:
+            event = build_batch_report_event(
+                market=market,
+                session=session,
+                trade_date=trade_date,
+                regime=regime,
+                ticker=ticker,
+                company_name=company_name,
+                summary=message,
+                artifact_path=path.resolve(),
+            )
+        except Exception as exc:
+            logger.warning("Could not build Kakao report event for %s: %s", path, exc)
+            continue
+        published += int(await publish_batch_event_best_effort(event) is not None)
+    return published
+
+
+async def publish_batch_tracking_story_best_effort(
+    *,
+    market: str,
+    session: str,
+    trade_date: Any,
+    regime: Optional[str],
+    messages: Sequence[tuple[Optional[str], str]],
+) -> int:
+    """Publish the tracking agent's actual decision and portfolio messages."""
+    decision_messages = [
+        str(message).strip()
+        for message_type, message in messages
+        if message_type == "analysis" and str(message).strip()
+    ]
+    portfolio_messages = [
+        str(message).strip()
+        for message_type, message in messages
+        if message_type == "portfolio" and str(message).strip()
+    ]
+    common = {
+        "market": market,
+        "session": session,
+        "trade_date": trade_date,
+        "regime": regime,
+        "occurred_at": None,
+    }
+    events = []
+    if decision_messages:
+        events.extend(
+            build_batch_decision_event(
+                **common,
+                decision_key=f"{index:02d}",
+                message=message,
+            )
+            for index, message in enumerate(decision_messages, 1)
+        )
+    else:
+        events.append(
+            build_batch_decision_event(
+                **common,
+                message="이번 배치에서 새로 실행된 가상 매수·매도는 없습니다.",
+            )
+        )
+    if portfolio_messages:
+        events.append(
+            build_batch_portfolio_event(
+                **common, message="\n\n".join(portfolio_messages)
+            )
+        )
+
+    published = 0
+    for event in events:
+        published += int(await publish_batch_event_best_effort(event) is not None)
+    return published

--- a/messaging/campaign_forwarder.py
+++ b/messaging/campaign_forwarder.py
@@ -20,15 +20,17 @@ need the Kakao stack installed to run it.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 
 # ssh is invoked with a fixed argv list and shell=False; the only caller-supplied
 # value is the payload, and that goes in on stdin.
 import subprocess  # nosec B404
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Protocol
 
 from messaging.local_campaign_queue import SQLiteBatchCampaignQueue
@@ -83,7 +85,10 @@ class SshCampaignShipper:
         queue_path: str,
         python_path: str,
         ssh_binary: str = "ssh",
+        scp_binary: str = "scp",
         identity_file: str | None = None,
+        local_artifact_roots: Sequence[str | Path] = (),
+        remote_artifact_root: str | None = None,
         timeout: int = DEFAULT_SSH_TIMEOUT,
     ) -> None:
         self._host = host
@@ -91,7 +96,14 @@ class SshCampaignShipper:
         self._queue_path = queue_path
         self._python_path = python_path
         self._ssh_binary = ssh_binary
+        self._scp_binary = scp_binary
         self._identity_file = identity_file
+        self._local_artifact_roots = tuple(
+            Path(root).resolve() for root in local_artifact_roots
+        )
+        self._remote_artifact_root = (
+            remote_artifact_root.rstrip("/") if remote_artifact_root else None
+        )
         self._timeout = timeout
 
     def _command(self) -> list[str]:
@@ -109,9 +121,15 @@ class SshCampaignShipper:
         return command
 
     def ship(self, payload: Mapping[str, object]) -> bool:
+        outbound = dict(payload)
+        artifact = outbound.get("artifact_path")
+        if artifact is not None:
+            outbound["artifact_path"] = self._copy_artifact(
+                str(artifact), event_id=str(outbound.get("event_id") or "")
+            )
         completed = subprocess.run(  # nosec B603
             self._command(),
-            input=json.dumps(dict(payload), ensure_ascii=False),
+            input=json.dumps(outbound, ensure_ascii=False),
             capture_output=True,
             text=True,
             timeout=self._timeout,
@@ -125,6 +143,54 @@ class SshCampaignShipper:
                 f"{completed.stderr.strip()[:300]}"
             )
         return completed.stdout.strip().endswith("NEW")
+
+    def _copy_artifact(self, artifact_path: str, *, event_id: str) -> str:
+        if not self._remote_artifact_root:
+            raise RuntimeError("remote artifact root is not configured")
+        source = Path(artifact_path).resolve()
+        if source.suffix.lower() != ".pdf" or not source.is_file():
+            raise RuntimeError(f"report artifact is unavailable: {source}")
+        if self._local_artifact_roots and not any(
+            source.is_relative_to(root) for root in self._local_artifact_roots
+        ):
+            raise RuntimeError(
+                f"report artifact is outside the allowed roots: {source}"
+            )
+        digest = hashlib.sha256(event_id.encode("utf-8")).hexdigest()[:16]
+        remote_path = f"{self._remote_artifact_root}/{digest}.pdf"
+        command = [self._scp_binary, "-q", "-o", "BatchMode=yes"]
+        if self._identity_file:
+            command += ["-i", self._identity_file]
+        command += [str(source), f"{self._host}:{remote_path}"]
+        completed = subprocess.run(  # nosec B603
+            command,
+            capture_output=True,
+            text=True,
+            timeout=self._timeout,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise RuntimeError(
+                f"artifact copy failed (rc={completed.returncode}): "
+                f"{completed.stderr.strip()[:300]}"
+            )
+        chmod = [self._ssh_binary, "-o", "BatchMode=yes"]
+        if self._identity_file:
+            chmod += ["-i", self._identity_file]
+        chmod += [self._host, "chmod", "0644", remote_path]
+        completed = subprocess.run(  # nosec B603
+            chmod,
+            capture_output=True,
+            text=True,
+            timeout=self._timeout,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise RuntimeError(
+                f"artifact permission failed (rc={completed.returncode}): "
+                f"{completed.stderr.strip()[:300]}"
+            )
+        return remote_path
 
 
 class CampaignForwarder:

--- a/messaging/local_campaign_queue.py
+++ b/messaging/local_campaign_queue.py
@@ -119,7 +119,12 @@ class SQLiteBatchCampaignQueue:
         self._connection.close()
 
     def enqueue(self, payload: Mapping[str, object]) -> str | None:
-        campaign_id = payload.get("campaign_id")
+        # A screening campaign has one event and historically used campaign_id
+        # as its queue key.  The automatic batch story adds report, decision,
+        # and portfolio events under that same campaign, so those events carry
+        # a distinct event_id.  Keep the column name for an online-compatible
+        # migration while storing the most specific id available.
+        campaign_id = payload.get("event_id") or payload.get("campaign_id")
         if not isinstance(campaign_id, str) or not campaign_id.strip():
             raise ValueError("campaign payload requires campaign_id")
         created_at = payload.get("occurred_at")

--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -40,6 +40,8 @@ from messaging.batch_campaign_publisher import (  # noqa: E402
     COLLECTING,
     SKIPPED,
     publish_batch_campaign_best_effort,
+    publish_batch_reports_best_effort,
+    publish_batch_tracking_story_best_effort,
 )
 
 # Load openai_debug from project root via importlib (prism-us/cores/ shadows root cores/)
@@ -1162,14 +1164,22 @@ class USStockAnalysisOrchestrator:
             # 4. PDF conversion
             pdf_paths = await self.convert_to_pdf(report_paths)
 
-            # 4-5. Generate and send telegram messages
-            if self.telegram_config.use_telegram:
-                logger.info("Telegram enabled - proceeding with US message generation and transmission")
+            message_paths = await self.generate_telegram_messages(pdf_paths, language)
+            await publish_batch_reports_best_effort(
+                market="US",
+                session=mode,
+                trade_date=effective_date,
+                regime=campaign_regime,
+                pdf_paths=pdf_paths,
+                message_paths=message_paths,
+            )
 
-                message_paths = await self.generate_telegram_messages(pdf_paths, language)
+            # 5. Send Telegram without coupling Kakao story production to it.
+            if self.telegram_config.use_telegram:
+                logger.info("Telegram enabled - proceeding with US transmission")
                 await self.send_telegram_messages(message_paths, pdf_paths, report_paths)
             else:
-                logger.info("Telegram disabled - skipping US message generation and transmission")
+                logger.info("Telegram disabled - skipping US Telegram transmission")
 
             # 6. Tracking system batch (runs concurrently with broadcast I/O tasks via async)
             if pdf_paths:
@@ -1203,6 +1213,14 @@ class USStockAnalysisOrchestrator:
                             pdf_paths, chat_id, language,
                             telegram_config=self.telegram_config,
                             trigger_results_file=trigger_results_file
+                        )
+
+                        await publish_batch_tracking_story_best_effort(
+                            market="US",
+                            session=mode,
+                            trade_date=effective_date,
+                            regime=campaign_regime,
+                            messages=tracking_agent.last_batch_messages,
                         )
 
                         if tracking_success:

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -520,6 +520,7 @@ class USStockTrackingAgent:
         self.max_slots = self.MAX_SLOTS
         self.message_queue = []
         self._msg_types = []  # msg_type for each message in queue
+        self.last_batch_messages: list[tuple[str | None, str]] = []
         self._broadcast_task = None  # Track broadcast translation task
         self.trading_agent = None
         self.sell_decision_agent = None
@@ -3541,6 +3542,28 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
             bool: Send success status
         """
         try:
+            try:
+                from portfolio_broadcast import should_send_portfolio
+                _emit_portfolio = should_send_portfolio("US", force=portfolio_force)
+            except Exception:
+                _emit_portfolio = True  # fail-open
+            if _emit_portfolio:
+                summary = await self.generate_report_summary()
+                self._msg_types.append("portfolio")
+                self.message_queue.append(summary)
+            else:
+                logger.info("[portfolio-dedup] US portfolio summary skipped (sent within debounce window)")
+
+            self.last_batch_messages = [
+                (
+                    self._msg_types[index]
+                    if index < len(self._msg_types)
+                    else None,
+                    message,
+                )
+                for index, message in enumerate(self.message_queue)
+            ]
+
             # Skip Telegram sending if chat_id is None
             if not chat_id:
                 logger.info("No Telegram channel ID. Skipping message send")
@@ -3566,21 +3589,6 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                 self.message_queue = []
                 self._msg_types = []
                 return False
-
-            # Generate summary report — de-duplicated so near-simultaneous run-ends
-            # (US batch + intraday loops A/B) don't emit 2-3 identical portfolio
-            # summaries. Other queued messages (sell notices) are unaffected.
-            try:
-                from portfolio_broadcast import should_send_portfolio
-                _emit_portfolio = should_send_portfolio("US", force=portfolio_force)
-            except Exception:
-                _emit_portfolio = True  # fail-open
-            if _emit_portfolio:
-                summary = await self.generate_report_summary()
-                self._msg_types.append("portfolio")
-                self.message_queue.append(summary)
-            else:
-                logger.info("[portfolio-dedup] US portfolio summary skipped (sent within debounce window)")
 
             # Translate messages if English is requested
             if language == "en":
@@ -3948,14 +3956,18 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
 
                 # Send Telegram message
                 if chat_id:
-                    message_sent = await self.send_telegram_message(chat_id, language)
+                    message_sent = await self.send_telegram_message(
+                        chat_id, language, portfolio_force=True
+                    )
                     if message_sent:
                         logger.info("US Telegram message sent successfully")
                     else:
                         logger.warning("US Telegram message send failed")
                 else:
                     logger.info("Telegram channel ID not provided, skipping message send")
-                    await self.send_telegram_message(None, language)
+                    await self.send_telegram_message(
+                        None, language, portfolio_force=True
+                    )
 
                 logger.info("US tracking system batch execution complete")
                 return True

--- a/stock_analysis_orchestrator.py
+++ b/stock_analysis_orchestrator.py
@@ -28,6 +28,8 @@ from messaging.batch_campaign_publisher import (  # noqa: E402
     COLLECTING,
     SKIPPED,
     publish_batch_campaign_best_effort,
+    publish_batch_reports_best_effort,
+    publish_batch_tracking_story_best_effort,
 )
 
 # Logger configuration
@@ -1168,17 +1170,24 @@ class StockAnalysisOrchestrator:
             # 3. PDF conversion
             pdf_paths = await self.convert_to_pdf(report_paths)
 
-            # 4-5. Generate and send telegram messages (only when telegram is enabled)
+            # 4. Generate the channel-neutral summary artifacts regardless of
+            # whether Telegram transport is enabled.
+            message_paths = await self.generate_telegram_messages(pdf_paths, language)
+            await publish_batch_reports_best_effort(
+                market="KR",
+                session=mode,
+                trade_date=campaign_trade_date,
+                regime=campaign_regime,
+                pdf_paths=pdf_paths,
+                message_paths=message_paths,
+            )
+
+            # 5. Telegram is one consumer; disabling it must not disable Kakao.
             if self.telegram_config.use_telegram:
-                logger.info("Telegram enabled - proceeding with message generation and transmission steps")
-
-                # 4. Generate telegram messages
-                message_paths = await self.generate_telegram_messages(pdf_paths, language)
-
-                # 5. Send telegram messages and PDFs
+                logger.info("Telegram enabled - proceeding with transmission steps")
                 await self.send_telegram_messages(message_paths, pdf_paths, report_paths)
             else:
-                logger.info("Telegram disabled - skipping message generation and transmission steps")
+                logger.info("Telegram disabled - skipping Telegram transmission")
 
             # 6. Tracking system batch (runs concurrently with broadcast I/O tasks via async)
             if pdf_paths:
@@ -1224,6 +1233,14 @@ class StockAnalysisOrchestrator:
                             pdf_paths, chat_id, language, self.telegram_config,
                             trigger_results_file=trigger_results_file,
                             sector_names=kr_sector_names
+                        )
+
+                        await publish_batch_tracking_story_best_effort(
+                            market="KR",
+                            session=mode,
+                            trade_date=campaign_trade_date,
+                            regime=campaign_regime,
+                            messages=tracking_agent.last_batch_messages,
                         )
 
                         if tracking_success:

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -180,6 +180,7 @@ class StockTrackingAgent:
         self.message_queue = []  # For storing Telegram messages
         self._msg_types = []  # msg_type for each message in queue
         self._msg_effect_ids = []  # durable effect id for each queued message
+        self.last_batch_messages: list[tuple[str | None, str]] = []
         self._broadcast_task = None  # Track broadcast translation task
         self.trading_agent = None
         self.db_path = db_path
@@ -3887,6 +3888,30 @@ class StockTrackingAgent:
             bool: Send success status
         """
         try:
+            # Build the post-batch portfolio before checking the Telegram
+            # transport. Kakao's automatic story must still be available when
+            # Telegram delivery is disabled or temporarily unavailable.
+            try:
+                from portfolio_broadcast import should_send_portfolio
+                _emit_portfolio = should_send_portfolio("KR", force=portfolio_force)
+            except Exception:
+                _emit_portfolio = True  # fail-open
+            if _emit_portfolio:
+                summary = await self.generate_report_summary()
+                self._queue_message(summary, "portfolio")
+            else:
+                logger.info("[portfolio-dedup] KR portfolio summary skipped (sent within debounce window)")
+
+            self.last_batch_messages = [
+                (
+                    self._msg_types[index]
+                    if index < len(self._msg_types)
+                    else None,
+                    message,
+                )
+                for index, message in enumerate(self.message_queue)
+            ]
+
             # Skip Telegram sending if chat_id is None
             if not chat_id:
                 logger.info("No Telegram channel ID. Skipping message send")
@@ -3910,21 +3935,6 @@ class StockTrackingAgent:
                 # Initialize message queue
                 self._clear_message_queue()
                 return False
-
-            # Generate summary report — de-duplicated so near-simultaneous run-ends
-            # (KR batch + intraday loops A/B) don't emit 2-3 identical portfolio
-            # summaries. Other queued messages (sell notices) are unaffected.
-            try:
-                from portfolio_broadcast import should_send_portfolio
-                # 배치 run-end(portfolio_force=True)는 완전한 최종 요약이므로 디바운스 우회.
-                _emit_portfolio = should_send_portfolio("KR", force=portfolio_force)
-            except Exception:
-                _emit_portfolio = True  # fail-open
-            if _emit_portfolio:
-                summary = await self.generate_report_summary()
-                self._queue_message(summary, "portfolio")
-            else:
-                logger.info("[portfolio-dedup] KR portfolio summary skipped (sent within debounce window)")
 
             # Translate messages if English is requested
             if language == "en":

--- a/tests/test_batch_campaign_publisher.py
+++ b/tests/test_batch_campaign_publisher.py
@@ -20,6 +20,8 @@ from messaging.batch_campaign_publisher import (
     build_batch_campaign_event,
     campaign_id_for,
     publish_batch_campaign_best_effort,
+    publish_batch_reports_best_effort,
+    publish_batch_tracking_story_best_effort,
     select_reported_candidates,
 )
 from messaging.local_campaign_queue import SQLiteBatchCampaignQueue
@@ -228,6 +230,74 @@ async def test_best_effort_helper_swallows_invalid_event():
         )
         is None
     )
+
+
+@pytest.mark.asyncio
+async def test_tracking_story_publishes_each_decision_before_portfolio(monkeypatch):
+    events = []
+
+    async def capture(event):
+        events.append(event)
+        return event["event_id"]
+
+    monkeypatch.setattr(
+        "messaging.batch_campaign_publisher.publish_batch_event_best_effort",
+        capture,
+    )
+
+    count = await publish_batch_tracking_story_best_effort(
+        market="US",
+        session="MORNING",
+        trade_date="20260807",
+        regime="UPTREND",
+        messages=[
+            ("analysis", "MU 진입 보류"),
+            ("analysis", "PH 진입 보류"),
+            ("portfolio", "실시간 포트폴리오 4/10"),
+        ],
+    )
+
+    assert count == 3
+    assert [event["event_type"] for event in events] == [
+        "BATCH_CAMPAIGN_DECISION_READY",
+        "BATCH_CAMPAIGN_DECISION_READY",
+        "BATCH_CAMPAIGN_PORTFOLIO_SNAPSHOT",
+    ]
+    assert events[0]["event_id"].endswith(":decision:01")
+    assert events[1]["event_id"].endswith(":decision:02")
+
+
+@pytest.mark.asyncio
+async def test_report_story_skips_partial_artifact_failures(tmp_path, monkeypatch):
+    complete_pdf = tmp_path / "005930_삼성_전자_20260807.pdf"
+    complete_pdf.write_bytes(b"%PDF-1.7")
+    no_summary_pdf = tmp_path / "000660_SK하이닉스_20260807.pdf"
+    no_summary_pdf.write_bytes(b"%PDF-1.7")
+    summary = tmp_path / "005930_삼성_전자_telegram.txt"
+    summary.write_text("실제 텔레그램 요약", encoding="utf-8")
+    events = []
+
+    async def capture(event):
+        events.append(event)
+        return event["event_id"]
+
+    monkeypatch.setattr(
+        "messaging.batch_campaign_publisher.publish_batch_event_best_effort",
+        capture,
+    )
+
+    count = await publish_batch_reports_best_effort(
+        market="KR",
+        session="AFTERNOON",
+        trade_date="20260807",
+        regime="UPTREND",
+        pdf_paths=[complete_pdf, no_summary_pdf, tmp_path / "missing.pdf"],
+        message_paths=[summary],
+    )
+
+    assert count == 1
+    assert events[0]["ticker"] == "005930"
+    assert events[0]["company_name"] == "삼성_전자"
 
 
 def test_campaign_publisher_has_no_network_transport_dependency():

--- a/tests/test_batch_story_pipeline.py
+++ b/tests/test_batch_story_pipeline.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from kakao_bot.adapters.kakao.campaign_renderer import render_campaign_delivery
+from kakao_bot.adapters.persistence.sqlite import SQLiteKakaoRepository
+from kakao_bot.domain.models import ApprovalStatus, ClaimedOutboundDelivery
+from kakao_bot.runtime.campaign_consumer_main import (
+    ConsumerRuntimeConfig,
+    run_consumer_once,
+)
+from messaging.batch_campaign_publisher import (
+    build_batch_decision_event,
+    build_batch_portfolio_event,
+    build_batch_report_event,
+)
+from messaging.local_campaign_queue import SQLiteBatchCampaignQueue
+
+NOW = datetime(2026, 8, 7, 6, 30, tzinfo=timezone.utc)
+
+
+def _common() -> dict[str, object]:
+    return {
+        "market": "KR",
+        "session": "AFTERNOON",
+        "trade_date": "20260807",
+        "regime": "UPTREND",
+        "occurred_at": NOW,
+    }
+
+
+def test_story_event_ids_are_stable_and_report_requires_pdf():
+    report = build_batch_report_event(
+        **_common(),
+        ticker="005930",
+        company_name="삼성전자",
+        summary="핵심 요약",
+        artifact_path="/srv/reports/005930.pdf",
+    )
+    decision = build_batch_decision_event(**_common(), message="신규 진입 보류")
+    portfolio = build_batch_portfolio_event(
+        **_common(), message="배치 종료 후 가격 기준 포트폴리오"
+    )
+
+    assert report["campaign_id"] == "kr-afternoon-2026-08-07"
+    assert report["event_id"] == "kr-afternoon-2026-08-07:report:005930"
+    assert report["event_type"] == "BATCH_CAMPAIGN_REPORT_READY"
+    assert decision["event_id"].endswith(":decision")
+    assert portfolio["event_id"].endswith(":portfolio")
+
+
+def test_consumer_plans_report_decision_portfolio_in_event_order(tmp_path, monkeypatch):
+    queue_path = tmp_path / "campaigns.sqlite"
+    database_path = tmp_path / "kakao.sqlite"
+    artifact = tmp_path / "005930.pdf"
+    artifact.write_bytes(b"%PDF-1.7 test")
+    monkeypatch.setenv("KAKAO_BOT_PUBLIC_BASE_URL", "https://bot.example")
+    monkeypatch.setenv("KAKAO_REPORT_LINK_TTL_HOURS", "72")
+
+    with SQLiteKakaoRepository(database_path) as repository:
+        repository.discover_room("room-1")
+        repository.set_room_approval("room-1", ApprovalStatus.APPROVED)
+    with SQLiteBatchCampaignQueue(queue_path) as queue:
+        queue.enqueue(
+            build_batch_report_event(
+                **_common(),
+                ticker="005930",
+                company_name="삼성전자",
+                summary="실제 텔레그램 요약",
+                artifact_path=str(artifact),
+            )
+        )
+        queue.enqueue(
+            build_batch_decision_event(**_common(), message="가상운용 판단: 관망")
+        )
+        queue.enqueue(
+            build_batch_portfolio_event(
+                **_common(), message="배치 종료 후 가격 기준 포트폴리오"
+            )
+        )
+
+    result = run_consumer_once(
+        ConsumerRuntimeConfig(
+            queue_path=queue_path,
+            database_path=database_path,
+            lease_owner="consumer-1",
+        ),
+        now=NOW,
+    )
+
+    assert result.consumed == 3
+    with SQLiteKakaoRepository(database_path) as repository:
+        deliveries = repository.list_outbox()
+        assert [row["message_type"] for row in deliveries] == [
+            "campaign_report",
+            "campaign_decision",
+            "campaign_portfolio",
+        ]
+        report_url = deliveries[0]["payload"]["pdf_url"]
+        assert report_url.startswith("https://bot.example/kakao/reports/")
+        token = report_url.rsplit("/", 1)[-1]
+        assert repository.resolve_report_link(token, now=NOW) == str(artifact)
+        assert (
+            repository.resolve_report_link(token, now=NOW + timedelta(hours=73)) is None
+        )
+
+
+def _claimed(message_type: str, payload: dict[str, object]):
+    return ClaimedOutboundDelivery(
+        delivery_key="story:1",
+        room_id="room-1",
+        message_type=message_type,
+        payload=payload,
+        attempt_count=1,
+        lease_owner="sender-1",
+        lease_expires_at=NOW,
+        created_at=NOW,
+    )
+
+
+def test_story_renderers_are_transparent_and_noninteractive():
+    report = render_campaign_delivery(
+        _claimed(
+            "campaign_report",
+            {
+                "ticker": "005930",
+                "company_name": "삼성전자",
+                "message": "실제 텔레그램 요약",
+                "pdf_url": "https://bot.example/kakao/reports/token",
+            },
+        )
+    )
+    decision = render_campaign_delivery(
+        _claimed("campaign_decision", {"message": "가상운용 판단: 관망"})
+    )
+    portfolio = render_campaign_delivery(
+        _claimed(
+            "campaign_portfolio",
+            {"message": "배치 종료 후 가격 기준 포트폴리오"},
+        )
+    )
+
+    report_text = str(report)
+    assert "실제 텔레그램 요약" in report_text
+    assert "전체 리포트" in report_text
+    assert "messageText" not in report_text
+    assert "가상운용" in str(decision)
+    assert "실시간" not in str(portfolio)
+    assert "배치 종료 후 가격 기준" in str(portfolio)
+
+
+def test_decision_event_can_be_keyed_per_stock_without_colliding():
+    first = build_batch_decision_event(
+        **_common(), decision_key="01", message="삼성전자 관망"
+    )
+    second = build_batch_decision_event(
+        **_common(), decision_key="02", message="SK하이닉스 진입 보류"
+    )
+
+    assert first["campaign_id"] == second["campaign_id"]
+    assert first["event_id"].endswith(":decision:01")
+    assert second["event_id"].endswith(":decision:02")

--- a/tests/test_campaign_forwarder.py
+++ b/tests/test_campaign_forwarder.py
@@ -224,3 +224,85 @@ class TestSshShipper:
 
     def test_no_identity_flag_when_none_is_configured(self):
         assert "-i" not in self.shipper()._command()
+
+    def test_report_artifact_copy_failure_prevents_remote_enqueue(
+        self, tmp_path, monkeypatch
+    ):
+        artifact = tmp_path / "005930.pdf"
+        artifact.write_bytes(b"%PDF-1.7")
+        shipper = self.shipper(remote_artifact_root="/srv/prism-reports")
+        calls = []
+
+        def run(command, **kwargs):
+            calls.append(command)
+            if command[0] == "scp":
+                return type(
+                    "Completed", (), {"returncode": 1, "stderr": "copy failed"}
+                )()
+            raise AssertionError("enqueue must not run after a failed artifact copy")
+
+        monkeypatch.setattr("messaging.campaign_forwarder.subprocess.run", run)
+
+        with pytest.raises(RuntimeError, match="artifact copy failed"):
+            shipper.ship(
+                {
+                    **event(),
+                    "event_id": "kr-afternoon-20260803:report:005930",
+                    "event_type": "BATCH_CAMPAIGN_REPORT_READY",
+                    "artifact_path": str(artifact),
+                }
+            )
+        assert calls[0][0] == "scp"
+
+    def test_report_artifact_remote_name_is_hash_only(self, tmp_path, monkeypatch):
+        artifact = tmp_path / "회사 이름;touch nope.pdf"
+        artifact.write_bytes(b"%PDF-1.7")
+        shipper = self.shipper(remote_artifact_root="/srv/prism-reports")
+        calls = []
+
+        def run(command, **kwargs):
+            calls.append((command, kwargs))
+            return type(
+                "Completed",
+                (),
+                {"returncode": 0, "stderr": "", "stdout": "NEW\n"},
+            )()
+
+        monkeypatch.setattr("messaging.campaign_forwarder.subprocess.run", run)
+        shipper.ship(
+            {
+                **event(),
+                "event_id": "kr-afternoon-20260803:report:005930",
+                "event_type": "BATCH_CAMPAIGN_REPORT_READY",
+                "artifact_path": str(artifact),
+            }
+        )
+
+        remote_target = calls[0][0][-1]
+        assert remote_target.startswith("root@10.0.0.2:/srv/prism-reports/")
+        assert remote_target.endswith(".pdf")
+        assert "회사" not in remote_target
+        assert calls[1][0][-3:] == ["chmod", "0644", remote_target.split(":", 1)[1]]
+        forwarded = calls[2][1]["input"]
+        assert "/srv/prism-reports/" in forwarded
+        assert str(artifact) not in forwarded
+
+    def test_report_artifact_outside_allowed_roots_is_rejected(self, tmp_path):
+        artifact = tmp_path / "secret.pdf"
+        artifact.write_bytes(b"%PDF-1.7")
+        allowed = tmp_path / "pdf_reports"
+        allowed.mkdir()
+        shipper = self.shipper(
+            local_artifact_roots=[allowed],
+            remote_artifact_root="/srv/prism-reports",
+        )
+
+        with pytest.raises(RuntimeError, match="outside the allowed roots"):
+            shipper.ship(
+                {
+                    **event(),
+                    "event_id": "kr-afternoon-20260803:report:005930",
+                    "event_type": "BATCH_CAMPAIGN_REPORT_READY",
+                    "artifact_path": str(artifact),
+                }
+            )

--- a/tests/test_local_campaign_queue.py
+++ b/tests/test_local_campaign_queue.py
@@ -120,3 +120,18 @@ def test_queue_concurrent_initialization_is_serialized(tmp_path):
 
     assert results.count("campaign-1") == 1
     assert results.count(None) == 7
+
+
+def test_queue_uses_event_id_to_allow_several_stages_for_one_campaign(tmp_path):
+    database_path = tmp_path / "campaigns.sqlite"
+    first = {**payload("kr-afternoon-2026-08-07"), "event_id": "batch:report:005930"}
+    second = {**payload("kr-afternoon-2026-08-07"), "event_id": "batch:portfolio"}
+
+    with SQLiteBatchCampaignQueue(database_path) as queue:
+        assert queue.enqueue(first) == "batch:report:005930"
+        assert queue.enqueue(second) == "batch:portfolio"
+        assert queue.enqueue(first) is None
+        assert [row["campaign_id"] for row in queue.list_entries()] == [
+            "batch:report:005930",
+            "batch:portfolio",
+        ]

--- a/tests/test_stock_tracking_agent_process_reports.py
+++ b/tests/test_stock_tracking_agent_process_reports.py
@@ -509,6 +509,29 @@ async def test_process_reports_returns_zero_for_empty_accounts(caplog):
 
 
 @pytest.mark.asyncio
+async def test_batch_story_messages_survive_when_telegram_is_disabled():
+    agent = StockTrackingAgent.__new__(StockTrackingAgent)
+    agent.message_queue = ["삼성전자 가상운용 판단: 관망"]
+    agent._msg_types = ["analysis"]
+    agent._msg_effect_ids = [None]
+    agent.last_batch_messages = []
+    agent.generate_report_summary = AsyncMock(
+        return_value="실시간 포트폴리오 4/10"
+    )
+
+    sent = await StockTrackingAgent.send_telegram_message(
+        agent, None, portfolio_force=True
+    )
+
+    assert sent is True
+    assert agent.last_batch_messages == [
+        ("analysis", "삼성전자 가상운용 판단: 관망"),
+        ("portfolio", "실시간 포트폴리오 4/10"),
+    ]
+    assert agent.message_queue == []
+
+
+@pytest.mark.asyncio
 async def test_process_reports_saves_watchlist_once_when_not_traded(monkeypatch):
     agent = StockTrackingAgent.__new__(StockTrackingAgent)
     agent.account_configs = [

--- a/tools/forward_campaign_events.py
+++ b/tools/forward_campaign_events.py
@@ -39,6 +39,7 @@ DEFAULT_QUEUE = "/var/lib/prism-kakao/prism_campaign_queue.sqlite"
 DEFAULT_REMOTE_REPO = "/home/prism/prism-insight"
 DEFAULT_REMOTE_QUEUE = "/var/lib/prism-kakao/prism_campaign_queue.sqlite"
 DEFAULT_REMOTE_PYTHON = "python3"
+DEFAULT_REMOTE_ARTIFACT_ROOT = "/home/prism/prism-insight/pdf_reports"
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -64,6 +65,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--remote-python",
         default=os.getenv("PRISM_CAMPAIGN_REMOTE_PYTHON", DEFAULT_REMOTE_PYTHON),
+    )
+    parser.add_argument(
+        "--remote-artifact-root",
+        default=os.getenv(
+            "PRISM_CAMPAIGN_REMOTE_ARTIFACT_ROOT", DEFAULT_REMOTE_ARTIFACT_ROOT
+        ),
+        help="remote directory served by the Kakao report-link runtime",
     )
     parser.add_argument(
         "--identity-file",
@@ -120,6 +128,11 @@ def main(argv: list[str] | None = None) -> int:
         queue_path=args.remote_queue,
         python_path=args.remote_python,
         identity_file=args.identity_file,
+        local_artifact_roots=(
+            Path.cwd() / "pdf_reports",
+            Path.cwd() / "prism-us" / "pdf_reports",
+        ),
+        remote_artifact_root=args.remote_artifact_root,
     )
 
     with SQLiteBatchCampaignQueue(queue_path) as queue:


### PR DESCRIPTION
## Summary
- publish report-ready, per-stock virtual-decision, and post-batch portfolio events after screening
- transfer generated PDFs over the existing SSH boundary and mint room-scoped expiring Kakao links
- preserve Telegram-produced messages while keeping Kakao independent of Telegram transport
- add event-level idempotency, delivery expiry, partial-artifact failure handling, and noninteractive renderers

## Verification
- 346 Kakao tests passed
- 113 campaign/report/parallel tests passed
- 43 focused story/queue/forwarder tests passed
- compile, Ruff fatal checks, formatting, and diff checks passed
- production KR morning COLLECTING event queued 3ms before 3-way report generation