### PR TITLE
fix(cla): show usable agreement links in signature prompts

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -47,8 +47,10 @@ jobs:
           allowlist: dragon1086,cokac-bot,dependabot[bot],github-actions[bot]
           custom-notsigned-prcomment: >-
             Thank you for your contribution. Before this pull request can be
-            merged, each contributor must read $pathToCLADocument and comment
-            the exact signature statement shown below.
+            merged, each contributor must read the
+            [authoritative English CLA](https://github.com/dragon1086/prism-insight/blob/main/CLA.md)
+            or its [Korean translation](https://github.com/dragon1086/prism-insight/blob/main/CLA_ko.md),
+            then comment the exact signature statement shown below.
           custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
           custom-allsigned-prcomment: All contributors have signed the CLA.
           create-file-commit-message: Create the PRISM-INSIGHT CLA signature ledger

--- a/tests/test_cla_configuration.py
+++ b/tests/test_cla_configuration.py
@@ -88,3 +88,7 @@ def test_cla_workflow_is_pinned_and_minimally_scoped() -> None:
     assert action_step["with"]["path-to-signatures"] == "signatures/cla.json"
     assert action_step["with"]["branch"] == "cla-signatures"
     assert SIGN_COMMENT in workflow_text
+    unsigned_comment = action_step["with"]["custom-notsigned-prcomment"]
+    assert "$pathToCLADocument" not in unsigned_comment
+    assert "/blob/main/CLA.md" in unsigned_comment
+    assert "/blob/main/CLA_ko.md" in unsigned_comment


### PR DESCRIPTION
## Summary

- replace the unexpanded `$pathToCLADocument` text in unsigned CLA comments
  with direct links to the authoritative English CLA and Korean translation
- keep unsigned contributors blocked by the required CLA check
- add a regression assertion for the rendered workflow configuration

## Root cause

CLA Assistant Lite accepts a custom unsigned comment as literal text and does
not expand `$pathToCLADocument` in that input. The unsigned failure in run
32500913194 is expected; only the contributor-facing document link was broken.

## Verification

- `python -m pytest tests/test_cla_configuration.py -q` — 4 passed
- YAML parsed and both CLA links verified
- `git diff --check`
