### PR TITLE
fix(insight): /insight 도움말 신설 + 서비스 중단 안내 + systemd 상주화

### DIFF
--- a/docs/archive/DEPLOYMENT.md
+++ b/docs/archive/DEPLOYMENT.md
@@ -216,7 +216,35 @@ ARCHIVE_API_PORT=8765
 EOF
 
 # archive_api 상주 실행 (단일 서버 모드에서는 텔레그램 봇이 직접 import하므로 불필요)
-nohup python archive_api.py >> logs/archive_api.log 2>&1 &
+#
+# ⚠️ nohup 으로 띄우지 말 것. 2026-07-21 호스팅사 리부트로 archive_api 와
+#    app-server 터널이 동시에 사라졌고, 되살리는 주체가 없어 /insight 가
+#    20일간 조용히 죽어 있었다. 반드시 systemd 로 상주시킨다.
+cat > /etc/systemd/system/prism-archive-api.service <<'EOF'
+[Unit]
+Description=PRISM Archive API (serves /insight to app-server over SSH tunnel)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/root/prism-insight
+Environment=PYTHONPATH=/root/prism-insight
+Environment=PYTHONUNBUFFERED=1
+# bash -c 래핑 이유: systemd 239(RHEL 8)는 StandardOutput=append: 를 모른다
+# (그대로 쓰면 status=209/STDOUT 으로 죽는다).
+ExecStart=/bin/bash -c "exec /root/.pyenv/versions/3.11.11/bin/python /root/prism-insight/archive_api.py >> /root/prism-insight/logs/archive_api.log 2>&1"
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl daemon-reload && systemctl enable --now prism-archive-api.service
+
+# 기동에 15~20초 걸린다 (무거운 import). active 확인 후 헬스 체크.
+systemctl is-active prism-archive-api.service
 
 # 헬스 체크
 curl -s http://127.0.0.1:8765/health
@@ -237,25 +265,28 @@ sudo -u prism ssh-keygen -t ed25519 -f ~prism/.ssh/id_ed25519 -N ""
 PRISM_PUB=$(sudo cat /home/prism/.ssh/id_ed25519.pub)
 ssh root@DB_SERVER_IP "echo 'command=\"echo tunnel-only\",no-pty,no-X11-forwarding,no-agent-forwarding,no-user-rc,permitopen=\"127.0.0.1:8765\" $PRISM_PUB' >> ~/.ssh/authorized_keys"
 
-# 3. SSH 터널 wrapper 스크립트
-sudo -u prism tee /home/prism/prism-insight/bin/archive_tunnel.sh <<'EOF'
-#!/bin/bash
-# Persistent SSH tunnel: app-server -> db-server:8765
-while true; do
-  ssh -N -o ServerAliveInterval=30 -o ServerAliveCountMax=3 \
-      -o ExitOnForwardFailure=yes -o StrictHostKeyChecking=accept-new \
-      -L 127.0.0.1:8765:127.0.0.1:8765 \
-      root@DB_SERVER_IP
-  echo "tunnel exited at $(date), reconnecting in 5s" >&2
-  sleep 5
-done
-EOF
-sudo chmod +x /home/prism/prism-insight/bin/archive_tunnel.sh
-sudo chown prism:prism /home/prism/prism-insight/bin/archive_tunnel.sh
+# 3~4. SSH 터널을 systemd 로 상주 (재부팅·연결 끊김 자동 복구)
+#      bin/archive_tunnel.sh 의 while 루프는 systemd Restart=always 가 대체한다.
+cat > /etc/systemd/system/prism-archive-tunnel.service <<'EOF'
+[Unit]
+Description=PRISM Archive API SSH tunnel (app-server -> db-server:8765)
+After=network-online.target
+Wants=network-online.target
 
-# 4. 터널 기동
-sudo -u prism nohup /home/prism/prism-insight/bin/archive_tunnel.sh \
-  >> /home/prism/prism-insight/logs/archive_tunnel.log 2>&1 &
+[Service]
+Type=simple
+User=prism
+# bash -c 래핑 이유: SELinux(Enforcing) 에서 systemd 가 /usr/bin/ssh 를 직접
+# exec 하면 status=203/EXEC "Permission denied" 로 죽는다 (ssh_exec_t 전이 거부).
+ExecStart=/bin/bash -c "exec /usr/bin/ssh -N -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=3 -o ExitOnForwardFailure=yes -o StrictHostKeyChecking=accept-new -L 127.0.0.1:8765:127.0.0.1:8765 root@DB_SERVER_IP"
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl daemon-reload && systemctl enable --now prism-archive-tunnel.service
+systemctl is-active prism-archive-tunnel.service
 
 # 5. .env에 app-server 설정 추가
 sudo -u prism tee -a /home/prism/prism-insight/.env <<EOF
@@ -347,11 +378,26 @@ systemctl enable --now archive-tunnel              # app-server
 ### 봇이 `/insight` 응답 없음
 
 - **단일 서버 모드**: `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` 확인. `python archive_query.py --insight-stats`가 에러 없으면 DB는 정상.
-- **양 서버 모드**: 봇 로그에서 `Archive API returned` 에러 확인. 터널 살아있는지:
+- **양 서버 모드**: 봇 로그에 `_call_insight_agent unreachable` 또는
+  `Cannot connect to host 127.0.0.1:8765` 가 찍히면 **터널 또는 archive_api 가 죽은 것**이다.
+  사용자에게는 "🛠 인사이트 서비스가 일시적으로 중단되어 있습니다" 가 나간다.
+
   ```bash
-  pgrep -af archive_tunnel.sh
-  pgrep -af "ssh.*8765:127.0.0.1:8765"
-  curl -s http://127.0.0.1:8765/health    # app-server에서
+  # app-server: 터널
+  systemctl status prism-archive-tunnel.service
+  ss -tln | grep 8765
+  sudo -u prism curl -s http://127.0.0.1:8765/health
+
+  # db-server: API 본체
+  systemctl status prism-archive-api.service
+  curl -s http://127.0.0.1:8765/health
+  tail -50 /root/prism-insight/logs/archive_api.log
+  ```
+
+  둘 중 하나라도 `enabled` 가 아니면 재부팅 때 다시 죽는다:
+  ```bash
+  systemctl is-enabled prism-archive-tunnel.service   # app-server
+  systemctl is-enabled prism-archive-api.service      # db-server
   ```
 
 ### `uvx: command not found` 오류

--- a/telegram_ai_bot.py
+++ b/telegram_ai_bot.py
@@ -448,6 +448,10 @@ class InsightPayload:
     tools_used: list
 
 
+class InsightServiceUnavailable(Exception):
+    """Archive API unreachable (tunnel/service down) — no quota was consumed."""
+
+
 class TelegramAIBot:
     """Telegram AI Conversational Bot"""
 
@@ -545,7 +549,7 @@ class TelegramAIBot:
             BotCommand("theme",       "국내 테마 진단"),
             BotCommand("us_theme",    "미국 테마 진단"),
             BotCommand("ask",         "자유 질문 (최신 정보 기반)"),
-            BotCommand("insight",     "누적 인사이트 기반 장기 분석"),
+            BotCommand("insight",     "그동안 발행된 분석 리포트에서 답 찾기 (일 20회)"),
             BotCommand("journal",     "매매 저널 조회"),
             BotCommand("cancel",      "진행 중인 명령어 취소 (evaluate·us_evaluate·report·us_report·history·signal·us_signal·theme·us_theme·ask·insight·journal)"),
             BotCommand("help",        "도움말"),
@@ -1453,6 +1457,9 @@ class TelegramAIBot:
             "/theme 2차전지 - 테마가 아직 살아있는지 진단\n"
             "/us_theme AI 반도체 - 미국 테마 건강도 체크\n"
             "/ask 코스피 17년래 최강 상승인데 다음주도 오를까? - 자유 질문 (일 3회)\n\n"
+            "🗂 <b>누적 리포트 인사이트</b>\n"
+            "/insight - 프리즘이 그동안 발행한 분석 리포트를 근거로 답변 (일 20회)\n"
+            "  명령어를 입력하면 봇이 질문을 물어봅니다\n\n"
             "💡 평가 응답에 답장(Reply)하여 추가 질문을 할 수 있습니다!\n\n"
             "이 봇은 '프리즘 인사이트' 채널 구독자만 사용할 수 있습니다.\n"
             "채널에서는 장 시작과 마감 시 AI가 선별한 특징주 3개를 소개하고,\n"
@@ -1498,6 +1505,17 @@ class TelegramAIBot:
             "/ask [질문] - AI에게 투자 관련 자유 질문 (일 3회)\n"
             "  예: <code>/ask 코스피 17년래 최강 상승 다음주도 오를까?</code>\n"
             "  예: <code>/ask 워렌 버핏이 올해 뭘 샀어?</code>\n\n"
+            "🗂 <b>누적 리포트 인사이트 (일 20회):</b>\n"
+            "/insight - 프리즘이 그동안 발행한 분석 리포트를 모아둔 창고에서 답을 찾아드립니다\n"
+            "  • 명령어만 입력하면 봇이 질문을 물어봅니다 (질문은 그다음에 입력)\n"
+            "  • <code>/ask</code>는 <b>웹의 최신 정보</b>를 찾아 답하고,\n"
+            "    <code>/insight</code>는 <b>프리즘이 실제로 분석한 종목과 그 이후 결과</b>를 근거로 답합니다\n"
+            "  • 그래서 '우리가 과거에 뭐라고 했고, 그게 맞았나?'를 묻기에 좋습니다\n"
+            "  예: <code>지난달 분석된 반도체 종목들 지금 수익률 어때?</code>\n"
+            "  예: <code>손절 신호가 떴다가 다시 오른 종목 비율은?</code>\n"
+            "  예: <code>2차전지 리포트에서 반복해서 지적된 리스크는?</code>\n"
+            "  • 답변에 답장(Reply)하면 30분간 이어서 캐물을 수 있습니다\n"
+            "  • 답변 아래 👍/👎를 눌러주시면 다음 답변 품질이 좋아집니다\n\n"
             "🖼️ <b>차트 이미지 분석 (일 10회):</b>\n"
             "차트 스크린샷을 그냥 사진으로 보내면 AI가 추세·지지/저항·거래량·리스크를 분석해 드립니다.\n"
             "  • 사진에 캡션을 달면 참고 정보로 활용됩니다\n\n"
@@ -3223,10 +3241,11 @@ class TelegramAIBot:
             )
             return ConversationHandler.END
         await update.message.reply_text(
-            "🗂 PRISM 아카이브에 쌓인 실제 분석 데이터를 기반으로 답변합니다.\n\n"
-            "질문을 입력해주세요:\n"
-            "예: 하락장에서 분석된 반도체 종목들 30일 수익률은?\n"
-            "예: 손절 발동 후 회복한 종목 비율은?"
+            "🗂 프리즘이 그동안 발행한 분석 리포트를 근거로 답해드립니다.\n"
+            "(웹의 최신 뉴스가 아니라, 실제로 분석했던 종목들의 기록입니다)\n\n"
+            "궁금한 점을 입력해주세요:\n"
+            "예: 지난달 분석된 반도체 종목들 지금 수익률 어때?\n"
+            "예: 손절 신호가 떴다가 다시 오른 종목 비율은?"
         )
         return INSIGHT_ENTERING_QUERY
 
@@ -3389,6 +3408,19 @@ class TelegramAIBot:
                 )
                 ic.add_turn(question, payload.answer, payload.insight_id)
                 self.insight_contexts[sent.message_id] = ic
+        except InsightServiceUnavailable:
+            logger.error("/insight archive service unavailable")
+            try:
+                await waiting_msg.delete()
+            except Exception:
+                pass
+            await self.application.bot.send_message(
+                chat_id=chat_id,
+                text=(
+                    "🛠 인사이트 서비스가 일시적으로 중단되어 있습니다.\n"
+                    "사용 횟수는 차감되지 않았으니 잠시 후 다시 시도해주세요."
+                ),
+            )
         except Exception as e:
             logger.error(f"/insight error: {e}", exc_info=True)
             try:
@@ -3446,6 +3478,13 @@ class TelegramAIBot:
                             tickers_mentioned=data.get("tickers_mentioned", []),
                             tools_used=data.get("tools_used", []),
                         )
+            except aiohttp.ClientConnectorError as e:
+                # Could not even open the connection (tunnel or archive_api is
+                # down), so the request never ran and no quota was consumed.
+                # Narrower than ClientConnectionError on purpose: a mid-request
+                # disconnect may have consumed quota, so that stays generic.
+                logger.error(f"_call_insight_agent unreachable: {e}")
+                raise InsightServiceUnavailable(str(e)) from e
             except Exception as e:
                 logger.error(
                     f"_call_insight_agent HTTP error: {e}", exc_info=True,
@@ -3521,6 +3560,16 @@ class TelegramAIBot:
             ic.add_turn(user_question, payload.answer, payload.insight_id)
             if sent is not None:
                 self.insight_contexts[sent.message_id] = ic
+        except InsightServiceUnavailable:
+            logger.error("/insight reply: archive service unavailable")
+            try:
+                await waiting.delete()
+            except Exception:
+                pass
+            await update.message.reply_text(
+                "🛠 인사이트 서비스가 일시적으로 중단되어 있습니다.\n"
+                "사용 횟수는 차감되지 않았으니 잠시 후 다시 시도해주세요."
+            )
         except Exception as e:
             logger.error(f"_handle_insight_reply error: {e}", exc_info=True)
             try:


### PR DESCRIPTION
## 배경 — /insight 가 20일간 죽어 있었다

app-server 봇 로그에 `/insight` 실패가 남아 있어 추적한 결과:

```
2026-08-10 12:44:48 - /insight - user=1087968824, q='지금 시점에 장기투자할만한거 추천좀...'
2026-08-10 12:44:50 - ERROR - _call_insight_agent HTTP error:
  Cannot connect to host 127.0.0.1:8765 [Connect call failed]
```

- `2026-07-21 01:26` 두 서버가 동시에 리부트됐다(호스팅사 정비 추정).
- db-server `archive_api.py` 와 app-server SSH 터널이 **둘 다 `nohup`** 으로만
  떠 있었다 → 리부트로 사라진 뒤 아무도 되살리지 않았다.
  systemd 유닛도, `@reboot` cron 도 없었다.
- 그래서 `/insight` 는 **매 호출 실패**했고, 사용자에게는 "조회에 실패했습니다"
  만 나갔다. `archive.db`(1.4GB) 자체는 정상적으로 계속 적재되고 있었다.

## 런타임 복구 (이미 반영, 이 PR 밖)

| 서버 | 유닛 | 상태 |
|---|---|---|
| db-server | `prism-archive-api.service` | active, enabled |
| app-server | `prism-archive-tunnel.service` | active, enabled |

둘 다 `Restart=always` + `enable` 이라 재부팅·연결 끊김에서 자동 복구된다.
실제 `/insight_agent` 호출까지 터널 경유로 정상 응답 확인했다. 봇 재기동은
불필요했다(호출 시마다 세션을 새로 열기 때문).

## 이 PR의 변경

### 1. `/help` 에 `/insight` 설명 신설
기존 도움말에 `/insight` 가 **아예 없었다**. 일반 사용자 기준으로 새로 썼고,
헷갈리기 쉬운 `/ask` 와의 차이를 명시했다.

- `/ask` → 웹의 최신 정보
- `/insight` → 프리즘이 실제 분석한 종목과 **그 이후 결과**

또한 `/insight` 는 **인자를 받지 않는다**(명령어 입력 → 봇이 질문을 되묻는 방식).
기존 도움말 관례(`/ask [질문]`)대로 `/insight 반도체 어때?` 를 쓰면 질문이 조용히
버려지므로, 이 점을 도움말에 분명히 적었다.

### 2. 서비스 중단을 정직하게 안내
연결 자체가 실패한 경우(`ClientConnectorError`)를 `InsightServiceUnavailable`
로 구분한다.

- 기존: `⚠️ 인사이트 조회에 실패했습니다` — 질문이 잘못된 것처럼 읽힌다
- 변경: `🛠 인사이트 서비스가 일시적으로 중단되어 있습니다 / 사용 횟수는 차감되지 않았으니…`

`ClientConnectionError` 가 아니라 더 좁은 `ClientConnectorError` 로 잡았다.
요청 **도중** 끊긴 경우(`ServerDisconnectedError`)는 이미 차감됐을 수 있어
"차감되지 않았다"고 단정할 수 없으므로, 기존 문구를 유지한다.

### 3. `DEPLOYMENT.md`: nohup → systemd
재발 원인이 문서였다. 절차를 systemd 로 교체하고 RHEL 8 함정 2개를 남겼다.

- systemd 239 는 `StandardOutput=append:` 미지원 → `status=209/STDOUT` 으로 죽는다
- SELinux(Enforcing) 가 systemd 의 `/usr/bin/ssh` 직접 exec 을 거부 → `203/EXEC`

둘 다 실제로 밟은 함정이고, `/bin/bash -c "exec …"` 래핑으로 우회했다.

트러블슈팅 절도 `pgrep` 대신 `systemctl status` / `is-enabled` 기준으로 고쳤다.

## 검증

- `py_compile` 통과
- AST 검사: 두 호출 지점 모두 `InsightServiceUnavailable` 핸들러가 `Exception`
  보다 앞에 위치, 도달 불가 코드 0건
- 도움말 HTML 태그 균형 28/28, 길이 1980자 (Telegram 4096 제한 내)
- `aiohttp` 예외 분류 실측: 죽은 포트 → `ClientConnectorError`,
  `ServerDisconnectedError` 는 비포함(의도대로 generic 경로)
- 실제 `/insight_agent` 엔드투엔드 응답 확인

## 참고 — 배포 시 유의

`main`(`648466c3`)이 app-server 배포본(`fe25e33`)보다 앞서 있다. 이 PR을 배포하면
`#577`~`#579` 도 함께 올라간다. 별도 판단이 필요해 봇 배포는 하지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)