### PR TITLE
fix: separate candidate and actual trigger feedback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -227,6 +227,13 @@ TELEGRAM_CHANNEL_ID=your_channel_id
 # REENTRY_COOLDOWN_LOSS_HOURS=24     # longer cooldown after a LOSS (revenge-trade prevention)
 # REENTRY_COOLDOWN_RISK_EXIT_LIVE=true  # also enforce cooldown for non-loss risk exits(stop)
 
+# Trigger performance feedback source.
+# - off: no trigger-performance score adjustment
+# - shadow (default): compute/log Actual-history adjustment, do not change score
+# - actual: apply ±1 only from executed trading_history (n>=5)
+# Candidate tracker outcomes are context only and never adjust the live score.
+# TRIGGER_PERFORMANCE_FEEDBACK=shadow
+
 # Market-regime override / restraint (급락·고변동장 오판 방지 & 약세장 매수 절제)
 # 급락·고변동장을 이동평균 위치만으로 온건강세로 오판하는 것 방지. 값: active(기본,
 # 실제 sideways 강등 적용) / shadow(긴급 관찰) / off(비활성). cores/data_prefetch.py.

--- a/performance_tracker_batch.py
+++ b/performance_tracker_batch.py
@@ -20,6 +20,8 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Any, Optional
 from pathlib import Path
 
+from tracking.performance_feedback import get_trigger_feedback
+
 # Logging setup
 logging.basicConfig(
     level=logging.INFO,
@@ -392,34 +394,21 @@ class PerformanceTrackerBatch:
             """)
             status_stats = {row['tracking_status']: row['count'] for row in cursor.fetchall()}
 
-            # Statistics by trigger type
-            cursor = conn.execute("""
-                SELECT
-                    trigger_type,
-                    COUNT(*) as count,
-                    SUM(CASE WHEN was_traded = 1 THEN 1 ELSE 0 END) as traded_count,
-                    AVG(tracked_7d_return) as avg_7d_return,
-                    AVG(tracked_14d_return) as avg_14d_return,
-                    AVG(tracked_30d_return) as avg_30d_return
-                FROM analysis_performance_tracker
-                WHERE tracking_status = 'completed'
-                GROUP BY trigger_type
-            """)
-            trigger_stats = cursor.fetchall()
-
-            # Traded vs watched performance comparison
-            cursor = conn.execute("""
-                SELECT
-                    CASE WHEN was_traded = 1 THEN 'Traded' ELSE 'Watched' END as decision,
-                    COUNT(*) as count,
-                    AVG(tracked_7d_return) as avg_7d_return,
-                    AVG(tracked_14d_return) as avg_14d_return,
-                    AVG(tracked_30d_return) as avg_30d_return
-                FROM analysis_performance_tracker
-                WHERE tracking_status = 'completed'
-                GROUP BY was_traded
-            """)
-            decision_stats = cursor.fetchall()
+            trigger_names = [
+                row[0]
+                for row in conn.execute(
+                    """SELECT DISTINCT trigger_type FROM analysis_performance_tracker
+                       WHERE trigger_type IS NOT NULL
+                       UNION
+                       SELECT DISTINCT trigger_type FROM trading_history
+                       WHERE trigger_type IS NOT NULL
+                       ORDER BY trigger_type"""
+                ).fetchall()
+            ]
+            trigger_feedback = [
+                get_trigger_feedback(conn.cursor(), "KR", trigger_type)
+                for trigger_type in trigger_names
+            ]
 
             # Generate report
             report = []
@@ -440,50 +429,36 @@ class PerformanceTrackerBatch:
                 report.append(f"  {status_name}: {count} records")
             report.append("")
 
-            # Performance by trigger type
-            report.append("## 2. Performance by Trigger Type (Completed only)")
+            # Candidate fixed-horizon vs actual realized performance.
+            report.append("## 2. Trigger Performance — Candidate vs Actual")
             report.append("-"*40)
-            if trigger_stats:
-                report.append(f"{'Trigger Type':<25} {'Count':>6} {'Traded':>6} {'7d':>8} {'14d':>8} {'30d':>8}")
-                report.append("-"*70)
-                for row in trigger_stats:
-                    trigger_type = row['trigger_type'] or 'unknown'
-                    count = row['count']
-                    traded = row['traded_count'] or 0
-                    avg_7d = row['avg_7d_return']
-                    avg_14d = row['avg_14d_return']
-                    avg_30d = row['avg_30d_return']
-
-                    # Format returns
-                    r7 = f"{avg_7d*100:+.1f}%" if avg_7d else "N/A"
-                    r14 = f"{avg_14d*100:+.1f}%" if avg_14d else "N/A"
-                    r30 = f"{avg_30d*100:+.1f}%" if avg_30d else "N/A"
-
-                    report.append(f"{trigger_type:<25} {count:>6} {traded:>6} {r7:>8} {r14:>8} {r30:>8}")
+            if trigger_feedback:
+                for feedback in trigger_feedback:
+                    report.append(f"- {feedback['trigger_type']}")
+                    candidate = feedback.get("candidate_trigger")
+                    actual = feedback.get("actual_trigger")
+                    if candidate:
+                        report.append(
+                            "    Candidate: "
+                            f"n={candidate['n']}, "
+                            f"30d positive={candidate['positive_rate_30d']*100:.0f}%, "
+                            f"avg7={candidate['avg_7d_pct']:+.1f}%, "
+                            f"avg30={candidate['avg_30d_pct']:+.1f}%"
+                        )
+                    else:
+                        report.append("    Candidate: unavailable")
+                    if actual:
+                        pf = actual.get("profit_factor")
+                        pf_text = f"{pf:.2f}" if pf is not None else "N/A"
+                        report.append(
+                            "    Actual:    "
+                            f"n={actual['n']}, win={actual['win_rate']*100:.0f}%, "
+                            f"PF={pf_text}, avg={actual['avg_return_pct']:+.1f}%"
+                        )
+                    else:
+                        report.append("    Actual:    unavailable")
             else:
-                report.append("  No completed tracking data.")
-            report.append("")
-
-            # Traded vs watched performance
-            report.append("## 3. Traded vs Watched Performance")
-            report.append("-"*40)
-            if decision_stats:
-                report.append(f"{'Type':<10} {'Count':>6} {'7d':>10} {'14d':>10} {'30d':>10}")
-                report.append("-"*50)
-                for row in decision_stats:
-                    decision = row['decision']
-                    count = row['count']
-                    avg_7d = row['avg_7d_return']
-                    avg_14d = row['avg_14d_return']
-                    avg_30d = row['avg_30d_return']
-
-                    r7 = f"{avg_7d*100:+.1f}%" if avg_7d else "N/A"
-                    r14 = f"{avg_14d*100:+.1f}%" if avg_14d else "N/A"
-                    r30 = f"{avg_30d*100:+.1f}%" if avg_30d else "N/A"
-
-                    report.append(f"{decision:<10} {count:>6} {r7:>10} {r14:>10} {r30:>10}")
-            else:
-                report.append("  No completed tracking data.")
+                report.append("  No trigger performance data.")
             report.append("")
 
             # Recently completed tracking

--- a/prism-us/tracking/journal.py
+++ b/prism-us/tracking/journal.py
@@ -53,6 +53,15 @@ def _import_from_main_cores(module_name: str, relative_path: str):
 _utils_module = _import_from_main_cores("cores_utils", "cores/utils.py")
 parse_llm_json = _utils_module.parse_llm_json
 
+_feedback_module = _import_from_main_cores(
+    "prism_root_performance_feedback",
+    "tracking/performance_feedback.py",
+)
+feedback_log_payload = _feedback_module.feedback_log_payload
+format_trigger_feedback = _feedback_module.format_trigger_feedback
+get_trigger_feedback = _feedback_module.get_trigger_feedback
+resolve_actual_adjustment = _feedback_module.resolve_actual_adjustment
+
 
 class USJournalManager:
     """Manages trading journal operations for US stocks."""
@@ -372,35 +381,20 @@ Please review the following completed US stock trade:
             if not self.cursor.fetchone():
                 return stats
 
-            # 1. Stats for the current trigger type (if provided)
+            # 1. Candidate and actual stats for the current trigger type.
             if trigger_type:
-                self.cursor.execute("""
-                    SELECT
-                        COUNT(*) as total,
-                        SUM(CASE WHEN return_30d > 0 THEN 1 ELSE 0 END) as wins,
-                        AVG(return_7d) as avg_7d,
-                        AVG(return_14d) as avg_14d,
-                        AVG(return_30d) as avg_30d
-                    FROM us_analysis_performance_tracker
-                    WHERE trigger_type = ? AND tracking_status = 'completed'
-                """, (trigger_type,))
-                row = self.cursor.fetchone()
-                if row and row[0] > 0:
-                    stats['current_trigger'] = {
-                        'trigger_type': trigger_type,
-                        'total': row[0],
-                        'win_rate': row[1] / row[0] if row[0] > 0 else 0,
-                        'avg_7d': row[2],
-                        'avg_14d': row[3],
-                        'avg_30d': row[4],
-                    }
+                feedback = get_trigger_feedback(self.cursor, "US", trigger_type)
+                if feedback.get("candidate_trigger"):
+                    stats["candidate_trigger"] = feedback["candidate_trigger"]
+                if feedback.get("actual_trigger"):
+                    stats["actual_trigger"] = feedback["actual_trigger"]
 
             # 2. Missed opportunities: stocks we skipped but went up
             self.cursor.execute("""
                 SELECT
                     COUNT(*) as total_skipped,
-                    SUM(CASE WHEN return_30d > 5 THEN 1 ELSE 0 END) as missed_gains,
-                    AVG(CASE WHEN return_30d > 5 THEN return_30d END) as avg_missed_gain
+                    SUM(CASE WHEN return_30d > 0.05 THEN 1 ELSE 0 END) as missed_gains,
+                    AVG(CASE WHEN return_30d > 0.05 THEN return_30d END) as avg_missed_gain
                 FROM us_analysis_performance_tracker
                 WHERE was_traded = 0 AND tracking_status = 'completed'
                     AND return_30d IS NOT NULL
@@ -413,27 +407,7 @@ Please review the following completed US stock trade:
                     'avg_missed_gain': row[2],
                 }
 
-            # 3. Traded vs watched comparison
-            self.cursor.execute("""
-                SELECT
-                    was_traded,
-                    COUNT(*) as count,
-                    AVG(return_30d) as avg_30d
-                FROM us_analysis_performance_tracker
-                WHERE tracking_status = 'completed' AND return_30d IS NOT NULL
-                GROUP BY was_traded
-            """)
-            traded_vs_watched = {}
-            for row in self.cursor.fetchall():
-                key = 'traded' if row[0] else 'watched'
-                traded_vs_watched[key] = {
-                    'count': row[1],
-                    'avg_30d': row[2],
-                }
-            if traded_vs_watched:
-                stats['traded_vs_watched'] = traded_vs_watched
-
-            # 4. All trigger types performance ranking
+            # 3. Candidate-only trigger ranking.
             self.cursor.execute("""
                 SELECT
                     trigger_type,
@@ -442,6 +416,7 @@ Please review the following completed US stock trade:
                     AVG(return_30d) as avg_30d
                 FROM us_analysis_performance_tracker
                 WHERE tracking_status = 'completed' AND return_30d IS NOT NULL
+                    AND COALESCE(was_traded, 0) = 0
                     AND trigger_type IS NOT NULL
                 GROUP BY trigger_type
                 HAVING total >= 3
@@ -456,7 +431,7 @@ Please review the following completed US stock trade:
                     'avg_30d': row[3],
                 })
             if trigger_ranking:
-                stats['trigger_ranking'] = trigger_ranking
+                stats['candidate_trigger_ranking'] = trigger_ranking
 
         except Exception as e:
             logger.warning(f"Failed to get US performance tracker stats: {e}")
@@ -469,24 +444,18 @@ Please review the following completed US stock trade:
         if not stats:
             return parts
 
-        parts.append("#### 📈 Analysis Performance Tracker (Actual Results)")
+        parts.append("#### 📈 Trigger Performance Feedback")
 
-        # Current trigger type stats
-        if 'current_trigger' in stats:
-            t = stats['current_trigger']
-            win_pct = t['win_rate'] * 100
-            avg_30d = t['avg_30d']
-            avg_30d_str = f"{avg_30d * 100:+.1f}%" if avg_30d is not None else "N/A"
-            parts.append(
-                f"- **This trigger ({t['trigger_type']})**: "
-                f"Win rate {win_pct:.0f}% (n={t['total']}), "
-                f"30d avg return {avg_30d_str}"
-            )
+        feedback = {
+            "actual_trigger": stats.get("actual_trigger"),
+            "candidate_trigger": stats.get("candidate_trigger"),
+        }
+        for line in format_trigger_feedback(feedback, language=self.language):
+            parts.append(f"- {line}")
 
-        # Trigger ranking
-        if 'trigger_ranking' in stats:
-            parts.append("- **Trigger Performance Ranking (30d, n>=3):**")
-            for rank, t in enumerate(stats['trigger_ranking'][:5], 1):
+        if 'candidate_trigger_ranking' in stats:
+            parts.append("- **Watched Candidate Ranking (30d, n>=3):**")
+            for rank, t in enumerate(stats['candidate_trigger_ranking'][:5], 1):
                 avg_30d_str = f"{t['avg_30d'] * 100:+.1f}%" if t['avg_30d'] is not None else "N/A"
                 win_pct = t['win_rate'] * 100
                 parts.append(
@@ -658,24 +627,33 @@ Please review the following completed US stock trade:
                         adjustment += 1
                         reasons.append(f"{sector} sector average profit {sector_stats[0]:.1f}%")
 
-            # Trigger type performance (from performance_tracker - ground truth)
+            # Trigger type performance: actual executed trades only.
             if trigger_type:
-                perf_stats = self.get_performance_tracker_stats(trigger_type)
-                if 'current_trigger' in perf_stats:
-                    t = perf_stats['current_trigger']
-                    if t['total'] >= 5:  # Require minimum sample size
-                        if t['win_rate'] < 0.35:
-                            adjustment -= 1
-                            reasons.append(
-                                f"Trigger '{trigger_type}' low win rate "
-                                f"{t['win_rate']*100:.0f}% (n={t['total']}, actual 30d data)"
-                            )
-                        elif t['win_rate'] > 0.65:
-                            adjustment += 1
-                            reasons.append(
-                                f"Trigger '{trigger_type}' high win rate "
-                                f"{t['win_rate']*100:.0f}% (n={t['total']}, actual 30d data)"
-                            )
+                feedback = get_trigger_feedback(self.cursor, "US", trigger_type)
+                trigger_adjustment = resolve_actual_adjustment(feedback)
+                logger.info(
+                    "[TRIGGER_FEEDBACK] %s",
+                    json.dumps(
+                        feedback_log_payload(
+                            feedback,
+                            trigger_adjustment,
+                            ticker=ticker,
+                            sector=sector,
+                        ),
+                        ensure_ascii=False,
+                        sort_keys=True,
+                    ),
+                )
+                applied = int(trigger_adjustment["applied_adjust"])
+                if applied:
+                    adjustment += applied
+                    actual = feedback.get("actual_trigger") or {}
+                    direction = "low" if applied < 0 else "high"
+                    reasons.append(
+                        f"Trigger '{trigger_type}' actual trade win rate {direction} "
+                        f"{float(actual.get('win_rate') or 0)*100:.0f}% "
+                        f"(n={int(actual.get('n') or 0)})"
+                    )
 
             # Recent stop-out churn guard (US market)
             # Must come last so it can cancel any net-positive bonus from above.

--- a/prism-us/us_performance_tracker_batch.py
+++ b/prism-us/us_performance_tracker_batch.py
@@ -17,6 +17,7 @@ import sys
 import sqlite3
 import argparse
 import logging
+import importlib.util
 from datetime import datetime
 from typing import Dict, List, Any, Optional
 from pathlib import Path
@@ -26,6 +27,15 @@ PROJECT_ROOT = Path(__file__).parent.parent
 PRISM_US_DIR = Path(__file__).parent
 sys.path.insert(0, str(PROJECT_ROOT))
 sys.path.insert(0, str(PRISM_US_DIR))
+
+_feedback_spec = importlib.util.spec_from_file_location(
+    "prism_root_performance_feedback_report",
+    PROJECT_ROOT / "tracking" / "performance_feedback.py",
+)
+_feedback_module = importlib.util.module_from_spec(_feedback_spec)
+assert _feedback_spec and _feedback_spec.loader
+_feedback_spec.loader.exec_module(_feedback_module)
+get_trigger_feedback = _feedback_module.get_trigger_feedback
 
 # Logging setup
 logging.basicConfig(
@@ -461,34 +471,21 @@ class USPerformanceTrackerBatch:
             """)
             status_stats = {row['status']: row['count'] for row in cursor.fetchall()}
 
-            # Trigger type performance
-            cursor = conn.execute("""
-                SELECT
-                    trigger_type,
-                    COUNT(*) as count,
-                    SUM(CASE WHEN was_traded = 1 THEN 1 ELSE 0 END) as traded_count,
-                    AVG(return_7d) as avg_7d_return,
-                    AVG(return_14d) as avg_14d_return,
-                    AVG(return_30d) as avg_30d_return
-                FROM us_analysis_performance_tracker
-                WHERE return_30d IS NOT NULL
-                GROUP BY trigger_type
-            """)
-            trigger_stats = cursor.fetchall()
-
-            # Traded vs Watched performance
-            cursor = conn.execute("""
-                SELECT
-                    CASE WHEN was_traded = 1 THEN 'Traded' ELSE 'Watched' END as decision,
-                    COUNT(*) as count,
-                    AVG(return_7d) as avg_7d_return,
-                    AVG(return_14d) as avg_14d_return,
-                    AVG(return_30d) as avg_30d_return
-                FROM us_analysis_performance_tracker
-                WHERE return_30d IS NOT NULL
-                GROUP BY was_traded
-            """)
-            decision_stats = cursor.fetchall()
+            trigger_names = [
+                row[0]
+                for row in conn.execute(
+                    """SELECT DISTINCT trigger_type FROM us_analysis_performance_tracker
+                       WHERE trigger_type IS NOT NULL
+                       UNION
+                       SELECT DISTINCT trigger_type FROM us_trading_history
+                       WHERE trigger_type IS NOT NULL
+                       ORDER BY trigger_type"""
+                ).fetchall()
+            ]
+            trigger_feedback = [
+                get_trigger_feedback(conn.cursor(), "US", trigger_type)
+                for trigger_type in trigger_names
+            ]
 
             # Build report
             report = []
@@ -509,50 +506,35 @@ class USPerformanceTrackerBatch:
                 report.append(f"  {status_name}: {count}")
             report.append("")
 
-            # Trigger type performance
-            report.append("## 2. Trigger Type Performance (Completed Only)")
+            report.append("## 2. Trigger Performance — Candidate vs Actual")
             report.append("-" * 40)
-            if trigger_stats:
-                report.append(f"{'Trigger Type':<25} {'Count':>6} {'Traded':>6} {'7D':>8} {'14D':>8} {'30D':>8}")
-                report.append("-" * 70)
-                for row in trigger_stats:
-                    trigger_type = row['trigger_type'] or 'unknown'
-                    count = row['count']
-                    traded = row['traded_count'] or 0
-                    avg_7d = row['avg_7d_return']
-                    avg_14d = row['avg_14d_return']
-                    avg_30d = row['avg_30d_return']
-
-                    # Format returns
-                    r7 = f"{avg_7d*100:+.1f}%" if avg_7d else "N/A"
-                    r14 = f"{avg_14d*100:+.1f}%" if avg_14d else "N/A"
-                    r30 = f"{avg_30d*100:+.1f}%" if avg_30d else "N/A"
-
-                    report.append(f"{trigger_type:<25} {count:>6} {traded:>6} {r7:>8} {r14:>8} {r30:>8}")
+            if trigger_feedback:
+                for feedback in trigger_feedback:
+                    report.append(f"- {feedback['trigger_type']}")
+                    candidate = feedback.get("candidate_trigger")
+                    actual = feedback.get("actual_trigger")
+                    if candidate:
+                        report.append(
+                            "    Candidate: "
+                            f"n={candidate['n']}, "
+                            f"30d positive={candidate['positive_rate_30d']*100:.0f}%, "
+                            f"avg7={candidate['avg_7d_pct']:+.1f}%, "
+                            f"avg30={candidate['avg_30d_pct']:+.1f}%"
+                        )
+                    else:
+                        report.append("    Candidate: unavailable")
+                    if actual:
+                        pf = actual.get("profit_factor")
+                        pf_text = f"{pf:.2f}" if pf is not None else "N/A"
+                        report.append(
+                            "    Actual:    "
+                            f"n={actual['n']}, win={actual['win_rate']*100:.0f}%, "
+                            f"PF={pf_text}, avg={actual['avg_return_pct']:+.1f}%"
+                        )
+                    else:
+                        report.append("    Actual:    unavailable")
             else:
-                report.append("  No completed tracking data available.")
-            report.append("")
-
-            # Traded vs Watched performance
-            report.append("## 3. Traded vs Watched Performance")
-            report.append("-" * 40)
-            if decision_stats:
-                report.append(f"{'Decision':<10} {'Count':>6} {'7D':>10} {'14D':>10} {'30D':>10}")
-                report.append("-" * 50)
-                for row in decision_stats:
-                    decision = row['decision']
-                    count = row['count']
-                    avg_7d = row['avg_7d_return']
-                    avg_14d = row['avg_14d_return']
-                    avg_30d = row['avg_30d_return']
-
-                    r7 = f"{avg_7d*100:+.1f}%" if avg_7d else "N/A"
-                    r14 = f"{avg_14d*100:+.1f}%" if avg_14d else "N/A"
-                    r30 = f"{avg_30d*100:+.1f}%" if avg_30d else "N/A"
-
-                    report.append(f"{decision:<10} {count:>6} {r7:>10} {r14:>10} {r30:>10}")
-            else:
-                report.append("  No completed tracking data available.")
+                report.append("  No trigger performance data available.")
             report.append("")
 
             # Recent completed stocks

--- a/tests/test_performance_feedback_semantics.py
+++ b/tests/test_performance_feedback_semantics.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "test_performance_feedback_module",
+    Path(__file__).resolve().parents[1] / "tracking" / "performance_feedback.py",
+)
+_MODULE = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+_SPEC.loader.exec_module(_MODULE)
+feedback_log_payload = _MODULE.feedback_log_payload
+format_trigger_feedback = _MODULE.format_trigger_feedback
+get_trigger_feedback = _MODULE.get_trigger_feedback
+resolve_actual_adjustment = _MODULE.resolve_actual_adjustment
+
+
+@pytest.fixture
+def db():
+    connection = sqlite3.connect(":memory:")
+    cursor = connection.cursor()
+    cursor.execute(
+        """CREATE TABLE analysis_performance_tracker (
+               trigger_type TEXT, was_traded INTEGER,
+               tracked_7d_return REAL, tracked_14d_return REAL,
+               tracked_30d_return REAL
+           )"""
+    )
+    cursor.execute(
+        """CREATE TABLE trading_history (
+               id INTEGER PRIMARY KEY, trigger_type TEXT,
+               profit_rate REAL, sell_date TEXT
+           )"""
+    )
+    cursor.execute(
+        """CREATE TABLE us_analysis_performance_tracker (
+               trigger_type TEXT, was_traded INTEGER,
+               return_7d REAL, return_14d REAL, return_30d REAL
+           )"""
+    )
+    cursor.execute(
+        """CREATE TABLE us_trading_history (
+               id INTEGER PRIMARY KEY, trigger_type TEXT,
+               profit_rate REAL, sell_date TEXT
+           )"""
+    )
+    yield connection, cursor
+    connection.close()
+
+
+def _seed(cursor, market: str):
+    candidate_table = (
+        "analysis_performance_tracker" if market == "KR" else "us_analysis_performance_tracker"
+    )
+    returns = (
+        "tracked_7d_return, tracked_14d_return, tracked_30d_return"
+        if market == "KR"
+        else "return_7d, return_14d, return_30d"
+    )
+    actual_table = "trading_history" if market == "KR" else "us_trading_history"
+    for value in (0.10, 0.05, -0.02, 0.07):
+        cursor.execute(
+            f"INSERT INTO {candidate_table} (trigger_type, was_traded, {returns}) "
+            "VALUES ('Gap', 0, ?, ?, ?)",
+            (value / 2, value * 0.75, value),
+        )
+    # This tracker row claims traded but must not contaminate Candidate or Actual.
+    cursor.execute(
+        f"INSERT INTO {candidate_table} (trigger_type, was_traded, {returns}) "
+        "VALUES ('Gap', 1, 9, 9, 9)"
+    )
+    for row_id, value in enumerate((-6.0, -5.0, -4.0, -3.0, 2.0), 1):
+        cursor.execute(
+            f"INSERT INTO {actual_table} (id, trigger_type, profit_rate, sell_date) "
+            "VALUES (?, 'Gap', ?, '2026-01-01')",
+            (row_id, value),
+        )
+
+
+@pytest.mark.parametrize("market", ["KR", "US"])
+def test_candidate_and_actual_stats_are_separate(db, market):
+    connection, cursor = db
+    _seed(cursor, market)
+    connection.commit()
+    feedback = get_trigger_feedback(cursor, market, "Gap")
+    candidate = feedback["candidate_trigger"]
+    actual = feedback["actual_trigger"]
+
+    assert candidate["source"] == "candidate_tracker"
+    assert candidate["n"] == 4
+    assert candidate["positive_rate_30d"] == pytest.approx(0.75)
+    assert candidate["avg_30d_pct"] == pytest.approx(5.0)
+    assert actual["source"] == "trading_history"
+    assert actual["n"] == 5
+    assert actual["win_rate"] == pytest.approx(0.2)
+    assert actual["avg_return_pct"] == pytest.approx(-3.2)
+
+
+def test_shadow_logs_actual_penalty_without_applying_it(db):
+    connection, cursor = db
+    _seed(cursor, "US")
+    connection.commit()
+    feedback = get_trigger_feedback(cursor, "US", "Gap")
+    adjustment = resolve_actual_adjustment(feedback, mode="shadow")
+    payload = feedback_log_payload(
+        feedback,
+        adjustment,
+        ticker="AAPL",
+        sector="Technology",
+    )
+
+    assert payload["schema_version"] == 1
+    assert payload["ticker"] == "AAPL"
+    assert payload["sector"] == "Technology"
+    assert adjustment["would_adjust"] == -1
+    assert adjustment["applied_adjust"] == 0
+    assert payload["candidate"]["n"] == 4
+    assert payload["actual"]["n"] == 5
+
+
+def test_actual_mode_applies_penalty_and_candidate_rows_do_not_change_it(db):
+    connection, cursor = db
+    _seed(cursor, "KR")
+    cursor.execute(
+        """INSERT INTO analysis_performance_tracker
+           (trigger_type, was_traded, tracked_7d_return, tracked_14d_return, tracked_30d_return)
+           VALUES ('Gap', 0, 100, 100, 100)"""
+    )
+    connection.commit()
+    feedback = get_trigger_feedback(cursor, "KR", "Gap")
+    adjustment = resolve_actual_adjustment(feedback, mode="actual")
+    assert adjustment["would_adjust"] == -1
+    assert adjustment["applied_adjust"] == -1
+
+
+def test_insufficient_actual_samples_never_adjust(db):
+    connection, cursor = db
+    for row_id, value in enumerate((-6.0, -5.0, -4.0, -3.0), 1):
+        cursor.execute(
+            "INSERT INTO us_trading_history (id, trigger_type, profit_rate, sell_date) "
+            "VALUES (?, 'Gap', ?, '2026-01-01')",
+            (row_id, value),
+        )
+    connection.commit()
+    feedback = get_trigger_feedback(cursor, "US", "Gap")
+    adjustment = resolve_actual_adjustment(feedback, mode="actual")
+    assert adjustment["actual_n"] == 4
+    assert adjustment["applied_adjust"] == 0
+
+
+def test_human_format_never_calls_candidates_trades(db):
+    connection, cursor = db
+    _seed(cursor, "US")
+    connection.commit()
+    feedback = get_trigger_feedback(cursor, "US", "Gap")
+    ko = format_trigger_feedback(feedback, language="ko")
+    en = format_trigger_feedback(feedback, language="en")
+    assert ko == ["실제 매매: 5건, 승률 20%, PF 0.11", "관찰 후보: 30일 상승 비율 75% (n=4)"]
+    assert en == [
+        "Actual trades: n=5, win rate 20%, PF 0.11",
+        "Watched candidates: 30d positive rate 75% (n=4)",
+    ]

--- a/tracking/journal.py
+++ b/tracking/journal.py
@@ -5,6 +5,7 @@ Handles trading journal creation, principle extraction, and context retrieval.
 Extracted from stock_tracking_agent.py for LLM context efficiency.
 """
 
+import importlib.util
 import json
 import logging
 import os
@@ -18,6 +19,18 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from cores.openai_error_logging import log_openai_error
 from cores.utils import parse_llm_json
+
+_feedback_spec = importlib.util.spec_from_file_location(
+    "prism_root_performance_feedback",
+    Path(__file__).resolve().with_name("performance_feedback.py"),
+)
+_feedback_module = importlib.util.module_from_spec(_feedback_spec)
+assert _feedback_spec and _feedback_spec.loader
+_feedback_spec.loader.exec_module(_feedback_module)
+feedback_log_payload = _feedback_module.feedback_log_payload
+format_trigger_feedback = _feedback_module.format_trigger_feedback
+get_trigger_feedback = _feedback_module.get_trigger_feedback
+resolve_actual_adjustment = _feedback_module.resolve_actual_adjustment
 
 logger = logging.getLogger(__name__)
 
@@ -389,35 +402,22 @@ Please review the following completed trade:
             if not self.cursor.fetchone():
                 return stats
 
-            # 1. Stats for the current trigger type (if provided)
+            # 1. Candidate and actual stats for the current trigger type.
+            # Candidate fixed-horizon outcomes and executed realized outcomes
+            # have different semantics and must never be pooled.
             if trigger_type:
-                self.cursor.execute("""
-                    SELECT
-                        COUNT(*) as total,
-                        SUM(CASE WHEN tracked_30d_return > 0 THEN 1 ELSE 0 END) as wins,
-                        AVG(tracked_7d_return) as avg_7d,
-                        AVG(tracked_14d_return) as avg_14d,
-                        AVG(tracked_30d_return) as avg_30d
-                    FROM analysis_performance_tracker
-                    WHERE trigger_type = ? AND tracking_status = 'completed'
-                """, (trigger_type,))
-                row = self.cursor.fetchone()
-                if row and row[0] > 0:
-                    stats['current_trigger'] = {
-                        'trigger_type': trigger_type,
-                        'total': row[0],
-                        'win_rate': row[1] / row[0] if row[0] > 0 else 0,
-                        'avg_7d': row[2],
-                        'avg_14d': row[3],
-                        'avg_30d': row[4],
-                    }
+                feedback = get_trigger_feedback(self.cursor, "KR", trigger_type)
+                if feedback.get("candidate_trigger"):
+                    stats["candidate_trigger"] = feedback["candidate_trigger"]
+                if feedback.get("actual_trigger"):
+                    stats["actual_trigger"] = feedback["actual_trigger"]
 
             # 2. Missed opportunities: stocks we skipped but went up
             self.cursor.execute("""
                 SELECT
                     COUNT(*) as total_skipped,
-                    SUM(CASE WHEN tracked_30d_return > 5 THEN 1 ELSE 0 END) as missed_gains,
-                    AVG(CASE WHEN tracked_30d_return > 5 THEN tracked_30d_return END) as avg_missed_gain
+                    SUM(CASE WHEN tracked_30d_return > 0.05 THEN 1 ELSE 0 END) as missed_gains,
+                    AVG(CASE WHEN tracked_30d_return > 0.05 THEN tracked_30d_return END) as avg_missed_gain
                 FROM analysis_performance_tracker
                 WHERE was_traded = 0 AND tracking_status = 'completed'
                     AND tracked_30d_return IS NOT NULL
@@ -430,27 +430,8 @@ Please review the following completed trade:
                     'avg_missed_gain': row[2],
                 }
 
-            # 3. Traded vs watched comparison
-            self.cursor.execute("""
-                SELECT
-                    was_traded,
-                    COUNT(*) as count,
-                    AVG(tracked_30d_return) as avg_30d
-                FROM analysis_performance_tracker
-                WHERE tracking_status = 'completed' AND tracked_30d_return IS NOT NULL
-                GROUP BY was_traded
-            """)
-            traded_vs_watched = {}
-            for row in self.cursor.fetchall():
-                key = 'traded' if row[0] else 'watched'
-                traded_vs_watched[key] = {
-                    'count': row[1],
-                    'avg_30d': row[2],
-                }
-            if traded_vs_watched:
-                stats['traded_vs_watched'] = traded_vs_watched
-
-            # 4. All trigger types performance ranking
+            # 3. Candidate-only trigger ranking. Actual trade ranking is kept
+            # separate in reports because it uses realized holding-period P&L.
             self.cursor.execute("""
                 SELECT
                     trigger_type,
@@ -459,6 +440,7 @@ Please review the following completed trade:
                     AVG(tracked_30d_return) as avg_30d
                 FROM analysis_performance_tracker
                 WHERE tracking_status = 'completed' AND tracked_30d_return IS NOT NULL
+                    AND COALESCE(was_traded, 0) = 0
                     AND trigger_type IS NOT NULL
                 GROUP BY trigger_type
                 HAVING total >= 3
@@ -473,7 +455,7 @@ Please review the following completed trade:
                     'avg_30d': row[3],
                 })
             if trigger_ranking:
-                stats['trigger_ranking'] = trigger_ranking
+                stats['candidate_trigger_ranking'] = trigger_ranking
 
         except Exception as e:
             logger.warning(f"Failed to get performance tracker stats: {e}")
@@ -486,24 +468,19 @@ Please review the following completed trade:
         if not stats:
             return parts
 
-        parts.append("#### 📈 Analysis Performance Tracker (Actual Results)")
+        parts.append("#### 📈 Trigger Performance Feedback")
 
-        # Current trigger type stats
-        if 'current_trigger' in stats:
-            t = stats['current_trigger']
-            win_pct = t['win_rate'] * 100
-            avg_30d = t['avg_30d']
-            avg_30d_str = f"{avg_30d * 100:+.1f}%" if avg_30d is not None else "N/A"
-            parts.append(
-                f"- **This trigger ({t['trigger_type']})**: "
-                f"Win rate {win_pct:.0f}% (n={t['total']}), "
-                f"30d avg return {avg_30d_str}"
-            )
+        feedback = {
+            "actual_trigger": stats.get("actual_trigger"),
+            "candidate_trigger": stats.get("candidate_trigger"),
+        }
+        for line in format_trigger_feedback(feedback, language=self.language):
+            parts.append(f"- {line}")
 
-        # Trigger ranking
-        if 'trigger_ranking' in stats:
-            parts.append("- **Trigger Performance Ranking (30d, n>=3):**")
-            for rank, t in enumerate(stats['trigger_ranking'][:5], 1):
+        # Candidate ranking (not actual trades).
+        if 'candidate_trigger_ranking' in stats:
+            parts.append("- **Watched Candidate Ranking (30d, n>=3):**")
+            for rank, t in enumerate(stats['candidate_trigger_ranking'][:5], 1):
                 avg_30d_str = f"{t['avg_30d'] * 100:+.1f}%" if t['avg_30d'] is not None else "N/A"
                 win_pct = t['win_rate'] * 100
                 parts.append(
@@ -726,24 +703,34 @@ Please review the following completed trade:
                         adjustment += 1
                         reasons.append(f"{sector} sector avg profit {sector_stats[0]:.1f}%")
 
-            # Trigger type performance (from performance_tracker - ground truth)
+            # Trigger type performance: actual executed trades only. Candidate
+            # tracker outcomes remain context and never adjust live scores.
             if trigger_type:
-                perf_stats = self.get_performance_tracker_stats(trigger_type)
-                if 'current_trigger' in perf_stats:
-                    t = perf_stats['current_trigger']
-                    if t['total'] >= 5:  # Require minimum sample size
-                        if t['win_rate'] < 0.35:
-                            adjustment -= 1
-                            reasons.append(
-                                f"Trigger '{trigger_type}' low win rate "
-                                f"{t['win_rate']*100:.0f}% (n={t['total']}, actual 30d data)"
-                            )
-                        elif t['win_rate'] > 0.65:
-                            adjustment += 1
-                            reasons.append(
-                                f"Trigger '{trigger_type}' high win rate "
-                                f"{t['win_rate']*100:.0f}% (n={t['total']}, actual 30d data)"
-                            )
+                feedback = get_trigger_feedback(self.cursor, "KR", trigger_type)
+                trigger_adjustment = resolve_actual_adjustment(feedback)
+                logger.info(
+                    "[TRIGGER_FEEDBACK] %s",
+                    json.dumps(
+                        feedback_log_payload(
+                            feedback,
+                            trigger_adjustment,
+                            ticker=ticker,
+                            sector=sector,
+                        ),
+                        ensure_ascii=False,
+                        sort_keys=True,
+                    ),
+                )
+                applied = int(trigger_adjustment["applied_adjust"])
+                if applied:
+                    adjustment += applied
+                    actual = feedback.get("actual_trigger") or {}
+                    direction = "low" if applied < 0 else "high"
+                    reasons.append(
+                        f"Trigger '{trigger_type}' actual trade win rate {direction} "
+                        f"{float(actual.get('win_rate') or 0)*100:.0f}% "
+                        f"(n={int(actual.get('n') or 0)})"
+                    )
 
             # Recent stop-out churn guard (KR market)
             # Must come last so it can cancel any net-positive bonus from above.

--- a/tracking/performance_feedback.py
+++ b/tracking/performance_feedback.py
@@ -1,0 +1,236 @@
+"""Candidate-vs-actual trigger performance feedback (read-only).
+
+Candidate forward returns live in the analysis performance trackers as decimal
+ratios.  Executed outcomes live in the trading-history tables as percentage
+points.  This module keeps those semantics separate and gives KR/US callers one
+auditable contract without adding tables or write paths.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import statistics
+from typing import Any
+
+_MARKET_TABLES = {
+    "KR": {
+        "candidate": "analysis_performance_tracker",
+        "actual": "trading_history",
+        "returns": ("tracked_7d_return", "tracked_14d_return", "tracked_30d_return"),
+    },
+    "US": {
+        "candidate": "us_analysis_performance_tracker",
+        "actual": "us_trading_history",
+        "returns": ("return_7d", "return_14d", "return_30d"),
+    },
+}
+
+_VALID_MODES = {"off", "shadow", "actual"}
+
+
+def _market(value: str) -> str:
+    market = str(value or "").strip().upper()
+    if market not in _MARKET_TABLES:
+        raise ValueError(f"unsupported market: {value!r}")
+    return market
+
+
+def _table_exists(cursor, table: str) -> bool:
+    return cursor.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+        (table,),
+    ).fetchone() is not None
+
+
+def _safe_mean(values: list[float]) -> float | None:
+    return statistics.mean(values) if values else None
+
+
+def _safe_median(values: list[float]) -> float | None:
+    return statistics.median(values) if values else None
+
+
+def candidate_trigger_stats(cursor, market: str, trigger_type: str) -> dict[str, Any] | None:
+    """Return watched-candidate fixed-horizon stats in percentage points."""
+    config = _MARKET_TABLES[_market(market)]
+    table = config["candidate"]
+    r7, r14, r30 = config["returns"]
+    if not trigger_type or not _table_exists(cursor, table):
+        return None
+    try:
+        rows = cursor.execute(
+            f"""
+            SELECT {r7}, {r14}, {r30}
+            FROM {table}
+            WHERE trigger_type=?
+              AND COALESCE(was_traded, 0)=0
+              AND {r30} IS NOT NULL
+            """,
+            (trigger_type,),
+        ).fetchall()
+    except sqlite3.Error:
+        return None
+    if not rows:
+        return None
+
+    values_7 = [float(row[0]) * 100.0 for row in rows if row[0] is not None]
+    values_14 = [float(row[1]) * 100.0 for row in rows if row[1] is not None]
+    values_30 = [float(row[2]) * 100.0 for row in rows if row[2] is not None]
+    return {
+        "source": "candidate_tracker",
+        "n": len(values_30),
+        "positive_rate_30d": (
+            sum(value > 0 for value in values_30) / len(values_30) if values_30 else None
+        ),
+        "avg_7d_pct": _safe_mean(values_7),
+        "median_7d_pct": _safe_median(values_7),
+        "avg_14d_pct": _safe_mean(values_14),
+        "median_14d_pct": _safe_median(values_14),
+        "avg_30d_pct": _safe_mean(values_30),
+        "median_30d_pct": _safe_median(values_30),
+    }
+
+
+def actual_trigger_stats(cursor, market: str, trigger_type: str) -> dict[str, Any] | None:
+    """Return executed-trade realized stats from trading history."""
+    config = _MARKET_TABLES[_market(market)]
+    table = config["actual"]
+    if not trigger_type or not _table_exists(cursor, table):
+        return None
+    try:
+        rows = cursor.execute(
+            f"SELECT profit_rate FROM {table} WHERE trigger_type=? ORDER BY sell_date, id",
+            (trigger_type,),
+        ).fetchall()
+    except sqlite3.Error:
+        return None
+    returns = [float(row[0]) for row in rows if row[0] is not None]
+    if not returns:
+        return None
+    wins = [value for value in returns if value > 0]
+    losses = [value for value in returns if value < 0]
+    gross_loss = abs(sum(losses))
+    return {
+        "source": "trading_history",
+        "n": len(returns),
+        "win_rate": sum(value > 0 for value in returns) / len(returns),
+        "avg_return_pct": statistics.mean(returns),
+        "median_return_pct": statistics.median(returns),
+        "avg_win_pct": _safe_mean(wins),
+        "avg_loss_pct": _safe_mean(losses),
+        "profit_factor": sum(wins) / gross_loss if gross_loss else None,
+    }
+
+
+def get_trigger_feedback(cursor, market: str, trigger_type: str) -> dict[str, Any]:
+    market_key = _market(market)
+    return {
+        "market": market_key,
+        "trigger_type": trigger_type,
+        "candidate_trigger": candidate_trigger_stats(cursor, market_key, trigger_type),
+        "actual_trigger": actual_trigger_stats(cursor, market_key, trigger_type),
+    }
+
+
+def trigger_feedback_mode(value: str | None = None) -> str:
+    raw = value if value is not None else os.getenv("TRIGGER_PERFORMANCE_FEEDBACK", "shadow")
+    mode = str(raw or "shadow").strip().lower()
+    return mode if mode in _VALID_MODES else "shadow"
+
+
+def resolve_actual_adjustment(
+    feedback: dict[str, Any],
+    *,
+    mode: str | None = None,
+    min_samples: int = 5,
+) -> dict[str, Any]:
+    """Return would/applied adjustment; Candidate stats never affect it."""
+    resolved_mode = trigger_feedback_mode(mode)
+    actual = feedback.get("actual_trigger") or {}
+    n = int(actual.get("n") or 0)
+    win_rate = actual.get("win_rate")
+    would_adjust = 0
+    if resolved_mode != "off" and n >= min_samples and win_rate is not None:
+        if float(win_rate) < 0.35:
+            would_adjust = -1
+        elif float(win_rate) > 0.65:
+            would_adjust = 1
+    return {
+        "mode": resolved_mode,
+        "min_samples": min_samples,
+        "actual_n": n,
+        "actual_win_rate": win_rate,
+        "would_adjust": would_adjust,
+        "applied_adjust": would_adjust if resolved_mode == "actual" else 0,
+    }
+
+
+def feedback_log_payload(
+    feedback: dict[str, Any],
+    adjustment: dict[str, Any],
+    *,
+    ticker: str | None = None,
+    sector: str | None = None,
+) -> dict[str, Any]:
+    """Small JSON-serializable payload for later operational analysis."""
+    return {
+        "schema_version": 1,
+        "event": "trigger_performance_feedback",
+        "market": feedback.get("market"),
+        "ticker": ticker,
+        "sector": sector,
+        "trigger_type": feedback.get("trigger_type"),
+        "candidate": feedback.get("candidate_trigger"),
+        "actual": feedback.get("actual_trigger"),
+        "mode": adjustment.get("mode"),
+        "would_adjust": adjustment.get("would_adjust"),
+        "applied_adjust": adjustment.get("applied_adjust"),
+        "min_samples": adjustment.get("min_samples"),
+    }
+
+
+def format_trigger_feedback(feedback: dict[str, Any], *, language: str = "ko") -> list[str]:
+    """Human-facing lines with explicit Candidate/Actual provenance."""
+    actual = feedback.get("actual_trigger")
+    candidate = feedback.get("candidate_trigger")
+    lines: list[str] = []
+    if language == "en":
+        if actual:
+            pf = actual.get("profit_factor")
+            pf_text = f", PF {pf:.2f}" if pf is not None else ""
+            lines.append(
+                f"Actual trades: n={actual['n']}, win rate {actual['win_rate'] * 100:.0f}%{pf_text}"
+            )
+        if candidate:
+            lines.append(
+                "Watched candidates: "
+                f"30d positive rate {candidate['positive_rate_30d'] * 100:.0f}% "
+                f"(n={candidate['n']})"
+            )
+        return lines
+
+    if actual:
+        pf = actual.get("profit_factor")
+        pf_text = f", PF {pf:.2f}" if pf is not None else ""
+        lines.append(
+            f"실제 매매: {actual['n']}건, 승률 {actual['win_rate'] * 100:.0f}%{pf_text}"
+        )
+    if candidate:
+        lines.append(
+            "관찰 후보: "
+            f"30일 상승 비율 {candidate['positive_rate_30d'] * 100:.0f}% "
+            f"(n={candidate['n']})"
+        )
+    return lines
+
+
+__all__ = [
+    "actual_trigger_stats",
+    "candidate_trigger_stats",
+    "feedback_log_payload",
+    "format_trigger_feedback",
+    "get_trigger_feedback",
+    "resolve_actual_adjustment",
+    "trigger_feedback_mode",
+]


### PR DESCRIPTION
## Summary
- separate watched-candidate fixed-horizon outcomes from realized trading history
- add structured `[TRIGGER_FEEDBACK]` JSON logging in shadow mode by default
- show Candidate vs Actual independently in KR/US performance reports

## Safety
- no DB schema or write-path changes
- no order, slot, trigger, regime, or stop-loss changes
- server-local stock agent hotfix files are intentionally untouched

## Verification
- 18 related tests passed on clean origin/main worktree
- py_compile passed
- Ruff passed for the new helper/test
- git diff --check passed