### PR TITLE
fix(mcp): Firecrawl 서버 3.23.6 고정

### DIFF
--- a/cores/llm/mcp_servers.yaml
+++ b/cores/llm/mcp_servers.yaml
@@ -6,10 +6,11 @@ servers:
     - '@mzxrai/mcp-webresearch@latest'
     read_timeout_seconds: 120
   firecrawl:
+    # Keep tool schemas deterministic across hosts and cron runs.
     command: npx
     args:
     - -y
-    - firecrawl-mcp
+    - firecrawl-mcp@3.23.6
     env:
       FIRECRAWL_API_KEY: ${FIRECRAWL_API_KEY}
   # 2026-08-05: kospi_kosdaq_stock_server(PyPI) 에서 리포 내 서버로 교체했다.

--- a/mcp_agent.config.yaml.example
+++ b/mcp_agent.config.yaml.example
@@ -20,10 +20,8 @@ mcp:
 
     firecrawl:
         command: "npx"
-        # Pin firecrawl-mcp version to avoid broken npx cache states (see issue #286).
-        # Unpinned `firecrawl-mcp` cached a release with a nested zod ESM/CJS mismatch,
-        # causing the MCP server to crash on startup and tools to silently disappear.
-        args: [ "-y", "firecrawl-mcp@3.17.0" ]
+        # Pin the production-verified release so tool schemas cannot drift.
+        args: [ "-y", "firecrawl-mcp@3.23.6" ]
         env:
           FIRECRAWL_API_KEY: "example key"
 

--- a/tests/test_firecrawl_mcp_config.py
+++ b/tests/test_firecrawl_mcp_config.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_PACKAGE = "firecrawl-mcp@3.23.6"
+
+
+def test_native_firecrawl_uses_verified_version():
+    config = yaml.safe_load(
+        (ROOT / "cores" / "llm" / "mcp_servers.yaml").read_text(encoding="utf-8")
+    )
+
+    firecrawl = config["servers"]["firecrawl"]
+    assert firecrawl["command"] == "npx"
+    assert firecrawl["args"] == ["-y", EXPECTED_PACKAGE]
+    assert firecrawl["env"] == {"FIRECRAWL_API_KEY": "${FIRECRAWL_API_KEY}"}
+
+
+def test_legacy_example_matches_native_firecrawl_version():
+    config = yaml.safe_load(
+        (ROOT / "mcp_agent.config.yaml.example").read_text(encoding="utf-8")
+    )
+
+    firecrawl = config["mcp"]["servers"]["firecrawl"]
+    assert firecrawl["command"] == "npx"
+    assert firecrawl["args"] == ["-y", EXPECTED_PACKAGE]


### PR DESCRIPTION
## 요약

Native MCP와 legacy 예제 설정의 Firecrawl 버전을 실제 검증한 `3.23.6`으로 통일합니다. cron/호스트별 `npx` 최신 버전 드리프트를 막습니다.

Based on the issue analysis and version-pinning direction in #493 by @hyeonyong8776-creator. 공동 작성자 trailer를 포함했습니다.

## 변경

- `cores/llm/mcp_servers.yaml`: `firecrawl-mcp@3.23.6`
- `mcp_agent.config.yaml.example`: 동일 버전
- 두 설정의 버전 일치를 고정하는 회귀 테스트

## 검증

- 관련 config/registry/OpenAI Agents/report/doctor: 108 passed
- 로컬 MCP 기동: 27개 도구 확인
- `firecrawl_search`, `firecrawl_scrape` 도구 존재 확인
- db-server 기존 legacy secret fallback으로 후보 버전 임시 기동
- db-server search 실제 호출 성공
- db-server example.com scrape 실제 호출 성공
- compileall, Ruff check/format, diff-check 통과

## 안전 범위

Perplexity, KR market-data, time, Yahoo MCP와 OpenAI SDK는 변경하지 않습니다. README/설치 문서는 런타임 PR 완료 후 별도 PR에서 맞춥니다.