### PR TITLE
fix(reports): restore US news and market MCPs

### DIFF
--- a/cores/llm/backends/openai_agents_backend.py
+++ b/cores/llm/backends/openai_agents_backend.py
@@ -130,7 +130,7 @@ def build_mcp_server(name: str, registry: McpServerRegistry) -> "MCPServerStdio"
         command=spec.command,
         args=list(spec.args),
         env=dict(spec.env) if spec.env else None,
-        cwd=None,
+        cwd=spec.cwd,
     )
 
     return MCPServerStdio(

--- a/cores/llm/config_loader.py
+++ b/cores/llm/config_loader.py
@@ -148,10 +148,14 @@ def load_report_mcp_registry(config_path: "str | Path | None" = None):
     if report_override:
         return load_mcp_registry(report_override)
 
-    return load_mcp_registry()
+    return load_mcp_registry(legacy_env_fallback=_LEGACY_CONFIG)
 
 
-def load_mcp_registry(config_path: "str | Path | None" = None):
+def load_mcp_registry(
+    config_path: "str | Path | None" = None,
+    *,
+    legacy_env_fallback: "str | Path | None" = None,
+):
     """Load and return a :class:`McpServerRegistry` from YAML config.
 
     Search order:
@@ -208,7 +212,9 @@ def load_mcp_registry(config_path: "str | Path | None" = None):
                 f"  - {_LEGACY_CONFIG}"
             )
 
-    raw = yaml.safe_load(resolved.read_text())
+    raw = yaml.safe_load(resolved.read_text()) or {}
+    if legacy_env_fallback is not None:
+        raw = _merge_missing_env_from_legacy(raw, Path(legacy_env_fallback))
     raw = _interpolate_obj(raw)
 
     # Auto-detect shape and normalise to {"mcp": {"servers": {...}}}
@@ -220,3 +226,52 @@ def load_mcp_registry(config_path: "str | Path | None" = None):
         normalised = raw
 
     return McpServerRegistry.from_yaml_dict(normalised)
+
+
+def _server_entries(raw: dict) -> dict:
+    """Return server entries from either native or legacy YAML shape."""
+    if "servers" in raw and "mcp" not in raw:
+        return raw.get("servers") or {}
+    return ((raw.get("mcp") or {}).get("servers") or {})
+
+
+def _merge_missing_env_from_legacy(raw: dict, legacy_path: Path) -> dict:
+    """Transitionally fill unresolved native MCP env values from legacy YAML.
+
+    Report MCP configuration moved to tracked, secret-free YAML before every
+    production host had migrated its credentials to ``.env``.  An unresolved
+    ``${VAR}`` became an empty string and launched a broken MCP child process.
+    Until host migration is complete, reuse only the same server/key pair from
+    the legacy config.  Environment variables still win, and secret values are
+    never logged.
+    """
+    if not legacy_path.exists():
+        return raw
+
+    legacy_raw = yaml.safe_load(legacy_path.read_text()) or {}
+    current_servers = _server_entries(raw)
+    legacy_servers = _server_entries(legacy_raw)
+    recovered: list[str] = []
+
+    for server_name, current_spec in current_servers.items():
+        current_env = current_spec.get("env") or {}
+        legacy_env = (legacy_servers.get(server_name) or {}).get("env") or {}
+        for key, configured in list(current_env.items()):
+            if os.environ.get(key):
+                continue
+            if configured != f"${{{key}}}":
+                continue
+            legacy_value = legacy_env.get(key)
+            if not legacy_value or _ENV_VAR_RE.search(str(legacy_value)):
+                continue
+            current_env[key] = str(legacy_value)
+            recovered.append(f"{server_name}.{key}")
+
+    if recovered:
+        logger.warning(
+            "DEPRECATION: recovered missing report MCP environment keys from "
+            "legacy config (%s). Move these keys to .env: %s",
+            legacy_path.name,
+            ", ".join(recovered),
+        )
+    return raw

--- a/cores/llm/mcp_registry.py
+++ b/cores/llm/mcp_registry.py
@@ -19,6 +19,7 @@ class McpServerSpec:
           command: uvx
           args: [mcp-server-perplexity-ask]
           env: {PERPLEXITY_API_KEY: "..."}
+          cwd: /tmp
           read_timeout_seconds: 120
     """
 
@@ -26,6 +27,7 @@ class McpServerSpec:
     command: str
     args: tuple = ()
     env: dict = field(default_factory=dict, compare=False, hash=False)
+    cwd: Optional[str] = None
     read_timeout_seconds: Optional[int] = None
 
 
@@ -74,6 +76,7 @@ class McpServerRegistry:
                 command=entry["command"],
                 args=tuple(raw_args),
                 env=dict(entry.get("env", {})),
+                cwd=entry.get("cwd"),
                 read_timeout_seconds=entry.get("read_timeout_seconds"),
             )
 

--- a/cores/llm/mcp_servers.yaml
+++ b/cores/llm/mcp_servers.yaml
@@ -80,6 +80,11 @@ servers:
     command: uvx
     args:
     - --from
+    - yahoo-finance-mcp==0.1.2
+    - --with
+    - mcp==1.26.0
     - yahoo-finance-mcp
-    - yahoo-finance-mcp
+    # yahoo-finance-mcp's FastMCP settings auto-read .env from cwd.  Running
+    # outside the repo prevents an unrelated protected .env from aborting it.
+    cwd: ${PRISM_MCP_WORKDIR:-/tmp}
     read_timeout_seconds: 120

--- a/cores/llm/tests/test_config.py
+++ b/cores/llm/tests/test_config.py
@@ -207,6 +207,60 @@ class TestLoadMcpRegistry:
 
         assert "legacyserver" in registry.names()
 
+    def test_report_registry_recovers_unmigrated_legacy_server_secret(
+        self, tmp_path, monkeypatch
+    ):
+        native = tmp_path / "native.yaml"
+        native.write_text(
+            "servers:\n"
+            "  perplexity:\n"
+            "    command: node\n"
+            "    env:\n"
+            "      PERPLEXITY_API_KEY: ${PERPLEXITY_API_KEY}\n"
+        )
+        legacy = tmp_path / "legacy.yaml"
+        legacy.write_text(
+            "mcp:\n"
+            "  servers:\n"
+            "    perplexity:\n"
+            "      command: node\n"
+            "      env:\n"
+            "        PERPLEXITY_API_KEY: legacy-secret\n"
+        )
+        monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
+        monkeypatch.setattr("cores.llm.config_loader._NATIVE_CONFIG", native)
+        monkeypatch.setattr("cores.llm.config_loader._LEGACY_CONFIG", legacy)
+
+        registry = load_report_mcp_registry()
+
+        assert registry.get("perplexity").env == {
+            "PERPLEXITY_API_KEY": "legacy-secret"
+        }
+
+    def test_environment_secret_wins_over_legacy_fallback(self, tmp_path, monkeypatch):
+        native = tmp_path / "native.yaml"
+        native.write_text(
+            "servers:\n"
+            "  perplexity:\n"
+            "    command: node\n"
+            "    env: {PERPLEXITY_API_KEY: '${PERPLEXITY_API_KEY}'}\n"
+        )
+        legacy = tmp_path / "legacy.yaml"
+        legacy.write_text(
+            "mcp:\n"
+            "  servers:\n"
+            "    perplexity:\n"
+            "      command: node\n"
+            "      env: {PERPLEXITY_API_KEY: legacy-secret}\n"
+        )
+        monkeypatch.setenv("PERPLEXITY_API_KEY", "environment-secret")
+        monkeypatch.setattr("cores.llm.config_loader._NATIVE_CONFIG", native)
+        monkeypatch.setattr("cores.llm.config_loader._LEGACY_CONFIG", legacy)
+
+        assert load_report_mcp_registry().get("perplexity").env == {
+            "PERPLEXITY_API_KEY": "environment-secret"
+        }
+
 
 # ---------------------------------------------------------------------------
 # Real mcp_servers.yaml: exists and contains no inline secrets
@@ -236,3 +290,11 @@ class TestRealMcpServersYaml:
         assert inline == [], (
             f"Found inline secret values (should be ${{VAR}}): {inline}"
         )
+
+    def test_yahoo_mcp_dependencies_and_workdir_are_pinned(self):
+        from cores.llm.config_loader import _NATIVE_CONFIG
+
+        yahoo = yaml.safe_load(_NATIVE_CONFIG.read_text())["servers"]["yahoo_finance"]
+        assert "yahoo-finance-mcp==0.1.2" in yahoo["args"]
+        assert "mcp==1.26.0" in yahoo["args"]
+        assert yahoo["cwd"] == "${PRISM_MCP_WORKDIR:-/tmp}"

--- a/cores/llm/tests/test_openai_agents_backend.py
+++ b/cores/llm/tests/test_openai_agents_backend.py
@@ -203,6 +203,26 @@ def test_build_mcp_server_perplexity_env():
     assert server.params.env == {"PERPLEXITY_API_KEY": "test-key"}
 
 
+def test_build_mcp_server_passes_configured_working_directory():
+    registry = McpServerRegistry.from_yaml_dict(
+        {
+            "mcp": {
+                "servers": {
+                    "yahoo_finance": {
+                        "command": "uvx",
+                        "args": ["yahoo-finance-mcp"],
+                        "cwd": "/tmp",
+                    }
+                }
+            }
+        }
+    )
+
+    server = build_mcp_server("yahoo_finance", registry)
+
+    assert server.params.cwd == "/tmp"
+
+
 def test_build_mcp_server_perplexity_name():
     """build_mcp_server sets the server name correctly."""
     registry = make_registry()


### PR DESCRIPTION
## Root cause
- report generation migrated to the native OpenAI Agents MCP registry, but the app server's Perplexity secret still lived only in the legacy MCP config; the native placeholder resolved to empty
- unpinned yahoo-finance-mcp resolved MCP 2.0.0, which removed mcp.server.fastmcp and crashed the server
- with MCP 1.x restored, yahoo-finance-mcp also auto-read the repository .env from its cwd and could fail before startup

## Fix
- transitional, environment-first fallback for identical server env keys in legacy MCP config without logging values
- pin yahoo-finance-mcp 0.1.2 and MCP 1.26.0
- carry MCP cwd through the registry/backend and run Yahoo MCP from /tmp

## Verification
- focused config/backend/report tests: 80 passed
- expanded root LLM/report tests: 124 passed, 1 skipped (one known local-secret-dependent test excluded)
- focused US analysis tests: 4 passed
- exact pinned Yahoo imports on app-server
- compile, critical Ruff checks, diff-check passed