### PR TITLE
feat(stance): add strategy profiles and approval onboarding

### DIFF
--- a/examples/dashboard/app/api/stance/v1/[...path]/route.ts
+++ b/examples/dashboard/app/api/stance/v1/[...path]/route.ts
@@ -14,6 +14,7 @@ const ALLOWED = new Map<string, ReadonlySet<string>>([
   ["stances", new Set(["POST"])],
   ["keys/rotate", new Set(["POST"])],
   ["portfolio", new Set(["GET"])],
+  ["profile", new Set(["PATCH"])],
 ])
 
 const registrations = new Map<string, number[]>()
@@ -114,3 +115,4 @@ export const dynamic = "force-dynamic"
 
 export const GET = proxy
 export const POST = proxy
+export const PATCH = proxy

--- a/examples/dashboard/components/stance-agent-connect-card.tsx
+++ b/examples/dashboard/components/stance-agent-connect-card.tsx
@@ -15,29 +15,35 @@ function agentPrompt(ko: boolean, origin: string) {
 
 먼저 머신용 명세 ${discovery} 를 읽고, 현재 저장소와 실행 환경을 분석해.
 
-1. 전략 ID, 표시 이름, 공개 핸들, 시장, 판단 주기를 제안하고 공개 API로 전략을 등록해.
-2. 발급된 API 키는 채팅·로그·명령 출력·커밋·패치에 절대 노출하지 마. 저장소 밖 비밀 환경 파일(권한 600)이나 기존 secret manager에 즉시 저장하고 Git 추적 제외를 확인해.
-3. 과거 거래는 이관하거나 소급 입력하지 마. 기존 포지션이 있다면 연결 시점의 현재 목표 비중만 초기 선언하고, 지금부터 발생하는 판단을 기록해.
-4. 실제 주문과 Stance 보고를 분리해. Stance 장애가 주문을 막거나 지연시키지 않도록 fail-open으로 연결해.
-5. 시작할 때 GET /portfolio의 last_seq + 1을 사용하고, 타임아웃에는 같은 seq와 같은 본문을 그대로 재전송해. writer는 전략당 하나만 둬.
-6. 기존 프로젝트의 패턴과 유틸을 재사용하고 새 의존성은 추가하지 마. 관련 테스트를 추가하고 실행해.
-7. health, 인증된 portfolio 조회, 연동 테스트를 검증한 뒤 결과만 요약해. API 키 값은 어떤 결과에도 쓰지 마.
+1. 저장소, 설정, 실행 진입점, 스케줄, 포트폴리오 경계를 조사해 독립 전략을 모두 식별해. 별도 포트폴리오나 의사결정 파이프라인이면 별도 전략으로 취급하되, 하나의 포트폴리오가 여러 거래소를 다룬다는 이유만으로 쪼개지는 마.
+2. 각 전략의 ID, 표시 이름, 공개 핸들, 시장, 판단 주기와 선택 프로필(운영자·팀 이름, 한 줄 소개, 상세 소개, 대표 링크, 소스 링크)을 제안해. 코드에서 확정할 수 없는 공개 정보만 사용자에게 짧게 질문해.
+3. 실제 등록 전에 감지 근거와 전략별 등록 계획을 표로 보여줘. 한 전략이 Stance의 여러 시장 코드에 걸치면 임의로 고르거나 쪼개지 말고 지원 제약으로 명시해. 등록은 되돌릴 수 없으므로 사용자가 이 계획을 명시적으로 승인하기 전에는 POST /strategies를 호출하지 마.
+4. 승인 후 각 전략을 따로 등록해. 각 전략마다 별도 API 키, seq, writer, 포트폴리오 복구 상태를 사용하고 시장 간에 공유하지 마.
+5. 발급된 API 키는 채팅·로그·명령 출력·커밋·패치에 절대 노출하지 마. 저장소 밖 비밀 환경 파일(권한 600)이나 기존 secret manager에 즉시 저장하고 Git 추적 제외를 확인해.
+6. 과거 거래는 이관하거나 소급 입력하지 마. 기존 포지션이 있다면 연결 시점의 현재 목표 비중만 초기 선언하고, 지금부터 발생하는 판단을 기록해.
+7. 실제 주문과 Stance 보고를 분리해. Stance 장애가 주문을 막거나 지연시키지 않도록 fail-open으로 연결해.
+8. 시작할 때 각 전략의 GET /portfolio last_seq + 1을 사용하고, 타임아웃에는 같은 seq와 같은 본문을 그대로 재전송해.
+9. 기존 프로젝트의 패턴과 유틸을 재사용하고 새 의존성은 추가하지 마. 관련 테스트를 추가하고 실행해.
+10. health, 인증된 portfolio 조회, 연동 테스트를 검증한 뒤 결과만 요약해. API 키 값은 어떤 결과에도 쓰지 마.
 
-명확하고 되돌릴 수 있는 단계는 묻지 말고 진행하되, 전략의 공개 신원이나 시장을 확정할 근거가 없을 때만 질문해.`
+조사와 계획 작성은 묻지 말고 진행해. 필요한 공개 정보와 최종 등록 승인만 질문해.`
   }
   return `Connect the currently open project to Stance automatically. This instruction is for a coding agent with repository and terminal access.
 
 First read the machine-readable contract at ${discovery}, then inspect the repository and runtime.
 
-1. Propose a strategy ID, display name, public handle, market, and cadence, then register through the public API.
-2. Never expose the issued API key in chat, logs, command output, commits, patches, or screenshots. Store it immediately outside the repository in a mode-0600 secret file or the existing secret manager, and verify it is not tracked by Git.
-3. Do not migrate or backfill historical trades. If positions already exist, declare only their current target weights from the connection time onward, then record new decisions.
-4. Keep live order execution separate from Stance reporting. Stance failures must not block or delay orders; integrate fail-open.
-5. Recover with GET /portfolio last_seq + 1. On timeout, retry the identical seq and body. Use one writer per strategy.
-6. Reuse existing project patterns and utilities. Add no dependency. Add and run relevant tests.
-7. Verify health, authenticated portfolio recovery, and integration tests, then report only the results. Never include the API key value.
+1. Inspect the repository, configuration, entry points, schedules, and portfolio boundaries to identify all multiple independent strategies. Separate distinct portfolios or decision pipelines, but do not split one portfolio merely because it trades on multiple exchanges.
+2. Propose each strategy's ID, display name, public handle, market, cadence, and optional profile (operator or team, tagline, description, website, and source URL). Ask the user only for public information that cannot be established from the project.
+3. Before any registration, show the evidence and a per-strategy registration plan. If one strategy spans multiple Stance market codes, report that support constraint instead of guessing or splitting it. Registration is irreversible: do not call POST /strategies until the user explicitly approves that plan.
+4. After approval, register every strategy separately. Give each strategy its own API key, seq, writer, and portfolio recovery state; never share them across markets.
+5. Never expose the issued API key in chat, logs, command output, commits, patches, or screenshots. Store it immediately outside the repository in a mode-0600 secret file or the existing secret manager, and verify it is not tracked by Git.
+6. Do not migrate or backfill historical trades. If positions already exist, declare only their current target weights from the connection time onward, then record new decisions.
+7. Keep live order execution separate from Stance reporting. Stance failures must not block or delay orders; integrate fail-open.
+8. Recover each strategy with GET /portfolio last_seq + 1. On timeout, retry the identical seq and body.
+9. Reuse existing project patterns and utilities. Add no dependency. Add and run relevant tests.
+10. Verify health, authenticated portfolio recovery, and integration tests, then report only the results. Never include an API key value.
 
-Proceed without asking for clear, reversible steps. Ask only if the public identity or market cannot be determined safely.`
+Proceed with inspection and planning without asking. Ask only for missing public profile information and final registration approval.`
 }
 
 export function StanceAgentConnectCard({ ko }: { ko: boolean }) {
@@ -87,11 +93,12 @@ export function StanceAgentConnectCard({ ko }: { ko: boolean }) {
       </CardHeader>
 
       <CardContent className="space-y-5">
-        <div className="grid gap-3 sm:grid-cols-3">
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
           {[
             [FolderCode, ko ? "1. 전략 프로젝트 열기" : "1. Open your strategy project", ko ? "Codex CLI · Claude Code · Cursor Agent 등" : "Codex CLI · Claude Code · Cursor Agent, etc."],
             [MessageSquareCode, ko ? "2. 에이전트 채팅에 붙여넣기" : "2. Paste into the agent chat", ko ? "일반 채팅이 아닌 파일·터미널 접근 모드" : "Use a mode with file and terminal access"],
-            [ShieldCheck, ko ? "3. 완료 보고 확인" : "3. Review the completion report", ko ? "등록 · 키 보관 · 코드 연동 · 테스트" : "Registration · key storage · code · tests"],
+            [Bot, ko ? "3. 등록 계획 승인" : "3. Approve the plan", ko ? "감지된 전략 · 공개 프로필 · 시장 확인" : "Review strategies · profiles · markets"],
+            [ShieldCheck, ko ? "4. 완료 보고 확인" : "4. Review completion", ko ? "전략별 등록 · 키 보관 · 코드 연동 · 테스트" : "Per-strategy registration · secrets · code · tests"],
           ].map(([Icon, title, description]) => (
             <div key={String(title)} className="rounded-xl border border-border/60 bg-background/70 p-4 backdrop-blur-sm">
               <Icon className="mb-3 h-5 w-5 text-violet-600" />

--- a/examples/dashboard/components/stance-leaderboard-page.tsx
+++ b/examples/dashboard/components/stance-leaderboard-page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
+import { ExternalLink, Github } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { useLanguage } from "@/components/language-provider"
@@ -325,7 +326,34 @@ function EntryTable({
             <tr key={e.strategy} className="border-b border-border/30 last:border-0">
               <td className="py-3 pr-4">
                 <div className="font-medium">{e.display_name}</div>
-                <div className="text-xs text-muted-foreground font-mono">{e.handle}</div>
+                <div className="text-xs text-muted-foreground">
+                  <span className="font-mono">{e.handle}</span>
+                  {e.owner_name && <span> · {e.owner_name}</span>}
+                </div>
+                {e.tagline && <div className="mt-1 max-w-sm text-xs text-muted-foreground">{e.tagline}</div>}
+                {(e.description || e.website_url || e.source_url) && (
+                  <details className="mt-1.5 max-w-sm text-xs">
+                    <summary className="cursor-pointer text-primary hover:underline">
+                      {ko ? "전략 소개" : "Strategy profile"}
+                    </summary>
+                    <div className="mt-2 space-y-2 rounded-md border border-border/50 bg-muted/20 p-3 text-muted-foreground">
+                      {e.description && <p className="whitespace-pre-wrap leading-relaxed">{e.description}</p>}
+                      <div className="flex flex-wrap gap-3">
+                        {e.website_url && (
+                          <a href={e.website_url} target="_blank" rel="nofollow ugc noopener noreferrer" className="inline-flex items-center gap-1 text-primary hover:underline">
+                            {ko ? "대표 링크" : "Website"}<ExternalLink className="h-3 w-3" />
+                          </a>
+                        )}
+                        {e.source_url && (
+                          <a href={e.source_url} target="_blank" rel="nofollow ugc noopener noreferrer" className="inline-flex items-center gap-1 text-primary hover:underline">
+                            {ko ? "소스" : "Source"}<Github className="h-3 w-3" />
+                          </a>
+                        )}
+                      </div>
+                      <p className="text-[10px] opacity-70">{ko ? "참여자가 직접 작성한 공개 정보" : "Public information supplied by the participant"}</p>
+                    </div>
+                  </details>
+                )}
                 {provisional && e.gate_failures.length > 0 && (
                   <div className="text-[11px] text-amber-600 dark:text-amber-500 mt-1">
                     {e.gate_failures.join(" · ")}

--- a/examples/dashboard/components/stance-registration-card.tsx
+++ b/examples/dashboard/components/stance-registration-card.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
 
 type Registration = {
   strategy: string
@@ -23,6 +24,11 @@ export function StanceRegistrationCard({ ko }: { ko: boolean }) {
   const [strategy, setStrategy] = useState("")
   const [displayName, setDisplayName] = useState("")
   const [handle, setHandle] = useState("")
+  const [ownerName, setOwnerName] = useState("")
+  const [tagline, setTagline] = useState("")
+  const [description, setDescription] = useState("")
+  const [websiteUrl, setWebsiteUrl] = useState("")
+  const [sourceUrl, setSourceUrl] = useState("")
   const [market, setMarket] = useState("KRX")
   const [cadence, setCadence] = useState("daily")
   const [registration, setRegistration] = useState<Registration | null>(null)
@@ -49,6 +55,11 @@ export function StanceRegistrationCard({ ko }: { ko: boolean }) {
           handle,
           market,
           cadence,
+          owner_name: ownerName || null,
+          tagline: tagline || null,
+          description: description || null,
+          website_url: websiteUrl || null,
+          source_url: sourceUrl || null,
         }),
       })
       const body = await response.json().catch(() => ({}))
@@ -188,6 +199,37 @@ export function StanceRegistrationCard({ ko }: { ko: boolean }) {
               </Select>
             </div>
           </div>
+
+          <details className="sm:col-span-2 rounded-lg border border-border/60 bg-muted/20">
+            <summary className="cursor-pointer px-4 py-3 text-sm font-medium">
+              {ko ? "선택 · 전략 소개와 링크" : "Optional · Strategy profile and links"}
+            </summary>
+            <div className="grid gap-4 border-t border-border/60 p-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="stance-owner">{ko ? "운영자·팀 이름" : "Operator or team"}</Label>
+                <Input id="stance-owner" value={ownerName} onChange={(event) => setOwnerName(event.target.value)} maxLength={100} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="stance-tagline">{ko ? "한 줄 소개" : "Tagline"}</Label>
+                <Input id="stance-tagline" value={tagline} onChange={(event) => setTagline(event.target.value)} maxLength={120} />
+              </div>
+              <div className="space-y-2 sm:col-span-2">
+                <Label htmlFor="stance-description">{ko ? "상세 소개" : "Description"}</Label>
+                <Textarea id="stance-description" value={description} onChange={(event) => setDescription(event.target.value)} maxLength={500} rows={3} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="stance-website">{ko ? "대표 링크" : "Website"}</Label>
+                <Input id="stance-website" type="url" inputMode="url" value={websiteUrl} onChange={(event) => setWebsiteUrl(event.target.value)} placeholder="https://" maxLength={500} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="stance-source">{ko ? "소스 저장소" : "Source repository"}</Label>
+                <Input id="stance-source" type="url" inputMode="url" value={sourceUrl} onChange={(event) => setSourceUrl(event.target.value)} placeholder="https://github.com/..." maxLength={500} />
+              </div>
+              <p className="text-xs text-muted-foreground sm:col-span-2">
+                {ko ? "모두 선택사항이며 점수와 순위에는 영향을 주지 않습니다. 공개 링크는 HTTPS만 허용합니다." : "All fields are optional and never affect scoring or rank. Public links must use HTTPS."}
+              </p>
+            </div>
+          </details>
 
           {error && (
             <div className="sm:col-span-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">

--- a/examples/dashboard/public/.well-known/stance.json
+++ b/examples/dashboard/public/.well-known/stance.json
@@ -14,15 +14,28 @@
     "method": "POST",
     "path": "/strategies",
     "content_type": "application/json",
-    "body": {
+      "body": {
       "strategy": "stable ASCII identifier: A-Z, a-z, 0-9, dot, underscore, hyphen",
       "display_name": "public display name",
       "handle": "public owner or project handle",
       "market": "KRX | NASDAQ | NYSE | CRYPTO",
-      "cadence": "daily | weekly | monthly | event"
+        "cadence": "daily | weekly | monthly | event"
+      },
+      "profile_fields": {
+        "owner_name": { "required": false, "max_length": 100 },
+        "tagline": { "required": false, "max_length": 120 },
+        "description": { "required": false, "max_length": 500 },
+        "website_url": { "required": false, "format": "https URL", "max_length": 500 },
+        "source_url": { "required": false, "format": "https URL", "max_length": 500 }
+      },
+      "api_key": "Returned once as api_key. Never print it in chat or logs. Store it outside the repository with mode 0600 or in a secret manager."
     },
-    "api_key": "Returned once as api_key. Never print it in chat or logs. Store it outside the repository with mode 0600 or in a secret manager."
-  },
+    "profile_update": {
+      "method": "PATCH",
+      "path": "/profile",
+      "authentication": "Authorization: Bearer <api_key>",
+      "note": "Optional public presentation metadata only. It never affects scoring or rank."
+    },
   "declaration": {
     "method": "POST",
     "path": "/stances",
@@ -39,6 +52,11 @@
   },
   "agent_rules": [
     "Inspect the repository before proposing registration metadata.",
+    "Identify all multiple independent strategies by inspecting market, decision pipeline, schedule, and portfolio boundaries.",
+    "Do not split one portfolio merely because it trades on multiple exchanges; report unsupported market spans before registration.",
+    "Ask only for optional public profile information that cannot be established from the project.",
+    "Show a per-strategy registration plan and obtain explicit user approval before calling POST /strategies; registration is irreversible.",
+    "Use a separate API key, seq, writer, and recovery state for every strategy.",
     "Do not migrate or backfill historical trades.",
     "If positions already exist, declare only their current target weights from the connection time onward.",
     "Never expose the API key in chat, logs, commits, patches, screenshots, or command output.",

--- a/examples/dashboard/types/dashboard.ts
+++ b/examples/dashboard/types/dashboard.ts
@@ -497,6 +497,11 @@ export interface StanceEntry {
   display_name: string
   handle: string
   market: string
+  owner_name: string | null
+  tagline: string | null
+  description: string | null
+  website_url: string | null
+  source_url: string | null
   qualified: boolean
   gate_failures: string[]
   experimental: boolean

--- a/stance/server/api.py
+++ b/stance/server/api.py
@@ -9,6 +9,7 @@
 
 엔드포인트
     POST /strategies        전략 등록 → 인증키 발급 (전략당 1회)
+    PATCH /profile          선택 공개 프로필 수정 (점수와 무관)
     POST /stances           선언 접수  ← 참여자가 쓰는 유일한 쓰기 엔드포인트
     POST /keys/rotate       인증키 교체
     GET  /portfolio         검산용 보유·자산 스냅샷
@@ -24,10 +25,11 @@ import os
 import secrets
 from datetime import datetime
 from typing import Any, Literal
+from urllib.parse import urlsplit
 
 from fastapi import Depends, FastAPI, Header, HTTPException, Query
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from .leaderboard import build as build_leaderboard
 from .leaderboard import preparing
@@ -118,9 +120,35 @@ def current_strategy(
 
 # ── 스키마 ────────────────────────────────────────────────────────────────
 
-class RegisterIn(BaseModel):
+class PublicProfileFields(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    owner_name: str | None = Field(default=None, max_length=100)
+    tagline: str | None = Field(default=None, max_length=120)
+    description: str | None = Field(default=None, max_length=500)
+    website_url: str | None = Field(default=None, max_length=500)
+    source_url: str | None = Field(default=None, max_length=500)
+
+    @field_validator("owner_name", "tagline", "description", "website_url", "source_url", mode="before")
+    @classmethod
+    def empty_profile_values_are_none(cls, value: Any) -> Any:
+        if not isinstance(value, str):
+            return value
+        stripped = value.strip()
+        return stripped or None
+
+    @field_validator("website_url", "source_url")
+    @classmethod
+    def safe_public_url(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        parsed = urlsplit(value)
+        if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password:
+            raise ValueError("공개 링크는 사용자 정보가 없는 HTTPS 주소여야 합니다")
+        return value
+
+
+class RegisterIn(PublicProfileFields):
     strategy: str = Field(
         min_length=1,
         max_length=64,
@@ -143,6 +171,14 @@ class RegisterOut(BaseModel):
     cadence: str
     api_key: str
     notice: str
+
+
+class ProfileIn(PublicProfileFields):
+    pass
+
+
+class ProfileOut(ProfileIn):
+    strategy: str
 
 
 class KeyRotationOut(BaseModel):
@@ -258,7 +294,10 @@ def register(
         raise HTTPException(401, "등록 토큰이 올바르지 않습니다")
 
     reg = service.register(body.strategy, body.display_name, body.handle,
-                           market=body.market, cadence=body.cadence)
+                           market=body.market, cadence=body.cadence,
+                           owner_name=body.owner_name, tagline=body.tagline,
+                           description=body.description, website_url=body.website_url,
+                           source_url=body.source_url)
     return RegisterOut(
         strategy=reg.strategy_id,
         market=reg.market,
@@ -266,6 +305,18 @@ def register(
         api_key=reg.api_key,
         notice="이 키는 다시 볼 수 없습니다. 안전한 곳에 보관하세요.",
     )
+
+
+@app.patch("/profile", response_model=ProfileOut)
+def update_profile(
+    body: ProfileIn,
+    strategy_id: str = Depends(current_strategy),
+    service: StanceService = Depends(get_service),
+) -> ProfileOut:
+    """Update optional public presentation metadata; scoring inputs remain unchanged."""
+    return ProfileOut(**service.update_profile(
+        strategy_id, **body.model_dump(exclude_unset=True)
+    ))
 
 
 @app.post("/keys/rotate", response_model=KeyRotationOut)

--- a/stance/server/leaderboard.py
+++ b/stance/server/leaderboard.py
@@ -31,6 +31,11 @@ class Entry:
     handle: str
     market: str
     metrics: Metrics
+    owner_name: str | None = None
+    tagline: str | None = None
+    description: str | None = None
+    website_url: str | None = None
+    source_url: str | None = None
 
     def to_dict(self) -> dict:
         m = self.metrics
@@ -39,6 +44,11 @@ class Entry:
             "display_name": self.display_name,
             "handle": self.handle,
             "market": self.market,
+            "owner_name": self.owner_name,
+            "tagline": self.tagline,
+            "description": self.description,
+            "website_url": self.website_url,
+            "source_url": self.source_url,
             "qualified": m.qualified,
             "gate_failures": m.gate_failures,
             "experimental": m.experimental,
@@ -61,19 +71,26 @@ class Entry:
         }
 
 
-def build(ledger: Ledger, strategies: list[tuple[str, str, str, str]]) -> dict:
+def build(ledger: Ledger, strategies: list[tuple[str | None, ...]]) -> dict:
     """리더보드 한 판을 만든다.
 
-    strategies 는 (strategy_id, display_name, handle, market) 목록이다.
+    첫 네 값은 strategy_id, display_name, handle, market 이며 뒤에는 선택 프로필이 온다.
     """
     boards: dict[str, dict] = {}
 
-    for strategy_id, display_name, handle, market in strategies:
+    for strategy in strategies:
+        strategy_id, display_name, handle, market = strategy[:4]
+        public_profile = (*strategy[4:9], None, None, None, None, None)[:5]
         profile = profile_for(market)
         # 일별 마킹까지 포함해 재생한다. 빠지면 시간축이 없어 지표가 전부 0 이 된다.
         result = replay(ledger.full_timeline(strategy_id), costs=profile.costs)
         metrics = score(result, cadence=ledger.cadence_of(strategy_id), profile=profile)
-        entry = Entry(strategy_id, display_name, handle, profile.code, metrics)
+        entry = Entry(
+            strategy_id, display_name, handle, profile.code, metrics,
+            owner_name=public_profile[0], tagline=public_profile[1],
+            description=public_profile[2], website_url=public_profile[3],
+            source_url=public_profile[4],
+        )
 
         board = boards.setdefault(profile.code, _empty_board(profile))
         board["entries"].append(entry.to_dict())

--- a/stance/server/ledger.py
+++ b/stance/server/ledger.py
@@ -165,9 +165,16 @@ class Ledger:
             row["name"]
             for row in self.conn.execute("PRAGMA table_info(strategies)").fetchall()
         }
-        for column in ("owner_name", "tagline", "description", "website_url", "source_url"):
+        migrations = {
+            "owner_name": "ALTER TABLE strategies ADD COLUMN owner_name TEXT",
+            "tagline": "ALTER TABLE strategies ADD COLUMN tagline TEXT",
+            "description": "ALTER TABLE strategies ADD COLUMN description TEXT",
+            "website_url": "ALTER TABLE strategies ADD COLUMN website_url TEXT",
+            "source_url": "ALTER TABLE strategies ADD COLUMN source_url TEXT",
+        }
+        for column, statement in migrations.items():
             if column not in existing:
-                self.conn.execute(f"ALTER TABLE strategies ADD COLUMN {column} TEXT")
+                self.conn.execute(statement)
 
     # ── 등록 ──────────────────────────────────────────────────────────────
 

--- a/stance/server/ledger.py
+++ b/stance/server/ledger.py
@@ -41,6 +41,11 @@ CREATE TABLE IF NOT EXISTS strategies (
   strategy_id   TEXT PRIMARY KEY,
   display_name  TEXT NOT NULL,
   handle        TEXT NOT NULL,          -- 계정 핸들. 한 계정의 전 전략이 함께 노출된다
+  owner_name    TEXT,                   -- 선택 공개 프로필. 채점에는 쓰지 않는다
+  tagline       TEXT,
+  description   TEXT,
+  website_url   TEXT,
+  source_url    TEXT,
   market        TEXT NOT NULL,          -- 한 전략 = 한 시장 = 한 통화
   currency      TEXT NOT NULL,
   cadence       TEXT NOT NULL DEFAULT 'daily',  -- daily|weekly|monthly|event
@@ -146,6 +151,7 @@ class Ledger:
         self.conn.row_factory = sqlite3.Row
         with self._lock:
             self.conn.executescript(SCHEMA)
+            self._migrate_strategy_profiles()
             self.conn.executescript(IMMUTABILITY)
             self.conn.commit()
 
@@ -153,12 +159,25 @@ class Ledger:
         with self._lock:
             self.conn.close()
 
+    def _migrate_strategy_profiles(self) -> None:
+        """Add optional public profile columns to pre-profile databases."""
+        existing = {
+            row["name"]
+            for row in self.conn.execute("PRAGMA table_info(strategies)").fetchall()
+        }
+        for column in ("owner_name", "tagline", "description", "website_url", "source_url"):
+            if column not in existing:
+                self.conn.execute(f"ALTER TABLE strategies ADD COLUMN {column} TEXT")
+
     # ── 등록 ──────────────────────────────────────────────────────────────
 
     def register(
         self, strategy_id: str, display_name: str, handle: str,
         market: str = "KRX", currency: str = "KRW", api_key_hash: str = "",
         cadence: Cadence | str = Cadence.DAILY,
+        owner_name: str | None = None, tagline: str | None = None,
+        description: str | None = None, website_url: str | None = None,
+        source_url: str | None = None,
     ) -> None:
         """전략을 등록한다.
 
@@ -169,10 +188,27 @@ class Ledger:
         c = cadence.value if isinstance(cadence, Cadence) else str(cadence)
         with self._lock:
             self.conn.execute(
-                "INSERT INTO strategies (strategy_id, display_name, handle, market,"
-                " currency, cadence, api_key_hash, created_at) VALUES (?,?,?,?,?,?,?,?)",
-                (strategy_id, display_name, handle, market, currency, c, api_key_hash, _now()),
+                "INSERT INTO strategies (strategy_id, display_name, handle, owner_name,"
+                " tagline, description, website_url, source_url, market, currency, cadence,"
+                " api_key_hash, created_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (strategy_id, display_name, handle, owner_name, tagline, description,
+                 website_url, source_url, market, currency, c, api_key_hash, _now()),
             )
+            self.conn.commit()
+
+    def update_profile(
+        self, strategy_id: str, *, owner_name: str | None, tagline: str | None,
+        description: str | None, website_url: str | None, source_url: str | None,
+    ) -> None:
+        """Update presentation metadata only; declarations and scoring inputs stay immutable."""
+        with self._lock:
+            cur = self.conn.execute(
+                "UPDATE strategies SET owner_name=?, tagline=?, description=?,"
+                " website_url=?, source_url=? WHERE strategy_id=?",
+                (owner_name, tagline, description, website_url, source_url, strategy_id),
+            )
+            if cur.rowcount != 1:
+                raise KeyError(strategy_id)
             self.conn.commit()
 
     def cadence_of(self, strategy_id: str) -> Cadence:

--- a/stance/server/service.py
+++ b/stance/server/service.py
@@ -115,6 +115,9 @@ class StanceService:
     def register(
         self, strategy_id: str, display_name: str, handle: str,
         market: str = "KRX", cadence: str = "daily",
+        owner_name: str | None = None, tagline: str | None = None,
+        description: str | None = None, website_url: str | None = None,
+        source_url: str | None = None,
     ) -> Registration:
         profile = profile_for(market)          # 알 수 없는 시장이면 여기서 걸린다
         try:
@@ -130,8 +133,32 @@ class StanceService:
             strategy_id, display_name, handle,
             market=profile.code, currency=profile.currency,
             api_key_hash=_hash(api_key), cadence=cad,
+            owner_name=owner_name, tagline=tagline, description=description,
+            website_url=website_url, source_url=source_url,
         )
         return Registration(strategy_id, api_key, profile.code, cad.value)
+
+    def update_profile(
+        self, strategy_id: str, **updates: str | None,
+    ) -> dict[str, str | None]:
+        fields = ("owner_name", "tagline", "description", "website_url", "source_url")
+        unknown = set(updates) - set(fields)
+        if unknown:
+            raise StanceError(f"알 수 없는 프로필 필드: {', '.join(sorted(unknown))}")
+        row = self.ledger.conn.execute(
+            f"SELECT {', '.join(fields)} FROM strategies WHERE strategy_id=?",
+            (strategy_id,),
+        ).fetchone()
+        if row is None:
+            raise StanceError("등록되지 않은 전략입니다", status=404)
+        profile = {field: updates.get(field, row[field]) for field in fields}
+        self.ledger.update_profile(
+            strategy_id, **profile,
+        )
+        return {
+            "strategy": strategy_id,
+            **profile,
+        }
 
     def _exists(self, strategy_id: str) -> bool:
         row = self.ledger.conn.execute(
@@ -297,11 +324,12 @@ class StanceService:
                      cadence=self.ledger.cadence_of(strategy_id),
                      profile=self._profile(strategy_id))
 
-    def strategies(self) -> list[tuple[str, str, str, str]]:
+    def strategies(self) -> list[tuple[str | None, ...]]:
         rows = self.ledger.conn.execute(
-            "SELECT strategy_id, display_name, handle, market FROM strategies ORDER BY created_at"
+            "SELECT strategy_id, display_name, handle, market, owner_name, tagline,"
+            " description, website_url, source_url FROM strategies ORDER BY created_at"
         ).fetchall()
-        return [(r["strategy_id"], r["display_name"], r["handle"], r["market"]) for r in rows]
+        return [tuple(r) for r in rows]
 
     # ── 내부 ──────────────────────────────────────────────────────────
 

--- a/stance/server/service.py
+++ b/stance/server/service.py
@@ -146,7 +146,8 @@ class StanceService:
         if unknown:
             raise StanceError(f"알 수 없는 프로필 필드: {', '.join(sorted(unknown))}")
         row = self.ledger.conn.execute(
-            f"SELECT {', '.join(fields)} FROM strategies WHERE strategy_id=?",
+            "SELECT owner_name, tagline, description, website_url, source_url"
+            " FROM strategies WHERE strategy_id=?",
             (strategy_id,),
         ).fetchone()
         if row is None:

--- a/stance/tests/test_api.py
+++ b/stance/tests/test_api.py
@@ -79,6 +79,70 @@ def test_register_returns_key_and_notice(client):
     assert "다시 볼 수 없습니다" in body["notice"]
 
 
+def test_register_accepts_optional_public_profile(client):
+    response = client.post("/strategies", json={
+        "strategy": "brand", "display_name": "Brand Strategy", "handle": "@team",
+        "owner_name": "Team Prism",
+        "tagline": "시장 국면을 따르는 추세 전략",
+        "description": "한국 시장에서 매일 목표 비중을 선언합니다.",
+        "website_url": "https://example.com/strategy",
+        "source_url": "https://github.com/example/strategy",
+    })
+    assert response.status_code == 201
+
+    entry = client.get("/leaderboard").json()["boards"]["KRX"]["entries"][0]
+    assert entry["owner_name"] == "Team Prism"
+    assert entry["tagline"] == "시장 국면을 따르는 추세 전략"
+    assert entry["description"].startswith("한국 시장")
+    assert entry["website_url"] == "https://example.com/strategy"
+    assert entry["source_url"] == "https://github.com/example/strategy"
+
+
+def test_profile_can_be_updated_with_own_key(client, registered):
+    response = client.patch("/profile", headers=auth(registered), json={
+        "owner_name": "Prism Team",
+        "tagline": "검증 가능한 판단 기록",
+        "website_url": "https://example.com",
+    })
+    assert response.status_code == 200
+    assert response.json()["strategy"] == "s1"
+
+    entry = client.get("/leaderboard").json()["boards"]["KRX"]["entries"][0]
+    assert entry["owner_name"] == "Prism Team"
+    assert entry["tagline"] == "검증 가능한 판단 기록"
+
+
+def test_profile_patch_preserves_fields_that_were_not_sent(client):
+    registered = client.post("/strategies", json={
+        "strategy": "partial", "display_name": "Partial", "handle": "@owner",
+        "owner_name": "Original owner", "website_url": "https://example.com/original",
+    }).json()
+
+    response = client.patch(
+        "/profile", headers=auth(registered["api_key"]), json={"tagline": "New tagline"},
+    )
+    assert response.status_code == 200
+    assert response.json()["owner_name"] == "Original owner"
+    assert response.json()["website_url"] == "https://example.com/original"
+    assert response.json()["tagline"] == "New tagline"
+
+
+@pytest.mark.parametrize("url", [
+    "http://example.com",
+    "javascript:alert(1)",
+    "https://user:pass@example.com",
+])
+def test_profile_links_require_safe_https_urls(client, registered, url):
+    response = client.patch(
+        "/profile", headers=auth(registered), json={"website_url": url},
+    )
+    assert response.status_code == 422
+
+
+def test_profile_update_requires_authentication(client):
+    assert client.patch("/profile", json={"tagline": "hello"}).status_code == 401
+
+
 def test_registration_token_can_close_public_registration(client, monkeypatch):
     monkeypatch.setenv("STANCE_REGISTRATION_TOKEN", "invite-only")
     body = {"strategy": "locked", "display_name": "A", "handle": "@x"}

--- a/stance/tests/test_leaderboard.py
+++ b/stance/tests/test_leaderboard.py
@@ -58,6 +58,27 @@ def test_build_from_ledger():
     led.close()
 
 
+def test_profile_metadata_is_public_but_does_not_change_metrics():
+    led = Ledger()
+    led.register(
+        "profiled", "Profiled", "@owner", market="KRX",
+        owner_name="Owner", tagline="One line", description="Longer introduction",
+        website_url="https://example.com", source_url="https://github.com/example/repo",
+    )
+
+    payload = build(led, [(
+        "profiled", "Profiled", "@owner", "KRX", "Owner", "One line",
+        "Longer introduction", "https://example.com", "https://github.com/example/repo",
+    )])
+    entry = payload["boards"]["KRX"]["entries"][0]
+
+    assert entry["owner_name"] == "Owner"
+    assert entry["website_url"] == "https://example.com"
+    assert entry["source_url"].startswith("https://github.com/")
+    assert entry["metrics"]["cumulative_return"] == 0
+    led.close()
+
+
 def test_boards_are_not_mixed_across_markets():
     """시장을 섞으면 벤치마크와 변동성 스케일이 달라 비교가 무의미해진다."""
     led = Ledger()

--- a/stance/tests/test_profile_migration.py
+++ b/stance/tests/test_profile_migration.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import sqlite3
+
+from stance.server import Ledger
+
+
+def test_existing_database_gets_optional_profile_columns(tmp_path):
+    path = tmp_path / "old-ledger.db"
+    connection = sqlite3.connect(path)
+    connection.execute(
+        """
+        CREATE TABLE strategies (
+          strategy_id TEXT PRIMARY KEY,
+          display_name TEXT NOT NULL,
+          handle TEXT NOT NULL,
+          market TEXT NOT NULL,
+          currency TEXT NOT NULL,
+          cadence TEXT NOT NULL DEFAULT 'daily',
+          api_key_hash TEXT NOT NULL,
+          created_at TEXT NOT NULL
+        )
+        """
+    )
+    connection.execute(
+        "INSERT INTO strategies VALUES (?,?,?,?,?,?,?,?)",
+        ("existing", "Existing", "@owner", "KRX", "KRW", "daily", "hash", "now"),
+    )
+    connection.commit()
+    connection.close()
+
+    ledger = Ledger(path)
+    columns = {
+        row["name"] for row in ledger.conn.execute("PRAGMA table_info(strategies)")
+    }
+    assert {"owner_name", "tagline", "description", "website_url", "source_url"} <= columns
+    assert ledger.conn.execute(
+        "SELECT display_name FROM strategies WHERE strategy_id='existing'"
+    ).fetchone()[0] == "Existing"
+    ledger.close()

--- a/tests/test_stance_agent_discovery.py
+++ b/tests/test_stance_agent_discovery.py
@@ -75,3 +75,34 @@ def test_onboarding_explains_where_to_paste_and_when_results_appear():
     assert "예선 명단에 바로 표시" in card
     assert "63거래일과 자산의 1% 이상을 투자했던 포지션 청산 20건" in card
     assert "그전에도 기록과 성과는 보입니다" in card
+
+
+def test_agent_onboarding_plans_multiple_strategies_before_registration():
+    card = (
+        ROOT
+        / "examples"
+        / "dashboard"
+        / "components"
+        / "stance-agent-connect-card.tsx"
+    ).read_text(encoding="utf-8")
+    contract = json.loads(DISCOVERY.read_text(encoding="utf-8"))
+
+    assert "독립 전략을 모두 식별" in card
+    assert "등록 계획" in card
+    assert "명시적으로 승인" in card
+    assert "각 전략마다 별도 API 키" in card
+    assert any("multiple independent strategies" in rule for rule in contract["agent_rules"])
+    assert contract["registration"]["profile_fields"]["tagline"]["required"] is False
+
+
+def test_dashboard_marks_participant_links_as_untrusted_content():
+    page = (
+        ROOT
+        / "examples"
+        / "dashboard"
+        / "components"
+        / "stance-leaderboard-page.tsx"
+    ).read_text(encoding="utf-8")
+
+    assert 'rel="nofollow ugc noopener noreferrer"' in page
+    assert "참여자가 직접 작성한 공개 정보" in page


### PR DESCRIPTION
## Summary
- add optional public strategy profiles: operator/team, tagline, description, website, and source URL
- allow authenticated partial profile updates without touching immutable declarations or scoring
- expose profiles on the leaderboard with safe untrusted-link attributes
- make the copied agent instruction detect multiple strategies, ask only for missing public metadata, show a per-strategy plan, and require explicit approval before irreversible registration
- keep separate keys, seq counters, writers, and recovery state per strategy
- migrate existing SQLite ledgers automatically without data loss

## Safety
- HTTPS-only links; rejects URL credentials and non-HTTPS schemes
- participant links use `nofollow ugc noopener noreferrer`
- profile metadata never participates in scoring or rank
- one portfolio spanning multiple exchanges is reported as a support constraint instead of guessed or split

## Verification
- full Stance/API/onboarding suite: 205 passed
- Next.js production build passed
- desktop/mobile visual QA: 95/100