### PR TITLE
fix(trading): 상승 전환 파일럿 진입으로 과차단 완화

### DIFF
--- a/cores/regime_policy.py
+++ b/cores/regime_policy.py
@@ -221,18 +221,30 @@ def regime_min_score_floor_enabled() -> bool:
     )
 
 
-def min_score_floor(market_regime: Optional[str]) -> int:
+def min_score_floor(
+    market_regime: Optional[str], pulse_state: Optional[str] = None
+) -> int:
     """Hard buy-score floor for ``market_regime`` (0 for bullish / unknown regimes).
 
     Tolerant of decorated labels (e.g. ``"strong_bear (하락)"`` -> ``strong_bear``):
     only the leading whitespace-delimited token is matched. Unmapped -> 0.
+
+    A sideways regime can lag a fresh broad-market recovery.  When the independent
+    Market Pulse state is already UPTREND, ease only that floor from 8 to 7.  A
+    missing/stale pulse keeps the defensive floor of 8.
     """
     raw = (market_regime or "").strip().lower()
     key = raw.split()[0] if raw else "unknown"
+    if key == "sideways" and (pulse_state or "").strip().upper() == UPTREND:
+        return 7
     return _REGIME_MIN_SCORE_FLOORS.get(key, 0)
 
 
-def effective_min_score(llm_min_score, market_regime: Optional[str]) -> int:
+def effective_min_score(
+    llm_min_score,
+    market_regime: Optional[str],
+    pulse_state: Optional[str] = None,
+) -> int:
     """Return ``max(llm_min_score, regime_floor)`` when the flag is ON; else the
     LLM value unchanged.
 
@@ -245,7 +257,63 @@ def effective_min_score(llm_min_score, market_regime: Optional[str]) -> int:
         base = 0
     if not regime_min_score_floor_enabled():
         return base
-    return max(base, min_score_floor(market_regime))
+    return max(base, min_score_floor(market_regime, pulse_state))
+
+
+def is_rebound_pilot_entry(
+    buy_score,
+    llm_min_score,
+    market_regime: Optional[str],
+    pulse_state: Optional[str],
+    decision: Optional[str],
+) -> bool:
+    """Allow one narrowly-scoped half-size entry during a rebound transition.
+
+    The exception applies only when all independent safeguards agree: the floor
+    feature is enabled, the deterministic regime is sideways, Market Pulse is
+    UPTREND, the AI explicitly chose entry, the score is exactly 6, and the AI's
+    own minimum did not require 7+.  Other gates (sector, slots, cooldown) remain
+    authoritative at their existing call sites.
+    """
+    if not regime_min_score_floor_enabled():
+        return False
+    try:
+        score = int(buy_score)
+        base = int(llm_min_score or 0)
+    except (TypeError, ValueError):
+        return False
+    raw_regime = (market_regime or "").strip().lower()
+    regime = raw_regime.split()[0] if raw_regime else "unknown"
+    normalized_decision = (decision or "").strip().lower()
+    return (
+        regime == "sideways"
+        and (pulse_state or "").strip().upper() == UPTREND
+        and normalized_decision in {"enter", "entry"}
+        and score == 6
+        and base <= 6
+    )
+
+
+def configured_entry_amount(
+    account: Optional[dict], market: str, position_fraction: float
+):
+    """Return a scaled configured order amount, or ``None`` for normal/default size.
+
+    Returning ``None`` preserves the broker adapter's existing default.  Invalid
+    account data also returns ``None`` so configuration parsing never blocks an
+    otherwise valid entry.
+    """
+    if position_fraction >= 1.0 or position_fraction <= 0.0 or not account:
+        return None
+    key = "buy_amount_krw" if (market or "").strip().lower() == "kr" else "buy_amount_usd"
+    try:
+        configured = float(account.get(key) or 0)
+    except (TypeError, ValueError):
+        return None
+    if configured <= 0:
+        return None
+    scaled = configured * position_fraction
+    return int(scaled) if key == "buy_amount_krw" else scaled
 
 
 # --------------------------------------------------------------------------- #

--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -27,6 +27,7 @@
 |---|---|---|---|---|
 | OAuth LLM 백엔드(ChatGPT 구독) | **LIVE** | crontab `PRISM_OPENAI_AUTH_MODE=chatgpt_oauth` | 카나리 검증 완료 | 전 배치 적용 |
 | Market Pulse 배치 정책 | **LIVE** | `.env MARKET_PULSE_MODE=live` | 정책 단위테스트 + 정규장 관측 | KR/US 모두 오전·오후 2회. `UNDER_PRESSURE`는 두 배치 유지, `CORRECTION`은 오후만 실행. 10분 hardstop/trend-exit 및 2분 fill-chaser는 모든 상태에서 유지 |
+| 레짐 최소점수 + 상승전환 파일럿 | **LIVE** | `.env REGIME_MIN_SCORE_FLOOR=true` | 순증 차단·차단 후 1/3/5/10일 성과 지속 관측 | 기본 `strong_bear=9`, `moderate_bear=8`, `sideways=8`. 단 `sideways + MARKET_PULSE=UPTREND`는 7점, AI가 `Enter`한 정확히 6점(원래 문턱 ≤6)은 설정 주문액의 50%로만 진입. 로그 `[REGIME_REBOUND_PILOT]` |
 | TIER0 이벤트 강제청산(뉴스 자율매도 + KIS 51 관리종목) | **LIVE** | 코드 상시 | 더존 등 실증 | KR+US 매도 프롬프트 핵심-0 |
 | Loop A — 고빈도 하드스톱(−7%/시나리오손절) | **LIVE** | `.env HARDSTOP_LIVE=true` (구 `LOOP_A_LIVE`, alias 유효) + cron 10분 | SHADOW 관측 후 승격(06-20) | KR 9–15 / US 9–16. 킬: `HARDSTOP_ENABLED=false` |
 | Loop B — 50MA 종가확인 추세이탈 | **LIVE** | `.env TREND_EXIT_LIVE=true` (구 `LOOP_B_LIVE`) + cron(KR 9–15 / US 9–16) | 백테스트 KR/US 순효과(휩쏘0·추가DD0) + 사용자 승인(06-24) | 코드: `tools/trend_exit_seller.py` (구 `tools/loop_b_trend_exit.py` shim 유효). 킬: `TREND_EXIT_ENABLED=false` |

--- a/docs/TRIGGER_BATCH_ALGORITHMS.md
+++ b/docs/TRIGGER_BATCH_ALGORITHMS.md
@@ -308,7 +308,7 @@ KR은 시나리오의 `buy_score`, US는 저널 조정까지 반영한 `adjusted
 - 동일 섹터 최대 3개
 - 보유 4개 이상일 때 섹터 비중 30% 제한
 
-`REGIME_MIN_SCORE_FLOOR`는 기본 비활성입니다. 활성 시 기본 바닥점수는 `strong_bear=9`, `sideways/moderate_bear=8`, 강세 체제는 추가 바닥 없음입니다.
+`REGIME_MIN_SCORE_FLOOR`는 기본 비활성입니다. 활성 시 기본 바닥점수는 `strong_bear=9`, `sideways/moderate_bear=8`, 강세 체제는 추가 바닥 없음입니다. 단 레짐이 `sideways`여도 독립적인 `MARKET_PULSE=UPTREND`가 확인되면 상승 전환 지연을 보완하기 위해 바닥점수를 7로 낮춥니다. 이때 AI가 명시적으로 진입을 선택했고 원래 문턱이 6 이하인 정확히 6점 신호는 `[REGIME_REBOUND_PILOT]`로 기록하며 설정 주문액의 50%만 진입합니다. Pulse 조회 실패, AI `Skip`, 약세 레짐에는 이 예외를 적용하지 않습니다.
 
 ## 11. 피라미딩
 

--- a/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
+++ b/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
@@ -7,6 +7,7 @@ import threading
 import types
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -689,6 +690,85 @@ async def test_process_reports_analyzes_once_and_dedupes_signals(monkeypatch, ca
     assert len(gcp_calls) == 1
     assert watchlist_calls == []
     assert "partial success" in caplog.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_sideways_uptrend_score_six_uses_half_size_us_order(monkeypatch, tmp_path):
+    regime_policy = _load_module(
+        "root_regime_policy_rebound_test", PROJECT_ROOT / "cores" / "regime_policy.py"
+    )
+
+    agent = USStockTrackingAgent.__new__(USStockTrackingAgent)
+    agent.db_path = str(tmp_path / "us-rebound-pilot.sqlite")
+    agent.account_configs = [{
+        "name": "us-primary",
+        "account_key": "vps:us-primary:01",
+        "product": "01",
+        "buy_amount_usd": 2000.0,
+    }]
+    agent.active_account = None
+    agent.max_slots = 10
+    agent.enable_journal = False
+    agent.conn = sqlite3.connect(":memory:")
+    agent.cursor = agent.conn.cursor()
+
+    async def fake_core(_report_path):
+        return {
+            "success": True,
+            "ticker": "AAPL",
+            "company_name": "Apple Inc.",
+            "current_price": 180.5,
+            "scenario": {"buy_score": 6, "min_score": 5, "sector": "Technology"},
+            "decision": "entry",
+            "raw_decision": "Enter",
+            "sector": "Technology",
+            "rank_change_msg": "Up",
+        }
+
+    agent._analyze_report_core = fake_core
+    agent.update_holdings = AsyncMock(return_value=[])
+    agent._is_ticker_in_holdings = AsyncMock(return_value=False)
+    agent._get_current_slots_count = AsyncMock(return_value=0)
+    agent._check_sector_diversity = AsyncMock(return_value=True)
+    agent._buy_floor_regime = lambda: "sideways"
+    agent._regime_policy_mod = lambda: regime_policy
+    agent._buy_stock_with_position = AsyncMock(
+        return_value=LegacyPositionWriteResult(True, 1)
+    )
+    agent._link_position_entry_intent = lambda **_kwargs: True
+    agent._save_watchlist_item = AsyncMock(return_value=True)
+
+    buy_amounts = []
+
+    class PilotTradingContext(_FakeAsyncUSTradingContext):
+        async def async_buy_stock(self, ticker, limit_price=None, buy_amount=None):
+            buy_amounts.append(buy_amount)
+            return await super().async_buy_stock(ticker, limit_price, buy_amount)
+
+    module = types.ModuleType("trading.us_stock_trading")
+    module.AsyncUSTradingContext = PilotTradingContext
+    monkeypatch.setitem(sys.modules, "trading.us_stock_trading", module)
+    redis_calls, gcp_calls = [], []
+    _install_signal_modules(monkeypatch, redis_calls, gcp_calls)
+    monkeypatch.setattr(regime_policy, "get_market_pulse_state", lambda _market: "UPTREND")
+    monkeypatch.setenv("REGIME_MIN_SCORE_FLOOR", "true")
+
+    buy_count, sell_count = await USStockTrackingAgent.process_reports(
+        agent, ["report-a.pdf"]
+    )
+
+    assert (buy_count, sell_count) == (1, 0)
+    assert buy_amounts == [1000.0]
+    assert redis_calls[0]["scenario"]["regime_entry_policy"] == {
+        "mode": "rebound_pilot",
+        "position_fraction": 0.5,
+        "regime": "sideways",
+        "market_pulse": "UPTREND",
+    }
+    cash_amount = sqlite3.connect(agent.db_path).execute(
+        "SELECT cash_amount FROM order_intents"
+    ).fetchone()[0]
+    assert float(cash_amount) == 1000.0
 
 
 @pytest.mark.asyncio

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -1489,6 +1489,10 @@ class USStockTrackingAgent:
                           f"Period: {scenario.get('investment_period', 'short')}\n" \
                           f"Sector: {scenario.get('sector', 'Unknown')}\n"
 
+            entry_policy = scenario.get("regime_entry_policy") or {}
+            if entry_policy.get("mode") == "rebound_pilot":
+                message += "Position Size: 50% (rebound pilot)\n"
+
             # Add trigger win rate
             trigger_win_rate = self._get_trigger_win_rate(trigger_type)
             if trigger_win_rate:
@@ -3251,6 +3255,12 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
 
                     buy_score = scenario.get("buy_score", 0)
                     min_score = scenario.get("min_score", 0)
+                    llm_min_score = min_score
+                    floor_regime = None
+                    pulse_state = None
+                    rebound_pilot = False
+                    entry_cash_amount = None
+                    _rp = None
 
                     # 레짐 적응 하한선(env-gated REGIME_MIN_SCORE_FLOOR, 기본 off). 플래그 ON 시
                     # 약세장 하한(strong_bear 9 / bear·sideways 8)을 강제해 min_score 를 끌어올린다.
@@ -3260,12 +3270,16 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     try:
                         _rp = self._regime_policy_mod()
                         if _rp is not None and _rp.regime_min_score_floor_enabled():
-                            _fr = self._buy_floor_regime()
-                            _eff = _rp.effective_min_score(min_score, _fr)
+                            floor_regime = self._buy_floor_regime()
+                            pulse_state = _rp.get_market_pulse_state("us")
+                            _eff = _rp.effective_min_score(
+                                min_score, floor_regime, pulse_state
+                            )
                             if _eff > min_score:
                                 logger.info(
                                     f"[REGIME_MIN_SCORE_FLOOR] {company_name}({ticker}) "
-                                    f"min_score {min_score}->{_eff} (regime={_fr})"
+                                    f"min_score {min_score}->{_eff} "
+                                    f"(regime={floor_regime}, pulse={pulse_state})"
                                 )
                                 min_score = _eff
                     except Exception as _fe:
@@ -3293,6 +3307,45 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     normalized_decision = analysis_result.get("decision", "no_entry")
                     if raw_decision and raw_decision.lower() != normalized_decision:
                         logger.debug(f"Decision normalized: '{raw_decision}' -> '{normalized_decision}'")
+
+                    if _rp is not None and floor_regime is not None:
+                        rebound_pilot = _rp.is_rebound_pilot_entry(
+                            adjusted_score,
+                            llm_min_score,
+                            floor_regime,
+                            pulse_state,
+                            normalized_decision,
+                        )
+                        if rebound_pilot:
+                            entry_cash_amount = _rp.configured_entry_amount(
+                                account, "us", 0.5
+                            )
+                            if entry_cash_amount is None:
+                                rebound_pilot = False
+                                logger.error(
+                                    "[REGIME_REBOUND_PILOT] %s(%s) blocked: "
+                                    "configured US buy amount unavailable",
+                                    company_name,
+                                    ticker,
+                                )
+                            else:
+                                scenario = dict(scenario)
+                                scenario["regime_entry_policy"] = {
+                                    "mode": "rebound_pilot",
+                                    "position_fraction": 0.5,
+                                    "regime": floor_regime,
+                                    "market_pulse": pulse_state,
+                                }
+                                analysis_result["scenario"] = scenario
+                                logger.warning(
+                                    "[REGIME_REBOUND_PILOT] %s(%s) score=%s "
+                                    "min=%s position=50%% cash_amount=%s",
+                                    company_name,
+                                    ticker,
+                                    adjusted_score,
+                                    min_score,
+                                    entry_cash_amount,
+                                )
 
                     rationale = scenario.get("rationale", "") or ""
                     logger.info(
@@ -3324,7 +3377,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                                 _cd["window_hours"], _cd["after_loss"], _cd.get("exit_kind"), _risk_only)
                             _cd_block = _enforce
 
-                    if normalized_decision == "entry" and adjusted_score >= min_score and sector_diverse and not _cd_block:
+                    if normalized_decision == "entry" and (adjusted_score >= min_score or rebound_pilot) and sector_diverse and not _cd_block:
                         # is_add => pyramiding additional independent row (#288)
                         buy_result = await self._buy_stock_with_position(
                             ticker,
@@ -3354,6 +3407,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                                         source="us_batch",
                                         source_decision_id=source_decision_id,
                                         source_position_id=opened_position_id,
+                                        cash_amount=entry_cash_amount,
                                         limit_price=current_price,
                                         reason="AI analysis entry",
                                     )
@@ -3363,6 +3417,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                                     ) as trading:
                                         trade_result = await trading.execute_buy(
                                             ticker=ticker,
+                                            buy_amount=entry_cash_amount,
                                             limit_price=current_price,
                                             intent=order_intent,
                                         )
@@ -3459,7 +3514,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                         reason_parts = []
                         if normalized_decision != "entry":
                             reason_parts.append(f"AI judgment: {normalized_decision}")
-                        if adjusted_score < min_score:
+                        if adjusted_score < min_score and not rebound_pilot:
                             reason_parts.append(f"Insufficient score ({adjusted_score}/{min_score})")
                         if not sector_diverse:
                             reason_parts.append(f"Sector concentration ({sector})")

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -1313,6 +1313,9 @@ class StockTrackingAgent:
             f"투자기간: {scenario.get('investment_period', '단기')}\n"
             f"산업군: {scenario.get('sector', '알 수 없음')}\n"
         )
+        entry_policy = scenario.get("regime_entry_policy") or {}
+        if entry_policy.get("mode") == "rebound_pilot":
+            message += "진입비중: 50% (상승 전환 파일럿)\n"
 
         trigger_win_rate = self._get_trigger_win_rate(trigger_type)
         if trigger_win_rate:
@@ -1432,6 +1435,7 @@ class StockTrackingAgent:
         source: str = "kr_batch",
         is_add: bool = False,
         expected_open_count: int | None = None,
+        cash_amount: int | None = None,
     ) -> _PreparedKrEntry:
         """Atomically persist the legacy holding, intent, and PENDING_ENTRY."""
 
@@ -1489,6 +1493,7 @@ class StockTrackingAgent:
                 source=source,
                 source_decision_id=source_decision_id,
                 source_position_id=legacy_position_id("KR", legacy_holding_id),
+                cash_amount=cash_amount,
                 limit_price=current_price,
                 reason="AI analysis entry",
             )
@@ -1541,6 +1546,7 @@ class StockTrackingAgent:
         ) as trading:
             return await trading.execute_pre_reserved_buy(
                 stock_code=prepared.symbol,
+                buy_amount=prepared.intent.cash_amount,
                 limit_price=current_price,
                 intent=prepared.intent,
                 reservation=prepared.reservation,
@@ -2221,6 +2227,10 @@ class StockTrackingAgent:
                           f"손절가: {scenario.get('stop_loss', 0):,.0f}원\n" \
                           f"투자기간: {scenario.get('investment_period', '단기')}\n" \
                           f"산업군: {scenario.get('sector', '알 수 없음')}\n"
+
+            entry_policy = scenario.get("regime_entry_policy") or {}
+            if entry_policy.get("mode") == "rebound_pilot":
+                message += "진입비중: 50% (상승 전환 파일럿)\n"
 
             # Add trigger win rate
             trigger_win_rate = self._get_trigger_win_rate(trigger_type)
@@ -3513,6 +3523,8 @@ class StockTrackingAgent:
 
                     buy_score = scenario.get("buy_score", 0)
                     min_score = scenario.get("min_score", 0)
+                    llm_min_score = min_score
+                    entry_cash_amount = None
                     logger.info(f"Buy score check: {company_name}({ticker}) - Score: {buy_score}")
 
                     # 레짐 적응 하한선 게이트(env-gated REGIME_MIN_SCORE_FLOOR, 기본 off).
@@ -3523,19 +3535,61 @@ class StockTrackingAgent:
                     _regime_floor_block = False
                     try:
                         from cores.regime_policy import (
+                            configured_entry_amount,
                             effective_min_score,
+                            get_market_pulse_state,
+                            is_rebound_pilot_entry,
                             regime_min_score_floor_enabled,
                         )
                         if regime_min_score_floor_enabled():
                             _fr = self._buy_floor_regime()
-                            _eff = effective_min_score(min_score, _fr)
+                            _pulse = get_market_pulse_state("kr")
+                            _eff = effective_min_score(min_score, _fr, _pulse)
                             if _eff > min_score:
                                 logger.info(
                                     f"[REGIME_MIN_SCORE_FLOOR] {company_name}({ticker}) "
-                                    f"min_score {min_score}->{_eff} (regime={_fr})"
+                                    f"min_score {min_score}->{_eff} "
+                                    f"(regime={_fr}, pulse={_pulse})"
                                 )
                                 min_score = _eff
-                            if buy_score < min_score:
+                            _pilot = is_rebound_pilot_entry(
+                                buy_score,
+                                llm_min_score,
+                                _fr,
+                                _pulse,
+                                analysis_result.get("decision"),
+                            )
+                            if _pilot:
+                                entry_cash_amount = configured_entry_amount(
+                                    account, "kr", 0.5
+                                )
+                                if entry_cash_amount is None:
+                                    _regime_floor_block = True
+                                    logger.error(
+                                        "[REGIME_REBOUND_PILOT] %s(%s) blocked: "
+                                        "configured KR buy amount unavailable",
+                                        company_name,
+                                        ticker,
+                                    )
+                                else:
+                                    scenario = dict(scenario)
+                                    scenario["regime_entry_policy"] = {
+                                        "mode": "rebound_pilot",
+                                        "position_fraction": 0.5,
+                                        "regime": _fr,
+                                        "market_pulse": _pulse,
+                                    }
+                                    analysis_result["scenario"] = scenario
+                                    logger.warning(
+                                        "[REGIME_REBOUND_PILOT] %s(%s) score=%s "
+                                        "min=%s position=50%% cash_amount=%s",
+                                        company_name,
+                                        ticker,
+                                        buy_score,
+                                        min_score,
+                                        entry_cash_amount,
+                                    )
+                            elif buy_score < min_score:
                                 _regime_floor_block = True
                     except Exception as _fe:
                         logger.warning(f"[REGIME_MIN_SCORE_FLOOR] fail-open, LLM min_score 유지: {_fe}")
@@ -3573,6 +3627,7 @@ class StockTrackingAgent:
                                     rank_change_msg=rank_change_msg,
                                     source_decision_id=source_decision_id,
                                     source="kr_batch",
+                                    cash_amount=entry_cash_amount,
                                 )
                                 trade_result = await self._execute_pending_kr_entry(
                                     prepared, current_price=current_price
@@ -3713,6 +3768,7 @@ class StockTrackingAgent:
                                 source="kr_batch",
                                 source_decision_id=source_decision_id,
                                 source_position_id=opened_position_id,
+                                cash_amount=entry_cash_amount,
                                 limit_price=current_price,
                                 reason="AI analysis entry",
                             )
@@ -3723,6 +3779,7 @@ class StockTrackingAgent:
                                 ) as trading:
                                     trade_result = await trading.execute_buy(
                                         stock_code=ticker,
+                                        buy_amount=entry_cash_amount,
                                         limit_price=current_price,
                                         intent=order_intent,
                                     )

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -476,6 +476,10 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                 # Check entry decision
                 buy_score = scenario.get("buy_score", 0)
                 min_score = scenario.get("min_score", 0)
+                llm_min_score = min_score
+                decision = analysis_result.get("decision")
+                entry_cash_amount = None
+                rebound_pilot = False
 
                 # 레짐 적응 하한선(env-gated REGIME_MIN_SCORE_FLOOR, 기본 off). 플래그 ON 시
                 # 약세장 하한(strong_bear 9 / bear·sideways 8)을 강제해 min_score 를 끌어올린다.
@@ -484,22 +488,59 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                 # 종목별 LLM market_condition은 설명용이며 안전 게이트 입력으로 쓰지 않는다.
                 try:
                     from cores.regime_policy import (
+                        configured_entry_amount,
                         effective_min_score,
+                        get_market_pulse_state,
+                        is_rebound_pilot_entry,
                         regime_min_score_floor_enabled,
                     )
                     if regime_min_score_floor_enabled():
                         _fr = self._buy_floor_regime()
-                        _eff = effective_min_score(min_score, _fr)
+                        _pulse = get_market_pulse_state("kr")
+                        _eff = effective_min_score(min_score, _fr, _pulse)
                         if _eff > min_score:
                             logger.info(
                                 f"[REGIME_MIN_SCORE_FLOOR] {company_name}({ticker}) "
-                                f"min_score {min_score}->{_eff} (regime={_fr})"
+                                f"min_score {min_score}->{_eff} "
+                                f"(regime={_fr}, pulse={_pulse})"
                             )
                             min_score = _eff
+                        rebound_pilot = is_rebound_pilot_entry(
+                            buy_score, llm_min_score, _fr, _pulse, decision
+                        )
+                        if rebound_pilot:
+                            entry_cash_amount = configured_entry_amount(
+                                getattr(self, "active_account", None), "kr", 0.5
+                            )
+                            if entry_cash_amount is None:
+                                rebound_pilot = False
+                                logger.error(
+                                    "[REGIME_REBOUND_PILOT] %s(%s) blocked: "
+                                    "configured KR buy amount unavailable",
+                                    company_name,
+                                    ticker,
+                                )
+                            else:
+                                scenario = dict(scenario)
+                                scenario["regime_entry_policy"] = {
+                                    "mode": "rebound_pilot",
+                                    "position_fraction": 0.5,
+                                    "regime": _fr,
+                                    "market_pulse": _pulse,
+                                }
+                                analysis_result["scenario"] = scenario
+                                logger.warning(
+                                    "[REGIME_REBOUND_PILOT] %s(%s) score=%s "
+                                    "min=%s position=50%% cash_amount=%s",
+                                    company_name,
+                                    ticker,
+                                    buy_score,
+                                    min_score,
+                                    entry_cash_amount,
+                                )
                 except Exception as _fe:
                     logger.warning(f"[REGIME_MIN_SCORE_FLOOR] fail-open, LLM min_score 유지: {_fe}")
 
-                decision = analysis_result.get("decision")
                 rationale = scenario.get("rationale", "") or ""
                 logger.info(f"Buy score check: {company_name}({ticker}) - Score: {buy_score}, Min required score: {min_score}")
                 logger.info(
@@ -519,7 +560,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                     )
 
                 # Generate message if not buying (watch/insufficient score/sector constraints)
-                if decision != "Enter" or buy_score < min_score or not sector_diverse:
+                if decision != "Enter" or (buy_score < min_score and not rebound_pilot) or not sector_diverse:
                     # Build a single reason string that lists ALL applicable causes,
                     # ordered by who actually blocked the entry. AI judgment is shown
                     # first when the AI itself rejected — so the displayed reason
@@ -528,7 +569,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
 
                     if decision != "Enter":
                         reason_parts.append(f"AI 판단: {decision}")
-                    elif buy_score < min_score:
+                    elif buy_score < min_score and not rebound_pilot:
                         # AI said Enter but score is below threshold — flip to Skip
                         decision = "Skip"
                         logger.info(
@@ -537,7 +578,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                             f"(Score: {buy_score} < {min_score})"
                         )
 
-                    if buy_score < min_score:
+                    if buy_score < min_score and not rebound_pilot:
                         reason_parts.append(f"점수 부족 ({buy_score}/{min_score})")
                     if not sector_diverse:
                         reason_parts.append(f"섹터 집중 ({sector})")
@@ -635,7 +676,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                         _cd_block = _enforce
 
                 # Process buy if entry decision
-                if decision == "Enter" and buy_score >= min_score and sector_diverse and not _cd_block:
+                if decision == "Enter" and (buy_score >= min_score or rebound_pilot) and sector_diverse and not _cd_block:
                     if self._position_pending_kr_enabled():
                         prepared = None
                         active_account = getattr(self, "active_account", None)
@@ -671,6 +712,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                                     if is_add
                                     else None
                                 ),
+                                cash_amount=entry_cash_amount,
                             )
                             trade_result = await self._execute_pending_kr_entry(
                                 prepared, current_price=current_price
@@ -786,6 +828,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                             source="kr_enhanced_batch",
                             source_decision_id=f"report:{os.path.basename(pdf_report_path)}",
                             source_position_id=opened_position_id,
+                            cash_amount=entry_cash_amount,
                             limit_price=current_price,
                             reason="AI analysis entry",
                         )
@@ -798,6 +841,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                                 # Execute async buy with limit price for reserved orders
                                 trade_result = await trading.execute_buy(
                                     stock_code=ticker,
+                                    buy_amount=entry_cash_amount,
                                     limit_price=current_price,
                                     intent=order_intent,
                                 )

--- a/tests/test_regime_min_score_floor.py
+++ b/tests/test_regime_min_score_floor.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 import pytest
 
 from cores.regime_policy import (
+    configured_entry_amount,
     effective_min_score,
+    is_rebound_pilot_entry,
     min_score_floor,
     regime_min_score_floor_enabled,
 )
@@ -61,6 +63,64 @@ def test_flag_on_applies_max(monkeypatch):
     assert effective_min_score(5, "strong_bull") == 5
     assert effective_min_score(2, "unknown") == 2
     assert effective_min_score(4, None) == 4
+
+
+def test_sideways_uptrend_relaxes_floor_to_seven(monkeypatch):
+    monkeypatch.setenv("REGIME_MIN_SCORE_FLOOR", "true")
+
+    assert min_score_floor("sideways", "UPTREND") == 7
+    assert effective_min_score(5, "sideways", "UPTREND") == 7
+    assert effective_min_score(8, "sideways", "UPTREND") == 8
+
+
+@pytest.mark.parametrize("pulse_state", [None, "", "UNDER_PRESSURE", "CORRECTION"])
+def test_sideways_without_uptrend_keeps_floor_eight(monkeypatch, pulse_state):
+    monkeypatch.setenv("REGIME_MIN_SCORE_FLOOR", "true")
+
+    assert min_score_floor("sideways", pulse_state) == 8
+    assert effective_min_score(5, "sideways", pulse_state) == 8
+
+
+@pytest.mark.parametrize("decision", ["Enter", "entry", " ENTER "])
+def test_score_six_enter_is_half_size_rebound_pilot(monkeypatch, decision):
+    monkeypatch.setenv("REGIME_MIN_SCORE_FLOOR", "true")
+
+    assert is_rebound_pilot_entry(6, 5, "sideways", "UPTREND", decision)
+
+
+@pytest.mark.parametrize(
+    "buy_score,llm_min_score,regime,pulse_state,decision",
+    [
+        (7, 5, "sideways", "UPTREND", "Enter"),
+        (6, 7, "sideways", "UPTREND", "Enter"),
+        (6, 5, "moderate_bear", "UPTREND", "Enter"),
+        (6, 5, "sideways", "UNDER_PRESSURE", "Enter"),
+        (6, 5, "sideways", "UPTREND", "Skip"),
+    ],
+)
+def test_rebound_pilot_remains_narrow(
+    monkeypatch, buy_score, llm_min_score, regime, pulse_state, decision
+):
+    monkeypatch.setenv("REGIME_MIN_SCORE_FLOOR", "true")
+
+    assert not is_rebound_pilot_entry(
+        buy_score, llm_min_score, regime, pulse_state, decision
+    )
+
+
+def test_rebound_pilot_is_disabled_with_floor_flag(monkeypatch):
+    monkeypatch.delenv("REGIME_MIN_SCORE_FLOOR", raising=False)
+
+    assert not is_rebound_pilot_entry(6, 5, "sideways", "UPTREND", "Enter")
+
+
+def test_configured_entry_amount_scales_by_market():
+    account = {"buy_amount_krw": 1_000_000, "buy_amount_usd": "2000"}
+
+    assert configured_entry_amount(account, "kr", 0.5) == 500_000
+    assert configured_entry_amount(account, "us", 0.5) == 1000.0
+    assert configured_entry_amount(account, "kr", 1.0) is None
+    assert configured_entry_amount({}, "us", 0.5) is None
 
 
 @pytest.mark.parametrize("raw,enabled", [

--- a/tests/test_stock_tracking_agent_process_reports.py
+++ b/tests/test_stock_tracking_agent_process_reports.py
@@ -421,6 +421,76 @@ async def test_process_reports_analyzes_once_and_dedupes_signals(monkeypatch, ca
 
 
 @pytest.mark.asyncio
+async def test_sideways_uptrend_score_six_uses_half_size_kr_order(monkeypatch, tmp_path):
+    from cores import regime_policy
+
+    agent = StockTrackingAgent.__new__(StockTrackingAgent)
+    agent.db_path = str(tmp_path / "kr-rebound-pilot.sqlite")
+    agent.account_configs = [{
+        "name": "kr-primary",
+        "account_key": "vps:kr-primary:01",
+        "buy_amount_krw": 1_000_000,
+    }]
+    agent.active_account = None
+    agent.max_slots = 10
+    agent._position_pending_kr_ready = False
+
+    async def fake_core(_report_path):
+        return {
+            "success": True,
+            "ticker": "005930",
+            "company_name": "Samsung Electronics",
+            "current_price": 70000,
+            "scenario": {"buy_score": 6, "min_score": 5, "sector": "Technology"},
+            "decision": "Enter",
+            "sector": "Technology",
+            "rank_change_msg": "Up",
+        }
+
+    agent._analyze_report_core = fake_core
+    agent.update_holdings = AsyncMock(return_value=[])
+    agent._is_ticker_in_holdings = AsyncMock(return_value=False)
+    agent._get_current_slots_count = AsyncMock(return_value=0)
+    agent._check_sector_diversity = AsyncMock(return_value=True)
+    agent._buy_floor_regime = lambda: "sideways"
+    agent._buy_stock_with_position = AsyncMock(
+        return_value=LegacyPositionWriteResult(True, 1)
+    )
+    agent._link_position_entry_intent = lambda **_kwargs: True
+
+    buy_amounts = []
+
+    class PilotTradingContext(_FakeAsyncTradingContext):
+        async def async_buy_stock(self, stock_code, limit_price=None, buy_amount=None):
+            buy_amounts.append(buy_amount)
+            return await super().async_buy_stock(stock_code, limit_price, buy_amount)
+
+    redis_calls, gcp_calls = [], []
+    _install_signal_modules(monkeypatch, redis_calls, gcp_calls)
+    monkeypatch.setattr(domestic_trading, "AsyncTradingContext", PilotTradingContext)
+    monkeypatch.setattr(regime_policy, "get_market_pulse_state", lambda _market: "UPTREND")
+    monkeypatch.setenv("REGIME_MIN_SCORE_FLOOR", "true")
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "false")
+
+    buy_count, sell_count = await StockTrackingAgent.process_reports(
+        agent, ["report-a.pdf"]
+    )
+
+    assert (buy_count, sell_count) == (1, 0)
+    assert buy_amounts == [500_000]
+    assert redis_calls[0]["scenario"]["regime_entry_policy"] == {
+        "mode": "rebound_pilot",
+        "position_fraction": 0.5,
+        "regime": "sideways",
+        "market_pulse": "UPTREND",
+    }
+    cash_amount = sqlite3.connect(agent.db_path).execute(
+        "SELECT cash_amount FROM order_intents"
+    ).fetchone()[0]
+    assert int(cash_amount) == 500_000
+
+
+@pytest.mark.asyncio
 async def test_kr_pending_gate_false_preserves_legacy_message_broker_publish_order(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
## 변경
- `sideways + MARKET_PULSE=UPTREND`에서 최소 점수 하한을 8→7로 완화
- AI가 Enter한 정확히 6점(원래 문턱 ≤6)은 설정 주문액의 50% 파일럿 진입
- KR 기본/pending/enhanced 및 US 매수 경로에 동일 정책·주문 금액·감사 로그 연결
- Skip, 약세 레짐, 섹터/슬롯/쿨다운 게이트는 그대로 유지

## 관측
- `[REGIME_MIN_SCORE_FLOOR]` 로그에 pulse 상태 추가
- 50% 진입은 `[REGIME_REBOUND_PILOT]` 및 scenario `regime_entry_policy`로 추적

## 검증
- KR 관련 76 passed
- US 관련 11 passed
- py_compile 통과
- 새 공통 정책/테스트 Ruff 통과
- git diff --check 통과