### PR TITLE
fix(cron): 존재하지 않는 US 압축 작업 제거

### DIFF
--- a/docker/crontab
+++ b/docker/crontab
@@ -16,7 +16,8 @@ PYTHONPATH=/app/prism-insight
 # Daily config backup at 02:00 KST
 0 2 * * * cd /app/prism-insight && chmod +x utils/backup_configs.sh && ./utils/backup_configs.sh >> /app/prism-insight/logs/backup.log 2>&1
 
-# Weekly memory compression at 03:00 KST (Sunday only)
+# Weekly KR+US memory compression at 03:00 KST (Sunday only)
+# compress_trading_memory.py runs the US pass via run_us_compression().
 0 3 * * 0 cd /app/prism-insight && python3 compress_trading_memory.py >> /app/prism-insight/logs/compression.log 2>&1
 
 # Daily log cleanup at 03:00 KST
@@ -65,9 +66,6 @@ PYTHONPATH=/app/prism-insight
 
 # US log cleanup at 03:30 KST (daily) - keep 30 days
 30 3 * * * find /app/prism-insight/logs -name "us_*.log" -mtime +30 -delete
-
-# US memory compression at 04:00 KST (Sunday only)
-0 4 * * 0 cd /app/prism-insight && python3 prism-us/compress_us_trading_memory.py >> /app/prism-insight/logs/us_compression.log 2>&1 || true
 
 # =============================================================================
 # Empty line required at the end of crontab file

--- a/tests/test_us_compression_cron.py
+++ b/tests/test_us_compression_cron.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REMOVED_US_RUNNER = "prism-us/compress_us_trading_memory.py"
+
+
+def test_docker_cron_uses_only_the_root_weekly_compression_runner():
+    crontab = (ROOT / "docker" / "crontab").read_text(encoding="utf-8")
+
+    assert REMOVED_US_RUNNER not in crontab
+    assert "python3 compress_trading_memory.py" in crontab
+
+
+def test_us_crontab_setup_does_not_install_removed_compression_runner():
+    setup_script = (ROOT / "utils" / "setup_us_crontab.sh").read_text(encoding="utf-8")
+
+    assert REMOVED_US_RUNNER not in setup_script
+    assert "US_MEMORY_COMPRESSION_TIME" not in setup_script

--- a/utils/setup_us_crontab.sh
+++ b/utils/setup_us_crontab.sh
@@ -96,7 +96,6 @@ fi
 
 # Other schedule times (KST)
 US_LOG_CLEANUP_TIME="30 3"           # 03:30 KST (daily)
-US_MEMORY_COMPRESSION_TIME="0 4"     # 04:00 KST (Sunday only)
 
 # =============================================================================
 # Functions
@@ -242,8 +241,9 @@ $US_DASHBOARD_TIME * * 2-6 cd $PROJECT_DIR && $PYTHON_PATH examples/generate_us_
 # Log cleanup for US logs (daily at 03:30 KST) - keep 30 days
 $US_LOG_CLEANUP_TIME * * * find $LOG_DIR -name "us_*.log" -mtime +30 -delete
 
-# Memory compression for US trading data (Sunday 04:00 KST)
-$US_MEMORY_COMPRESSION_TIME * * 0 cd $PROJECT_DIR && $PYTHON_PATH prism-us/compress_us_trading_memory.py >> $LOG_DIR/us_compression.log 2>&1 || true
+# US memory compression is handled by the root weekly compression job:
+#   compress_trading_memory.py -> run_us_compression()
+# Do not schedule the removed US-only runner here.
 
 # =============================================================================
 # Optional: Uncomment to enable additional features


### PR DESCRIPTION
## 요약

삭제된 `prism-us/compress_us_trading_memory.py`를 호출하는 Docker/US crontab 항목을 제거합니다. 루트 `compress_trading_memory.py`가 `run_us_compression()`까지 호출하므로 일요일 03:00 작업 하나가 KR+US를 모두 처리합니다.

Based on the issue analysis and proposed direction in #493 by @hyeonyong8776-creator. 원 변경을 직접 반영한 커밋에는 공동 작성자 trailer도 포함했습니다.

## 변경

- `docker/crontab`: 잘못된 04:00 US 전용 작업 제거
- `utils/setup_us_crontab.sh`: 잘못된 변수·생성 항목 제거
- 회귀 테스트: 삭제된 경로와 중복 스케줄 재도입 방지

## 검증

- `tests/test_us_compression_cron.py` + `tests/test_us_compression_wiring.py`: 5 passed
- 활성 Docker/setup cron의 Python·shell 경로 누락: 0
- `bash -n utils/setup_us_crontab.sh`
- Python compileall
- Ruff check/format
- `git diff --check`

## 안전 범위

MCP, OpenAI SDK, 분석·매매 코드, 실제 운영 crontab은 이 PR에서 변경하지 않습니다.