### PR TITLE
docs: MCP 버전과 Docker cron을 실제 런타임에 정렬

### DIFF
--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -35,8 +35,8 @@ Run Ubuntu 24.04-based AI stock analysis system easily with Docker.
 - **Cron**: Built-in scheduled task automation (KR/US stock analysis)
 
 #### Python Packages
-- OpenAI API (GPT-4.1, GPT-5.1)
-- Anthropic API (Claude Sonnet 4.5)
+- OpenAI SDK 2.43.0 and OpenAI Agents 0.7.0
+- Anthropic API (optional compatibility workflows)
 - MCP Agent and related servers
 - pykrx (Korean stock data)
 - matplotlib, seaborn (data visualization)
@@ -44,7 +44,7 @@ Run Ubuntu 24.04-based AI stock analysis system easily with Docker.
 
 #### MCP Servers
 - **kospi-kosdaq**: Korean stock data
-- **perplexity-ask**: AI search
+- **perplexity**: AI search
 - **firecrawl**: Web crawling
 - **sqlite**: Database
 - **time**: Time management
@@ -192,26 +192,23 @@ mcp:
   servers:
     firecrawl:
       command: "npx"
-      args: [ "-y", "firecrawl-mcp" ]
+      args: [ "-y", "firecrawl-mcp@3.23.6" ]
       env:
         FIRECRAWL_API_KEY: "your_firecrawl_api_key_here"
     kospi_kosdaq:
       command: "python3"
-      args: ["-m", "kospi_kosdaq_stock_server"]
+      args: ["-m", "cores.market_data.mcp_server"]
     perplexity:
-      command: "node"
-      args: ["perplexity-ask/dist/index.js"]
+      command: "npx"
+      args: ["-y", "@perplexity-ai/mcp-server@1.2.0"]
       env:
         PERPLEXITY_API_KEY: "your_perplexity_api_key_here"
     sqlite:
       command: "uv"
-      args: ["--directory", "sqlite", "run", "mcp-server-sqlite", "--db-path", "stock_tracking_db"]
+      args: ["--directory", "sqlite", "run", "mcp-server-sqlite", "--db-path", "../stock_tracking_db.sqlite"]
     time:
-      command: "uvx"
-      args: ["mcp-server-time"]
-openai:
-  default_model: gpt-5.1
-  reasoning_effort: high
+      command: "python3"
+      args: ["-m", "cores.llm.time_mcp_server"]
 ```
 
 #### 3. `mcp_agent.secrets.yaml` File
@@ -247,7 +244,7 @@ The Docker container includes **built-in cron** for automated stock analysis. Cr
 |------|-----|------|
 | 02:00 | Config backup | Daily |
 | 03:00 | Log cleanup | Daily |
-| 03:00 | Memory compression | Sunday |
+| 03:00 | KR+US memory compression | Sunday |
 | 07:00 | Stock data update | Mon-Fri |
 | 09:30 | **KR Morning batch** | Mon-Fri |
 | 15:40 | **KR Afternoon batch** | Mon-Fri |
@@ -255,18 +252,19 @@ The Docker container includes **built-in cron** for automated stock analysis. Cr
 | 17:00 | Performance tracker | Mon-Fri |
 | 17:10 | Dashboard refresh | Mon-Fri |
 
-#### US Stock Market (KST, based on EST)
+#### US Stock Market (KST)
 
 | Time (KST) | US Time (EST) | Job | Days |
 |------------|---------------|-----|------|
 | 00:15 | 10:15 | **US Morning batch** | Tue-Sat |
+| 03:30 | - | US log cleanup (30 days) | Daily |
 | 06:30 | 16:30 | **US Afternoon batch** | Tue-Sat |
 | 07:30 | 17:30 | US Performance tracker | Tue-Sat |
 | 08:00 | 18:00 | US Dashboard refresh | Tue-Sat |
-| 03:30 | - | US log cleanup (30 days) | Daily |
-| 04:00 | - | US memory compression | Sunday |
+| 10:05 | - | US pending-order reconciliation | Tue-Sat |
 
-> **Note**: US market runs 3 times daily (no price limits). Tue-Sat in KST = Mon-Fri in US time.
+> **Note**: Docker cron runs in the `Asia/Seoul` timezone and US analysis runs twice daily.
+> Tue-Sat in KST = Mon-Fri in US time. EST/EDT columns are explanatory and do not change the cron timezone.
 > Yahoo Finance data has 15-20 min delay, so schedules are adjusted accordingly.
 
 ### Cron Management Commands
@@ -612,7 +610,6 @@ sudo chown -R $USER:$USER data reports pdf_reports
 └── prism-insight/            # Project root
     ├── cores/                # AI analysis engine
     ├── trading/              # Automated trading
-    ├── perplexity-ask/       # MCP server
     ├── sqlite/               # Database
     ├── reports/              # Analysis reports
     └── pdf_reports/          # PDF reports

--- a/README_DOCKER_ko.md
+++ b/README_DOCKER_ko.md
@@ -33,8 +33,8 @@ Ubuntu 24.04 기반 AI 주식 분석 시스템을 Docker로 간편하게 실행�
 - **Cron**: 내장 스케줄 자동화 (한국/미국 주식 분석)
 
 #### Python 패키지
-- OpenAI API (GPT-4.1, GPT-5.1)
-- Anthropic API (Claude Sonnet 4.5)
+- OpenAI SDK 2.43.0 및 OpenAI Agents 0.7.0
+- Anthropic API (선택적 호환 워크플로우)
 - MCP Agent 및 관련 서버들
 - pykrx (한국 주식 데이터)
 - matplotlib, seaborn (데이터 시각화)
@@ -42,7 +42,7 @@ Ubuntu 24.04 기반 AI 주식 분석 시스템을 Docker로 간편하게 실행�
 
 #### MCP 서버
 - **kospi-kosdaq**: 한국 주식 데이터
-- **perplexity-ask**: AI 검색
+- **perplexity**: AI 검색
 - **firecrawl**: 웹 크롤링
 - **sqlite**: 데이터베이스
 - **time**: 시간 관리
@@ -190,26 +190,23 @@ mcp:
   servers:
     firecrawl:
       command: "npx"
-      args: [ "-y", "firecrawl-mcp" ]
+      args: [ "-y", "firecrawl-mcp@3.23.6" ]
       env:
         FIRECRAWL_API_KEY: "여기에_Firecrawl_API키_입력"
     kospi_kosdaq:
       command: "python3"
-      args: ["-m", "kospi_kosdaq_stock_server"]
+      args: ["-m", "cores.market_data.mcp_server"]
     perplexity:
-      command: "node"
-      args: ["perplexity-ask/dist/index.js"]
+      command: "npx"
+      args: ["-y", "@perplexity-ai/mcp-server@1.2.0"]
       env:
         PERPLEXITY_API_KEY: "여기에_Perplexity_API키_입력"
     sqlite:
       command: "uv"
-      args: ["--directory", "sqlite", "run", "mcp-server-sqlite", "--db-path", "stock_tracking_db"]
+      args: ["--directory", "sqlite", "run", "mcp-server-sqlite", "--db-path", "../stock_tracking_db.sqlite"]
     time:
-      command: "uvx"
-      args: ["mcp-server-time"]
-openai:
-  default_model: gpt-5.1
-  reasoning_effort: high
+      command: "python3"
+      args: ["-m", "cores.llm.time_mcp_server"]
 ```
 
 #### 3. `mcp_agent.secrets.yaml` 파일
@@ -245,7 +242,7 @@ Docker 컨테이너에는 **내장 cron**이 포함되어 있어 주식 분석�
 |------|------|------|
 | 02:00 | 설정 백업 | 매일 |
 | 03:00 | 로그 정리 | 매일 |
-| 03:00 | 메모리 압축 | 일요일 |
+| 03:00 | KR+US 메모리 압축 | 일요일 |
 | 07:00 | 종목 데이터 업데이트 | 월-금 |
 | 09:30 | **KR 오전 배치** | 월-금 |
 | 15:40 | **KR 오후 배치** | 월-금 |
@@ -253,19 +250,19 @@ Docker 컨테이너에는 **내장 cron**이 포함되어 있어 주식 분석�
 | 17:00 | 성과 추적 | 월-금 |
 | 17:10 | 대시보드 갱신 | 월-금 |
 
-#### 미국 주식 시장 (KST 기준, EST 기반)
+#### 미국 주식 시장 (KST)
 
 | 시간 (KST) | 미국 시간 (EST) | 작업 | 요일 |
 |------------|----------------|------|------|
 | 00:15 | 10:15 | **US 오전 배치** | 화-토 |
-| 02:30 | 12:30 | **US 장중 배치** | 화-토 |
+| 03:30 | - | US 로그 정리 (30일) | 매일 |
 | 06:30 | 16:30 | **US 마감 배치** | 화-토 |
 | 07:30 | 17:30 | US 성과 추적 | 화-토 |
 | 08:00 | 18:00 | US 대시보드 갱신 | 화-토 |
-| 03:30 | - | US 로그 정리 (30일) | 매일 |
-| 04:00 | - | US 메모리 압축 | 일요일 |
+| 10:05 | - | US 미체결 주문 정합화 | 화-토 |
 
-> **참고**: 미국 시장은 가격제한이 없어 하루 3회 실행합니다. KST 기준 화-토는 미국 시간 기준 월-금에 해당합니다.
+> **참고**: Docker cron은 `Asia/Seoul` 시간대에서 실행되며 US 분석은 하루 2회 실행합니다.
+> KST 기준 화-토는 미국 시간 기준 월-금입니다. EST/EDT 표기는 설명용이며 cron 시간대를 바꾸지 않습니다.
 > Yahoo Finance 데이터는 15-20분 지연이 있어 이를 감안하여 스케줄을 설정했습니다.
 
 ### Cron 관리 명령어
@@ -611,7 +608,6 @@ sudo chown -R $USER:$USER data reports pdf_reports
 └── prism-insight/            # 프로젝트 루트
     ├── cores/                # AI 분석 엔진
     ├── trading/              # 자동매매
-    ├── perplexity-ask/       # MCP 서버
     ├── sqlite/               # 데이터베이스
     ├── reports/              # 분석 보고서
     └── pdf_reports/          # PDF 보고서

--- a/docs/SETUP_ko.md
+++ b/docs/SETUP_ko.md
@@ -130,6 +130,9 @@ cd prism-insight
 pip install -r requirements.txt
 ```
 
+현재 검증된 OpenAI 런타임 조합은 `openai==2.43.0`, `openai-agents==0.7.0`입니다.
+호환성 검증 없이 OpenAI SDK 범위를 넓히지 마십시오.
+
 ### 3단계: 설정 파일 준비
 
 예시 파일을 복사하여 설정 파일을 생성합니다:
@@ -174,24 +177,27 @@ mcp:
   servers:
     kospi_kosdaq:
       command: "python3"
-      args: ["-m", "kospi_kosdaq_stock_server"]
-      env:
-        KAKAO_ID: "your_kakao_email@example.com"
-        KAKAO_PW: "your_kakao_password"
+      args: ["-m", "cores.market_data.mcp_server"]
 
-    firecrawl: firecrawl-mcp
-    perplexity: npx -y @perplexity-ai/mcp-server
-    sqlite: uv run mcp-server-sqlite --directory sqlite stock_tracking_db.sqlite
-    time: uvx mcp-server-time
+    firecrawl:
+      command: "npx"
+      args: ["-y", "firecrawl-mcp@3.23.6"]
 
-openai:
-  default_model: gpt-5
-  reasoning_effort: medium
+    perplexity:
+      command: "npx"
+      args: ["-y", "@perplexity-ai/mcp-server@1.2.0"]
+
+    sqlite:
+      command: "uv"
+      args: ["--directory", "sqlite", "run", "mcp-server-sqlite", "--db-path", "../stock_tracking_db.sqlite"]
+
+    time:
+      command: "python3"
+      args: ["-m", "cores.llm.time_mcp_server"]
 ```
 
-> **참고**: 한국 시장 데이터(KRX 데이터 마켓플레이스 인증)를 위해 카카오 계정 정보가 필요합니다.
->
-> **2단계 인증 사용자**: 카카오 2단계 인증이 설정되어 있으면 매 분석시마다 앱에서 확인이 필요합니다. 비활성화하려면: 카카오앱 > 전체 설정 > 카카오계정 > 계정 보안 > 2단계 인증 '사용 안함'.
+> **참고**: 현재 한국 시장 MCP는 저장소 내부 market-data 소스 체인을 사용합니다.
+> 운영 환경에서는 오케스트레이터와 같은 Python을 `PRISM_MCP_PYTHON`으로 지정하십시오.
 
 ### 6단계: Playwright 설치 (PDF 생성용)
 
@@ -208,8 +214,8 @@ python3 -m playwright install chromium
 ### 7단계: Perplexity MCP 서버 설치
 
 ```bash
-# 방법 A: 글로벌 설치 (권장)
-npm install -g @perplexity-ai/mcp-server
+# 방법 A: 검증 버전 글로벌 설치
+npm install -g @perplexity-ai/mcp-server@1.2.0
 
 # 방법 B: npx 사용 (설치 불필요, 필요시 자동 실행)
 # mcp_agent.config.yaml.example에서 이미 npx 방식을 사용합니다

--- a/tests/test_runtime_docs_alignment.py
+++ b/tests/test_runtime_docs_alignment.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCKER_DOCS = ("README_DOCKER.md", "README_DOCKER_ko.md")
+ALL_DOCS = (*DOCKER_DOCS, "docs/SETUP_ko.md")
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_mcp_versions_and_commands_match_runtime():
+    for path in ALL_DOCS:
+        text = _read(path)
+        assert "firecrawl-mcp@3.23.6" in text, path
+        assert "@perplexity-ai/mcp-server@1.2.0" in text, path
+        assert "perplexity-ask/dist/index.js" not in text, path
+
+
+def test_docker_docs_match_kst_cron_schedule():
+    for path in DOCKER_DOCS:
+        text = _read(path)
+        assert "Asia/Seoul" in text, path
+        assert "10:05" in text, path
+        assert "04:00" not in text, path
+        assert "3 times daily" not in text, path
+        assert "하루 3회" not in text, path
+        assert "perplexity-ask/" not in text, path
+
+
+def test_korean_setup_documents_verified_openai_pair():
+    text = _read("docs/SETUP_ko.md")
+    assert "openai==2.43.0" in text
+    assert "openai-agents==0.7.0" in text


### PR DESCRIPTION
## 요약

PR #573~#575에서 확정된 런타임과 실제 `docker/crontab`을 Docker/설치 문서에 반영합니다. #493의 대규모 문서 재작성 대신 잘못된 항목만 최소 수정했습니다.

Based on the documentation alignment proposed in #493 by @hyeonyong8776-creator. 공동 작성자 trailer를 포함했습니다.

## 반영 내용

- OpenAI `2.43.0` + OpenAI Agents `0.7.0`
- Perplexity MCP `1.2.0`
- Firecrawl MCP `3.23.6`
- 저장소 내부 KR market-data/time MCP
- Docker cron `Asia/Seoul`/KST 고정
- US 분석 하루 2회 및 10:05 pending-order 작업
- 삭제된 US 압축·로컬 perplexity 경로 제거

## 검증

- 런타임/MCP/cron/압축 문서 회귀: 11 passed
- 상대 Markdown 링크 누락: 0
- Ruff check/format 통과
- `git diff --check` 통과

## 안전 범위

문서 3개와 문서 회귀 테스트만 변경합니다. 런타임·cron·거래 코드는 변경하지 않습니다.