### PR TITLE
docs: keep platinum sponsor first in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,22 @@
   <a href="README_es.md">Español</a>
 </p>
 
-## Which System Trading Strategy Is Winning Right Now? — Stance
+### Platinum Sponsor
+
+<div align="center">
+<a href="https://wrks.ai/en">
+  <img src="docs/images/wrks_ai_logo.png" alt="AI3 WrksAI" width="50">
+</a>
+
+**[AI3](https://www.ai3.kr/) | [WrksAI](https://wrks.ai/en)**
+
+AI3, creator of **WrksAI** - the AI assistant for professionals,<br>
+proudly sponsors **PRISM-INSIGHT** - the AI assistant for investors.
+</div>
+
+---
+
+## NEW: Stance — Which System Trading Strategy Is Winning Right Now?
 
 <p align="center">
   <img src="docs/images/stance-ecosystem-en.png" alt="Stance strategy leaderboard comparing return, worst drawdown, average invested exposure, and record rate across KRX and US strategies" width="100%">
@@ -54,21 +69,6 @@ Open your strategy project in **Codex CLI, Cursor, Claude Code, or another codin
 
 Your strategy appears under **Building a record** from its first decision. For stock markets, official ranking begins after **63 trading days and 20 closed trades that each used at least 1% of assets**. The record starts on connection day; historical results cannot be backfilled. No live brokerage account, balance, or broker key is required.
 </details>
-
----
-
-### Platinum Sponsor
-
-<div align="center">
-<a href="https://wrks.ai/en">
-  <img src="docs/images/wrks_ai_logo.png" alt="AI3 WrksAI" width="50">
-</a>
-
-**[AI3](https://www.ai3.kr/) | [WrksAI](https://wrks.ai/en)**
-
-AI3, creator of **WrksAI** - the AI assistant for professionals,<br>
-proudly sponsors **PRISM-INSIGHT** - the AI assistant for investors.
-</div>
 
 ---
 

--- a/README_es.md
+++ b/README_es.md
@@ -28,7 +28,22 @@
   <a href="README_es.md">Español</a>
 </p>
 
-## Which System Trading Strategy Is Winning Right Now? — Stance
+### Patrocinador Platino
+
+<div align="center">
+<a href="https://wrks.ai/en">
+  <img src="docs/images/wrks_ai_logo.png" alt="AI3 WrksAI" width="50">
+</a>
+
+**[AI3](https://www.ai3.kr/) | [WrksAI](https://wrks.ai/en)**
+
+AI3, creador de **WrksAI** — el asistente de IA para profesionales,<br>
+patrocina con orgullo **PRISM-INSIGHT** — el asistente de IA para inversionistas.
+</div>
+
+---
+
+## NEW: Stance — Which System Trading Strategy Is Winning Right Now?
 
 <p align="center">
   <img src="docs/images/stance-ecosystem-en.png" alt="Stance strategy leaderboard comparing return, worst drawdown, average invested exposure, and record rate across KRX and US strategies" width="100%">
@@ -54,21 +69,6 @@ Open your strategy project in **Codex CLI, Cursor, Claude Code, or another codin
 
 Your strategy appears under **Building a record** from its first decision. For stock markets, official ranking begins after **63 trading days and 20 closed trades that each used at least 1% of assets**. The record starts on connection day; historical results cannot be backfilled. No live brokerage account, balance, or broker key is required.
 </details>
-
----
-
-### Patrocinador Platino
-
-<div align="center">
-<a href="https://wrks.ai/en">
-  <img src="docs/images/wrks_ai_logo.png" alt="AI3 WrksAI" width="50">
-</a>
-
-**[AI3](https://www.ai3.kr/) | [WrksAI](https://wrks.ai/en)**
-
-AI3, creador de **WrksAI** — el asistente de IA para profesionales,<br>
-patrocina con orgullo **PRISM-INSIGHT** — el asistente de IA para inversionistas.
-</div>
 
 ---
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -28,7 +28,22 @@
   <a href="README_es.md">Español</a>
 </p>
 
-## Which System Trading Strategy Is Winning Right Now? — Stance
+### プラチナスポンサー
+
+<div align="center">
+<a href="https://wrks.ai/en">
+  <img src="docs/images/wrks_ai_logo.png" alt="AI3 WrksAI" width="50">
+</a>
+
+**[AI3](https://www.ai3.kr/) | [WrksAI](https://wrks.ai/en)**
+
+**WrksAI**（プロフェッショナル向けAIアシスタント）の開発元であるAI3が、<br>
+投資家のためのAIアシスタント **PRISM-INSIGHT** を誇りを持ってスポンサーしています。
+</div>
+
+---
+
+## NEW: Stance — Which System Trading Strategy Is Winning Right Now?
 
 <p align="center">
   <img src="docs/images/stance-ecosystem-en.png" alt="Stance strategy leaderboard comparing return, worst drawdown, average invested exposure, and record rate across KRX and US strategies" width="100%">
@@ -54,21 +69,6 @@ Open your strategy project in **Codex CLI, Cursor, Claude Code, or another codin
 
 Your strategy appears under **Building a record** from its first decision. For stock markets, official ranking begins after **63 trading days and 20 closed trades that each used at least 1% of assets**. The record starts on connection day; historical results cannot be backfilled. No live brokerage account, balance, or broker key is required.
 </details>
-
----
-
-### プラチナスポンサー
-
-<div align="center">
-<a href="https://wrks.ai/en">
-  <img src="docs/images/wrks_ai_logo.png" alt="AI3 WrksAI" width="50">
-</a>
-
-**[AI3](https://www.ai3.kr/) | [WrksAI](https://wrks.ai/en)**
-
-**WrksAI**（プロフェッショナル向けAIアシスタント）の開発元であるAI3が、<br>
-投資家のためのAIアシスタント **PRISM-INSIGHT** を誇りを持ってスポンサーしています。
-</div>
 
 ---
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -28,7 +28,22 @@
   <a href="README_es.md">Español</a>
 </p>
 
-## 그래서 요즘, 어떤 시스템 트레이딩 전략이 제일 잘나가는데? — Stance
+### 플래티넘 스폰서
+
+<div align="center">
+<a href="https://wrks.ai/ko">
+  <img src="docs/images/wrks_ai_logo.png" alt="AI3 WrksAI" width="50">
+</a>
+
+**[AI3](https://www.ai3.kr/) | [WrksAI](https://wrks.ai/ko)**
+
+직장인을 위한 AI 비서 **웍스AI**를 만드는 **AI3**가<br>
+투자자를 위한 AI 비서 **PRISM-INSIGHT**를 후원합니다.
+</div>
+
+---
+
+## 신기능: Stance — 그래서 요즘, 어떤 시스템 트레이딩 전략이 제일 잘나가는데?
 
 <p align="center">
   <img src="docs/images/stance-ecosystem-ko.png" alt="한국과 미국 시스템 트레이딩 전략의 수익, 최대 하락, 평균 투자비중, 기록률을 비교하는 Stance 리더보드" width="100%">
@@ -54,21 +69,6 @@
 
 등록 직후부터 **‘기록 쌓는 중’**에 나오고 첫 판단부터 성과가 공개됩니다. 주식 공식 순위는 **63거래일 동안 기록하고, 자산의 1% 이상을 넣었던 거래를 20번 마친 뒤** 시작됩니다. 연결한 날부터 새 기록이 쌓이며 과거 성과는 끼워 넣을 수 없습니다. 실계좌·잔고·증권사 키는 필요 없습니다.
 </details>
-
----
-
-### 플래티넘 스폰서
-
-<div align="center">
-<a href="https://wrks.ai/ko">
-  <img src="docs/images/wrks_ai_logo.png" alt="AI3 WrksAI" width="50">
-</a>
-
-**[AI3](https://www.ai3.kr/) | [WrksAI](https://wrks.ai/ko)**
-
-직장인을 위한 AI 비서 **웍스AI**를 만드는 **AI3**가<br>
-투자자를 위한 AI 비서 **PRISM-INSIGHT**를 후원합니다.
-</div>
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -28,7 +28,22 @@
   <a href="README_es.md">Español</a>
 </p>
 
-## Which System Trading Strategy Is Winning Right Now? — Stance
+### 铂金赞助商
+
+<div align="center">
+<a href="https://wrks.ai/en">
+  <img src="docs/images/wrks_ai_logo.png" alt="AI3 WrksAI" width="50">
+</a>
+
+**[AI3](https://www.ai3.kr/) | [WrksAI](https://wrks.ai/en)**
+
+**WrksAI** 的开发者 **AI3** —— 专为职场人士打造的 AI 助手，<br>
+自豪地赞助 **PRISM-INSIGHT** —— 专为投资者打造的 AI 助手。
+</div>
+
+---
+
+## NEW: Stance — Which System Trading Strategy Is Winning Right Now?
 
 <p align="center">
   <img src="docs/images/stance-ecosystem-en.png" alt="Stance strategy leaderboard comparing return, worst drawdown, average invested exposure, and record rate across KRX and US strategies" width="100%">
@@ -54,21 +69,6 @@ Open your strategy project in **Codex CLI, Cursor, Claude Code, or another codin
 
 Your strategy appears under **Building a record** from its first decision. For stock markets, official ranking begins after **63 trading days and 20 closed trades that each used at least 1% of assets**. The record starts on connection day; historical results cannot be backfilled. No live brokerage account, balance, or broker key is required.
 </details>
-
----
-
-### 铂金赞助商
-
-<div align="center">
-<a href="https://wrks.ai/en">
-  <img src="docs/images/wrks_ai_logo.png" alt="AI3 WrksAI" width="50">
-</a>
-
-**[AI3](https://www.ai3.kr/) | [WrksAI](https://wrks.ai/en)**
-
-**WrksAI** 的开发者 **AI3** —— 专为职场人士打造的 AI 助手，<br>
-自豪地赞助 **PRISM-INSIGHT** —— 专为投资者打造的 AI 助手。
-</div>
 
 ---
 


### PR DESCRIPTION
## What changed
- move the Platinum Sponsor block back to the top of every README
- place Stance immediately above the ChatGPT Plus/Pro feature
- label Stance explicitly as a new feature
- keep Korean Stance copy in Korean and the other Stance headings in English

## Verified
- sponsor -> Stance -> ChatGPT order in all five README files
- one sponsor block per README
- balanced HTML and details blocks
- git diff --check