### PR TITLE
fix(insight): bound research and diversify recommendations

### DIFF
--- a/cores/archive/insight_agent.py
+++ b/cores/archive/insight_agent.py
@@ -51,14 +51,11 @@ logger = logging.getLogger(__name__)
 DEFAULT_MODEL = os.getenv("INSIGHT_MODEL", "claude-sonnet-5")
 _MAX_REPORTS_IN_CONTEXT = 6
 
-# MCP 서버 연결 순서 — 무료 우선, 유료 후순 (프롬프트 가드레일과 함께 동작)
-_MCP_SERVERS = ["yahoo_finance", "kospi_kosdaq", "perplexity", "firecrawl"]
-
 # 도구 루프 상한. mcp-agent 기본값은 10인데, 그 값을 다 쓰면 마지막 턴에
 # 라이브러리가 "도구를 멈추고 최종 답변을 하라"는 프롬프트를 주입한다.
 # 그 프롬프트에는 JSON 요구가 없어서 모델이 산문으로 답하고, 결과적으로
 # JSON 파싱이 깨진다. 상한에 닿지 않는 것이 1차 방어선이다.
-_MAX_AGENT_ITERATIONS = 6
+_MAX_AGENT_ITERATIONS = 8
 
 # 도구 화이트리스트 (bare 이름 → mcp-agent 가 namespaced 이름으로 노출).
 #
@@ -99,6 +96,64 @@ def _is_archive_only_question(question: str) -> bool:
         r"\bno\s+(?:external|web)\s+(?:search|tools?|sources?)\b",
     )
     return any(re.search(pattern, question, re.IGNORECASE) for pattern in patterns)
+
+
+def _is_broad_recommendation(question: str) -> bool:
+    """Detect cross-company recommendation requests without explicit tickers."""
+    if extract_query_tickers(question):
+        return False
+    return bool(re.search(
+        r"장기\s*투자.{0,20}(?:할\s*만|추천|찾아|골라)|"
+        r"(?:추천|찾아|골라).{0,20}장기\s*투자",
+        question,
+        re.IGNORECASE,
+    ))
+
+
+def _needs_paid_research(question: str) -> bool:
+    return bool(re.search(
+        r"최신\s*(?:뉴스|업황|이벤트)|뉴스|외부\s*검색|웹\s*검색|"
+        r"latest\s+news|web\s+search",
+        question,
+        re.IGNORECASE,
+    ))
+
+
+def _select_mcp_servers(
+    question: str, hints: Dict[str, Optional[str]],
+) -> List[str]:
+    """Expose only servers necessary for this question."""
+    if _is_archive_only_question(question):
+        return []
+    market = hints.get("market")
+    if market == "kr":
+        servers = ["kospi_kosdaq"]
+    elif market == "us":
+        servers = ["yahoo_finance"]
+    else:
+        servers = ["yahoo_finance", "kospi_kosdaq"]
+    if _needs_paid_research(question):
+        servers.append("perplexity")
+    if re.search(r"https?://", question):
+        servers.append("firecrawl")
+    return servers
+
+
+def _has_internal_tool_status(answer: str) -> bool:
+    """Detect internal orchestration state that must never reach Telegram."""
+    return bool(re.search(
+        r"도구\s*호출\s*한도|도구.{0,20}(?:정상\s*응답|실패)|"
+        r"perplexity.{0,30}(?:정상\s*응답|실패)|max_iterations|"
+        r"tool\s*call\s*limit",
+        answer or "",
+        re.IGNORECASE,
+    ))
+
+
+def _strip_internal_tool_status(answer: str) -> str:
+    paragraphs = re.split(r"\n\s*\n", answer or "")
+    clean = [p for p in paragraphs if not _has_internal_tool_status(p)]
+    return "\n\n".join(clean).strip()
 
 
 def _extract_actual_tools(raw: str) -> List[str]:
@@ -188,6 +243,10 @@ class InsightAgent:
         explicit_tickers = extract_query_tickers(question)
 
         async def retrieve_reports():
+            if _is_broad_recommendation(question):
+                return await engine.retrieve_recent_diverse(
+                    market=hints["market"], limit=_MAX_REPORTS_IN_CONTEXT,
+                )
             if len(explicit_tickers) <= 1:
                 return await engine.retrieve(
                     text=question, market=hints["market"],
@@ -471,6 +530,8 @@ class InsightAgent:
             msg += f"## 앞선 조사 메모\n{clean_draft[:2000]}\n\n"
         msg += (
             "위 내용만으로 최종 답변을 만드세요. 도구를 쓰지 마세요.\n"
+            "도구명, 도구 호출 한도, 도구 실패나 내부 실행 상태는 언급하지 "
+            "마세요. 확보된 데이터의 범위와 한계만 사용자 관점에서 설명하세요.\n"
             "answer 는 합쇼체 400~1200자로, 확인된 사실만 담으세요."
         )
 
@@ -546,13 +607,25 @@ class InsightAgent:
                 f"{INSIGHT_SYSTEM_PROMPT}"
             )
             archive_only = _is_archive_only_question(question)
-            server_names = [] if archive_only else _MCP_SERVERS
+            hints = parse_query_hints(question)
+            server_names = _select_mcp_servers(question, hints)
             tool_filter = {} if archive_only else _MCP_TOOL_ALLOWLIST
             if archive_only:
                 dated_prompt += (
                     "\n\n# 이번 요청의 도구 정책\n"
                     "사용자가 PRISM 아카이브만 요청했습니다. 외부 검색이나 "
                     "MCP 도구를 사용하지 말고 제공된 리포트만 근거로 답하세요."
+                )
+            else:
+                dated_prompt += (
+                    "\n\n# 이번 요청의 도구 실행 규칙\n"
+                    "- 컨텍스트에서 후보를 먼저 좁힌 뒤 무료 도구는 합계 4회 "
+                    "이내로 핵심 후보 2~3개만 검증하세요.\n"
+                    "- 같은 도구와 같은 종목을 반복 호출하지 마세요.\n"
+                    "- Perplexity가 제공된 경우에도 전체 요청에서 최대 1회만 "
+                    "사용하세요.\n"
+                    "- 최종 답변에는 도구명, 도구 실패, 호출 횟수나 내부 실행 "
+                    "상태를 절대 언급하지 마세요. 확보된 근거만으로 결론내리세요."
                 )
             agent = Agent(
                 name="insight_agent",
@@ -579,7 +652,9 @@ class InsightAgent:
                     # 세션이 살아 있는 동안 파싱한다. 실패 시 같은 대화 이력
                     # 위에서 구조화 복구를 한 번 시도한다.
                     parsed = self._parse_response(response_text)
-                    if parsed is None:
+                    if parsed is None or _has_internal_tool_status(
+                        parsed.get("answer", "") if parsed else ""
+                    ):
                         parsed = await self._repair_to_json(
                             llm, question, context_str, response_text,
                         )
@@ -628,6 +703,15 @@ class InsightAgent:
                 evidence_report_ids=[],
                 remaining_quota=remaining, model_used=self.model,
             )
+
+        if _has_internal_tool_status(parsed["answer"]):
+            parsed["answer"] = _strip_internal_tool_status(parsed["answer"])
+            if not parsed["answer"]:
+                parsed["answer"] = (
+                    "현재 확보된 PRISM 데이터만으로는 신뢰도 높은 후보를 "
+                    "확정하기 어렵습니다. 종목별 장기 시계열과 낙폭 데이터가 "
+                    "보강된 뒤 다시 비교하겠습니다."
+                )
 
         parsed = self._ground_response_metadata(parsed, ctx, response_text)
 

--- a/cores/archive/query_engine.py
+++ b/cores/archive/query_engine.py
@@ -184,7 +184,11 @@ def parse_query_hints(text: str) -> Dict[str, Optional[str]]:
     # Market hint
     if re.search(r"\b(us|미국|nasdaq|nyse|s&p|s&p500|spy)\b", text, re.IGNORECASE):
         hints["market"] = "us"
-    elif re.search(r"\b(kr|코스피|코스닥|한국|국내|kospi|kosdaq)\b", text, re.IGNORECASE):
+    elif re.search(
+        r"\b(kr|코스피|코스닥|한국|국내|우리나라|국장|kospi|kosdaq)\b",
+        text,
+        re.IGNORECASE,
+    ):
         hints["market"] = "kr"
 
     # A single ticker can use the structured fast path. Multiple tickers are
@@ -734,6 +738,58 @@ class QueryEngine:
             ))
 
         return snippets
+
+    async def retrieve_recent_diverse(
+        self,
+        market: Optional[str],
+        limit: int = _MAX_REPORTS_IN_CONTEXT,
+    ) -> List[ReportSnippet]:
+        """Return one recent representative report per well-covered ticker.
+
+        Broad recommendation questions do not contain a company keyword, so
+        FTS relevance can collapse onto one accidental match. Coverage count
+        supplies a deterministic cross-company candidate set instead.
+        """
+        rows = await get_report_ids(market=market, db_path=self.db_path)
+        if not rows:
+            return []
+
+        counts: Dict[str, int] = {}
+        latest: Dict[str, Dict] = {}
+        for row in rows:
+            ticker = str(row.get("ticker") or "").upper()
+            if not ticker:
+                continue
+            counts[ticker] = counts.get(ticker, 0) + 1
+            latest.setdefault(ticker, row)
+
+        selected = sorted(
+            latest.values(),
+            key=lambda row: (
+                counts[str(row["ticker"]).upper()],
+                row.get("report_date") or "",
+            ),
+            reverse=True,
+        )[:limit]
+        ids = [row["id"] for row in selected]
+        enrichments, excerpts = await asyncio.gather(
+            _fetch_enrichments(ids, self.db_path),
+            _fetch_content_excerpts(ids, self.db_path),
+        )
+        return [
+            ReportSnippet(
+                report_id=row["id"],
+                ticker=row["ticker"],
+                company_name=row.get("company_name", ""),
+                report_date=row.get("report_date", ""),
+                market=row.get("market", ""),
+                mode=row.get("mode", ""),
+                snippet=row.get("snippet", ""),
+                content_excerpt=excerpts.get(row["id"], ""),
+                enrichment=enrichments.get(row["id"], {}),
+            )
+            for row in selected
+        ]
 
     async def retrieve_by_outcome(
         self,

--- a/tests/test_insight_agent_grounding.py
+++ b/tests/test_insight_agent_grounding.py
@@ -6,7 +6,10 @@ from cores.archive import insight_agent as insight_module
 from cores.archive.insight_agent import (
     InsightAgent,
     _extract_actual_tools,
+    _has_internal_tool_status,
     _is_archive_only_question,
+    _is_broad_recommendation,
+    _select_mcp_servers,
 )
 from cores.archive.query_engine import parse_query_hints
 
@@ -41,6 +44,28 @@ def test_archive_only_language_disables_external_tools():
     assert _is_archive_only_question("외부 검색 없이 아카이브만 사용해")
     assert _is_archive_only_question("Use archive reports only; no web search")
     assert not _is_archive_only_question("최신 주가까지 확인해줘")
+
+
+def test_broad_korean_recommendation_uses_only_free_kr_server():
+    question = "우리나라 주식중에 지금부터 장기투자할만한거 찾아줘"
+    hints = parse_query_hints(question)
+
+    assert hints["market"] == "kr"
+    assert _is_broad_recommendation(question)
+    assert _select_mcp_servers(question, hints) == ["kospi_kosdaq"]
+
+
+def test_explicit_news_request_enables_single_paid_research_server():
+    question = "미국 MU 최신 뉴스와 업황을 외부 검색해서 확인해줘"
+    hints = parse_query_hints(question)
+
+    assert _select_mcp_servers(question, hints) == ["yahoo_finance", "perplexity"]
+
+
+def test_internal_tool_limit_language_requires_repair():
+    assert _has_internal_tool_status("본 답변은 도구 호출 한도 도달로 완전하지 않습니다")
+    assert _has_internal_tool_status("perplexity 도구 호출이 정상 응답을 반환하지 않았습니다")
+    assert not _has_internal_tool_status("현재 데이터가 부족해 후보를 추천하기 어렵습니다")
 
 
 def test_actual_tools_come_from_trace_not_model_claims():

--- a/tests/test_query_engine_constraints.py
+++ b/tests/test_query_engine_constraints.py
@@ -36,3 +36,34 @@ async def test_retrieve_applies_date_constraint_to_fts_hits(monkeypatch):
     )
 
     assert [report.report_id for report in reports] == [2]
+
+
+@pytest.mark.asyncio
+async def test_retrieve_recent_diverse_prefers_covered_unique_tickers(monkeypatch):
+    rows = [
+        {"id": 1, "ticker": "AAA", "company_name": "A",
+         "report_date": "2026-08-10", "market": "kr", "mode": "analysis"},
+        {"id": 2, "ticker": "AAA", "company_name": "A",
+         "report_date": "2026-08-09", "market": "kr", "mode": "analysis"},
+        {"id": 3, "ticker": "BBB", "company_name": "B",
+         "report_date": "2026-08-10", "market": "kr", "mode": "analysis"},
+        {"id": 4, "ticker": "CCC", "company_name": "C",
+         "report_date": "2026-08-08", "market": "kr", "mode": "analysis"},
+    ]
+
+    async def fake_report_ids(*args, **kwargs):
+        return rows
+
+    async def fake_empty(*args, **kwargs):
+        return {}
+
+    monkeypatch.setattr(qe, "get_report_ids", fake_report_ids)
+    monkeypatch.setattr(qe, "_fetch_enrichments", fake_empty)
+    monkeypatch.setattr(qe, "_fetch_content_excerpts", fake_empty)
+
+    reports = await qe.QueryEngine(db_path=":memory:").retrieve_recent_diverse(
+        market="kr", limit=3,
+    )
+
+    assert [report.ticker for report in reports] == ["AAA", "BBB", "CCC"]
+    assert [report.report_id for report in reports] == [1, 3, 4]


### PR DESCRIPTION
## Summary
- classify broad long-term recommendation questions and retrieve diverse representative reports
- expose only market-relevant free MCP servers unless news/web research is explicit
- constrain model research planning and prevent repeated paid calls
- repair or strip internal tool-limit/failure language before Telegram delivery

## Verification
- 24 related pytest tests passed
- Python compile check passed
- Ruff F-rule check passed
- reproduced production incident in persistent insight id 47 before fix