### PR TITLE
fix(archive): restore US report ingestion

### DIFF
--- a/prism-us/tests/test_us_analysis_cores_shadow.py
+++ b/prism-us/tests/test_us_analysis_cores_shadow.py
@@ -24,6 +24,8 @@ must not corrupt the pytest interpreter's sys.modules) and assert:
 2. With the fix, importing ``cores.us_analysis`` under the shadow succeeds, the
    ReportAgent-backed callables are present, and ``sys.modules['cores']`` is
    restored to the prism-us package afterwards (no global corruption).
+3. The US orchestrator can load ROOT ``cores.archive.ingest`` with its relative
+   imports intact, then restores the prism-us ``cores`` package.
 """
 import subprocess
 import sys
@@ -121,3 +123,27 @@ def test_us_analysis_loader_resolves_root_cores_under_shadow():
     assert "FIX_OK" in result.stdout, (
         "Post-fix assertions did not pass:\n" + result.stdout + result.stderr
     )
+
+
+def test_us_orchestrator_loads_archive_ingest_under_shadow():
+    """The archive hook must load ROOT cores.archive, not prism-us/cores."""
+    body = """
+        import cores
+        shadow_cores = cores
+
+        import us_stock_analysis_orchestrator as orchestrator
+        ingest = orchestrator._import_main_archive_ingest()
+
+        assert callable(ingest.ingest_reports_async)
+        assert ingest.__file__.replace("\\\\", "/").endswith(
+            "/cores/archive/ingest.py"
+        )
+        assert sys.modules["cores"] is shadow_cores
+        print("ARCHIVE_IMPORT_OK")
+    """
+    result = _run_in_shadow_subprocess(body)
+    assert result.returncode == 0, (
+        "Loading ROOT cores.archive.ingest under the shadow failed:\n"
+        + result.stdout + result.stderr
+    )
+    assert "ARCHIVE_IMPORT_OK" in result.stdout

--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -102,6 +102,38 @@ def _import_from_main_cores(module_name: str, relative_path: str):
     return module
 
 
+def _import_main_archive_ingest():
+    """Import ROOT ``cores.archive.ingest`` without leaking it globally.
+
+    File-path loading via :func:`_import_from_main_cores` is insufficient for
+    package modules such as ``cores.archive.ingest`` because they use relative
+    imports. Temporarily make the project root authoritative, import the whole
+    package chain, then restore the prism-us ``cores`` modules exactly as they
+    were. The returned module retains its already-resolved ROOT dependencies.
+    """
+    saved_path = list(sys.path)
+    saved_modules = {
+        name: module
+        for name, module in list(sys.modules.items())
+        if name == "cores" or name.startswith("cores.")
+    }
+    try:
+        for name in saved_modules:
+            sys.modules.pop(name, None)
+        sys.path.insert(0, str(PROJECT_ROOT))
+        import cores.archive.ingest as archive_ingest
+        return archive_ingest
+    finally:
+        sys.path[:] = saved_path
+        for name in [
+            key
+            for key in list(sys.modules)
+            if key == "cores" or key.startswith("cores.")
+        ]:
+            sys.modules.pop(name, None)
+        sys.modules.update(saved_modules)
+
+
 def _import_proxy_safe():
     """Load chatgpt_proxy from main project cores/ without polluting sys.modules['cores'].
 
@@ -1156,10 +1188,12 @@ class USStockAnalysisOrchestrator:
 
             # 3. Archive ingest (fire-and-forget, does not block pipeline)
             try:
-                from cores.archive.ingest import ingest_reports_async  # type: ignore[import]
-                asyncio.create_task(ingest_reports_async(report_paths, market="us"))
+                archive_ingest = _import_main_archive_ingest()
+                asyncio.create_task(
+                    archive_ingest.ingest_reports_async(report_paths, market="us")
+                )
             except Exception as _e:
-                logger.warning(f"Archive ingest hook skipped: {_e}")
+                logger.exception(f"Archive ingest hook failed to start: {_e}")
 
             # 4. PDF conversion
             pdf_paths = await self.convert_to_pdf(report_paths)


### PR DESCRIPTION
## Summary
- load root `cores.archive.ingest` safely when `prism-us/cores` shadows the root package
- restore the original `cores` module view after loading
- log archive hook startup failures at ERROR with traceback
- add subprocess regression coverage for the production import layout

## Verification
- `pytest prism-us/tests/test_us_analysis_cores_shadow.py -q -p no:cacheprovider` (3 passed)
- `py_compile prism-us/us_stock_analysis_orchestrator.py`
- `git diff --check`
- broader phase7 suite: 30 passed, 1 pre-existing fixture failure (`_FakeTrackingAgent.last_batch_messages` missing; identical on origin/main)