### PR TITLE
fix(insight): 구조화 복구 패스가 깨진 이력을 재생하지 않게 한다

### DIFF
--- a/cores/archive/insight_agent.py
+++ b/cores/archive/insight_agent.py
@@ -365,22 +365,47 @@ class InsightAgent:
         logger.warning("InsightAgent: 응답에서 JSON 을 찾지 못했다")
         return None
 
-    async def _repair_to_json(self, llm) -> Optional[Dict[str, Any]]:
+    async def _repair_to_json(
+        self, llm, question: str, context_str: str, draft: str,
+    ) -> Optional[Dict[str, Any]]:
         """JSON 파싱이 실패했을 때의 복구 패스.
 
         `generate_structured` 는 Anthropic 의 강제 tool_call 로 스키마를 받아내는
-        한 턴 호출이라 형식이 보장된다. 도구를 주지 않으므로 추가 유료 호출도
-        없고, use_history=True 라 앞선 도구 결과를 그대로 활용한다.
+        한 턴 호출이라 형식이 보장된다. 도구를 주지 않으므로 추가 유료 호출도 없다.
+
+        **`use_history=False` 가 핵심이다.** 파싱이 깨지는 상황은 대개 도구 루프가
+        중간에 끊긴 경우인데, 그때 이력의 마지막이 `tool_result` 없는 `tool_use` 로
+        남는다. 그 이력을 재생하면 Anthropic 이 400 으로 거절한다:
+
+            messages.4: `tool_use` ids were found without `tool_result` blocks
+            immediately after
+
+        그래서 이력을 버리고 질문·컨텍스트·조사 메모를 직접 실어 자립적인 한 턴으로
+        만든다. 메모에서 도구 추적 줄은 걷어낸다 — 모델에게 다시 먹일 내용이 아니다.
         """
+        clean_draft = "\n".join(
+            ln for ln in (draft or "").splitlines()
+            if not ln.lstrip().startswith(_TRACE_MARKER)
+        ).strip()
+
+        msg = (
+            f"## 사용자 질문\n{question}\n\n"
+            f"## 컨텍스트 (누적 인사이트 + 리포트)\n{context_str}\n\n"
+        )
+        if clean_draft:
+            msg += f"## 앞선 조사 메모\n{clean_draft[:2000]}\n\n"
+        msg += (
+            "위 내용만으로 최종 답변을 만드세요. 도구를 쓰지 마세요.\n"
+            "answer 는 합쇼체 400~1200자로, 확인된 사실만 담으세요."
+        )
+
         try:
             result = await llm.generate_structured(
-                message=(
-                    "위 조사 결과만으로 최종 답변을 만드세요. 새로 도구를 쓰지 마세요.\n"
-                    "answer 는 합쇼체 400~1200자로, 확인된 사실만 담으세요."
-                ),
+                message=msg,
                 response_model=InsightJSON,
                 request_params=RequestParams(
-                    model=self.model, maxTokens=4000, max_iterations=1,
+                    model=self.model, maxTokens=4000,
+                    max_iterations=1, use_history=False,
                 ),
             )
         except Exception as e:
@@ -471,7 +496,9 @@ class InsightAgent:
                     # 위에서 구조화 복구를 한 번 시도한다.
                     parsed = self._parse_response(response_text)
                     if parsed is None:
-                        parsed = await self._repair_to_json(llm)
+                        parsed = await self._repair_to_json(
+                            llm, question, context_str, response_text,
+                        )
             except Exception as agent_err:
                 logger.error(
                     f"InsightAgent LLM call failed: {agent_err}", exc_info=True


### PR DESCRIPTION
#582 로 추적 유출은 막혔지만, 구조화 복구 패스가 실제로는 **한 번도 성공하지 못했다.**

```
InsightAgent structured 복구 실패: Error code: 400 - invalid_request_error
messages.4: `tool_use` ids were found without `tool_result` blocks
immediately after: toolu_01PsWoAoXUV3gMEDsgNmWs5A
```

## 원인

JSON 파싱이 깨지는 상황은 대개 **도구 루프가 중간에 끊긴 경우**다. 그때 대화
이력의 마지막이 `tool_result` 없는 `tool_use` 로 남는다. `use_history=True` 라
복구 패스가 그 깨진 이력을 그대로 재생하고, Anthropic 이 400 으로 거절한다.

결과적으로 사용자는 `⚠️ 답변을 정리하는 데 실패했습니다` 를 받았다. 추적 유출은
막았지만 답을 못 준 셈이다 — 안전하지만 완성이 아니었다.

## 변경

복구 패스를 **자립적인 한 턴**으로 바꿨다.

- `use_history=False` — 깨진 이력을 아예 쓰지 않는다
- 질문·컨텍스트·조사 메모를 메시지에 직접 싣는다
- 메모에서 `[Calling tool ...]` 줄은 걷어낸다 (모델에게 다시 먹일 내용이 아니다)

## 검증 — 직전에 실패했던 질문들

운영 db-server, Sonnet 5:

- `하락장에서 분석된 반도체 종목들 30일 수익률은?` → 226초, **1110자 정상 답변**
- `손절 발동 후 회복한 종목 비율은?` → 80초, **1155자 정상 답변**

둘 다 추적 유출 없음. 로그에서 복구 발동을 확인했다:

```
WARNING InsightAgent: 응답에서 JSON 을 찾지 못했다
INFO    InsightAgent: structured 복구 패스로 JSON 을 확보했다   ← 2회 발동 2회 성공
```

도구 사용이 무료 중심으로 역전됐다(2건 합계): `get_stock_ohlcv` 13회 +
`load_all_tickers` 1회(무료) 대 `perplexity_ask` 2회(유료). #582 의 화이트리스트와
PATH 복구가 함께 작동한 결과다.

## 참고 — 지연

`get_stock_ohlcv` 를 종목마다 부르면 1코어 db-server 에서 226초까지 간다.
봇 타임아웃이 300초라 여유가 74초뿐이므로, app-server `.env` 의
`INSIGHT_HTTP_TIMEOUT` 을 420 으로 올린다(코드 변경 불필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)