### PR TITLE
docs: fix broken Star History chart across READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ Currently serving 450+ users for free.
 
 ## Project Growth
 
-[![Star History Chart](https://api.star-history.com/svg?repos=dragon1086/prism-insight&type=Date)](https://star-history.com/#dragon1086/prism-insight&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=dragon1086/prism-insight&type=Date)](https://star-history.dera.page/#dragon1086/prism-insight&type=Date)
 
 ---
 

--- a/README_es.md
+++ b/README_es.md
@@ -467,7 +467,7 @@ Actualmente sirviendo a mas de 450 usuarios de forma gratuita.
 
 ## Crecimiento del Proyecto
 
-[![Star History Chart](https://api.star-history.com/svg?repos=dragon1086/prism-insight&type=Date)](https://star-history.com/#dragon1086/prism-insight&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=dragon1086/prism-insight&type=Date)](https://star-history.dera.page/#dragon1086/prism-insight&type=Date)
 
 ---
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -466,7 +466,7 @@ SaaS企業の場合、別途商用ライセンスが必要です。
 
 ## プロジェクトの成長
 
-[![Star History Chart](https://api.star-history.com/svg?repos=dragon1086/prism-insight&type=Date)](https://star-history.com/#dragon1086/prism-insight&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=dragon1086/prism-insight&type=Date)](https://star-history.dera.page/#dragon1086/prism-insight&type=Date)
 
 ---
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -471,7 +471,7 @@ SaaS 기업은 별도의 상업 라이선스가 필요합니다.
 
 ## 프로젝트 성장
 
-[![Star History Chart](https://api.star-history.com/svg?repos=dragon1086/prism-insight&type=Date)](https://star-history.com/#dragon1086/prism-insight&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=dragon1086/prism-insight&type=Date)](https://star-history.dera.page/#dragon1086/prism-insight&type=Date)
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -464,7 +464,7 @@ SaaS 公司需要单独的商业许可证。
 
 ## 项目成长
 
-[![Star History Chart](https://api.star-history.com/svg?repos=dragon1086/prism-insight&type=Date)](https://star-history.com/#dragon1086/prism-insight&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=dragon1086/prism-insight&type=Date)](https://star-history.dera.page/#dragon1086/prism-insight&type=Date)
 
 ---
 


### PR DESCRIPTION
The project growth Star History chart is currently broken on the README and all localized READMEs, as the upstream stargazer API no longer works for new requests. This PR switches the chart and its wrapping link to the star-history.dera.page deployment so the chart displays correctly again. A working project growth chart is a simple way to thank contributors and attract new ones, so fixing it is well worth the small change.