### PR TITLE
fix(kakao): parse 만원 evaluation prices

### DIFF
--- a/kakao_bot/application/command_parser.py
+++ b/kakao_bot/application/command_parser.py
@@ -26,7 +26,8 @@ US_MARKET = "us"
 _MENTION = re.compile(r"^@\S+\s*")
 _KR_CODE = re.compile(r"^\d{6}$")
 _US_TICKER = re.compile(r"^[A-Za-z]{1,5}$")
-_PRICE = re.compile(r"^₩?(\d+(?:,\d{3})*(?:\.\d+)?)원?$")
+_PRICE = re.compile(r"^₩?(\d+(?:,\d{3})*(?:\.\d+)?)(만)?원?$")
+_KRW_SUFFIX = "원"
 # Marks that make a token part of a sentence rather than a name on its own.
 _SENTENCE_MARK = re.compile(r"[?？!！.,、。]")
 _PERIOD = re.compile(r"^(\d+)\s*(?:개월|달|months?|m)?$", re.IGNORECASE)
@@ -240,6 +241,11 @@ def _parse_evaluate(market: str | None, tokens: list[str]) -> ParsedCommand:
         if numbers:
             # Past the numbers: a second number is the holding period, anything
             # else begins the tone.
+            if token == _KRW_SUFFIX:
+                # Korean amounts are commonly spaced as "5만 원". The price
+                # token already carries the multiplier, so consume only the
+                # separated currency suffix here.
+                continue
             if len(numbers) < 2 and _PERIOD.match(token):
                 numbers.append(token)
             else:
@@ -272,7 +278,8 @@ def _to_price(token: str) -> float | None:
     if not match:
         return None
     try:
-        return float(match.group(1).replace(",", ""))
+        value = float(match.group(1).replace(",", ""))
+        return value * 10_000 if match.group(2) else value
     except ValueError:
         return None
 

--- a/tests/test_kakao_evaluate.py
+++ b/tests/test_kakao_evaluate.py
@@ -197,6 +197,24 @@ class TestEnqueue:
         assert job["payload"]["avg_price"] == 50000.0
         assert job["payload"]["period_months"] == 3
 
+    @pytest.mark.parametrize(
+        "utterance",
+        (
+            "카카오 5만원 3개월 평가해줘",
+            "카카오 5만 원 3개월 평가해줘",
+        ),
+    )
+    def test_a_natural_evaluate_accepts_manwon_price_units(
+        self, repository, service, utterance
+    ):
+        outcome = service.handle(message(utterance), now=NOW)
+
+        assert outcome.kind is CommandOutcomeKind.ACCEPTED
+        [job] = repository.list_analysis_jobs()
+        assert job["ticker"] == "005930"
+        assert job["payload"]["avg_price"] == 50000.0
+        assert job["payload"]["period_months"] == 3
+
     def test_the_tone_travels_with_the_job(self, repository, service):
         service.handle(message("평가 삼성전자 70000 6 취한 친구처럼"), now=NOW)
 


### PR DESCRIPTION
## Summary
- parse Korean `만원` price units in natural evaluation commands
- accept both `5만원` and `5만 원` as 50,000 KRW
- preserve existing numeric price and holding-period parsing

## Verification
- `.venv/bin/python -m pytest -q tests/test_kakao_*.py` (348 passed)
- `ruff check kakao_bot/application/command_parser.py tests/test_kakao_evaluate.py`
- `py_compile` and `git diff --check`