### PR TITLE
chore(kakao): 실제 운영 systemd 유닛 반영 + 수동 기동 금지 문서화

### DIFF
--- a/deploy/systemd/prism-kakao-consumer.service.example
+++ b/deploy/systemd/prism-kakao-consumer.service.example
@@ -1,5 +1,5 @@
 [Unit]
-Description=PRISM Kakao Local Campaign Consumer
+Description=PRISM Kakao Campaign Consumer
 After=network-online.target
 Wants=network-online.target
 
@@ -7,17 +7,18 @@ Wants=network-online.target
 Type=simple
 User=prism
 Group=prism
-WorkingDirectory=/opt/prism-insight
+WorkingDirectory=/home/prism/prism-insight-repo
 EnvironmentFile=/etc/prism/kakao-bot.env
-ExecStart=/opt/prism-insight/.venv/bin/python -m kakao_bot.runtime.campaign_consumer_main
-Restart=on-failure
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/home/prism/prism-insight-repo/venv/bin/python -m kakao_bot.runtime.campaign_consumer_main
+Restart=always
 RestartSec=5
-UMask=0077
+StandardOutput=append:/home/prism/prism-insight-repo/logs/kakao_campaign_consumer.log
+StandardError=append:/home/prism/prism-insight-repo/logs/kakao_campaign_consumer.log
 NoNewPrivileges=true
-PrivateTmp=true
-ProtectSystem=strict
-ProtectHome=true
-ReadWritePaths=/var/lib/prism-kakao
+ProtectSystem=full
+ProtectHome=false
+
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/systemd/prism-kakao-gateway.service.example
+++ b/deploy/systemd/prism-kakao-gateway.service.example
@@ -2,25 +2,25 @@
 Description=PRISM Kakao Gateway
 After=network-online.target
 Wants=network-online.target
-StartLimitIntervalSec=120
-StartLimitBurst=5
 
 [Service]
 Type=simple
 User=prism
 Group=prism
-WorkingDirectory=/opt/prism-insight
+WorkingDirectory=/home/prism/prism-insight-repo
 EnvironmentFile=/etc/prism/kakao-bot.env
-ExecStart=/opt/prism-insight/.venv/bin/python -m kakao_bot.runtime.gateway_main
-Restart=on-failure
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/home/prism/prism-insight-repo/venv/bin/python -m kakao_bot.runtime.gateway_main
+Restart=always
 RestartSec=5
-RuntimeDirectory=prism-kakao
-UMask=0077
+StandardOutput=append:/home/prism/prism-insight-repo/logs/kakao_gateway.log
+StandardError=append:/home/prism/prism-insight-repo/logs/kakao_gateway.log
 NoNewPrivileges=true
-PrivateTmp=true
-ProtectSystem=strict
-ProtectHome=true
-ReadWritePaths=/var/lib/prism-kakao /run/prism-kakao
+ProtectSystem=full
+ProtectHome=false
+RuntimeDirectory=prism-kakao
+RuntimeDirectoryMode=0755
+RuntimeDirectoryPreserve=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/systemd/prism-kakao-report.service.example
+++ b/deploy/systemd/prism-kakao-report.service.example
@@ -1,5 +1,5 @@
 [Unit]
-Description=PRISM Kakao Analysis Worker
+Description=PRISM Kakao Report Server
 After=network-online.target
 Wants=network-online.target
 
@@ -10,11 +10,11 @@ Group=prism
 WorkingDirectory=/home/prism/prism-insight-repo
 EnvironmentFile=/etc/prism/kakao-bot.env
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/home/prism/prism-insight-repo/venv/bin/python -m kakao_bot.runtime.analysis_worker_main
+ExecStart=/home/prism/prism-insight-repo/venv/bin/python -m kakao_bot.runtime.report_server_main
 Restart=always
 RestartSec=5
-StandardOutput=append:/home/prism/prism-insight-repo/logs/kakao_analysis_worker.log
-StandardError=append:/home/prism/prism-insight-repo/logs/kakao_analysis_worker.log
+StandardOutput=append:/home/prism/prism-insight-repo/logs/kakao_report_server.log
+StandardError=append:/home/prism/prism-insight-repo/logs/kakao_report_server.log
 NoNewPrivileges=true
 ProtectSystem=full
 ProtectHome=false

--- a/deploy/systemd/prism-kakao-sender.service.example
+++ b/deploy/systemd/prism-kakao-sender.service.example
@@ -1,5 +1,5 @@
 [Unit]
-Description=PRISM Kakao Durable Outbox Sender
+Description=PRISM Kakao Outbox Sender
 After=network-online.target
 Wants=network-online.target
 
@@ -7,17 +7,18 @@ Wants=network-online.target
 Type=simple
 User=prism
 Group=prism
-WorkingDirectory=/opt/prism-insight
+WorkingDirectory=/home/prism/prism-insight-repo
 EnvironmentFile=/etc/prism/kakao-bot.env
-ExecStart=/opt/prism-insight/.venv/bin/python -m kakao_bot.runtime.sender_main
-Restart=on-failure
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/home/prism/prism-insight-repo/venv/bin/python -m kakao_bot.runtime.sender_main
+Restart=always
 RestartSec=5
-UMask=0077
+StandardOutput=append:/home/prism/prism-insight-repo/logs/kakao_sender.log
+StandardError=append:/home/prism/prism-insight-repo/logs/kakao_sender.log
 NoNewPrivileges=true
-PrivateTmp=true
-ProtectSystem=strict
-ProtectHome=true
-ReadWritePaths=/var/lib/prism-kakao
+ProtectSystem=full
+ProtectHome=false
+
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/superpowers/runbooks/2026-07-23-kakao-bot-operations.md
+++ b/docs/superpowers/runbooks/2026-07-23-kakao-bot-operations.md
@@ -166,11 +166,13 @@ python -m kakao_bot.runtime.campaign_smoke_main --confirm-enqueue
 
 ## 6. systemd
 
-템플릿:
+템플릿 (prism-backend 운영 유닛과 동일한 내용):
 
 - `deploy/systemd/prism-kakao-gateway.service.example`
-- `deploy/systemd/prism-kakao-consumer.service.example`
+- `deploy/systemd/prism-kakao-analysis.service.example`
 - `deploy/systemd/prism-kakao-sender.service.example`
+- `deploy/systemd/prism-kakao-consumer.service.example`
+- `deploy/systemd/prism-kakao-report.service.example`
 
 운영 서버 경로와 사용자를 맞춘 뒤 `/etc/systemd/system`에 배치한다.
 
@@ -178,20 +180,57 @@ python -m kakao_bot.runtime.campaign_smoke_main --confirm-enqueue
 sudo systemctl daemon-reload
 sudo systemctl enable --now \
   prism-kakao-gateway \
+  prism-kakao-analysis \
+  prism-kakao-sender \
   prism-kakao-consumer \
-  prism-kakao-sender
+  prism-kakao-report
 ```
 
 Gateway는 반드시 하나만 실행한다. 배포 순서는 stop-old, 종료 확인,
 start-new다.
+
+### 프로세스를 수동으로 띄우지 않는다
+
+다섯 프로세스는 전부 systemd 유닛으로만 기동한다. `runuser`나 SSH 셸에서
+직접 띄우면 두 가지가 동시에 깨진다.
+
+- 세션이 끊기면 프로세스가 같이 죽는다 (`Session terminated, killing shell`).
+- 재기동 시 `/etc/prism/kakao-bot.env`가 로드되지 않는다.
+
+두 번째가 특히 조용하게 위험하다. `KAKAO_BOT_DATABASE_PATH`가 없으면
+`kakao_bot.sqlite`는 CWD 기준 상대경로로 열린다. analysis worker가 gateway와
+**다른 빈 DB**를 폴링하게 되고, 할 일이 없으니 로그도 남기지 않는다.
+프로세스는 살아 있고 gateway는 접수 응답까지 정상으로 보내는데 분석 결과만
+영영 오지 않는다. 2026-08-07 장애가 정확히 이 경로였다.
+
+점검 방법:
+
+```bash
+# 다섯 프로세스가 모두 같은 DB를 열고 있어야 한다
+for s in gateway analysis sender consumer report; do
+  pid=$(systemctl show -p MainPID --value prism-kakao-$s)
+  echo "$s: $(tr '\0' '\n' < /proc/$pid/environ | grep '^KAKAO_BOT_DATABASE_PATH=')"
+done
+```
+
+### 유닛 작성 시 주의
+
+- `ProtectHome=false`가 필요하다. 저장소·venv·로그·PDF 산출물이 모두
+  `/home/prism` 아래에 있어서 기본값 `true`로 두면 기동에 실패한다.
+- `ProtectSystem=strict` 대신 `full`을 쓴다. `strict`는 `/home`까지
+  읽기 전용으로 만들어 로그 기록이 막힌다.
+- gateway만 `RuntimeDirectory=prism-kakao`가 필요하다. 싱글턴 lock이
+  `/run/prism-kakao/gateway.lock`인데 `/run`은 tmpfs라 재부팅 시 사라진다.
 
 ## 7. Rollback
 
 ```bash
 sudo systemctl stop \
   prism-kakao-gateway \
+  prism-kakao-analysis \
+  prism-kakao-sender \
   prism-kakao-consumer \
-  prism-kakao-sender
+  prism-kakao-report
 ```
 
 Kakao consumer/sender 장애는 기존 Telegram과 매매 실행을 중단시키지 않는다.


### PR DESCRIPTION
## 배경

2026-08-07 밤 카톡봇 분석 응답이 3일간 멈췄다. 원인 중 하나가 배포 방식이었다.

- `23:16` analysis worker가 SSH 세션 종료로 사망 (`Session terminated, killing shell`)
- `23:17` 수동 재기동 — 이때 `/etc/prism/kakao-bot.env`가 로드되지 않음
- `KAKAO_BOT_DATABASE_PATH`가 없으니 `kakao_bot.sqlite`를 CWD 기준 상대경로로 열었고, gateway와 **다른 빈 DB**를 폴링

프로세스는 살아 있고 gateway는 접수 응답까지 정상으로 보냈다. 워커는 빈 DB라 할 일이 없어 로그도 남기지 않았다. 사용자 입장에서는 "접수했습니다" 후 영원히 무응답이었다.

## 변경

기존 `.example` 4개는 `/opt/prism-insight` 경로와 `ProtectHome=true`를 전제해서 prism-backend에 그대로 배치하면 기동에 실패한다. 운영 중인 유닛과 동일한 내용으로 교체했다.

- 경로를 실제 배포 위치(`/home/prism/prism-insight-repo`)에 맞춤
- 누락돼 있던 `prism-kakao-report.service.example` 추가 (프로세스는 5개인데 템플릿은 4개였다)
- 런북에 수동 기동 금지, 위 장애 경로, 점검 명령, 유닛 작성 시 주의사항 문서화

## 유닛 작성 시 주의 (런북에 기록)

- `ProtectHome=false`가 필요하다. 저장소·venv·로그·PDF가 모두 `/home/prism` 아래라 기본값 `true`면 기동 실패.
- `ProtectSystem`은 `strict`가 아니라 `full`. `strict`는 `/home`까지 읽기 전용으로 만들어 로그 기록이 막힌다.
- gateway만 `RuntimeDirectory=prism-kakao` 필요. 싱글턴 lock이 `/run/prism-kakao/gateway.lock`인데 `/run`은 tmpfs라 재부팅 시 사라진다.

## 검증

prism-backend에 이미 적용해서 5개 서비스 모두 `active / enabled` 확인했다. 이 PR은 서버에 적용된 내용을 저장소에 되돌려 반영하는 것이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)