### PR TITLE
refactor(pdf): remove copyleft conversion dependencies

### DIFF
--- a/docs/superpowers/plans/2026-08-23-remove-copyleft-pdf-dependencies.md
+++ b/docs/superpowers/plans/2026-08-23-remove-copyleft-pdf-dependencies.md
@@ -1,0 +1,175 @@
+# Copyleft PDF Dependency Removal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the unused `mdpdf`/PyMuPDF path and replace GPL-licensed `html2text` with deterministic standard-library normalization while preserving PDF report consumption.
+
+**Architecture:** Keep `PyPDF2` as the PDF text extractor. Normalize its plain-text output locally instead of passing it through an HTML parser. Remove the unused fourth PDF renderer so production continues to use Playwright, with pdfkit and ReportLab retained as explicit alternatives.
+
+**Tech Stack:** Python 3.10+, PyPDF2, pytest, GitHub Actions, db-server pyenv Python 3.11.11
+
+**Spec:** Conversation-approved design from 2026-08-23: no new runtime dependency; `mdpdf`, PyMuPDF, and `html2text` must be absent after deployment.
+
+## Global Constraints
+
+- Do not add a replacement package for `html2text`.
+- Preserve Unicode, URLs, Markdown punctuation, and paragraph boundaries in PDF-extracted text.
+- Production PDF rendering must continue to use Playwright.
+- Do not modify or overwrite unrelated local or db-server worktree changes.
+- Re-run `pip-licenses --format=markdown` in the actual db-server pyenv environment after uninstalling obsolete packages.
+
+---
+
+### Task 1: Lock PDF text normalization behavior
+
+**Files:**
+- Create: `tests/test_pdf_text_normalization.py`
+- Modify: none
+- Test: `tests/test_pdf_text_normalization.py`
+
+**Interfaces:**
+- Consumes: `pdf_converter.normalize_pdf_text(text: str) -> str`
+- Produces: Behavioral contract for Unicode-safe whitespace normalization
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+from pdf_converter import normalize_pdf_text
+
+
+def test_normalize_pdf_text_preserves_content_and_markdown_symbols():
+    source = "# 삼성전자  \\r\\n목표가: 100,000원  \\r\\nhttps://example.com?a=1&b=2\\r\\n"
+    assert normalize_pdf_text(source) == (
+        "# 삼성전자\\n목표가: 100,000원\\nhttps://example.com?a=1&b=2\\n"
+    )
+
+
+def test_normalize_pdf_text_caps_blank_lines_and_handles_empty_input():
+    assert normalize_pdf_text("첫 문단\\n\\n\\n\\n둘째 문단") == "첫 문단\\n\\n둘째 문단\\n"
+    assert normalize_pdf_text("") == ""
+```
+
+- [ ] **Step 2: Run the tests and verify the expected failure**
+
+Run: `python -m pytest tests/test_pdf_text_normalization.py -q`
+
+Expected: collection fails because `normalize_pdf_text` does not exist.
+
+- [ ] **Step 3: Do not implement production code in this task**
+
+This task ends after the failing test proves the new behavioral boundary.
+
+---
+
+### Task 2: Remove copyleft PDF dependencies and implement normalization
+
+**Files:**
+- Modify: `pdf_converter.py`
+- Modify: `requirements.txt`
+- Test: `tests/test_pdf_text_normalization.py`
+
+**Interfaces:**
+- Consumes: `text: str` returned by `extract_text_from_pdf`
+- Produces: `normalize_pdf_text(text: str) -> str`; backward-compatible `convert_to_markdown(text: str) -> str`
+
+- [ ] **Step 1: Implement the standard-library normalizer**
+
+```python
+def normalize_pdf_text(text: str) -> str:
+    if not text:
+        return ""
+    normalized = text.replace("\\r\\n", "\\n").replace("\\r", "\\n")
+    normalized = "\\n".join(line.rstrip() for line in normalized.split("\\n"))
+    normalized = re.sub(r"\\n{3,}", "\\n\\n", normalized).strip()
+    return f"{normalized}\\n" if normalized else ""
+
+
+def convert_to_markdown(text: str) -> str:
+    return normalize_pdf_text(text)
+```
+
+- [ ] **Step 2: Remove `html2text`**
+
+Remove the top-level import from `pdf_converter.py` and the `html2text` line from `requirements.txt`.
+
+- [ ] **Step 3: Remove the unused mdpdf renderer**
+
+Delete `markdown_to_pdf_mdpdf`, remove `mdpdf` from the documented method list and fallback chain, and remove `mdpdf` from `requirements.txt`. The fallback chain ends after ReportLab.
+
+- [ ] **Step 4: Run the focused tests**
+
+Run: `python -m pytest tests/test_pdf_text_normalization.py tests/test_pdf_renderer.py -q`
+
+Expected: all tests pass.
+
+---
+
+### Task 3: Verify repository behavior and licensing surface
+
+**Files:**
+- Modify: none
+- Test: targeted PDF and report contract tests
+
+**Interfaces:**
+- Consumes: the changed dependency declarations and PDF converter
+- Produces: evidence that no runtime import requires the removed packages
+
+- [ ] **Step 1: Run static checks**
+
+Run: `python -m compileall pdf_converter.py telegram_summary_agent.py prism-us/us_telegram_summary_agent.py`
+
+Expected: compilation succeeds.
+
+- [ ] **Step 2: Run report/PDF tests**
+
+Run: `python -m pytest tests/test_pdf_text_normalization.py tests/test_pdf_renderer.py tests/test_telegram_report_backend.py tests/test_report_generator_contract.py -q`
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Confirm the removed packages have no tracked references**
+
+Run: `rg -n "html2text|mdpdf|PyMuPDF|import fitz|import pymupdf" requirements.txt pdf_converter.py tests`
+
+Expected: no runtime dependency or import references; only historical plan text may match.
+
+---
+
+### Task 4: Integrate and deploy to db-server
+
+**Files:**
+- Commit the approved code and tests on `codex/remove-copyleft-pdf-deps`
+- Deploy to `/root/prism-insight` on db-server
+
+**Interfaces:**
+- Consumes: merged `main`
+- Produces: db-server runtime without `mdpdf`, PyMuPDF, or `html2text`
+
+- [ ] **Step 1: Commit and create a pull request**
+
+Stage only `requirements.txt`, `pdf_converter.py`, `tests/test_pdf_text_normalization.py`, and this plan. Use a Lore-formatted commit message.
+
+- [ ] **Step 2: Wait for CLA and CI checks, then merge**
+
+Confirm Python matrix, dashboard, Codacy, and CLA checks pass before merge.
+
+- [ ] **Step 3: Audit db-server before pull**
+
+Fetch remote `main`; compare incoming paths with the dirty worktree. Stop if incoming changes overlap modified server files. Preserve all unrelated server changes.
+
+- [ ] **Step 4: Fast-forward db-server and remove obsolete packages**
+
+Run the server's deployment-safe fast-forward. Then run:
+
+```bash
+/root/.pyenv/versions/3.11.11/bin/python -m pip uninstall -y mdpdf PyMuPDF html2text
+```
+
+Do not install a replacement package.
+
+- [ ] **Step 5: Verify server imports and license scan**
+
+Verify `pdf_converter`, Telegram summary agents, and tracking agents import successfully. Run `pip-licenses --format=markdown` from a temporary tool installation and confirm `PyMuPDF` and `html2text` are absent.
+
+- [ ] **Step 6: Preserve legal scan artifacts**
+
+Save the post-removal `pip-licenses` report and `pip freeze` under `~/Downloads/prism-insight/legal/dependency-license-scan/2026-08-23-post-removal/` with SHA-256 checksums.

--- a/pdf_converter.py
+++ b/pdf_converter.py
@@ -6,16 +6,15 @@ Provides various conversion methods:
 1. Playwright-based HTML conversion (Recommended) - Uses Chromium browser engine
 2. pdfkit-based HTML conversion (Legacy) - Requires wkhtmltopdf, archived in 2023
 3. reportlab direct rendering - Theme not supported
-4. mdpdf simple conversion - Theme not supported
 
-Recommended order: Playwright > pdfkit > reportlab > mdpdf
+Recommended order: Playwright > pdfkit > reportlab
 """
 import os
 import logging
+import re
 import markdown
 import tempfile
 import PyPDF2
-import html2text
 import base64
 from datetime import datetime
 
@@ -1347,33 +1346,6 @@ def markdown_to_pdf_reportlab(md_file_path, pdf_file_path):
         logger.error(f"Error during ReportLab conversion: {str(e)}")
         raise
 
-def markdown_to_pdf_mdpdf(md_file_path, pdf_file_path):
-    """
-    Convert Markdown to PDF using mdpdf library
-
-    Installation: pip install mdpdf
-
-    Args:
-        md_file_path (str): Markdown file path
-        pdf_file_path (str): Output PDF file path
-    """
-    try:
-        # Import mdpdf (requires installation: pip install mdpdf)
-        from mdpdf import MarkdownPdf
-
-        # Convert markdown to PDF
-        md = MarkdownPdf()
-        md.convert(md_file_path, pdf_file_path)
-
-        logger.info(f"PDF conversion complete with mdpdf: {pdf_file_path}")
-
-    except ImportError:
-        logger.error("mdpdf library is not installed. Install with pip install mdpdf.")
-        raise
-    except Exception as e:
-        logger.error(f"Error during mdpdf conversion: {str(e)}")
-        raise
-
 def markdown_to_pdf(md_file_path, pdf_file_path, method='playwright', add_theme=False, logo_path=None, enable_watermark=False, watermark_opacity=0.02):
     """
     Convert Markdown file to PDF (default method selection)
@@ -1381,7 +1353,7 @@ def markdown_to_pdf(md_file_path, pdf_file_path, method='playwright', add_theme=
     Args:
         md_file_path (str): Markdown file path
         pdf_file_path (str): Output PDF file path
-        method (str): Conversion method ('playwright', 'pdfkit', 'reportlab', 'mdpdf')
+        method (str): Conversion method ('playwright', 'pdfkit', 'reportlab')
                      Default: 'playwright' (recommended)
         add_theme (bool): Whether to add theme and logo
         logo_path (str): Logo image path (uses default logo if None)
@@ -1398,11 +1370,8 @@ def markdown_to_pdf(md_file_path, pdf_file_path, method='playwright', add_theme=
         elif method == 'reportlab':
             # Note: reportlab method currently does not support themes
             markdown_to_pdf_reportlab(md_file_path, pdf_file_path)
-        elif method == 'mdpdf':
-            # Note: mdpdf method currently does not support themes
-            markdown_to_pdf_mdpdf(md_file_path, pdf_file_path)
         else:
-            # Default tries playwright first, then pdfkit, reportlab, and finally mdpdf
+            # Default tries playwright first, then pdfkit, then reportlab
             try:
                 markdown_to_pdf_playwright(md_file_path, pdf_file_path, add_theme, logo_path, enable_watermark, watermark_opacity)
             except Exception as e1:
@@ -1414,8 +1383,8 @@ def markdown_to_pdf(md_file_path, pdf_file_path, method='playwright', add_theme=
                     try:
                         markdown_to_pdf_reportlab(md_file_path, pdf_file_path)
                     except Exception as e3:
-                        logger.warning(f"ReportLab failed, trying mdpdf: {str(e3)}")
-                        markdown_to_pdf_mdpdf(md_file_path, pdf_file_path)
+                        logger.error(f"ReportLab failed: {str(e3)}")
+                        raise
 
     except Exception as e:
         logger.error(f"PDF conversion failed: {str(e)}")
@@ -1431,12 +1400,18 @@ def extract_text_from_pdf(pdf_path):
             text += page.extract_text()
     return text
 
+def normalize_pdf_text(text: str) -> str:
+    if not text:
+        return ""
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    normalized = "\n".join(line.rstrip() for line in normalized.split("\n"))
+    normalized = re.sub(r"\n{3,}", "\n\n", normalized).strip()
+    return f"{normalized}\n" if normalized else ""
+
+
 # Convert text to markdown
-def convert_to_markdown(text):
-    h = html2text.HTML2Text()
-    h.ignore_links = False
-    markdown_text = h.handle(text)
-    return markdown_text
+def convert_to_markdown(text: str) -> str:
+    return normalize_pdf_text(text)
 
 # PDF to markdown_text
 def pdf_to_markdown_text(pdf_path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,6 @@ python-dotenv>=1.0.0
 playwright>=1.40.0  # Chromium 기반 PDF 변환 (권장)
 pdfkit>=1.0.0  # wkhtmltopdf 기반 PDF 변환 (레거시, 백업용)
 reportlab>=4.0.0  # 직접 PDF 생성 (대체 방식)
-mdpdf>=0.0.9  # 간편한 마크다운 변환 (대체 방식)
 
 # 주식 데이터 관련
 pykrx==1.0.48
@@ -65,7 +64,6 @@ mplfinance~=0.12.10b0
 tenacity
 
 PyPDF2
-html2text
 
 scipy
 

--- a/tests/test_pdf_text_normalization.py
+++ b/tests/test_pdf_text_normalization.py
@@ -1,0 +1,13 @@
+from pdf_converter import normalize_pdf_text
+
+
+def test_normalize_pdf_text_preserves_content_and_markdown_symbols():
+    source = "# 삼성전자  \r\n목표가: 100,000원  \r\nhttps://example.com?a=1&b=2\r\n"
+    assert normalize_pdf_text(source) == (
+        "# 삼성전자\n목표가: 100,000원\nhttps://example.com?a=1&b=2\n"
+    )
+
+
+def test_normalize_pdf_text_caps_blank_lines_and_handles_empty_input():
+    assert normalize_pdf_text("첫 문단\n\n\n\n둘째 문단") == "첫 문단\n\n둘째 문단\n"
+    assert normalize_pdf_text("") == ""


### PR DESCRIPTION
## Summary

- remove the unused `mdpdf` renderer and dependency, eliminating its PyMuPDF/AGPL transitive dependency
- replace GPL-licensed `html2text` with deterministic standard-library normalization of PyPDF2 plain-text output
- retain `convert_to_markdown()` as a compatibility wrapper
- add regression tests for Unicode, URLs, Markdown punctuation, line endings, and paragraph spacing

## Evidence

- all tracked production PDF generation callers explicitly select Playwright
- representative Korean, English, and Chinese PDFs preserve identical non-whitespace content
- no replacement runtime dependency was added

## Verification

- 10 related tests passed
- `compileall` passed for the PDF converter and KR/US Telegram summary modules
- `git diff --check` passed
- independent task review and whole-branch review approved with no findings

## Known limitation

The repository-wide `pytest -q` collection is not a valid gate because pre-existing script-style test modules call `sys.exit()` during import. The focused suites above and repository CI are used as merge gates.

## Deployment

After merge, db-server will fast-forward only after checking incoming paths against its dirty worktree. The server pyenv will uninstall `mdpdf`, `PyMuPDF`, and `html2text`, then rerun `pip-licenses`.
