### PR TITLE
fix(insight): enforce grounded retrieval and tool provenance

### DIFF
--- a/cores/archive/insight_agent.py
+++ b/cores/archive/insight_agent.py
@@ -22,23 +22,26 @@ import logging
 import os
 import re
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
-
-from pydantic import BaseModel, Field
-
-from datetime import datetime, timezone, timedelta
 
 from mcp_agent.agents.agent import Agent
 from mcp_agent.workflows.llm.augmented_llm import RequestParams
 from mcp_agent.workflows.llm.augmented_llm_anthropic import AnthropicAugmentedLLM
-
-_KST = timezone(timedelta(hours=9))
+from pydantic import BaseModel, Field
 
 from . import persistent_insights as pi_store
 from .archive_db import ARCHIVE_DB_PATH
 from .embedding import embed_text
 from .insight_prompts import INSIGHT_SYSTEM_PROMPT
-from .query_engine import QueryEngine, load_api_key
+from .query_engine import (
+    QueryEngine,
+    extract_query_tickers,
+    load_api_key,
+    parse_query_hints,
+)
+
+_KST = timezone(timedelta(hours=9))
 
 logger = logging.getLogger(__name__)
 
@@ -65,10 +68,8 @@ _MAX_AGENT_ITERATIONS = 6
 # 전부 0 인 UUID 로 호출하고 `perplexity_ask` 를 'placeholder'·'ignore' 같은
 # 인자로 8번 호출해 유료 크레딧을 태웠다.
 #
-# 필터 dict 에 없는 서버는 필터링되지 않는다(전체 허용). yahoo_finance 를
-# 일부러 비워둔 이유는 현재 그 서버가 도구를 0개 노출하기 때문이다 —
-# uvx 캐시의 yahoo-finance-mcp 가 `mcp.server.fastmcp` 를 못 찾아 죽는다.
-# 고쳐지면 도구가 그대로 돌아오도록 열어둔다.
+# 필터 dict 에 없는 서버는 필터링되지 않는다(전체 허용). yahoo_finance 는
+# 서버가 제공하는 금융 도구 전체를 쓸 수 있도록 의도적으로 비워둔다.
 _MCP_TOOL_ALLOWLIST = {
     "perplexity": {"perplexity_ask"},
     "firecrawl": {"firecrawl_scrape"},
@@ -86,6 +87,27 @@ _MCP_TOOL_ALLOWLIST = {
 # generate_str() 은 모든 반복의 assistant 턴을 이어붙이므로 tool_use 블록이
 # 이 문자열로 함께 들어온다. 사용자에게 절대 나가면 안 되는 표식이다.
 _TRACE_MARKER = "[Calling tool "
+
+
+def _is_archive_only_question(question: str) -> bool:
+    """Return True when the user explicitly forbids external research."""
+    patterns = (
+        r"(?:PRISM|프리즘)?\s*(?:리포트|보고서|아카이브)\s*(?:만|만을|에만)",
+        r"외부\s*(?:검색|도구|자료)\s*(?:없이|금지|사용하지)",
+        r"웹\s*검색\s*(?:없이|금지|사용하지)",
+        r"\b(?:archive|prism)\s+(?:reports?\s+)?only\b",
+        r"\bno\s+(?:external|web)\s+(?:search|tools?|sources?)\b",
+    )
+    return any(re.search(pattern, question, re.IGNORECASE) for pattern in patterns)
+
+
+def _extract_actual_tools(raw: str) -> List[str]:
+    """Extract de-duplicated tool names from mcp-agent's actual call trace."""
+    tools: List[str] = []
+    for name in re.findall(r"\[Calling tool\s+([^\s\]]+)", raw or ""):
+        if name not in tools:
+            tools.append(name)
+    return tools[:10]
 
 
 def _balanced_json_objects(text: str) -> List[str]:
@@ -161,18 +183,51 @@ class InsightAgent:
     async def _build_retrieval_context(self, question: str) -> Dict[str, Any]:
         api_key = self._api_key or load_api_key()
         self._api_key = api_key
-        q_emb = await embed_text(question, api_key) if api_key else None
-
         engine = QueryEngine(db_path=self.db_path, model=self.model)
+        hints = parse_query_hints(question)
+        explicit_tickers = extract_query_tickers(question)
+
+        async def retrieve_reports():
+            if len(explicit_tickers) <= 1:
+                return await engine.retrieve(
+                    text=question, market=hints["market"],
+                    ticker=hints["ticker"], date_from=hints["date_from"],
+                    date_to=hints["date_to"],
+                )
+            batches = await asyncio.gather(*(
+                engine.retrieve(
+                    text=question, market=hints["market"], ticker=ticker,
+                    date_from=hints["date_from"], date_to=hints["date_to"],
+                )
+                for ticker in explicit_tickers
+            ))
+            seen: set[int] = set()
+            merged = []
+            for batch in batches:
+                for report in batch:
+                    if report.report_id not in seen:
+                        seen.add(report.report_id)
+                        merged.append(report)
+            return merged[:_MAX_REPORTS_IN_CONTEXT]
+
+        reports_task = retrieve_reports()
+
+        # "PRISM 리포트만" means exactly that: skip accumulated summaries and
+        # derived facts as well as all external MCP tools.
+        if _is_archive_only_question(question):
+            reports = await reports_task
+            return {
+                "insights": [], "weekly": [],
+                "reports": (reports or [])[:_MAX_REPORTS_IN_CONTEXT],
+                "outcomes": {}, "semantic_facts": {}, "q_emb": None,
+            }
+
+        q_emb = await embed_text(question, api_key) if api_key else None
 
         insights_task = pi_store.search_insights(
             question, q_emb, limit=5, exclude_superseded=True, db_path=self.db_path,
         )
         weekly_task = pi_store.recent_weekly_summaries(weeks=4, db_path=self.db_path)
-        reports_task = engine.retrieve(
-            text=question, market=None, ticker=None,
-            date_from=None, date_to=None,
-        )
         insights, weekly, reports = await asyncio.gather(
             insights_task, weekly_task, reports_task,
             return_exceptions=True,
@@ -311,6 +366,26 @@ class InsightAgent:
                 excerpt = ((r.content_excerpt or "")[:400]).replace("\n", " ")
                 parts.append(f"  {excerpt}")
         return "\n".join(parts) if parts else "(관련 컨텍스트 없음)"
+
+    def _ground_response_metadata(
+        self,
+        parsed: Dict[str, Any],
+        ctx: Dict[str, Any],
+        response_text: str,
+    ) -> Dict[str, Any]:
+        """Replace model self-reporting with server-observed provenance."""
+        allowed_ids = [r.report_id for r in (ctx.get("reports") or [])]
+        allowed_set = set(allowed_ids)
+        claimed_ids = parsed.get("evidence_report_ids") or []
+        evidence_ids = [rid for rid in claimed_ids if rid in allowed_set]
+        if not evidence_ids and allowed_ids:
+            evidence_ids = allowed_ids
+
+        actual_tools = _extract_actual_tools(response_text)
+        tools_used = (["archive_retrieval"] if allowed_ids else []) + actual_tools
+        parsed["evidence_report_ids"] = evidence_ids[:10]
+        parsed["tools_used"] = tools_used[:10]
+        return parsed
 
     # ------------------------------------------------------------------
     # JSON response parser — resilient to model quirks
@@ -470,10 +545,19 @@ class InsightAgent:
                 "- 외부 도구 호출 시에도 이 기준일 범위의 데이터를 요청하세요.\n\n"
                 f"{INSIGHT_SYSTEM_PROMPT}"
             )
+            archive_only = _is_archive_only_question(question)
+            server_names = [] if archive_only else _MCP_SERVERS
+            tool_filter = {} if archive_only else _MCP_TOOL_ALLOWLIST
+            if archive_only:
+                dated_prompt += (
+                    "\n\n# 이번 요청의 도구 정책\n"
+                    "사용자가 PRISM 아카이브만 요청했습니다. 외부 검색이나 "
+                    "MCP 도구를 사용하지 말고 제공된 리포트만 근거로 답하세요."
+                )
             agent = Agent(
                 name="insight_agent",
                 instruction=dated_prompt,
-                server_names=_MCP_SERVERS,
+                server_names=server_names,
             )
             try:
                 async with agent:
@@ -489,7 +573,7 @@ class InsightAgent:
                             model=self.model,
                             maxTokens=4000,
                             max_iterations=_MAX_AGENT_ITERATIONS,
-                            tool_filter=_MCP_TOOL_ALLOWLIST,
+                            tool_filter=tool_filter,
                         ),
                     )
                     # 세션이 살아 있는 동안 파싱한다. 실패 시 같은 대화 이력
@@ -544,6 +628,8 @@ class InsightAgent:
                 evidence_report_ids=[],
                 remaining_quota=remaining, model_used=self.model,
             )
+
+        parsed = self._ground_response_metadata(parsed, ctx, response_text)
 
         # 5. Embedding for key_takeaways (fire-and-forget 성격)
         api_key = self._api_key or load_api_key()

--- a/cores/archive/query_engine.py
+++ b/cores/archive/query_engine.py
@@ -148,7 +148,30 @@ def _to_fts_query(text: str) -> str:
     return " OR ".join(parts)
 
 
-def _parse_hints(text: str) -> Dict[str, Optional[str]]:
+_TICKER_STOPWORDS = frozenset({
+    "AI", "US", "OR", "AN", "AS", "AT", "BE", "BY", "DO", "GO", "IF",
+    "IN", "IS", "IT", "ME", "MY", "NO", "OF", "OK", "ON", "SO", "TO",
+    "UP", "WE", "AM", "ARE", "THE", "AND", "FOR", "NOT", "BUT", "ALL",
+    "CAN", "HAS", "HER", "HIM", "HIS", "HOW", "ITS", "MAY", "NEW",
+    "NOW", "OLD", "OUR", "OUT", "OWN", "SAY", "SHE", "TOO", "USE",
+    "ETF", "IPO", "CEO", "CFO", "NYSE", "SEC", "FDA", "GDP", "PRISM",
+})
+
+
+def extract_query_tickers(text: str) -> List[str]:
+    """Extract unique explicit US symbols and Korean six-digit codes."""
+    tickers: List[str] = []
+    # Python's \b treats Korean particles as word characters, so `HPE의` and
+    # `005930은` need ASCII-specific boundaries.
+    candidates = re.findall(r"(?<![A-Z0-9])([A-Z]{2,5})(?![A-Z0-9])", text)
+    candidates.extend(re.findall(r"(?<!\d)(\d{6})(?!\d)", text))
+    for ticker in candidates:
+        if ticker not in _TICKER_STOPWORDS and ticker not in tickers:
+            tickers.append(ticker)
+    return tickers
+
+
+def parse_query_hints(text: str) -> Dict[str, Optional[str]]:
     """
     Best-effort extraction of ticker / market / date hints from NL query.
 
@@ -164,26 +187,37 @@ def _parse_hints(text: str) -> Dict[str, Optional[str]]:
     elif re.search(r"\b(kr|코스피|코스닥|한국|국내|kospi|kosdaq)\b", text, re.IGNORECASE):
         hints["market"] = "kr"
 
-    # Ticker hint — US: 2-5 uppercase letters; KR: 6-digit code
-    _TICKER_STOPWORDS = frozenset({
-        "AI", "US", "OR", "AN", "AS", "AT", "BE", "BY", "DO", "GO", "IF",
-        "IN", "IS", "IT", "ME", "MY", "NO", "OF", "OK", "ON", "SO", "TO",
-        "UP", "WE", "AM", "ARE", "THE", "AND", "FOR", "NOT", "BUT", "ALL",
-        "CAN", "HAS", "HER", "HIM", "HIS", "HOW", "ITS", "MAY", "NEW",
-        "NOW", "OLD", "OUR", "OUT", "OWN", "SAY", "SHE", "TOO", "USE",
-        "ETF", "IPO", "CEO", "CFO", "NYSE", "SEC", "FDA", "GDP",
-    })
-    m = re.search(r"\b([A-Z]{2,5})\b", text)
-    if m and m.group(1) not in _TICKER_STOPWORDS:
-        hints["ticker"] = m.group(1)
-    m = re.search(r"\b(\d{6})\b", text)
-    if m:
-        hints["ticker"] = m.group(1)
+    # A single ticker can use the structured fast path. Multiple tickers are
+    # handled by callers as separate constrained retrievals.
+    tickers = extract_query_tickers(text)
+    if len(tickers) == 1:
+        hints["ticker"] = tickers[0]
 
-    # Date hints — ISO dates or Korean shorthand like "10월", "2025년 4분기"
+    # Exact dates are closed ranges. A lower bound alone silently mixed older
+    # reports into "on YYYY-MM-DD" requests in the /insight agent.
     m = re.search(r"(\d{4}-\d{2}-\d{2})", text)
     if m:
         hints["date_from"] = m.group(1)
+        hints["date_to"] = m.group(1)
+    else:
+        m = re.search(
+            r"(\d{4})\s*[년./-]\s*(\d{1,2})\s*[월./-]\s*(\d{1,2})\s*일?",
+            text,
+        )
+        if not m:
+            m = re.search(r"(?<!\d)(\d{1,2})\s*[월/]\s*(\d{1,2})\s*일?(?!\d)", text)
+            date_parts = (datetime.today().year, *m.groups()) if m else None
+        else:
+            date_parts = m.groups()
+        if m:
+            try:
+                exact_date = datetime(
+                    *(int(part) for part in date_parts)
+                ).strftime("%Y-%m-%d")
+                hints["date_from"] = exact_date
+                hints["date_to"] = exact_date
+            except ValueError:
+                pass
 
     # "지난 N일" / "최근 N일"
     m = re.search(r"(?:지난|최근)\s*(\d+)일", text)
@@ -192,6 +226,10 @@ def _parse_hints(text: str) -> Dict[str, Optional[str]]:
         hints["date_from"] = (datetime.today() - timedelta(days=days)).strftime("%Y-%m-%d")
 
     return hints
+
+
+# Backward compatibility for code/tests that imported the former private name.
+_parse_hints = parse_query_hints
 
 
 def _parse_outcome_filter(text: str) -> Dict[str, Any]:
@@ -455,7 +493,7 @@ class QueryEngine:
         await init_db(self.db_path)
 
         # Merge explicit args with hints parsed from NL
-        hints = _parse_hints(text)
+        hints = parse_query_hints(text)
         effective_market = market or hints["market"]
         effective_ticker = ticker or hints["ticker"]
         effective_date_from = date_from or hints["date_from"]
@@ -649,7 +687,14 @@ class QueryEngine:
                 db_path=self.db_path,
             )
 
-        # Merge: FTS hits first (most relevant), then structured-only hits
+        # Structured constraints are hard filters, not extra candidates. The
+        # old union allowed an older, highly relevant FTS hit to bypass an exact
+        # date requested by the user.
+        if ticker or date_from or date_to:
+            allowed_ids = {hit["id"] for hit in structured_hits}
+            fts_hits = [hit for hit in fts_hits if hit["id"] in allowed_ids]
+
+        # Merge: constrained FTS hits first, then structured-only hits.
         seen: set = set()
         merged: List[Dict] = []
         for hit in fts_hits:

--- a/cores/llm/mcp_servers.yaml
+++ b/cores/llm/mcp_servers.yaml
@@ -76,8 +76,10 @@ servers:
     - http://localhost:8000/sse
     read_timeout_seconds: 120
   yahoo_finance:
-    command: uvx
+    command: uv
     args:
+    - tool
+    - run
     - --from
     - yahoo-finance-mcp==0.1.2
     - --with

--- a/mcp_agent.config.yaml.example
+++ b/mcp_agent.config.yaml.example
@@ -79,8 +79,8 @@ mcp:
     # Python-based, uses stable yfinance library (not deprecated yahoo-finance2)
     # Provides: OHLCV, company info, financials, institutional holders, news, recommendations
     yahoo_finance:
-      command: "uvx"
-      args: ["--from", "yahoo-finance-mcp", "yahoo-finance-mcp"]
+      command: "uv"
+      args: ["tool", "run", "--from", "yahoo-finance-mcp==0.1.2", "--with", "mcp==1.26.0", "yahoo-finance-mcp"]
       read_timeout_seconds: 120
 
     # SEC EDGAR MCP server for official SEC filings and financial data (PyPI: sec-edgar-mcp)

--- a/tests/test_insight_agent_grounding.py
+++ b/tests/test_insight_agent_grounding.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+
+import pytest
+
+from cores.archive import insight_agent as insight_module
+from cores.archive.insight_agent import (
+    InsightAgent,
+    _extract_actual_tools,
+    _is_archive_only_question,
+)
+from cores.archive.query_engine import parse_query_hints
+
+
+def test_exact_korean_date_is_a_closed_range():
+    hints = parse_query_hints(
+        "미국 MU SMCI HPE의 2026년 8월 10일 PRISM 리포트만 요약해줘"
+    )
+
+    assert hints["market"] == "us"
+    assert hints["ticker"] is None
+    assert hints["date_from"] == "2026-08-10"
+    assert hints["date_to"] == "2026-08-10"
+
+
+def test_exact_iso_date_is_a_closed_range():
+    hints = parse_query_hints("US reports on 2026-08-10")
+
+    assert hints["date_from"] == "2026-08-10"
+    assert hints["date_to"] == "2026-08-10"
+
+
+def test_month_day_shorthand_uses_current_year_as_a_closed_range():
+    hints = parse_query_hints("US MU 8/10 리포트만")
+
+    assert hints["date_from"] == hints["date_to"]
+    assert hints["date_from"].endswith("-08-10")
+
+
+def test_archive_only_language_disables_external_tools():
+    assert _is_archive_only_question("PRISM 리포트만 근거로 답해줘")
+    assert _is_archive_only_question("외부 검색 없이 아카이브만 사용해")
+    assert _is_archive_only_question("Use archive reports only; no web search")
+    assert not _is_archive_only_question("최신 주가까지 확인해줘")
+
+
+def test_actual_tools_come_from_trace_not_model_claims():
+    raw = """[Calling tool perplexity_ask with arguments {'messages': []}]
+    [Calling tool get_stock_ohlcv with arguments {'ticker': '005930'}]
+    {"tools_used": []}
+    """
+
+    assert _extract_actual_tools(raw) == ["perplexity_ask", "get_stock_ohlcv"]
+
+
+def test_ground_metadata_rejects_unretrieved_evidence_and_records_archive():
+    agent = InsightAgent(db_path=":memory:")
+    parsed = {
+        "answer": "ok",
+        "key_takeaways": [],
+        "tickers_mentioned": ["MU"],
+        "tools_used": [],
+        "evidence_report_ids": [1430, 1420, 999999],
+    }
+    context = {
+        "reports": [SimpleNamespace(report_id=1430), SimpleNamespace(report_id=1451)]
+    }
+
+    grounded = agent._ground_response_metadata(parsed, context, "")
+
+    assert grounded["evidence_report_ids"] == [1430]
+    assert grounded["tools_used"] == ["archive_retrieval"]
+
+
+@pytest.mark.asyncio
+async def test_archive_only_multi_ticker_retrieval_keeps_each_exact_date(monkeypatch):
+    calls = []
+
+    class FakeQueryEngine:
+        def __init__(self, **kwargs):
+            pass
+
+        async def retrieve(self, **kwargs):
+            calls.append(kwargs)
+            ids = {"MU": 1430, "SMCI": 1451, "HPE": 1393}
+            return [SimpleNamespace(report_id=ids[kwargs["ticker"]])]
+
+    monkeypatch.setattr(insight_module, "QueryEngine", FakeQueryEngine)
+    monkeypatch.setattr(insight_module, "load_api_key", lambda: None)
+
+    context = await InsightAgent(db_path=":memory:")._build_retrieval_context(
+        "미국 MU SMCI HPE의 2026년 8월 10일 PRISM 리포트만 요약해줘"
+    )
+
+    assert [call["ticker"] for call in calls] == ["MU", "SMCI", "HPE"]
+    assert all(
+        call["date_from"] == call["date_to"] == "2026-08-10" for call in calls
+    )
+    assert [report.report_id for report in context["reports"]] == [1430, 1451, 1393]
+    assert context["insights"] == []

--- a/tests/test_query_engine_constraints.py
+++ b/tests/test_query_engine_constraints.py
@@ -1,0 +1,38 @@
+import pytest
+
+from cores.archive import query_engine as qe
+
+
+@pytest.mark.asyncio
+async def test_retrieve_applies_date_constraint_to_fts_hits(monkeypatch):
+    old_fts = {
+        "id": 1, "ticker": "MU", "company_name": "Micron",
+        "report_date": "2026-07-24", "market": "us", "mode": "analysis",
+        "snippet": "old but text-relevant",
+    }
+    exact_date = {
+        "id": 2, "ticker": "MU", "company_name": "Micron",
+        "report_date": "2026-08-10", "market": "us", "mode": "analysis",
+        "snippet": "exact date",
+    }
+
+    async def fake_search(*args, **kwargs):
+        return [old_fts, exact_date]
+
+    async def fake_structured(*args, **kwargs):
+        return [exact_date]
+
+    async def fake_empty(*args, **kwargs):
+        return {}
+
+    monkeypatch.setattr(qe, "search_fts", fake_search)
+    monkeypatch.setattr(qe, "get_report_ids", fake_structured)
+    monkeypatch.setattr(qe, "_fetch_enrichments", fake_empty)
+    monkeypatch.setattr(qe, "_fetch_content_excerpts", fake_empty)
+
+    reports = await qe.QueryEngine(db_path=":memory:").retrieve(
+        text="MU", market="us", ticker=None,
+        date_from="2026-08-10", date_to="2026-08-10",
+    )
+
+    assert [report.report_id for report in reports] == [2]

--- a/tests/test_yahoo_mcp_config.py
+++ b/tests/test_yahoo_mcp_config.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_ARGS = [
+    "tool", "run", "--from", "yahoo-finance-mcp==0.1.2",
+    "--with", "mcp==1.26.0", "yahoo-finance-mcp",
+]
+
+
+def test_native_yahoo_uses_uv_tool_run_with_compatible_mcp():
+    config = yaml.safe_load(
+        (ROOT / "cores" / "llm" / "mcp_servers.yaml").read_text(encoding="utf-8")
+    )
+    yahoo = config["servers"]["yahoo_finance"]
+
+    assert yahoo["command"] == "uv"
+    assert yahoo["args"] == EXPECTED_ARGS
+
+
+def test_legacy_example_matches_native_yahoo_command():
+    config = yaml.safe_load(
+        (ROOT / "mcp_agent.config.yaml.example").read_text(encoding="utf-8")
+    )
+    yahoo = config["mcp"]["servers"]["yahoo_finance"]
+
+    assert yahoo["command"] == "uv"
+    assert yahoo["args"] == EXPECTED_ARGS


### PR DESCRIPTION
## Summary
- enforce exact date constraints across FTS and structured archive retrieval
- support multiple explicit tickers and archive-only requests without external MCP servers
- derive evidence/tool provenance from retrieved reports and actual call traces
- run Yahoo Finance MCP via compatible `uv tool run` command

## Verification
- `python3 -m py_compile cores/archive/query_engine.py cores/archive/insight_agent.py`
- Ruff F-rule check on changed Python files
- 20 related pytest tests passed
- production-style `uv tool run --from yahoo-finance-mcp==0.1.2 --with mcp==1.26.0 yahoo-finance-mcp --help` returned 0 on db server