### PR TITLE
fix(kis): support external config root for Stance deploy worktree

### DIFF
--- a/tests/test_kis_config_root.py
+++ b/tests/test_kis_config_root.py
@@ -1,0 +1,57 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_kis_auth_honors_external_config_root(tmp_path):
+    config_root = tmp_path / "external-kis"
+    config_root.mkdir()
+    (config_root / "kis_devlp.yaml").write_text(
+        "my_agent: stance-config-test\n", encoding="utf-8"
+    )
+
+    env = os.environ.copy()
+    env["KIS_CONFIG_ROOT"] = str(config_root)
+    env["PYTHONPATH"] = str(PROJECT_ROOT / "trading")
+    script = """
+import sys
+import types
+
+crypto = types.ModuleType("Crypto")
+cipher = types.ModuleType("Crypto.Cipher")
+cipher.AES = types.SimpleNamespace()
+util = types.ModuleType("Crypto.Util")
+padding = types.ModuleType("Crypto.Util.Padding")
+padding.unpad = lambda value, _block_size: value
+crypto.Cipher = cipher
+crypto.Util = util
+util.Padding = padding
+sys.modules["Crypto"] = crypto
+sys.modules["Crypto.Cipher"] = cipher
+sys.modules["Crypto.Util"] = util
+sys.modules["Crypto.Util.Padding"] = padding
+
+import kis_auth
+print(kis_auth.config_root)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert result.stdout.strip() == str(config_root.resolve())
+
+
+def test_domestic_trading_reuses_kis_auth_config_root():
+    source = (PROJECT_ROOT / "trading" / "domestic_stock_trading.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'CONFIG_FILE = Path(ka.config_root) / "kis_devlp.yaml"' in source

--- a/trading/domestic_stock_trading.py
+++ b/trading/domestic_stock_trading.py
@@ -58,8 +58,9 @@ def _domestic_order_window(now: Optional[datetime.datetime] = None) -> str:
     from prism_core.time_windows import domestic_order_window
     return domestic_order_window(now)
 
-# Load configuration file
-CONFIG_FILE = TRADING_DIR / "config" / "kis_devlp.yaml"
+# Use the same credential root as kis_auth so clean deploy worktrees can share
+# one protected, external KIS configuration directory.
+CONFIG_FILE = Path(ka.config_root) / "kis_devlp.yaml"
 with open(CONFIG_FILE, encoding="UTF-8") as f:
     _cfg = yaml.safe_load(f)
 

--- a/trading/kis_auth.py
+++ b/trading/kis_auth.py
@@ -72,9 +72,13 @@ class TokenRequestError(KISAuthError):
 clearConsole = lambda: subprocess.run(["cls" if os.name in ("nt", "dos") else "clear"], check=False, shell=(os.name in ("nt", "dos")))
 
 key_bytes = 32
-# Find config folder based on kis_auth.py file directory
+# Keep credentials outside deploy worktrees when KIS_CONFIG_ROOT is provided.
 current_dir = os.path.dirname(os.path.abspath(__file__))
-config_root = os.path.join(current_dir, "config")
+config_root = os.path.abspath(
+    os.path.expanduser(
+        os.environ.get("KIS_CONFIG_ROOT", os.path.join(current_dir, "config"))
+    )
+)
 # config_root = "$HOME/KIS/config/"  # Folder where token files are stored, set path to be difficult for third parties to find
 # token_tmp = config_root + 'KIS000000'  # Specify file name for local token storage, avoid file names that can infer token value
 # token_tmp = config_root + 'KIS' + datetime.today().strftime("%Y%m%d%H%M%S")  # Token local storage filename YYYYMMDDHHMMSS


### PR DESCRIPTION
## Summary
- allow KIS credentials to live outside clean deployment worktrees via `KIS_CONFIG_ROOT`
- make domestic trading reuse the same resolved config root
- add regression coverage

## Verification
- `42 passed` across config-root, Stance adapter, and marker tests
- `git diff --check`