### PR TITLE
feat(market-data): use KIS intraday investor estimates

### DIFF
--- a/cores/data_prefetch.py
+++ b/cores/data_prefetch.py
@@ -35,7 +35,9 @@ def _dict_to_markdown(data: dict, title: str = "") -> str:
     if not data or "error" in data:
         return ""
 
-    df = pd.DataFrame.from_dict(data, orient='index')
+    metadata = data.get("__meta__") if isinstance(data, dict) else None
+    rows = {key: value for key, value in data.items() if key != "__meta__"}
+    df = pd.DataFrame.from_dict(rows, orient='index')
     if df.empty:
         return ""
 
@@ -44,6 +46,9 @@ def _dict_to_markdown(data: dict, title: str = "") -> str:
     result = ""
     if title:
         result += f"### {title}\n\n"
+
+    if metadata and metadata.get("note"):
+        result += f"> **데이터 상태:** {metadata['note']}\n\n"
 
     result += df.to_markdown(index=True) + "\n"
     return result

--- a/cores/market_data/__init__.py
+++ b/cores/market_data/__init__.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 
 import logging
 import os
+from datetime import datetime, time, timedelta
+from zoneinfo import ZoneInfo
 
 import pandas as pd
 
@@ -71,6 +73,11 @@ _BUILDERS = {
 _DEFAULT_ORDER = "krx,fdr"
 
 _chain: SourceChain | None = None
+_KST = ZoneInfo("Asia/Seoul")
+
+
+def _now_kst() -> datetime:
+    return datetime.now(_KST)
 
 
 def default_chain() -> SourceChain:
@@ -148,18 +155,55 @@ def get_market_fundamental_by_date(
 def get_market_trading_volume_by_date(
     start_date: str, end_date: str, ticker: str
 ) -> pd.DataFrame:
-    return _empty_on_exhaustion("investor_flows", ticker, start_date, end_date)
+    now = _now_kst()
+    today = now.strftime("%Y%m%d")
+    wants_today = start_date <= today <= end_date
+    estimate_window = (
+        wants_today
+        and now.weekday() < 5
+        and time(9, 30) <= now.time() < time(15, 40)
+    )
+
+    if not estimate_window:
+        return _empty_on_exhaustion("investor_flows", ticker, start_date, end_date)
+
+    # Keep the historical part on the ordinary source chain, but ask only
+    # through yesterday: KIS's daily endpoint rejects requests before 15:40
+    # when today's date is used as the as-of date.
+    history_end = min(
+        end_date, (now.date() - timedelta(days=1)).strftime("%Y%m%d")
+    )
+    history = (
+        _empty_on_exhaustion("investor_flows", ticker, start_date, history_end)
+        if start_date <= history_end
+        else pd.DataFrame()
+    )
+
+    try:
+        estimate = default_chain().fetch(
+            "intraday_investor_estimate", ticker, as_of=now
+        )
+    except Unavailable as exc:
+        logger.warning("KIS intraday investor estimate unavailable: %s", exc)
+        return history
+
+    combined = pd.concat([history, estimate]).sort_index()
+    combined = combined[~combined.index.duplicated(keep="last")]
+    combined.attrs.update(estimate.attrs)
+    logger.info(
+        "using %s intraday investor estimate for %s as of %s",
+        estimate.attrs.get("estimate_source", "KIS"),
+        ticker,
+        estimate.attrs.get("estimate_as_of", "unknown"),
+    )
+    return combined
 
 
-def get_market_trading_volume_by_investor(*args, **kwargs):
-    """Not re-routed: no alternative source publishes investor flows.
-
-    Kept as a direct pass-through so the caller's behaviour is unchanged rather
-    than quietly becoming something else.
-    """
-    import krx_data_client
-
-    return krx_data_client.get_market_trading_volume_by_investor(*args, **kwargs)
+def get_market_trading_volume_by_investor(
+    start_date: str, end_date: str, ticker: str
+) -> pd.DataFrame:
+    """Compatibility alias for the shared investor-flow source chain."""
+    return get_market_trading_volume_by_date(start_date, end_date, ticker)
 
 
 def get_market_ticker_name(ticker: str) -> str:

--- a/cores/market_data/kis_source.py
+++ b/cores/market_data/kis_source.py
@@ -29,6 +29,8 @@ from __future__ import annotations
 
 import logging
 import threading
+from datetime import datetime, time
+from zoneinfo import ZoneInfo
 
 import pandas as pd
 
@@ -48,6 +50,21 @@ _INDEX_CHART_TR = "FHKUP03500100"
 
 _INVESTOR_DAILY = "/uapi/domestic-stock/v1/quotations/investor-trade-by-stock-daily"
 _INVESTOR_DAILY_TR = "FHPTJ04160001"
+
+_INVESTOR_ESTIMATE = "/uapi/domestic-stock/v1/quotations/investor-trend-estimate"
+_INVESTOR_ESTIMATE_TR = "HHPTJ04160200"
+
+_KST = ZoneInfo("Asia/Seoul")
+
+# KIS publishes five intraday snapshots.  The first contains only the foreign
+# estimate because the first institution snapshot is published at 10:00.
+_ESTIMATE_BUCKETS = {
+    "1": (time(9, 30), "09:30"),
+    "2": (time(10, 0), "10:00"),
+    "3": (time(11, 20), "11:20"),
+    "4": (time(13, 20), "13:20"),
+    "5": (time(14, 30), "14:30"),
+}
 
 # KIS names every price field the same way across these endpoints.
 _PRICE_COLUMNS = {
@@ -288,6 +305,71 @@ class KisSource:
         return frame[
             (frame.index >= pd.Timestamp(start)) & (frame.index <= pd.Timestamp(end))
         ]
+
+    def intraday_investor_estimate(
+        self, ticker: str, *, as_of: datetime | None = None
+    ) -> pd.DataFrame:
+        """Latest KIS intraday foreign/institution net-buy estimate.
+
+        This is explicitly an estimate, not a substitute for the daily endpoint.
+        KIS publishes snapshots during the session; callers merge the latest one
+        onto the historical daily series and preserve the metadata in ``attrs``.
+        """
+        current = as_of or datetime.now(_KST)
+        if current.tzinfo is None:
+            current = current.replace(tzinfo=_KST)
+        else:
+            current = current.astimezone(_KST)
+
+        if current.weekday() >= 5:
+            raise Unsupported("KIS intraday investor estimate is unavailable on weekends")
+
+        eligible = [
+            bucket
+            for bucket, (published_at, _) in _ESTIMATE_BUCKETS.items()
+            if current.time() >= published_at
+        ]
+        if not eligible or current.time() >= time(15, 40):
+            raise Unsupported("KIS intraday investor estimate is outside its session window")
+
+        bucket = max(eligible, key=int)
+        body = self._fetch(
+            _INVESTOR_ESTIMATE,
+            _INVESTOR_ESTIMATE_TR,
+            {"MKSC_SHRN_ISCD": ticker},
+        )
+        rows = list(getattr(body, "output2", None) or [])
+        row = next((item for item in rows if str(item.get("bsop_hour_gb")) == bucket), None)
+        if row is None:
+            raise Unavailable(f"KIS investor estimate has no published bucket {bucket}")
+
+        values = {
+            "외국인합계": pd.to_numeric(row.get("frgn_fake_ntby_qty"), errors="coerce"),
+            "기관합계": pd.to_numeric(row.get("orgn_fake_ntby_qty"), errors="coerce"),
+        }
+        # At 09:30 KIS has not published an institution estimate.  Its zero is
+        # a placeholder, not an observed zero, so keep it missing.
+        if bucket == "1":
+            values["기관합계"] = float("nan")
+
+        if all(pd.isna(value) for value in values.values()):
+            raise Unavailable(f"KIS investor estimate bucket {bucket} has no usable values")
+
+        label = _ESTIMATE_BUCKETS[bucket][1]
+        frame = pd.DataFrame([values], index=[pd.Timestamp(current.date())])
+        frame.attrs.update(
+            {
+                "intraday_estimate": True,
+                "estimate_source": "KIS",
+                "estimate_bucket": bucket,
+                "estimate_as_of": f"{current.date().isoformat()} {label} KST",
+                "estimate_note": (
+                    f"오늘 외국인·기관 값은 KIS 장중 추정치({label} KST 기준)이며 "
+                    "개인·기타법인 장중 값은 제공되지 않습니다."
+                ),
+            }
+        )
+        return frame
 
     def market_cap_history(self, ticker: str, start: str, end: str) -> pd.DataFrame:
         # The chart endpoint carries 시가총액 only in output1, as one current

--- a/cores/market_data/mcp_server.py
+++ b/cores/market_data/mcp_server.py
@@ -139,6 +139,13 @@ def _answer(df, what: str) -> Dict[str, Any]:
     """
     payload = _frame_to_dated_dict(df)
     if payload:
+        note = getattr(df, "attrs", {}).get("estimate_note")
+        if note:
+            payload["__meta__"] = {
+                "data_status": "intraday_estimate",
+                "note": note,
+                "as_of": df.attrs.get("estimate_as_of"),
+            }
         return payload
     return {
         "error": (

--- a/cores/market_data/source.py
+++ b/cores/market_data/source.py
@@ -64,6 +64,11 @@ class MarketDataSource(Protocol):
     def investor_flows(self, ticker: str, start: str, end: str) -> pd.DataFrame:
         """Net buying by investor type — the figure only exchanges publish."""
 
+    def intraday_investor_estimate(
+        self, ticker: str, *, as_of=None
+    ) -> pd.DataFrame:
+        """Current-session investor-flow estimate, when a provider publishes it."""
+
     def fundamentals(self, ticker: str, start: str, end: str) -> pd.DataFrame:
         """PER/PBR/dividend yield over time."""
 

--- a/cores/stock_chart.py
+++ b/cores/stock_chart.py
@@ -407,7 +407,8 @@ def create_mpf_style(base_mpl_style='seaborn-v0_8-whitegrid'):
 # None and the report shipped with no prices and no charts (2026-08-04: 17,387
 # characters against a normal 351,311, with no error anywhere). The package
 # tries each configured provider in turn and says so in the log when it falls
-# through; investor flows stay on KRX because nothing else publishes them.
+# through. Investor flows use KIS intraday estimates before 15:40 KST and KIS
+# daily values afterward when KIS is configured first.
 from cores.market_data import (
     get_index_ohlcv_by_date,
     get_market_cap_by_date,
@@ -415,7 +416,6 @@ from cores.market_data import (
     get_market_ohlcv_by_date,
     get_market_ticker_name,
     get_market_trading_volume_by_date,
-    get_market_trading_volume_by_investor,
 )
 
 # Professional chart style configuration
@@ -1120,19 +1120,20 @@ def create_trading_volume_chart(ticker, company_name=None, days=30, save_path=No
         except Exception:
             company_name = ticker
 
-    # Fetch stock data - trading volume by investor
-    df_volume = get_market_trading_volume_by_investor(start_date, end_date, ticker)
+    # Fetch once through the shared source chain.  This may merge KIS's latest
+    # intraday estimate onto the historical daily series before 15:40 KST.
+    df_volume = get_market_trading_volume_by_date(start_date, end_date, ticker)
 
     if df_volume is None or len(df_volume) == 0:
         logger.info(f"No trading volume data available for {ticker}.")
         return None
 
-    # Fetch daily net purchase data
-    df_daily = get_market_trading_volume_by_date(start_date, end_date, ticker)
-
-    if df_daily is None or len(df_daily) == 0:
-        logger.info(f"No daily trading volume data available for {ticker}.")
-        return None
+    df_daily = df_volume
+    estimate_note = getattr(df_daily, "attrs", {}).get("estimate_note")
+    estimate_as_of = getattr(df_daily, "attrs", {}).get("estimate_as_of")
+    estimate_title = None
+    if estimate_as_of:
+        estimate_title = estimate_as_of.split(" ", 1)[-1]
 
     # Create chart
     fig, axes = plt.subplots(2, 1, figsize=(12, 10), gridspec_kw={'height_ratios': [2, 3]})
@@ -1183,7 +1184,11 @@ def create_trading_volume_chart(ticker, company_name=None, days=30, save_path=No
         )
 
         # Set subplot title
-        axes[0].set_title("Net Purchase by Investor Type", fontsize=12, loc='left')
+        bar_title = "Net Purchase by Investor Type"
+        if estimate_note:
+            suffix = f", {estimate_title}" if estimate_title else ""
+            bar_title += f" (latest: KIS intraday estimate{suffix})"
+        axes[0].set_title(bar_title, fontsize=12, loc='left')
 
         axes[0].set_xticks(pos)
 
@@ -1258,7 +1263,11 @@ def create_trading_volume_chart(ticker, company_name=None, days=30, save_path=No
         )
 
     # Set subplot title and labels
-    axes[1].set_title("Daily Cumulative Net Purchase Trend", fontsize=12, loc='left')
+    trend_title = "Daily Cumulative Net Purchase Trend"
+    if estimate_note:
+        suffix = f", {estimate_title}" if estimate_title else ""
+        trend_title += f" (latest: KIS intraday estimate{suffix})"
+    axes[1].set_title(trend_title, fontsize=12, loc='left')
 
     axes[1].set_xlabel('')
     axes[1].axhline(y=0, color='black', linestyle='-', alpha=0.3)  # Zero reference line

--- a/tests/test_data_prefetch_metadata.py
+++ b/tests/test_data_prefetch_metadata.py
@@ -1,0 +1,18 @@
+from cores.data_prefetch import _dict_to_markdown
+
+
+def test_intraday_estimate_metadata_is_rendered_without_becoming_a_table_row():
+    rendered = _dict_to_markdown(
+        {
+            "2026-08-07": {"외국인합계": 100, "기관합계": 200},
+            "__meta__": {
+                "data_status": "intraday_estimate",
+                "note": "오늘 값은 KIS 장중 추정치(14:30 KST 기준)입니다.",
+            },
+        },
+        "Investor Trading Volume",
+    )
+
+    assert "**데이터 상태:**" in rendered
+    assert "KIS 장중 추정치" in rendered
+    assert "__meta__" not in rendered

--- a/tests/test_kis_source.py
+++ b/tests/test_kis_source.py
@@ -7,6 +7,9 @@ loops share.
 
 from __future__ import annotations
 
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
 import pytest
 
 pd = pytest.importorskip("pandas")
@@ -42,12 +45,14 @@ class _FakeClient:
     def __init__(self, windows=None, ok=True, error="", name="삼성전자"):
         self.windows = windows if windows is not None else []
         self.calls: list[dict] = []
+        self.requests: list[tuple[str, str, dict]] = []
         self._ok = ok
         self._error = error
         self._name = name
 
     def _request(self, api_url, tr_id, params):
         self.calls.append(params)
+        self.requests.append((api_url, tr_id, params))
         if not self._ok:
             return _Response([], ok=False, error=self._error)
         index = min(len(self.calls) - 1, len(self.windows) - 1) if self.windows else 0
@@ -149,6 +154,64 @@ def test_investor_flows_asks_as_of_the_end_date():
     client = _FakeClient([[_flow_row("20260803")]])
     _source(client).investor_flows("005930", "20260728", "20260803")
     assert client.calls[0]["FID_INPUT_DATE_1"] == "20260803"
+
+
+def _estimate_row(bucket, foreign="100", institution="200"):
+    return {
+        "bsop_hour_gb": str(bucket),
+        "frgn_fake_ntby_qty": foreign,
+        "orgn_fake_ntby_qty": institution,
+        "sum_fake_ntby_qty": str(int(foreign) + int(institution)),
+    }
+
+
+def _kst(hour, minute):
+    return datetime(2026, 8, 7, hour, minute, tzinfo=ZoneInfo("Asia/Seoul"))
+
+
+@pytest.mark.parametrize(
+    "as_of,expected_bucket,expected_label",
+    [
+        (_kst(9, 30), "1", "09:30"),
+        (_kst(10, 0), "2", "10:00"),
+        (_kst(11, 20), "3", "11:20"),
+        (_kst(13, 20), "4", "13:20"),
+        (_kst(14, 30), "5", "14:30"),
+    ],
+)
+def test_intraday_estimate_selects_latest_published_bucket(
+    as_of, expected_bucket, expected_label
+):
+    rows = [_estimate_row(bucket, str(int(bucket) * 100), str(int(bucket) * 200))
+            for bucket in range(1, 6)]
+    client = _FakeClient([rows])
+
+    frame = _source(client).intraday_investor_estimate("005930", as_of=as_of)
+
+    assert frame.attrs["estimate_bucket"] == expected_bucket
+    assert expected_label in frame.attrs["estimate_note"]
+    assert frame.iloc[0]["외국인합계"] == int(expected_bucket) * 100
+    assert client.requests[0][1] == "HHPTJ04160200"
+    assert client.calls[0] == {"MKSC_SHRN_ISCD": "005930"}
+
+
+def test_first_intraday_bucket_does_not_fabricate_institution_zero():
+    frame = _source(_FakeClient([[_estimate_row(1, "753000", "0")]])).intraday_investor_estimate(
+        "005930", as_of=_kst(9, 35)
+    )
+
+    assert frame.iloc[0]["외국인합계"] == 753000
+    assert pd.isna(frame.iloc[0]["기관합계"])
+    assert "개인" not in frame.columns
+    assert "기타법인" not in frame.columns
+
+
+@pytest.mark.parametrize("as_of", [_kst(9, 29), _kst(15, 40)])
+def test_intraday_estimate_is_not_used_outside_published_window(as_of):
+    client = _FakeClient([[_estimate_row(1)]])
+    with pytest.raises(Unsupported, match="session window"):
+        _source(client).intraday_investor_estimate("005930", as_of=as_of)
+    assert client.calls == []
 
 
 def _index_row():

--- a/tests/test_market_data_mcp_server.py
+++ b/tests/test_market_data_mcp_server.py
@@ -89,6 +89,20 @@ def test_trading_volume_reads_through_the_chain(monkeypatch):
     assert called["ticker"] == "005930"
 
 
+def test_trading_volume_preserves_intraday_estimate_note(monkeypatch):
+    frame = _ohlcv()
+    frame.attrs.update(
+        estimate_note="오늘 외국인·기관 값은 KIS 장중 추정치(14:30 KST 기준)입니다.",
+        estimate_as_of="2026-08-07 14:30 KST",
+    )
+    monkeypatch.setattr(srv, "get_market_trading_volume_by_date", lambda *a: frame)
+
+    result = srv.get_stock_trading_volume("20260701", "20260807", "005930")
+
+    assert result["__meta__"]["data_status"] == "intraday_estimate"
+    assert "14:30" in result["__meta__"]["note"]
+
+
 def test_index_ohlcv_keeps_the_index_code_unpadded(monkeypatch):
     """지수 코드는 종목코드가 아니다 — 1001 을 001001 로 만들면 안 된다."""
     seen = {}

--- a/tests/test_market_data_sources.py
+++ b/tests/test_market_data_sources.py
@@ -15,6 +15,8 @@ import pytest
 from cores.market_data import (
     default_chain,
     get_market_ohlcv_by_date,
+    get_market_trading_volume_by_date,
+    get_market_trading_volume_by_investor,
     set_default_chain,
 )
 from cores.market_data.schema import has_ohlcv, normalize, to_dashed
@@ -221,6 +223,72 @@ class TestCallerFacingApi:
         frame = get_market_ohlcv_by_date("20260801", "20260803", "005930")
 
         assert frame.empty
+
+    def test_intraday_estimate_is_appended_to_daily_history(self, monkeypatch):
+        history = pd.DataFrame(
+            {"외국인합계": [10], "기관합계": [20], "개인": [-30]},
+            index=pd.to_datetime(["2026-08-06"]),
+        )
+        estimate = pd.DataFrame(
+            {"외국인합계": [100], "기관합계": [200]},
+            index=pd.to_datetime(["2026-08-07"]),
+        )
+        estimate.attrs.update(
+            intraday_estimate=True,
+            estimate_as_of="2026-08-07 14:30 KST",
+            estimate_note="오늘 값은 KIS 장중 추정치입니다.",
+        )
+
+        class HybridSource(FakeSource):
+            def investor_flows(self, ticker, start, end):
+                self.calls.append(("investor_flows", ticker, start, end))
+                return history
+
+            def intraday_investor_estimate(self, ticker, *, as_of=None):
+                self.calls.append(("intraday_investor_estimate", ticker, as_of))
+                return estimate
+
+        source = HybridSource("kis")
+        set_default_chain(SourceChain([source]))
+        monkeypatch.setattr(
+            "cores.market_data._now_kst",
+            lambda: pd.Timestamp("2026-08-07 14:52", tz="Asia/Seoul").to_pydatetime(),
+        )
+
+        frame = get_market_trading_volume_by_date("20260801", "20260807", "005930")
+
+        assert list(frame.index.strftime("%Y%m%d")) == ["20260806", "20260807"]
+        assert frame.loc["2026-08-07", "외국인합계"] == 100
+        assert pd.isna(frame.loc["2026-08-07", "개인"])
+        assert frame.attrs["intraday_estimate"] is True
+        assert source.calls[0][3] == "20260806"
+
+    def test_after_1540_uses_daily_flow_without_estimate(self, monkeypatch):
+        source = FakeSource("kis", result=ohlcv(150))
+        set_default_chain(SourceChain([source]))
+        monkeypatch.setattr(
+            "cores.market_data._now_kst",
+            lambda: pd.Timestamp("2026-08-07 15:40", tz="Asia/Seoul").to_pydatetime(),
+        )
+
+        get_market_trading_volume_by_date("20260801", "20260807", "005930")
+
+        assert source.calls == [("investor_flows", "005930")]
+
+    def test_investor_compatibility_api_no_longer_calls_krx_directly(self, monkeypatch):
+        source = FakeSource("chain", result=ohlcv(175))
+        set_default_chain(SourceChain([source]))
+        monkeypatch.setattr(
+            "cores.market_data._now_kst",
+            lambda: pd.Timestamp("2026-08-07 16:00", tz="Asia/Seoul").to_pydatetime(),
+        )
+
+        frame = get_market_trading_volume_by_investor(
+            "20260801", "20260807", "005930"
+        )
+
+        assert frame["Close"].iloc[0] == 175
+        assert source.calls == [("investor_flows", "005930")]
 
 
 class TestRealSources:


### PR DESCRIPTION
## Summary
- merge KIS intraday foreign/institution estimates onto daily investor-flow history before 15:40 KST
- keep unavailable individual/other-corporation values missing rather than fabricating zero
- propagate estimate status and reference time through MCP prefetch and chart titles
- remove the stock chart's duplicate direct KRX investor-flow call

## Verification
- 80 market-data tests passed
- compileall passed
- ruff critical-error selection passed
- git diff --check passed

## Operational behavior
- 09:30–15:39 KST: latest KIS estimate snapshot
- 15:40 onward: normal daily investor-flow endpoint through configured source chain
- configured fallbacks remain available if KIS fails