### PR TITLE
fix: surface decisions for held US candidates

### DIFF
--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -3109,6 +3109,25 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
             logger.error(f"Error generating report summary: {str(e)}")
             return f"Error generating report: {str(e)}"
 
+    def _queue_existing_holding_decision(
+        self, analysis_result: Dict[str, Any], reason: str
+    ) -> None:
+        """Surface a candidate decision even when an existing holding blocks entry."""
+        ticker = analysis_result.get("ticker", "")
+        company_name = analysis_result.get("company_name", ticker)
+        current_price = analysis_result.get("current_price", 0)
+        scenario = analysis_result.get("scenario", {}) or {}
+        rationale = scenario.get("rationale") or "기존 보유분을 유지하며 추가 진입하지 않습니다."
+        message = (
+            f"ℹ️ 추가매수 보류: {company_name}({ticker})\n"
+            f"현재가: ${current_price:,.2f}\n"
+            "결정: 기존 보유 유지 (추가매수 없음)\n"
+            f"보류 사유: {reason}\n"
+            f"분석 의견: {rationale}"
+        )
+        self._msg_types.append("analysis")
+        self.message_queue.append(message)
+
     async def process_reports(self, pdf_report_paths: List[str]) -> Tuple[int, int]:
         """
         Process analysis reports and make buy/sell decisions.
@@ -3150,6 +3169,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                         "traded": False,
                         "should_save_watchlist": False,
                         "skip_reason": None,
+                        "held_skip_reason": None,
                     }
                 )
 
@@ -3193,6 +3213,9 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                             _pilot_freeze = False
                         if _pilot_freeze:
                             logger.info(f"[PULSE_PILOT] 중복매수 동결: {ticker} ({company_name}) already in holdings")
+                            state["held_skip_reason"] = state["held_skip_reason"] or (
+                                "기존 보유 종목이며 파일럿 정책에 따라 추가매수를 동결했습니다."
+                            )
                             continue
                         acct_key = self._account_scope()[0]
                         existing = get_us_existing_position_for_ticker(self.cursor, ticker, account_key=acct_key)
@@ -3204,6 +3227,9 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                         )
                         if not allowed:
                             logger.info(f"Skipping stock in holdings: {ticker} — add gate blocked: {gate_reason}")
+                            state["held_skip_reason"] = state["held_skip_reason"] or (
+                                f"기존 보유 종목이며 추가매수 조건을 충족하지 못했습니다 ({gate_reason})."
+                            )
                             continue
                         logger.info(f"{ticker} pyramiding add gate passed: {gate_reason}")
                         is_add = True
@@ -3443,7 +3469,16 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                         state["skip_reason"] = state["skip_reason"] or reason
 
             for state in analysis_states:
-                if state["traded"] or not state["should_save_watchlist"]:
+                if state["traded"]:
+                    continue
+
+                if state["held_skip_reason"] and not state["should_save_watchlist"]:
+                    self._queue_existing_holding_decision(
+                        state["analysis"], state["held_skip_reason"]
+                    )
+                    continue
+
+                if not state["should_save_watchlist"]:
                     continue
 
                 analysis_result = state["analysis"]

--- a/tests/test_us_held_candidate_decision.py
+++ b/tests/test_us_held_candidate_decision.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import ast
+import copy
+import logging
+import os
+import traceback
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).parent.parent
+AGENT_PATH = PROJECT_ROOT / "prism-us" / "us_stock_tracking_agent.py"
+
+
+def _load_real_method(name: str):
+    """Compile one real method without importing the agent's broker/LLM stack."""
+    source = AGENT_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(AGENT_PATH))
+    class_node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "USStockTrackingAgent"
+    )
+    method = copy.deepcopy(
+        next(
+            node
+            for node in class_node.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == name
+        )
+    )
+    method.decorator_list = []
+    module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {
+        "Any": Any,
+        "Dict": Dict,
+        "List": List,
+        "Optional": Optional,
+        "Tuple": Tuple,
+        "logger": logging.getLogger("us-held-candidate-test"),
+        "os": os,
+        "traceback": traceback,
+    }
+    exec(compile(module, str(AGENT_PATH), "exec"), namespace)
+    return namespace[name]
+
+
+@pytest.mark.asyncio
+async def test_pilot_frozen_held_candidate_still_queues_one_decision():
+    process_reports = _load_real_method("process_reports")
+    agent = SimpleNamespace(
+        account_configs=[{"name": "primary"}],
+        active_account=None,
+        max_slots=10,
+        message_queue=[],
+        _msg_types=[],
+    )
+    analysis = {
+        "success": True,
+        "ticker": "NVDA",
+        "company_name": "NVIDIA Corporation",
+        "current_price": 223.26,
+        "scenario": {
+            "buy_score": 8,
+            "min_score": 4,
+            "market_condition": "strong_bull",
+            "rationale": "기존 보유분의 추세는 유지 중입니다.",
+        },
+        "decision": "entry",
+        "sector": "Technology",
+    }
+
+    agent._analyze_report_core = AsyncMock(return_value=analysis)
+    agent.update_holdings = AsyncMock(return_value=[])
+    agent._is_ticker_in_holdings = AsyncMock(return_value=True)
+    agent._save_watchlist_item = AsyncMock(return_value=True)
+    agent._set_active_account = lambda account: setattr(agent, "active_account", account)
+    agent._safe_account_log_label = lambda account: account["name"]
+    agent._regime_policy_mod = lambda: SimpleNamespace(
+        pilot_reexposure_active=lambda market: market == "us"
+    )
+    agent._queue_existing_holding_decision = types.MethodType(
+        _load_real_method("_queue_existing_holding_decision"), agent
+    )
+
+    buy_count, sell_count = await process_reports(agent, ["reports/NVDA.pdf"])
+
+    assert (buy_count, sell_count) == (0, 0)
+    assert agent._msg_types == ["analysis"]
+    assert len(agent.message_queue) == 1
+    assert "NVDA" in agent.message_queue[0]
+    assert "기존 보유" in agent.message_queue[0]
+    assert "추가매수" in agent.message_queue[0]
+    agent._save_watchlist_item.assert_not_awaited()


### PR DESCRIPTION
## Summary
- queue an explicit decision when a US report candidate is already held and additional buying is frozen
- cover both the active pulse-pilot freeze and the normal pyramid add-gate rejection
- emit at most one held-candidate decision after all accounts are processed, without writing a duplicate watchlist row

## Incident
The 2026-08-07 US morning batch produced reports for NVDA, PLTR, and MCHP, but only PLTR/MCHP decision messages. NVDA hit the existing-holding pilot-freeze `continue` before any user-facing analysis message was queued. The transport stack was healthy; the event was never produced.

## Verification
- `.venv/bin/python -m pytest tests/test_us_held_candidate_decision.py tests/test_batch_campaign_publisher.py tests/test_pulse_pilot_reexposure.py tests/test_local_campaign_queue.py tests/test_campaign_forwarder.py -q` (67 passed)
- `.venv/bin/python -m compileall -q prism-us/us_stock_tracking_agent.py tests/test_us_held_candidate_decision.py`
- Ruff fatal checks and `git diff --check`