### PR TITLE
fix: publish PRISM Stance decisions reliably

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,6 +146,22 @@ TELEGRAM_CHANNEL_ID=your_channel_id
 # FINNHUB_API_KEY=your_finnhub_api_key
 
 # ============================================
+# Stance live decision ledger (optional)
+# ============================================
+# One strategy key per market. Decisions are declared before broker orders;
+# no-trade batches submit Hold. Legacy STANCE_API_KEY/STANCE_UNIT_AMOUNT still
+# work for a single-market deployment.
+# STANCE_ENDPOINT=https://analysis.stocksimulation.kr/api/stance/v1
+# STANCE_KR_API_KEY=stk_...
+# STANCE_US_API_KEY=stk_...
+# STANCE_KR_UNIT_AMOUNT=1000000   # KRW; normal one-slot order amount
+# STANCE_US_UNIT_AMOUNT=1000      # USD; normal one-slot order amount
+# Optional in multi-account deployments: only this account reports set decisions.
+# STANCE_KR_ACCOUNT=your_live_account_name
+# STANCE_US_ACCOUNT=your_live_account_name
+# STANCE_TIMEOUT=3
+
+# ============================================
 # PRISM-BTC (Optional - BTC futures auto-trading module)
 # ============================================
 # Bybit DEMO trading credentials (prism-btc/live/demo.py)

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -40,6 +40,8 @@ sys.path.insert(0, str(PROJECT_ROOT))
 from prism_core.execution_service import (  # noqa: E402
     ExecutionService,
     OrderOutcomeUnknown,
+    declare_stance_hold,
+    stance_declaration_count,
 )
 from prism_core.order_intents import OrderIntent  # noqa: E402
 from prism_core.positions import (  # noqa: E402
@@ -4042,7 +4044,10 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
 
             try:
                 # Process reports
+                stance_before = stance_declaration_count("US")
                 buy_count, sell_count = await self.process_reports(pdf_report_paths)
+                if stance_declaration_count("US") == stance_before:
+                    await declare_stance_hold("US")
 
                 # Send Telegram message
                 if chat_id:

--- a/prism_core/execution_service.py
+++ b/prism_core/execution_service.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import sys
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +20,8 @@ from prism_core.order_intents import IntentStore, OrderIntent
 
 
 logger = logging.getLogger(__name__)
+_stance_count_lock = threading.Lock()
+_stance_set_counts = {"KR": 0, "US": 0}
 
 
 def normalize_checked_holding(result: Any) -> tuple[str, int | None]:
@@ -60,7 +64,10 @@ class _LocalFlatPersistenceError(RuntimeError):
         self.cause = cause
 
 
-def _stance_reporter_from_env():
+def _stance_reporter_from_env(
+    market: str | None = None,
+    account_name: str | None = None,
+):
     """Stance 리포터를 만든다. 환경변수가 없으면 꺼진 것을 돌려준다.
 
     STANCE_ENDPOINT / STANCE_API_KEY 가 모두 있어야 켜진다.
@@ -69,10 +76,33 @@ def _stance_reporter_from_env():
     try:
         from prism_core.stance_adapter import StanceReporter
 
-        return StanceReporter.from_env()
+        normalized_market = (market or "").upper()
+        selected_account = os.getenv(f"STANCE_{normalized_market}_ACCOUNT")
+        if selected_account and account_name is not None and selected_account != account_name:
+            return None
+        return StanceReporter.from_env(market)
     except Exception:  # pragma: no cover - 리포터가 매매를 막아서는 안 된다
         logger.debug("Stance reporter unavailable", exc_info=True)
         return None
+
+
+def stance_declaration_count(market: str) -> int:
+    """현재 프로세스에서 시도한 시장별 set 선언 수를 돌려준다."""
+    with _stance_count_lock:
+        return _stance_set_counts.get(market.upper(), 0)
+
+
+async def declare_stance_hold(market: str, reason: str = "prism:no_portfolio_change") -> bool:
+    """거래 없는 판단 주기의 Hold를 fail-open으로 한 번 전송한다."""
+    reporter = _stance_reporter_from_env(market)
+    if reporter is None or not getattr(reporter, "enabled", False):
+        return False
+    try:
+        result = await asyncio.to_thread(reporter.report_hold, reason=reason)
+        return result is not None
+    except Exception:  # pragma: no cover - 리포터가 매매 배치를 막아서는 안 된다
+        logger.warning("[STANCE] hold declaration failed market=%s", market, exc_info=True)
+        return False
 
 
 class ExecutionService:
@@ -103,6 +133,7 @@ class ExecutionService:
         *,
         intent_store: IntentStore | None = None,
         stance_reporter: Any | None = None,
+        stance_market: str | None = None,
     ):
         self._resource = context_or_trader
         self._trader: Any | None = None
@@ -110,6 +141,7 @@ class ExecutionService:
         self._intent_store = intent_store
         # Stance 선언 전송. 환경변수가 없으면 꺼진 상태로 만들어져 아무 일도 하지 않는다.
         self._stance = stance_reporter
+        self._stance_market = (stance_market or "").upper() or None
 
     @classmethod
     def domestic(
@@ -136,7 +168,8 @@ class ExecutionService:
         return cls(
             AsyncTradingContext(account_name=account_name),
             intent_store=store,
-            stance_reporter=_stance_reporter_from_env(),
+            stance_reporter=_stance_reporter_from_env("KR", account_name),
+            stance_market="KR",
         )
 
     @classmethod
@@ -168,6 +201,8 @@ class ExecutionService:
         return cls(
             AsyncUSTradingContext(account_name=account_name),
             intent_store=store,
+            stance_reporter=_stance_reporter_from_env("US", account_name),
+            stance_market="US",
         )
 
     async def __aenter__(self) -> "ExecutionService":
@@ -235,9 +270,12 @@ class ExecutionService:
         method,
         *args,
         intent: OrderIntent | None = None,
+        before_order=None,
         **kwargs,
     ):
         if intent is None:
+            if before_order is not None:
+                await before_order()
             return await method(*args, **kwargs)
         if self._intent_store is None:
             raise RuntimeError(
@@ -255,6 +293,9 @@ class ExecutionService:
             )
             return self._intent_store.blocked_result(existing)
         await asyncio.to_thread(self._intent_store.mark_submitting, intent.id)
+
+        if before_order is not None:
+            await before_order()
 
         return await self._execute_submitting_order(
             method, *args, intent=intent, **kwargs
@@ -356,6 +397,7 @@ class ExecutionService:
         intent: OrderIntent,
         reservation: Any,
         side: str,
+        before_order=None,
         **kwargs,
     ):
         await self._claim_pre_reserved(
@@ -363,6 +405,8 @@ class ExecutionService:
             reservation=reservation,
             side=side,
         )
+        if before_order is not None:
+            await before_order()
         return await self._execute_submitting_order(
             method, *args, intent=intent, **kwargs
         )
@@ -423,9 +467,12 @@ class ExecutionService:
         method,
         *args,
         intent: OrderIntent | None = None,
+        before_order=None,
         **kwargs,
     ):
         if intent is None:
+            if before_order is not None:
+                before_order()
             return method(*args, **kwargs)
         if self._intent_store is None:
             raise RuntimeError(
@@ -441,6 +488,9 @@ class ExecutionService:
             )
             return self._intent_store.blocked_result(existing)
         self._intent_store.mark_submitting(intent.id)
+
+        if before_order is not None:
+            before_order()
 
         return self._execute_submitting_order_sync(
             method, *args, intent=intent, **kwargs
@@ -514,6 +564,7 @@ class ExecutionService:
         intent: OrderIntent,
         reservation: Any,
         side: str,
+        before_order=None,
         **kwargs,
     ):
         if self._intent_store is None:
@@ -523,17 +574,18 @@ class ExecutionService:
         self._intent_store.claim_reservation(
             reservation, intent, expected_side=side
         )
+        if before_order is not None:
+            before_order()
         return self._execute_submitting_order_sync(
             method, *args, intent=intent, **kwargs
         )
 
 
-    async def _declare_stance(self, side: str, kwargs: dict) -> None:
+    def _declare_stance_sync(self, side: str, kwargs: dict) -> None:
         """Stance 에 판단을 선언한다. **매매를 막지 않는 것이 최우선이다.**
 
-        - 주문이 끝난 뒤에 호출된다. 주문 자체를 지연시키지 않는다.
+        - 주문 전에 호출한다. 사후 성과가 아니라 당시 판단을 기록한다.
         - 모든 예외를 삼킨다.
-        - 블로킹 I/O 라 스레드에서 돌린다. 이벤트 루프를 잡지 않는다.
         - 서버가 죽어 있으면 클라이언트 타임아웃(기본 3초)만큼만 기다린다.
         """
         reporter = self._stance
@@ -544,23 +596,35 @@ class ExecutionService:
         if not symbol:
             return
 
-        def _send() -> None:
+        if self._stance_market:
+            with _stance_count_lock:
+                _stance_set_counts[self._stance_market] = (
+                    _stance_set_counts.get(self._stance_market, 0) + 1
+                )
+
+        try:
             from prism_core.stance_adapter import snapshot_from_trader
 
             snapshot = snapshot_from_trader(self._active_trader)
             if side == "BUY":
-                reporter.report_buy(snapshot, symbol, reason="prism")
+                reporter.report_buy(
+                    snapshot,
+                    symbol,
+                    reason="prism",
+                    add_amount=kwargs.get("buy_amount"),
+                )
             else:
                 reporter.report_sell(
                     symbol, reason="prism", snapshot=snapshot,
                     sold_qty=kwargs.get("quantity"),
                     held_qty=self._active_trader.get_holding_quantity(symbol),
                 )
-
-        try:
-            await asyncio.to_thread(_send)
         except Exception:
             logger.warning("Stance declaration failed (%s %s)", side, symbol, exc_info=True)
+
+    async def _declare_stance(self, side: str, kwargs: dict) -> None:
+        """블로킹 선언 I/O를 이벤트 루프 밖에서 실행한다."""
+        await asyncio.to_thread(self._declare_stance_sync, side, kwargs)
 
     async def execute_buy(
         self,
@@ -568,14 +632,13 @@ class ExecutionService:
         intent: OrderIntent | None = None,
         **kwargs,
     ):
-        result = await self._execute_order(
+        return await self._execute_order(
             self._active_trader.async_buy_stock,
             *args,
             intent=intent,
+            before_order=lambda: self._declare_stance("BUY", kwargs),
             **kwargs,
         )
-        await self._declare_stance("BUY", kwargs)
-        return result
 
     async def execute_sell(
         self,
@@ -583,14 +646,13 @@ class ExecutionService:
         intent: OrderIntent | None = None,
         **kwargs,
     ):
-        result = await self._execute_order(
+        return await self._execute_order(
             self._active_trader.async_sell_stock,
             *args,
             intent=intent,
+            before_order=lambda: self._declare_stance("SELL", kwargs),
             **kwargs,
         )
-        await self._declare_stance("SELL", kwargs)
-        return result
 
     async def execute_pre_reserved_buy(
         self,
@@ -599,16 +661,15 @@ class ExecutionService:
         reservation: Any,
         **kwargs,
     ):
-        result = await self._execute_pre_reserved_order(
+        return await self._execute_pre_reserved_order(
             self._active_trader.async_buy_stock,
             *args,
             intent=intent,
             reservation=reservation,
             side="BUY",
+            before_order=lambda: self._declare_stance("BUY", kwargs),
             **kwargs,
         )
-        await self._declare_stance("BUY", kwargs)
-        return result
 
     async def execute_pre_reserved_sell(
         self,
@@ -617,16 +678,15 @@ class ExecutionService:
         reservation: Any,
         **kwargs,
     ):
-        result = await self._execute_pre_reserved_order(
+        return await self._execute_pre_reserved_order(
             self._active_trader.async_sell_stock,
             *args,
             intent=intent,
             reservation=reservation,
             side="SELL",
+            before_order=lambda: self._declare_stance("SELL", kwargs),
             **kwargs,
         )
-        await self._declare_stance("SELL", kwargs)
-        return result
 
     async def execute_pre_reserved_local_flat_sell(
         self,
@@ -735,6 +795,7 @@ class ExecutionService:
             self._active_trader.buy_reserved_order,
             *args,
             intent=intent,
+            before_order=lambda: self._declare_stance_sync("BUY", kwargs),
             **kwargs,
         )
 
@@ -748,6 +809,7 @@ class ExecutionService:
             self._active_trader.sell_reserved_order,
             *args,
             intent=intent,
+            before_order=lambda: self._declare_stance_sync("SELL", kwargs),
             **kwargs,
         )
 
@@ -764,6 +826,7 @@ class ExecutionService:
             intent=intent,
             reservation=reservation,
             side="BUY",
+            before_order=lambda: self._declare_stance_sync("BUY", kwargs),
             **kwargs,
         )
 
@@ -780,6 +843,7 @@ class ExecutionService:
             intent=intent,
             reservation=reservation,
             side="SELL",
+            before_order=lambda: self._declare_stance_sync("SELL", kwargs),
             **kwargs,
         )
 

--- a/prism_core/stance_adapter.py
+++ b/prism_core/stance_adapter.py
@@ -123,14 +123,34 @@ class StanceReporter:
         self.unit_amount = Decimal(str(unit_amount))
         self.enabled = enabled and client is not None
 
-    def report_buy(self, snapshot: AccountSnapshot, symbol: str, reason: str | None = None):
+    @staticmethod
+    def _log_success(kind: str, symbol: str | None, result) -> None:
+        detail = result if isinstance(result, dict) else {}
+        logger.info(
+            "[STANCE] declared kind=%s symbol=%s admit=%s seq=%s",
+            kind,
+            symbol or "-",
+            detail.get("admit", "accepted"),
+            detail.get("seq", "-"),
+        )
+
+    def report_buy(
+        self,
+        snapshot: AccountSnapshot,
+        symbol: str,
+        reason: str | None = None,
+        add_amount: Decimal | float | None = None,
+    ):
         if not self.enabled:
             return None
         try:
-            w = buy_target_weight(snapshot, symbol, self.unit_amount)
-            return self.client.set(symbol, w, reason=reason)
+            amount = self.unit_amount if add_amount is None else Decimal(str(add_amount))
+            w = buy_target_weight(snapshot, symbol, amount)
+            result = self.client.set(symbol, w, reason=reason)
+            self._log_success("set", symbol, result)
+            return result
         except Exception:
-            logger.exception("[stance] 매수 선언 전송 실패 (%s) — 매매는 계속 진행한다", symbol)
+            logger.exception("[STANCE] 매수 선언 전송 실패 (%s) — 매매는 계속 진행한다", symbol)
             return None
 
     def report_sell(self, symbol: str, reason: str | None = None,
@@ -143,26 +163,33 @@ class StanceReporter:
                 sell_target_weight(snapshot, symbol, sold_qty, held_qty)
                 if snapshot is not None else Decimal(0)
             )
-            return self.client.set(symbol, target, reason=reason)
+            result = self.client.set(symbol, target, reason=reason)
+            self._log_success("set", symbol, result)
+            return result
         except Exception:
-            logger.exception("[stance] 매도 선언 전송 실패 (%s) — 매매는 계속 진행한다", symbol)
+            logger.exception("[STANCE] 매도 선언 전송 실패 (%s) — 매매는 계속 진행한다", symbol)
             return None
 
     @classmethod
-    def from_env(cls) -> "StanceReporter":
+    def from_env(cls, market: str | None = None) -> "StanceReporter":
         """환경변수가 없으면 **꺼진 상태**로 만들어진다.
 
         서버가 뜨기 전에 켜면 주문마다 죽은 엔드포인트로 HTTP 를 때린다.
         그래서 기본이 꺼짐이고, 명시적으로 설정해야만 켜진다.
 
             STANCE_ENDPOINT   http://127.0.0.1:8800
-            STANCE_API_KEY    stk_...
-            STANCE_UNIT_AMOUNT  슬롯 금액 (기본 kis_devlp.yaml 의 default_unit_amount)
+            STANCE_KR_API_KEY / STANCE_US_API_KEY  시장별 전략 키
+            STANCE_KR_UNIT_AMOUNT / STANCE_US_UNIT_AMOUNT  시장별 슬롯 금액
+
+        기존 STANCE_API_KEY / STANCE_UNIT_AMOUNT 도 단일 시장 연동용으로 지원한다.
         """
         import os
 
         endpoint = os.getenv("STANCE_ENDPOINT")
-        api_key = os.getenv("STANCE_API_KEY")
+        market_name = (market or "").strip().upper()
+        api_key = (
+            os.getenv(f"STANCE_{market_name}_API_KEY") if market_name else None
+        ) or os.getenv("STANCE_API_KEY")
         if not (endpoint and api_key):
             return cls(client=None)
 
@@ -176,16 +203,21 @@ class StanceReporter:
             logger.exception("[stance] 클라이언트를 만들지 못했습니다 — 선언을 보내지 않는다")
             return cls(client=None)
 
-        return cls(client=client, unit_amount=os.getenv("STANCE_UNIT_AMOUNT") or 0)
+        unit_amount = (
+            os.getenv(f"STANCE_{market_name}_UNIT_AMOUNT") if market_name else None
+        ) or os.getenv("STANCE_UNIT_AMOUNT") or 0
+        return cls(client=client, unit_amount=unit_amount)
 
     def report_hold(self, reason: str | None = None):
         """매매하지 않은 날에도 보낸다. 제출률에 반영된다."""
         if not self.enabled:
             return None
         try:
-            return self.client.hold(reason=reason)
+            result = self.client.hold(reason=reason)
+            self._log_success("hold", None, result)
+            return result
         except Exception:
-            logger.exception("[stance] hold 선언 전송 실패 — 매매는 계속 진행한다")
+            logger.exception("[STANCE] hold 선언 전송 실패 — 매매는 계속 진행한다")
             return None
 
 

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -52,7 +52,9 @@ from cores.utils import parse_llm_json
 from prism_core.execution_service import (
     ExecutionService,
     OrderOutcomeUnknown,
+    declare_stance_hold,
     normalize_checked_holding,
+    stance_declaration_count,
 )
 from prism_core.exit_effects import ExitEffectStore
 from prism_core.exit_effect_replay import deliver_exit_effect_once
@@ -4270,7 +4272,10 @@ class StockTrackingAgent:
 
             try:
                 # Process reports
+                stance_before = stance_declaration_count("KR")
                 buy_count, sell_count = await self.process_reports(pdf_report_paths)
+                if stance_declaration_count("KR") == stance_before:
+                    await declare_stance_hold("KR")
 
                 # Send Telegram message (only if chat_id is provided)
                 if chat_id:

--- a/tests/test_stance_adapter.py
+++ b/tests/test_stance_adapter.py
@@ -110,6 +110,21 @@ def test_reporter_sends_expected_weight():
     assert sent == [("005930", D("0.1"), "눌림목")]
 
 
+def test_reporter_buy_uses_actual_order_amount_when_provided():
+    """반 슬롯 매수는 기본 슬롯이 아니라 실제 주문금액으로 선언한다."""
+    sent = []
+
+    class Recorder:
+        def set(self, symbol, weight, reason=None):
+            sent.append((symbol, weight, reason))
+            return {"admit": "accepted"}
+
+    r = StanceReporter(client=Recorder(), unit_amount=D(1_000_000))
+    r.report_buy(snap(10_000_000), "005930", add_amount=500_000)
+
+    assert sent == [("005930", D("0.05"), None)]
+
+
 def test_snapshot_from_kis_shape():
     balance = {
         "output1": [{"pdno": "005930", "evlu_amt": "7000000"},
@@ -249,3 +264,30 @@ def test_reporter_needs_only_endpoint_and_api_key(monkeypatch):
     monkeypatch.setenv("STANCE_API_KEY", "stk_x")
     monkeypatch.delenv("STANCE_STRATEGY", raising=False)
     assert StanceReporter.from_env().enabled
+
+
+def test_reporter_uses_market_specific_key_and_amount(monkeypatch):
+    monkeypatch.setenv("STANCE_ENDPOINT", "http://127.0.0.1:8800")
+    monkeypatch.setenv("STANCE_API_KEY", "stk_legacy")
+    monkeypatch.setenv("STANCE_KR_API_KEY", "stk_kr")
+    monkeypatch.setenv("STANCE_US_API_KEY", "stk_us")
+    monkeypatch.setenv("STANCE_KR_UNIT_AMOUNT", "1000000")
+    monkeypatch.setenv("STANCE_US_UNIT_AMOUNT", "750")
+
+    kr = StanceReporter.from_env("KR")
+    us = StanceReporter.from_env("US")
+
+    assert kr.client.token == "stk_kr"
+    assert us.client.token == "stk_us"
+    assert kr.unit_amount == D("1000000")
+    assert us.unit_amount == D("750")
+
+
+def test_market_specific_config_does_not_fall_back_to_other_market(monkeypatch):
+    monkeypatch.setenv("STANCE_ENDPOINT", "http://127.0.0.1:8800")
+    monkeypatch.setenv("STANCE_KR_API_KEY", "stk_kr")
+    monkeypatch.delenv("STANCE_API_KEY", raising=False)
+    monkeypatch.delenv("STANCE_US_API_KEY", raising=False)
+
+    assert StanceReporter.from_env("KR").enabled
+    assert not StanceReporter.from_env("US").enabled

--- a/tests/test_stance_execution_hook.py
+++ b/tests/test_stance_execution_hook.py
@@ -28,6 +28,14 @@ class FakeTrader:
         self.sells.append(kwargs)
         return {"status": "success", "order_no": "S1"}
 
+    def buy_reserved_order(self, **kwargs):
+        self.buys.append(kwargs)
+        return {"status": "success", "order_no": "RB1"}
+
+    def sell_reserved_order(self, **kwargs):
+        self.sells.append(kwargs)
+        return {"status": "success", "order_no": "RS1"}
+
     def get_portfolio(self):
         return [{"stock_code": "005930", "eval_amount": 3_000_000}]
 
@@ -45,10 +53,10 @@ class RecordingReporter:
         self.boom = boom
         self.calls: list[tuple] = []
 
-    def report_buy(self, snapshot, symbol, reason=None):
+    def report_buy(self, snapshot, symbol, reason=None, add_amount=None):
         if self.boom:
             raise RuntimeError("Stance 서버 다운")
-        self.calls.append(("BUY", symbol, snapshot.total_assets))
+        self.calls.append(("BUY", symbol, snapshot.total_assets, add_amount))
 
     def report_sell(self, symbol, reason=None, snapshot=None, sold_qty=None, held_qty=None):
         if self.boom:
@@ -82,6 +90,16 @@ def test_env_gating_keeps_it_off(monkeypatch):
     assert reporter is None or not reporter.enabled
 
 
+def test_account_selector_prevents_duplicate_strategy_reporting(monkeypatch):
+    monkeypatch.setenv("STANCE_ENDPOINT", "http://127.0.0.1:8800")
+    monkeypatch.setenv("STANCE_KR_API_KEY", "stk_kr")
+    monkeypatch.setenv("STANCE_KR_ACCOUNT", "real")
+    from prism_core.execution_service import _stance_reporter_from_env
+
+    assert _stance_reporter_from_env("KR", "demo") is None
+    assert _stance_reporter_from_env("KR", "real").enabled
+
+
 # ── 켜졌을 때 ─────────────────────────────────────────────────────────────
 
 def test_buy_declares_with_account_snapshot():
@@ -92,9 +110,40 @@ def test_buy_declares_with_account_snapshot():
     run(svc.execute_buy(stock_code="005930", limit_price=70000))
 
     assert len(reporter.calls) == 1
-    side, symbol, total = reporter.calls[0]
+    side, symbol, total, add_amount = reporter.calls[0]
     assert (side, symbol) == ("BUY", "005930")
     assert total == 10_000_000       # 예수금 700만 + 보유 300만
+    assert add_amount is None
+
+
+def test_buy_passes_actual_order_amount():
+    reporter = RecordingReporter()
+    svc = ExecutionService(FakeTrader(), stance_reporter=reporter)
+
+    run(svc.execute_buy(stock_code="005930", buy_amount=500_000))
+
+    assert reporter.calls[0] == ("BUY", "005930", 10_000_000, 500_000)
+
+
+def test_synchronous_reserved_order_also_declares_first():
+    order = []
+
+    class OrderedTrader(FakeTrader):
+        def buy_reserved_order(self, **kwargs):
+            order.append("order")
+            return {"status": "success"}
+
+        def get_portfolio(self):
+            order.append("declare")
+            return []
+
+        def get_account_summary(self):
+            return {"deposit": 1_000_000}
+
+    svc = ExecutionService(OrderedTrader(), stance_reporter=RecordingReporter())
+    svc.execute_reserved_buy(stock_code="005930")
+
+    assert order == ["declare", "order"]
 
 
 def test_sell_passes_quantities_for_partial_exit():
@@ -134,8 +183,8 @@ def test_broken_snapshot_does_not_break_the_order():
     assert result["status"] == "success"
 
 
-def test_declaration_happens_after_the_order():
-    """주문을 지연시키지 않는다 — 주문이 끝난 뒤에 선언한다."""
+def test_declaration_happens_before_the_order():
+    """사후 성과가 아니라 당시 판단을 증명하므로 주문 전에 선언한다."""
     order: list[str] = []
 
     class OrderedTrader(FakeTrader):
@@ -153,7 +202,63 @@ def test_declaration_happens_after_the_order():
     svc = ExecutionService(OrderedTrader(), stance_reporter=RecordingReporter())
     run(svc.execute_buy(stock_code="005930"))
 
-    assert order == ["order", "declare"]
+    assert order == ["declare", "order"]
+
+
+def test_failed_order_still_keeps_the_prior_declaration():
+    class FailingTrader(FakeTrader):
+        async def async_buy_stock(self, **kwargs):
+            raise RuntimeError("broker rejected")
+
+    reporter = RecordingReporter()
+    svc = ExecutionService(FailingTrader(), stance_reporter=reporter)
+
+    with pytest.raises(RuntimeError, match="broker rejected"):
+        run(svc.execute_buy(stock_code="005930"))
+
+    assert reporter.calls[0][:2] == ("BUY", "005930")
+
+
+def test_batch_counter_marks_set_attempt_before_broker_failure():
+    from prism_core.execution_service import stance_declaration_count
+
+    class FailingTrader(FakeTrader):
+        async def async_buy_stock(self, **kwargs):
+            raise RuntimeError("broker rejected")
+
+    before = stance_declaration_count("KR")
+    svc = ExecutionService(
+        FailingTrader(),
+        stance_reporter=RecordingReporter(),
+        stance_market="KR",
+    )
+
+    with pytest.raises(RuntimeError):
+        run(svc.execute_buy(stock_code="005930"))
+
+    assert stance_declaration_count("KR") == before + 1
+
+
+def test_hold_helper_reports_no_trade_batch(monkeypatch):
+    import prism_core.execution_service as execution_service
+
+    calls = []
+
+    class HoldReporter:
+        enabled = True
+
+        def report_hold(self, reason=None):
+            calls.append(reason)
+            return {"admit": "accepted"}
+
+    monkeypatch.setattr(
+        execution_service,
+        "_stance_reporter_from_env",
+        lambda market, account_name=None: HoldReporter(),
+    )
+
+    assert run(execution_service.declare_stance_hold("US"))
+    assert calls == ["prism:no_portfolio_change"]
 
 
 def test_missing_symbol_is_skipped_quietly():


### PR DESCRIPTION
## Summary
- declare KR/US Stance decisions before broker submission, including synchronous reserved orders
- publish one Hold for completed no-trade batches without overwriting a prior set attempt
- split market keys/unit amounts, select one reporting account, and use actual partial-buy amount
- add explicit success/failure logs and deployment configuration documentation

## Verification
- `ruff check prism_core/stance_adapter.py prism_core/execution_service.py tests/test_stance_adapter.py tests/test_stance_execution_hook.py`
- `python3 -m pytest -q tests/test_stance_adapter.py tests/test_stance_execution_hook.py` (47 passed)
- `python3 -m py_compile prism_core/stance_adapter.py prism_core/execution_service.py stock_tracking_agent.py prism-us/us_stock_tracking_agent.py`
- `git diff --check`

Full local execution-service suite reached 60 passed; one unrelated test could not collect because the local interpreter lacks the existing `Crypto` dependency.