### PR TITLE
fix(prism-btc): 미확정 spot 봉을 재조회해 확정 승격

### DIFF
--- a/prism-btc/analysis/round8_spot_collector.py
+++ b/prism-btc/analysis/round8_spot_collector.py
@@ -35,12 +35,27 @@ CREATE TABLE IF NOT EXISTS spot_klines (
 
 
 def fetch(symbol: str, start_ms: int) -> list:
-    params = {"symbol": symbol, "interval": INTERVAL,
-              "startTime": start_ms, "limit": 1000}
-    resp = requests.get(BASE, params=params,
-                        headers={"User-Agent": "prism-btc-research"}, timeout=30)
+    params = {
+        "symbol": symbol,
+        "interval": INTERVAL,
+        "startTime": start_ms,
+        "limit": 1000,
+    }
+    resp = requests.get(
+        BASE, params=params, headers={"User-Agent": "prism-btc-research"}, timeout=30
+    )
     resp.raise_for_status()
     return resp.json()
+
+
+def get_fetch_cursor(conn: sqlite3.Connection, symbol: str) -> int:
+    """Resume after the latest confirmed bar so open bars are re-fetched."""
+    row = conn.execute(
+        "SELECT MAX(open_time) FROM spot_klines "
+        "WHERE symbol=? AND timeframe=? AND confirmed=1",
+        (symbol, INTERVAL),
+    ).fetchone()
+    return (int(row[0]) + 1) if row and row[0] is not None else START_MS
 
 
 def main() -> None:
@@ -50,17 +65,15 @@ def main() -> None:
     now_ms = int(time.time() * 1000)
 
     for sym in SYMBOLS:
-        row = conn.execute(
-            "SELECT MAX(open_time) FROM spot_klines WHERE symbol=? AND timeframe=?",
-            (sym, INTERVAL)).fetchone()
-        cursor = (row[0] + 1) if row and row[0] else START_MS
+        cursor = get_fetch_cursor(conn, sym)
         total = 0
         while True:
             batch = fetch(sym, cursor)
             if not batch:
                 break
             for k in batch:
-                open_time, o, h, l, c, v = int(k[0]), k[1], k[2], k[3], k[4], k[5]
+                open_time = int(k[0])
+                open_value, high, low, close, volume = k[1], k[2], k[3], k[4], k[5]
                 close_time, qv = int(k[6]), k[7]
                 confirmed = 1 if close_time < now_ms else 0
                 conn.execute(
@@ -70,8 +83,20 @@ def main() -> None:
                     "close=excluded.close, volume=excluded.volume, "
                     "quote_volume=excluded.quote_volume, confirmed=excluded.confirmed, "
                     "fetched_at=excluded.fetched_at",
-                    (sym, INTERVAL, open_time, float(o), float(h), float(l),
-                     float(c), float(v), float(qv), confirmed, now_ms))
+                    (
+                        sym,
+                        INTERVAL,
+                        open_time,
+                        float(open_value),
+                        float(high),
+                        float(low),
+                        float(close),
+                        float(volume),
+                        float(qv),
+                        confirmed,
+                        now_ms,
+                    ),
+                )
             total += len(batch)
             cursor = int(batch[-1][6]) + 1  # last close_time + 1ms
             conn.commit()
@@ -80,10 +105,14 @@ def main() -> None:
             time.sleep(0.3)  # rate-limit 예의
         n, lo, hi = conn.execute(
             "SELECT COUNT(*), MIN(open_time), MAX(open_time) FROM spot_klines "
-            "WHERE symbol=? AND confirmed=1", (sym,)).fetchone()
-        print(f"{sym}: fetched {total}, confirmed rows {n}, "
-              f"range {time.strftime('%Y-%m-%d', time.gmtime(lo/1000))} ~ "
-              f"{time.strftime('%Y-%m-%d', time.gmtime(hi/1000))}")
+            "WHERE symbol=? AND confirmed=1",
+            (sym,),
+        ).fetchone()
+        print(
+            f"{sym}: fetched {total}, confirmed rows {n}, "
+            f"range {time.strftime('%Y-%m-%d', time.gmtime(lo / 1000))} ~ "
+            f"{time.strftime('%Y-%m-%d', time.gmtime(hi / 1000))}"
+        )
     conn.close()
     print(f"saved → {DB}")
 

--- a/prism-btc/tests/test_round8_spot_collector.py
+++ b/prism-btc/tests/test_round8_spot_collector.py
@@ -1,0 +1,84 @@
+import sqlite3
+
+from analysis import round8_spot_collector as collector
+
+
+def _kline(open_time: int, close_time: int) -> list:
+    return [
+        open_time,
+        "100.0",
+        "110.0",
+        "90.0",
+        "105.0",
+        "12.0",
+        close_time,
+        "1260.0",
+    ]
+
+
+def _insert_row(
+    conn: sqlite3.Connection,
+    *,
+    open_time: int,
+    confirmed: int,
+) -> None:
+    conn.execute(
+        "INSERT INTO spot_klines VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+        (
+            "BTCUSDT",
+            collector.INTERVAL,
+            open_time,
+            100.0,
+            110.0,
+            90.0,
+            105.0,
+            12.0,
+            1260.0,
+            confirmed,
+            1,
+        ),
+    )
+    conn.commit()
+
+
+def test_fetch_cursor_ignores_newer_unconfirmed_rows():
+    conn = sqlite3.connect(":memory:")
+    conn.execute(collector.DDL)
+    _insert_row(conn, open_time=1_000, confirmed=1)
+    _insert_row(conn, open_time=2_000, confirmed=0)
+    _insert_row(conn, open_time=3_000, confirmed=0)
+
+    assert collector.get_fetch_cursor(conn, "BTCUSDT") == 1_001
+
+
+def test_main_refetches_and_promotes_existing_unconfirmed_bar(tmp_path, monkeypatch):
+    db_path = tmp_path / "btc_spot.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(collector.DDL)
+    _insert_row(conn, open_time=1_000, confirmed=1)
+    _insert_row(conn, open_time=2_000, confirmed=0)
+    conn.close()
+
+    requested_cursors = []
+
+    def fake_fetch(symbol: str, start_ms: int) -> list:
+        requested_cursors.append((symbol, start_ms))
+        return [
+            _kline(2_000, 2_999),
+            _kline(3_000, 20_000),
+        ]
+
+    monkeypatch.setattr(collector, "DB", db_path)
+    monkeypatch.setattr(collector, "SYMBOLS", ("BTCUSDT",))
+    monkeypatch.setattr(collector, "fetch", fake_fetch)
+    monkeypatch.setattr(collector.time, "time", lambda: 10.0)
+
+    collector.main()
+
+    assert requested_cursors == [("BTCUSDT", 1_001)]
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(
+        "SELECT open_time, confirmed FROM spot_klines ORDER BY open_time"
+    ).fetchall()
+    conn.close()
+    assert rows == [(1_000, 1), (2_000, 1), (3_000, 0)]


### PR DESCRIPTION
## 요약

BTC spot 일봉 collector의 증분 커서가 미확정봉까지 포함한 `MAX(open_time)` 뒤에서 시작해, 기존 미확정봉을 다시 가져오지 못하던 조용한 실패를 수정합니다.

- 커서를 마지막 `confirmed=1` 봉 다음으로 계산
- 기존 미확정봉을 재조회해 upsert 시 확정 승격
- L계층은 계속 `L_LAYER_ENABLED=False`; 거래·사이징 로직 변경 없음

## 장애 영향

2026-07-25~08-07 일봉이 `confirmed=0`에 남아 확정 데이터가 2026-07-24에서 정체됐습니다. cron과 네트워크는 성공해 로그만으로는 장애를 알기 어려웠습니다.

## 검증

- 기존 코드에서 회귀 테스트 2건 실패 확인
  - 최신 미확정봉 뒤로 커서를 건너뛰는 문제
  - 기존 미확정봉이 확정 승격되지 않는 문제
- 수정 후 신규 테스트: `2 passed`
- Python compileall 통과
- Ruff check/format 통과
- `git diff --check` 통과
- BTC 전체: `316 passed, 6 failed`
  - 6건은 현재 `L_LAYER_ENABLED=False`인데 활성 배수를 기대하는 기존 `test_leadership.py` 불일치로 이번 변경과 무관

## 배포 후 확인

- db-server fast-forward 배포
- collector 1회 수동 실행
- BTCUSDT/ETHUSDT 최신 확정봉과 과거 좀비 `confirmed=0` 해소 확인
- 다음 01:05 cron 확인