### PR TITLE
fix(insight): keep broad screening archive-only

### DIFF
--- a/cores/archive/insight_agent.py
+++ b/cores/archive/insight_agent.py
@@ -125,6 +125,11 @@ def _select_mcp_servers(
     """Expose only servers necessary for this question."""
     if _is_archive_only_question(question):
         return []
+    # Broad screening is grounded in the diversified, latest archive set.
+    # Live tools are reserved for a follow-up about a concrete ticker; there is
+    # no reliable per-tool hard cap in mcp-agent's loop.
+    if _is_broad_recommendation(question):
+        return []
     market = hints.get("market")
     if market == "kr":
         servers = ["kospi_kosdaq"]
@@ -154,6 +159,19 @@ def _strip_internal_tool_status(answer: str) -> str:
     paragraphs = re.split(r"\n\s*\n", answer or "")
     clean = [p for p in paragraphs if not _has_internal_tool_status(p)]
     return "\n\n".join(clean).strip()
+
+
+def _clean_answer_text(answer: str) -> str:
+    """Remove structured-output residue accidentally embedded in answer."""
+    text = (answer or "").strip()
+    text = re.split(
+        r"</?answer>|<key_takeaways>|<tickers_mentioned>|<tools_used>|"
+        r"<evidence_report_ids>|</invoke>",
+        text,
+        maxsplit=1,
+        flags=re.IGNORECASE,
+    )[0]
+    return text.strip()
 
 
 def _extract_actual_tools(raw: str) -> List[str]:
@@ -472,7 +490,7 @@ class InsightAgent:
                 obj = json.loads(candidate)
                 if "answer" not in obj:
                     continue
-                answer = str(obj.get("answer") or "").strip()
+                answer = _clean_answer_text(str(obj.get("answer") or ""))
                 if not answer or _TRACE_MARKER in answer:
                     logger.warning(
                         "InsightAgent: answer 가 비었거나 도구 추적을 포함한다"
@@ -548,7 +566,7 @@ class InsightAgent:
             logger.error(f"InsightAgent structured 복구 실패: {e}")
             return None
 
-        answer = (result.answer or "").strip()
+        answer = _clean_answer_text(result.answer or "")
         if not answer or _TRACE_MARKER in answer:
             return None
         logger.info("InsightAgent: structured 복구 패스로 JSON 을 확보했다")
@@ -607,6 +625,7 @@ class InsightAgent:
                 f"{INSIGHT_SYSTEM_PROMPT}"
             )
             archive_only = _is_archive_only_question(question)
+            broad_recommendation = _is_broad_recommendation(question)
             hints = parse_query_hints(question)
             server_names = _select_mcp_servers(question, hints)
             tool_filter = {} if archive_only else _MCP_TOOL_ALLOWLIST
@@ -615,6 +634,14 @@ class InsightAgent:
                     "\n\n# 이번 요청의 도구 정책\n"
                     "사용자가 PRISM 아카이브만 요청했습니다. 외부 검색이나 "
                     "MCP 도구를 사용하지 말고 제공된 리포트만 근거로 답하세요."
+                )
+            elif broad_recommendation:
+                dated_prompt += (
+                    "\n\n# 이번 요청의 선별 정책\n"
+                    "여러 종목의 최신 대표 리포트가 이미 제공됐습니다. 도구를 "
+                    "사용하지 말고 이 후보군을 비교해 1차 선별 결과를 답하세요. "
+                    "장기 수익률·MDD가 부족하면 그 한계를 사용자 데이터 관점에서 "
+                    "설명하고, 내부 실행 상태나 도구는 언급하지 마세요."
                 )
             else:
                 dated_prompt += (

--- a/tests/test_insight_agent_grounding.py
+++ b/tests/test_insight_agent_grounding.py
@@ -5,6 +5,7 @@ import pytest
 from cores.archive import insight_agent as insight_module
 from cores.archive.insight_agent import (
     InsightAgent,
+    _clean_answer_text,
     _extract_actual_tools,
     _has_internal_tool_status,
     _is_archive_only_question,
@@ -46,13 +47,13 @@ def test_archive_only_language_disables_external_tools():
     assert not _is_archive_only_question("최신 주가까지 확인해줘")
 
 
-def test_broad_korean_recommendation_uses_only_free_kr_server():
+def test_broad_korean_recommendation_uses_archive_without_mcp_tools():
     question = "우리나라 주식중에 지금부터 장기투자할만한거 찾아줘"
     hints = parse_query_hints(question)
 
     assert hints["market"] == "kr"
     assert _is_broad_recommendation(question)
-    assert _select_mcp_servers(question, hints) == ["kospi_kosdaq"]
+    assert _select_mcp_servers(question, hints) == []
 
 
 def test_explicit_news_request_enables_single_paid_research_server():
@@ -66,6 +67,15 @@ def test_internal_tool_limit_language_requires_repair():
     assert _has_internal_tool_status("본 답변은 도구 호출 한도 도달로 완전하지 않습니다")
     assert _has_internal_tool_status("perplexity 도구 호출이 정상 응답을 반환하지 않았습니다")
     assert not _has_internal_tool_status("현재 데이터가 부족해 후보를 추천하기 어렵습니다")
+
+
+def test_clean_answer_removes_structured_xml_tail():
+    raw = (
+        "확보된 데이터 기준으로 후보를 정리합니다.</answer>\n"
+        '<key_takeaways>["내부 배열"]</key_takeaways>\n</invoke>'
+    )
+
+    assert _clean_answer_text(raw) == "확보된 데이터 기준으로 후보를 정리합니다."
 
 
 def test_actual_tools_come_from_trace_not_model_claims():


### PR DESCRIPTION
## Summary
- disable live MCP tools for broad recommendation screening
- reserve live price validation for concrete-ticker follow-ups
- strip structured XML residue from repaired answers

## Verification
- 20 related tests passed
- compile and Ruff F-rule checks passed
- production replay after #586 confirmed diversified six-report retrieval and zero Perplexity calls