### PR TITLE
fix(mcp): 공식 Perplexity 서버 1.2.0 고정

### DIFF
--- a/cores/llm/mcp_servers.yaml
+++ b/cores/llm/mcp_servers.yaml
@@ -41,14 +41,12 @@ servers:
       # 우선순위 결정은 서버가 한다.
       PRISM_REPORT_DATA_SOURCES: ${PRISM_REPORT_DATA_SOURCES:-}
   perplexity:
-    # Published from github.com/modelcontextprotocol/servers by Perplexity
-    # (maintainer james.liounis@perplexity.ai). Fetching it removes the need to
-    # build and ship perplexity-ask/dist on every host, which is how the Mac
-    # mini ended up pointing at a path from someone else's machine.
+    # Official Perplexity MCP server. Pin the package so tool schemas cannot
+    # drift between cron runs or hosts.
     command: npx
     args:
     - -y
-    - server-perplexity-ask
+    - '@perplexity-ai/mcp-server@1.2.0'
     env:
       PERPLEXITY_API_KEY: ${PERPLEXITY_API_KEY}
   sqlite:

--- a/tests/test_perplexity_mcp_config.py
+++ b/tests/test_perplexity_mcp_config.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_perplexity_uses_versioned_official_mcp_package():
+    config = yaml.safe_load(
+        (ROOT / "cores" / "llm" / "mcp_servers.yaml").read_text(encoding="utf-8")
+    )
+
+    perplexity = config["servers"]["perplexity"]
+    assert perplexity["command"] == "npx"
+    assert perplexity["args"] == ["-y", "@perplexity-ai/mcp-server@1.2.0"]
+    assert perplexity["env"] == {"PERPLEXITY_API_KEY": "${PERPLEXITY_API_KEY}"}


### PR DESCRIPTION
## 요약

Deprecated된 `server-perplexity-ask` 대신 Perplexity 공식 MCP 서버를 정확한 버전으로 고정합니다.

```yaml
@perplexity-ai/mcp-server@1.2.0
```

Based on the issue analysis and proposed direction in #493 by @hyeonyong8776-creator. 원 제안의 공식 MCP 전환 방향을 반영해 공동 작성자 trailer도 포함했습니다.

## 검증

- 설정/registry/OpenAI Agents/report contract: 85 passed
- 로컬 MCP 기동: 4개 도구 확인
  - `perplexity_ask`
  - `perplexity_search`
  - `perplexity_research`
  - `perplexity_reason`
- db-server에서 기존 legacy secret fallback으로 공식 MCP 임시 기동
- db-server `perplexity_ask` 실제 호출 성공, `MCP_OK` 응답 확인
- compileall, Ruff check/format, diff-check 통과

## 안전 범위

- 현재 프롬프트가 요구하는 `perplexity_ask` 계약 보존
- KR market-data, time, Yahoo MCP 설정 무변경
- OpenAI SDK 및 거래 로직 무변경

## 배포 후 확인

- API-key/OpenAI Agents 경로 smoke
- ChatGPT OAuth proxy 경로 smoke
- KR/US 뉴스·시장분석 보고서 smoke