### PR TITLE
fix(kakao): recognize stock forecast questions

### DIFF
--- a/kakao_bot/adapters/prism/report_adapter.py
+++ b/kakao_bot/adapters/prism/report_adapter.py
@@ -73,6 +73,12 @@ _INTRADAY_GROUNDING = (
     "가능한 요인을 구분하고, 확인되지 않은 원인은 명확히 미확정이라고 밝혀라."
 )
 
+_FORECAST_GROUNDING = (
+    "\n\n미래 주가를 확정적으로 예언하지 마라. 최신 증권사 목표주가와 실적·밸류에이션 "
+    "근거가 확인되면 낙관·기준·비관 시나리오의 조건과 범위로 답하고, 확인되지 않은 "
+    "숫자는 만들지 마라."
+)
+
 _STOCK_RESEARCH_SUFFIX = re.compile(
     r"\s*(?:지금\s*)?"
     r"(?:사도\s*(?:될까|돼)|살까|매수(?:해도)?\s*(?:될까|괜찮을까)|"
@@ -85,6 +91,11 @@ _STOCK_RESEARCH_SUFFIX = re.compile(
 _INTRADAY_EVENT_QUESTION = re.compile(
     r"(?=.*(?:오늘|장중|일봉|급락|급등|하한가|상한가))"
     r"(?=.*(?:왜|이유|원인|무슨\s*일)).*",
+    re.IGNORECASE,
+)
+
+_STOCK_FORECAST_QUESTION = re.compile(
+    r"(?:얼마|어디)까지|목표\s*(?:주)?가|주가\s*예측|(?:오를|내릴)지",
     re.IGNORECASE,
 )
 
@@ -293,6 +304,8 @@ async def _ask(question: str) -> str | None:
         f"한국어로, 카카오톡 메시지 형태로 이모지 포함하여 작성. "
         f"{_ASK_ANSWER_BUDGET}자 이내. 표와 마크다운 문법은 쓰지 마라."
     ) + _ASK_GROUNDING + (_INTRADAY_GROUNDING if is_intraday else "")
+    if _STOCK_FORECAST_QUESTION.search(question):
+        prompt += _FORECAST_GROUNDING
 
     queries, use_primary_sources = _ask_search_plan(question)
     # General free-form questions stay unrestricted because their subject is
@@ -360,6 +373,11 @@ def _stock_question(question: str) -> tuple[str | None, bool]:
         subject = _find_kr_stock_mention(text)
         if subject:
             return subject, True
+
+    if _STOCK_FORECAST_QUESTION.search(text):
+        subject = _find_kr_stock_mention(text)
+        if subject:
+            return subject, False
 
     match = _STOCK_RESEARCH_SUFFIX.search(text)
     if not match:

--- a/tests/test_kakao_ask.py
+++ b/tests/test_kakao_ask.py
@@ -305,6 +305,26 @@ def test_recent_stock_outlook_question_uses_the_stock_research_plan():
     assert all("알려줘" not in query for query in queries)
 
 
+@pytest.mark.parametrize(
+    "question",
+    (
+        "하이닉스 얼마까지 오를지 작두탄듯이 예측해보세요",
+        "SK하이닉스 어디까지 내릴지 예측해줘",
+        "하이닉스 목표주가 얼마야?",
+    ),
+)
+def test_stock_price_forecast_question_uses_the_stock_research_plan(question):
+    from kakao_bot.adapters.prism.report_adapter import _ask_search_plan
+
+    queries, use_primary_sources = _ask_search_plan(question)
+
+    assert use_primary_sources is True
+    assert len(queries) == 2
+    assert all("SK하이닉스" in query for query in queries)
+    assert any("목표주가" in query for query in queries)
+    assert all("작두" not in query and "예측해" not in query for query in queries)
+
+
 def test_intraday_stock_move_question_uses_today_cause_queries():
     from kakao_bot.adapters.prism.report_adapter import _ask_search_plan
 


### PR DESCRIPTION
## Summary
- recognize stock target-price and prediction phrasing as stock research questions
- expand aliases such as 하이닉스 into evidence-oriented SK하이닉스 queries
- require sourced scenario ranges instead of deterministic price predictions

## Verification
- `.venv/bin/python -m pytest -q tests/test_kakao_ask.py` (36 passed)
- `.venv/bin/python -m pytest -q tests/test_kakao_*.py` (351 passed)
- Ruff, py_compile, diff-check