### PR TITLE
fix(insight): 90초 타임아웃 제거 + 합성 모델 Sonnet 5 교체

### DIFF
--- a/cores/archive/insight_agent.py
+++ b/cores/archive/insight_agent.py
@@ -3,7 +3,8 @@ insight_agent.py — /insight 명령을 처리하는 메인 에이전트.
 
 흐름:
   1. retrieval: persistent_insights (FTS + embedding) + weekly_summary + report_archive
-  2. synthesis: mcp-agent Agent + AnthropicAugmentedLLM (claude-sonnet-4-6)
+  2. synthesis: mcp-agent Agent + AnthropicAugmentedLLM (기본 claude-sonnet-5,
+                INSIGHT_MODEL 로 교체 가능)
                 function calling으로 필요시 MCP 도구 자동 선택
                 (perplexity / firecrawl / yahoo_finance / kospi_kosdaq)
 
@@ -18,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
@@ -39,7 +41,9 @@ from .query_engine import QueryEngine, load_api_key
 logger = logging.getLogger(__name__)
 
 # Claude handles MCP function calling reliably in this repo (firecrawl pattern).
-DEFAULT_MODEL = "claude-sonnet-4-6"
+# Overridable so model swaps don't need a code change — the report path already
+# works this way via REPORT_MODEL.
+DEFAULT_MODEL = os.getenv("INSIGHT_MODEL", "claude-sonnet-5")
 _MAX_REPORTS_IN_CONTEXT = 6
 
 # MCP 서버 연결 순서 — 무료 우선, 유료 후순 (프롬프트 가드레일과 함께 동작)

--- a/telegram_ai_bot.py
+++ b/telegram_ai_bot.py
@@ -452,6 +452,11 @@ class InsightServiceUnavailable(Exception):
     """Archive API unreachable (tunnel/service down) — no quota was consumed."""
 
 
+class InsightTimeout(Exception):
+    """Client gave up waiting. The server keeps going and usually finishes, so
+    the answer may already be saved and the quota already consumed."""
+
+
 class TelegramAIBot:
     """Telegram AI Conversational Bot"""
 
@@ -3356,7 +3361,7 @@ class TelegramAIBot:
         logger.info(f"/insight - user={user_id}, q='{question[:60]}'")
 
         waiting_msg = await update.message.reply_text(
-            "🧭 누적 인사이트 + 시장 데이터 결합 중…"
+            "🧭 누적 인사이트 + 시장 데이터 결합 중…\n(1~2분 걸릴 수 있습니다)"
         )
 
         try:
@@ -3421,6 +3426,19 @@ class TelegramAIBot:
                     "사용 횟수는 차감되지 않았으니 잠시 후 다시 시도해주세요."
                 ),
             )
+        except InsightTimeout:
+            try:
+                await waiting_msg.delete()
+            except Exception:
+                pass
+            await self.application.bot.send_message(
+                chat_id=chat_id,
+                text=(
+                    "⏳ 답변 생성이 예상보다 오래 걸려 응답을 받지 못했습니다.\n"
+                    "질문이 무거우면 시간이 더 걸립니다. 범위를 좁혀 다시 물어봐 주세요.\n"
+                    "(이번 시도는 사용 횟수가 차감됐을 수 있습니다)"
+                ),
+            )
         except Exception as e:
             logger.error(f"/insight error: {e}", exc_info=True)
             try:
@@ -3444,6 +3462,11 @@ class TelegramAIBot:
         api_url = os.getenv("ARCHIVE_API_URL", "").rstrip("/")
         api_key = os.getenv("ARCHIVE_API_KEY", "")
         daily_limit = int(os.getenv("INSIGHT_DAILY_LIMIT", "20"))
+        # The agent runs retrieval + Claude with 4 MCP servers, then embeds and
+        # saves. A measured heavy question took 101s, so the old 90s ceiling cut
+        # off work the server went on to finish — the answer was persisted and
+        # the quota consumed while the user only saw an error.
+        http_timeout = int(os.getenv("INSIGHT_HTTP_TIMEOUT", "300"))
 
         if api_url:
             import aiohttp
@@ -3462,7 +3485,7 @@ class TelegramAIBot:
                     async with s.post(
                         f"{api_url}/insight_agent",
                         json=payload_body, headers=headers,
-                        timeout=aiohttp.ClientTimeout(total=90),
+                        timeout=aiohttp.ClientTimeout(total=http_timeout),
                     ) as resp:
                         if resp.status != 200:
                             logger.error(
@@ -3478,6 +3501,14 @@ class TelegramAIBot:
                             tickers_mentioned=data.get("tickers_mentioned", []),
                             tools_used=data.get("tools_used", []),
                         )
+            except asyncio.TimeoutError as e:
+                # Server-side work is NOT cancelled by our giving up: it goes on
+                # to save the insight and charge the quota. Say so honestly
+                # instead of implying the request never happened.
+                logger.error(
+                    f"_call_insight_agent timeout after {http_timeout}s"
+                )
+                raise InsightTimeout(str(e)) from e
             except aiohttp.ClientConnectorError as e:
                 # Could not even open the connection (tunnel or archive_api is
                 # down), so the request never ran and no quota was consumed.
@@ -3522,7 +3553,7 @@ class TelegramAIBot:
             return
         chat_id = update.effective_chat.id
         waiting = await update.message.reply_text(
-            "🧭 누적 인사이트 + 시장 데이터 결합 중…"
+            "🧭 누적 인사이트 + 시장 데이터 결합 중…\n(1~2분 걸릴 수 있습니다)"
         )
         try:
             payload = await self._call_insight_agent(
@@ -3569,6 +3600,16 @@ class TelegramAIBot:
             await update.message.reply_text(
                 "🛠 인사이트 서비스가 일시적으로 중단되어 있습니다.\n"
                 "사용 횟수는 차감되지 않았으니 잠시 후 다시 시도해주세요."
+            )
+        except InsightTimeout:
+            try:
+                await waiting.delete()
+            except Exception:
+                pass
+            await update.message.reply_text(
+                "⏳ 답변 생성이 예상보다 오래 걸려 응답을 받지 못했습니다.\n"
+                "질문 범위를 좁혀 다시 물어봐 주세요.\n"
+                "(이번 시도는 사용 횟수가 차감됐을 수 있습니다)"
             )
         except Exception as e:
             logger.error(f"_handle_insight_reply error: {e}", exc_info=True)


### PR DESCRIPTION
`/insight` 연결 장애(#580)를 고친 직후, 실사용에서 **다른 원인**으로 또 실패했다.

## 1. 90초 타임아웃이 완료된 작업을 버리고 있었다

```
20:46:18  /insight - user=1087968824, q='지금 시점에 장기투자할만한거 추천좀...'
20:47:50  ERROR - _call_insight_agent HTTP error:        <- 메시지가 비어 있다
          asyncio.exceptions.CancelledError -> TimeoutError
```

에러 메시지가 빈 문자열인 게 단서였다. `asyncio.TimeoutError` 는 `str()` 이 비어 있다.

**클라이언트는 90초에 포기했지만 서버는 계속 돌아 101초에 정상 완료했다.**

- `20:46:21` 임베딩(리트리벌 시작) → `20:46:35` Claude #1 → `20:47:20` #2 → `20:48:01` #3 → `20:48:02` 임베딩(저장)
- Anthropic 3회 왕복 = MCP 도구 호출 루프(`perplexity`·`yahoo_finance`·`firecrawl_scrape` 각 1회)

결과적으로 **원장에는 답변이 남고**(`id=27`, 1357자) **할당량도 차감**됐는데
사용자는 "조회에 실패했습니다"만 받았다. 가장 나쁜 조합이다.

### 변경
- `total=90` → `INSIGHT_HTTP_TIMEOUT`(기본 **300초**). 실측 101초 대비 여유를 뒀다.
- 타임아웃을 `InsightTimeout` 으로 분리했다. 이 경우 서버 작업은 취소되지 않으므로
  "차감되지 않았다"고 말하면 **거짓**이 된다. 차감됐을 수 있다고 알리고 질문 범위를
  좁히도록 안내한다.
- 대기 메시지에 `(1~2분 걸릴 수 있습니다)` 를 붙였다. 이전에는 소요 시간 안내가 없어
  사용자가 멈춘 것으로 오해할 수밖에 없었다.

연결 실패(`ClientConnectorError`)와 타임아웃(`asyncio.TimeoutError`)은 **차감 여부가
다르므로** 계속 분리해 둔다.

## 2. 합성 모델 Sonnet 5 교체

`claude-sonnet-4-6` → `claude-sonnet-5`, 그리고 `INSIGHT_MODEL` 로 교체 가능하게 했다.
리포트 경로는 `REPORT_MODEL` 로 바꿀 수 있는데 insight 만 상수로 박혀 있어
교체마다 코드 수정·배포가 필요했다.

모델 ID 는 **실제 Anthropic API 로 검증**했다. 잘못된 ID 는 LLM 호출을 실패시키고
`[인사이트 엔진 오류]` 폴백(검색 컨텍스트 원문)을 내보내므로 겉보기엔 도는 것처럼
보인다.

```
claude-sonnet-5   -> 200, resolved=claude-sonnet-5
claude-sonnet-4-6 -> 200, resolved=claude-sonnet-4-6
claude-opus-5     -> 200, resolved=claude-opus-5
```

## 검증

- `py_compile` 통과 (`telegram_ai_bot.py`, `insight_agent.py`)
- AST: 두 호출 지점 모두 핸들러 순서 `InsightServiceUnavailable` → `InsightTimeout` → `Exception`
- **느린 서버로 실제 타임아웃 재현** → `asyncio.TimeoutError` 로 분류되고 `str()` 이
  빈 문자열인 것까지 운영 로그와 일치
- `total=90` 잔존 0건, insight 경로 모델 하드코딩 잔존 0건
- `INSIGHT_MODEL` 오버라이드 동작 확인

## 배포 후 확인할 것

`model_used` 가 `claude-sonnet-5` 로 기록되는지, 소요 시간이 300초 안에 들어오는지.

```sql
SELECT id, model_used, created_at FROM persistent_insights ORDER BY id DESC LIMIT 3;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)