### PR TITLE
feat: expose KIS intraday personal-other residual

### DIFF
--- a/cores/market_data/__init__.py
+++ b/cores/market_data/__init__.py
@@ -152,6 +152,30 @@ def get_market_fundamental_by_date(
     return _empty_on_exhaustion("fundamentals", ticker, start_date, end_date)
 
 
+def _with_individual_other_total(frame: pd.DataFrame) -> pd.DataFrame:
+    """Add the combined group used by an intraday estimate chart.
+
+    Historical daily rows provide exact personal and other values, while the
+    intraday endpoint exposes only their combined residual. Giving historical
+    rows the same combined column keeps the cumulative series continuous and
+    avoids charting the combined estimate alongside its component columns.
+    """
+    if frame.empty or "개인·기타합계" in frame.columns or "개인" not in frame.columns:
+        return frame
+
+    if "기타합계" in frame.columns:
+        other = frame["기타합계"]
+    else:
+        other_columns = [
+            column for column in ("기타법인", "기타단체") if column in frame.columns
+        ]
+        if not other_columns:
+            return frame
+        other = frame[other_columns].sum(axis=1, min_count=1)
+
+    return frame.assign(**{"개인·기타합계": frame["개인"].add(other)})
+
+
 def get_market_trading_volume_by_date(
     start_date: str, end_date: str, ticker: str
 ) -> pd.DataFrame:
@@ -187,6 +211,7 @@ def get_market_trading_volume_by_date(
         logger.warning("KIS intraday investor estimate unavailable: %s", exc)
         return history
 
+    history = _with_individual_other_total(history)
     combined = pd.concat([history, estimate]).sort_index()
     combined = combined[~combined.index.duplicated(keep="last")]
     combined.attrs.update(estimate.attrs)

--- a/cores/market_data/kis_source.py
+++ b/cores/market_data/kis_source.py
@@ -102,7 +102,9 @@ _FLOW_COLUMNS = {
     "orgn_ntby_qty": "기관합계",
     "frgn_ntby_qty": "외국인합계",
     "prsn_ntby_qty": "개인",
+    "etc_ntby_qty": "기타합계",
     "etc_corp_ntby_vol": "기타법인",
+    "etc_orgt_ntby_vol": "기타단체",
 }
 
 _DATE_FIELD = "stck_bsop_date"
@@ -343,9 +345,23 @@ class KisSource:
         if row is None:
             raise Unavailable(f"KIS investor estimate has no published bucket {bucket}")
 
+        foreign = pd.to_numeric(row.get("frgn_fake_ntby_qty"), errors="coerce")
+        institution = pd.to_numeric(row.get("orgn_fake_ntby_qty"), errors="coerce")
+        combined_estimate = pd.to_numeric(
+            row.get("sum_fake_ntby_qty"), errors="coerce"
+        )
+        if pd.isna(combined_estimate) and not (
+            pd.isna(foreign) or pd.isna(institution)
+        ):
+            combined_estimate = foreign + institution
+
         values = {
-            "외국인합계": pd.to_numeric(row.get("frgn_fake_ntby_qty"), errors="coerce"),
-            "기관합계": pd.to_numeric(row.get("orgn_fake_ntby_qty"), errors="coerce"),
+            "외국인합계": foreign,
+            "기관합계": institution,
+            # KIS does not split personal and other investors intraday. Since
+            # all investor groups net to zero, the opposite of its published
+            # foreign+institution estimate is the remaining combined group.
+            "개인·기타합계": -combined_estimate,
         }
         # At 09:30 KIS has not published an institution estimate.  Its zero is
         # a placeholder, not an observed zero, so keep it missing.
@@ -365,7 +381,8 @@ class KisSource:
                 "estimate_as_of": f"{current.date().isoformat()} {label} KST",
                 "estimate_note": (
                     f"오늘 외국인·기관 값은 KIS 장중 추정치({label} KST 기준)이며 "
-                    "개인·기타법인 장중 값은 제공되지 않습니다."
+                    "개인·기타합계는 두 집단 합계의 반대값으로 역산한 잔여 "
+                    "추정치입니다. 개인 단독 수급이 아닙니다."
                 ),
             }
         )

--- a/cores/stock_chart.py
+++ b/cores/stock_chart.py
@@ -1089,6 +1089,14 @@ def create_fundamentals_chart(ticker, company_name=None, days=730, save_path=Non
     else:
         return fig
 
+def _investor_types_for_chart(frame):
+    """Return mutually exclusive investor groups for the available data."""
+    if getattr(frame, "attrs", {}).get("intraday_estimate"):
+        return ['기관합계', '외국인합계', '개인·기타합계']
+    other_type = '기타합계' if '기타합계' in frame.columns else '기타법인'
+    return ['기관합계', '외국인합계', '개인', other_type]
+
+
 def create_trading_volume_chart(ticker, company_name=None, days=30, save_path=None):
     """
     Generate trading volume chart by investor type
@@ -1140,7 +1148,10 @@ def create_trading_volume_chart(ticker, company_name=None, days=30, save_path=No
 
     # 1. Net purchase analysis by major investor groups
     # Korean investor type names (as returned by pykrx API)
-    investor_types = ['기관합계', '외국인합계', '개인', '기타법인']
+    # An intraday latest row contains a derived personal+other residual rather
+    # than its components. Plot mutually exclusive groups so the estimate is
+    # neither omitted nor double-counted.
+    investor_types = _investor_types_for_chart(df_daily)
 
     # Korean to English investor name mapping (comprehensive pykrx field mapping)
     investor_names_en = {
@@ -1148,6 +1159,8 @@ def create_trading_volume_chart(ticker, company_name=None, days=30, save_path=No
         '기관합계': 'Institutions',
         '외국인합계': 'Foreigners',
         '개인': 'Individuals',
+        '개인·기타합계': 'Individuals + Others (estimated)',
+        '기타합계': 'Others',
         '기타법인': 'Other Corps',
         # Institutional subcategories
         '금융투자': 'Securities',

--- a/tests/test_data_prefetch_metadata.py
+++ b/tests/test_data_prefetch_metadata.py
@@ -4,10 +4,17 @@ from cores.data_prefetch import _dict_to_markdown
 def test_intraday_estimate_metadata_is_rendered_without_becoming_a_table_row():
     rendered = _dict_to_markdown(
         {
-            "2026-08-07": {"외국인합계": 100, "기관합계": 200},
+            "2026-08-07": {
+                "외국인합계": 100,
+                "기관합계": 200,
+                "개인·기타합계": -300,
+            },
             "__meta__": {
                 "data_status": "intraday_estimate",
-                "note": "오늘 값은 KIS 장중 추정치(14:30 KST 기준)입니다.",
+                "note": (
+                    "오늘 값은 KIS 장중 추정치(14:30 KST 기준)이며 "
+                    "개인·기타합계는 역산 추정치입니다."
+                ),
             },
         },
         "Investor Trading Volume",
@@ -15,4 +22,6 @@ def test_intraday_estimate_metadata_is_rendered_without_becoming_a_table_row():
 
     assert "**데이터 상태:**" in rendered
     assert "KIS 장중 추정치" in rendered
+    assert "개인·기타합계" in rendered
+    assert "역산 추정치" in rendered
     assert "__meta__" not in rendered

--- a/tests/test_kis_source.py
+++ b/tests/test_kis_source.py
@@ -125,18 +125,29 @@ def test_investor_flows_uses_the_column_names_the_chart_indexes():
             "orgn_ntby_qty": "1000",
             "frgn_ntby_qty": "-2000",
             "prsn_ntby_qty": "500",
+            "etc_ntby_qty": "500",
             "etc_corp_ntby_vol": "12",
+            "etc_orgt_ntby_vol": "488",
         }
     ]
     frame = _source(_FakeClient([rows])).investor_flows("005930", "20260801", "20260803")
 
-    assert set(frame.columns) == {"기관합계", "외국인합계", "개인", "기타법인"}
+    assert set(frame.columns) == {
+        "기관합계",
+        "외국인합계",
+        "개인",
+        "기타합계",
+        "기타법인",
+        "기타단체",
+    }
     assert frame.loc["2026-08-03", "외국인합계"] == -2000
+    assert frame.loc["2026-08-03", "기타합계"] == 500
 
 
 def _flow_row(date, qty="1"):
     return {"stck_bsop_date": date, "orgn_ntby_qty": qty, "frgn_ntby_qty": qty,
-            "prsn_ntby_qty": qty, "etc_corp_ntby_vol": qty}
+            "prsn_ntby_qty": qty, "etc_ntby_qty": qty,
+            "etc_corp_ntby_vol": qty, "etc_orgt_ntby_vol": "0"}
 
 
 def test_investor_flows_trims_to_the_requested_range():
@@ -191,6 +202,8 @@ def test_intraday_estimate_selects_latest_published_bucket(
     assert frame.attrs["estimate_bucket"] == expected_bucket
     assert expected_label in frame.attrs["estimate_note"]
     assert frame.iloc[0]["외국인합계"] == int(expected_bucket) * 100
+    assert frame.iloc[0]["개인·기타합계"] == -(int(expected_bucket) * 300)
+    assert "역산" in frame.attrs["estimate_note"]
     assert client.requests[0][1] == "HHPTJ04160200"
     assert client.calls[0] == {"MKSC_SHRN_ISCD": "005930"}
 
@@ -202,6 +215,7 @@ def test_first_intraday_bucket_does_not_fabricate_institution_zero():
 
     assert frame.iloc[0]["외국인합계"] == 753000
     assert pd.isna(frame.iloc[0]["기관합계"])
+    assert frame.iloc[0]["개인·기타합계"] == -753000
     assert "개인" not in frame.columns
     assert "기타법인" not in frame.columns
 

--- a/tests/test_market_data_mcp_server.py
+++ b/tests/test_market_data_mcp_server.py
@@ -92,7 +92,10 @@ def test_trading_volume_reads_through_the_chain(monkeypatch):
 def test_trading_volume_preserves_intraday_estimate_note(monkeypatch):
     frame = _ohlcv()
     frame.attrs.update(
-        estimate_note="오늘 외국인·기관 값은 KIS 장중 추정치(14:30 KST 기준)입니다.",
+        estimate_note=(
+            "오늘 외국인·기관 값은 KIS 장중 추정치(14:30 KST 기준)이며 "
+            "개인·기타합계는 역산 추정치입니다. 개인 단독 수급이 아닙니다."
+        ),
         estimate_as_of="2026-08-07 14:30 KST",
     )
     monkeypatch.setattr(srv, "get_market_trading_volume_by_date", lambda *a: frame)
@@ -101,6 +104,7 @@ def test_trading_volume_preserves_intraday_estimate_note(monkeypatch):
 
     assert result["__meta__"]["data_status"] == "intraday_estimate"
     assert "14:30" in result["__meta__"]["note"]
+    assert "개인 단독 수급이 아닙니다" in result["__meta__"]["note"]
 
 
 def test_index_ohlcv_keeps_the_index_code_unpadded(monkeypatch):

--- a/tests/test_market_data_sources.py
+++ b/tests/test_market_data_sources.py
@@ -226,11 +226,16 @@ class TestCallerFacingApi:
 
     def test_intraday_estimate_is_appended_to_daily_history(self, monkeypatch):
         history = pd.DataFrame(
-            {"외국인합계": [10], "기관합계": [20], "개인": [-30]},
+            {
+                "외국인합계": [10],
+                "기관합계": [20],
+                "개인": [-35],
+                "기타합계": [5],
+            },
             index=pd.to_datetime(["2026-08-06"]),
         )
         estimate = pd.DataFrame(
-            {"외국인합계": [100], "기관합계": [200]},
+            {"외국인합계": [100], "기관합계": [200], "개인·기타합계": [-300]},
             index=pd.to_datetime(["2026-08-07"]),
         )
         estimate.attrs.update(
@@ -260,6 +265,8 @@ class TestCallerFacingApi:
         assert list(frame.index.strftime("%Y%m%d")) == ["20260806", "20260807"]
         assert frame.loc["2026-08-07", "외국인합계"] == 100
         assert pd.isna(frame.loc["2026-08-07", "개인"])
+        assert frame.loc["2026-08-06", "개인·기타합계"] == -30
+        assert frame.loc["2026-08-07", "개인·기타합계"] == -300
         assert frame.attrs["intraday_estimate"] is True
         assert source.calls[0][3] == "20260806"
 

--- a/tests/test_stock_chart_investor_types.py
+++ b/tests/test_stock_chart_investor_types.py
@@ -1,0 +1,27 @@
+import pandas as pd
+
+from cores.stock_chart import _investor_types_for_chart
+
+
+def test_intraday_chart_uses_combined_personal_other_group_only():
+    frame = pd.DataFrame(
+        columns=["기관합계", "외국인합계", "개인", "기타합계", "개인·기타합계"]
+    )
+    frame.attrs["intraday_estimate"] = True
+
+    assert _investor_types_for_chart(frame) == [
+        "기관합계",
+        "외국인합계",
+        "개인·기타합계",
+    ]
+
+
+def test_daily_chart_prefers_exact_other_total():
+    frame = pd.DataFrame(columns=["기관합계", "외국인합계", "개인", "기타합계", "기타법인"])
+
+    assert _investor_types_for_chart(frame) == [
+        "기관합계",
+        "외국인합계",
+        "개인",
+        "기타합계",
+    ]


### PR DESCRIPTION
## Summary
- expose KIS daily other-total and detailed other-investor fields
- derive an intraday `개인·기타합계` residual from KIS foreign+institution estimates
- keep historical and intraday chart groups mutually exclusive
- label the residual as derived, not personal-only flow

## Verification
- `.venv/bin/python -m pytest tests/test_kis_source.py tests/test_kis_market_snapshot.py tests/test_market_data_sources.py tests/test_market_data_mcp_server.py tests/test_data_prefetch_metadata.py tests/test_stock_chart_investor_types.py tests/test_multi_account_kis_auth.py -q` (90 passed)
- `.venv/bin/python -m compileall -q cores/market_data cores/stock_chart.py`
- `git diff --check`
- live KIS daily-field check on 005930, 000660, 100090 confirmed `etc_ntby_qty = etc_corp_ntby_vol + etc_orgt_ntby_vol` for sampled latest rows