### PR TITLE
feat: show latest Stance decision on leaderboard

### DIFF
--- a/examples/dashboard/components/stance-leaderboard-page.tsx
+++ b/examples/dashboard/components/stance-leaderboard-page.tsx
@@ -32,6 +32,30 @@ function plainGateFailure(message: string, ko: boolean) {
   return message
 }
 
+function latestDecision(entry: StanceEntry, ko: boolean) {
+  const decision = entry.latest_decision
+  if (!decision) return ko ? "아직 판단 기록 없음" : "No decision recorded yet"
+
+  let action: string
+  if (decision.kind === "hold") action = ko ? "관망" : "Hold"
+  else if (decision.kind === "pause") action = ko ? "기록 일시중지" : "Paused"
+  else if (decision.kind === "resume") action = ko ? "기록 재개" : "Resumed"
+  else if ((decision.target_weight ?? 0) === 0) action = `${decision.symbol ?? ""} ${ko ? "전량 매도" : "Exit"}`.trim()
+  else action = `${decision.symbol ?? ""} ${((decision.target_weight ?? 0) * 100).toFixed(1)}% ${ko ? "목표" : "target"}`.trim()
+
+  if (decision.admit === "pending") action += ko ? " · 가격 확인 중" : " · price pending"
+  if (decision.admit === "rejected") action += ko ? " · 미반영" : " · not applied"
+  if (decision.admit === "clamped") action += ko ? " · 가능 비중만 반영" : " · capped"
+
+  const time = new Intl.DateTimeFormat(ko ? "ko-KR" : "en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(decision.received_at))
+  return `${action} · ${time}`
+}
+
 export function StanceLeaderboardPage() {
   const { language } = useLanguage()
   const ko = language === "ko"
@@ -352,6 +376,9 @@ function EntryTable({
                   {e.owner_name && <span> · {e.owner_name}</span>}
                 </div>
                 {e.tagline && <div className="mt-1 max-w-sm text-xs text-muted-foreground">{e.tagline}</div>}
+                <div className="mt-2 inline-flex rounded-full border border-primary/25 bg-primary/5 px-2.5 py-1 text-[11px] font-medium text-primary">
+                  {ko ? "최근 판단" : "Latest"}: {latestDecision(e, ko)}
+                </div>
                 {(e.description || e.website_url || e.source_url) && (
                   <details className="mt-1.5 max-w-sm text-xs">
                     <summary className="cursor-pointer text-primary hover:underline">

--- a/examples/dashboard/types/dashboard.ts
+++ b/examples/dashboard/types/dashboard.ts
@@ -502,6 +502,14 @@ export interface StanceEntry {
   description: string | null
   website_url: string | null
   source_url: string | null
+  latest_decision: {
+    seq: number
+    kind: "set" | "hold" | "pause" | "resume"
+    symbol: string | null
+    target_weight: number | null
+    received_at: string
+    admit: "accepted" | "clamped" | "rejected" | "pending" | null
+  } | null
   qualified: boolean
   gate_failures: string[]
   experimental: boolean

--- a/stance/server/leaderboard.py
+++ b/stance/server/leaderboard.py
@@ -36,6 +36,7 @@ class Entry:
     description: str | None = None
     website_url: str | None = None
     source_url: str | None = None
+    latest_decision: dict | None = None
 
     def to_dict(self) -> dict:
         m = self.metrics
@@ -49,6 +50,7 @@ class Entry:
             "description": self.description,
             "website_url": self.website_url,
             "source_url": self.source_url,
+            "latest_decision": self.latest_decision,
             "qualified": m.qualified,
             "gate_failures": m.gate_failures,
             "experimental": m.experimental,
@@ -83,13 +85,16 @@ def build(ledger: Ledger, strategies: list[tuple[str | None, ...]]) -> dict:
         public_profile = (*strategy[4:9], None, None, None, None, None)[:5]
         profile = profile_for(market)
         # 일별 마킹까지 포함해 재생한다. 빠지면 시간축이 없어 지표가 전부 0 이 된다.
+        timeline = ledger.timeline(strategy_id)
         result = replay(ledger.full_timeline(strategy_id), costs=profile.costs)
         metrics = score(result, cadence=ledger.cadence_of(strategy_id), profile=profile)
+        latest_decision = _latest_decision(timeline, result)
         entry = Entry(
             strategy_id, display_name, handle, profile.code, metrics,
             owner_name=public_profile[0], tagline=public_profile[1],
             description=public_profile[2], website_url=public_profile[3],
             source_url=public_profile[4],
+            latest_decision=latest_decision,
         )
 
         board = boards.setdefault(profile.code, _empty_board(profile))
@@ -106,6 +111,24 @@ def build(ledger: Ledger, strategies: list[tuple[str | None, ...]]) -> dict:
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "status": "live" if any(b["entries"] for b in boards.values()) else "preparing",
         "boards": boards,
+    }
+
+
+def _latest_decision(timeline: list, result) -> dict | None:
+    """화면에 보여줄 마지막 원본 판단과 서버 판정을 함께 만든다."""
+    if not timeline:
+        return None
+    stance, _quote = timeline[-1]
+    fill = next((item for item in reversed(result.fills) if item.seq == stance.seq), None)
+    return {
+        "seq": stance.seq,
+        "kind": stance.kind.value,
+        "symbol": stance.symbol,
+        "target_weight": (
+            None if stance.target_weight is None else float(stance.target_weight)
+        ),
+        "received_at": stance.received_at.isoformat(),
+        "admit": None if fill is None else fill.admit.value,
     }
 
 

--- a/stance/tests/test_leaderboard.py
+++ b/stance/tests/test_leaderboard.py
@@ -55,6 +55,31 @@ def test_build_from_ledger():
     assert e["gate_failures"]
     # 투자비중은 항상 실려야 한다 — 다른 지표를 해석하는 기준이다
     assert "avg_exposure" in e["metrics"]
+    assert e["latest_decision"] == {
+        "seq": 3,
+        "kind": "set",
+        "symbol": "005930",
+        "target_weight": 0.0,
+        "received_at": (T0 + timedelta(days=3)).isoformat(),
+        "admit": "accepted",
+    }
+    led.close()
+
+
+def test_latest_hold_is_visible_without_a_symbol():
+    led = Ledger()
+    led.register("holding", "Holding", "@me", market="NASDAQ")
+    led.append_stance(
+        "holding", 1, Kind.HOLD, received_at=T0.isoformat(), reason="no signal",
+    )
+
+    entry = build(
+        led, [("holding", "Holding", "@me", "NASDAQ")]
+    )["boards"]["NASDAQ"]["entries"][0]
+
+    assert entry["latest_decision"]["kind"] == "hold"
+    assert entry["latest_decision"]["symbol"] is None
+    assert entry["latest_decision"]["received_at"] == T0.isoformat()
     led.close()
 
 


### PR DESCRIPTION
## Summary
- include each strategy's latest immutable decision and server verdict in the leaderboard API
- show the latest Hold, target weight, exit, pause, or resume with receipt time under the strategy name
- surface pending, rejected, and clamped outcomes instead of making stale data look current

## Verification
- `python3 -m pytest -q stance/tests tests/test_stance_adapter.py tests/test_stance_execution_hook.py` (214 passed, 1 skipped)
- `ruff check stance/server/leaderboard.py stance/tests/test_leaderboard.py`
- dashboard production build is covered by CI (local worktree has no node_modules)