### PR TITLE
feat: add fail-open trading observability pipeline

### DIFF
--- a/deploy/nginx/prism-observability-8443.conf.example
+++ b/deploy/nginx/prism-observability-8443.conf.example
@@ -1,0 +1,26 @@
+server {
+    listen 8443 ssl;
+    server_name prism-api.duckdns.org;
+
+    ssl_certificate /etc/letsencrypt/live/prism-api.duckdns.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/prism-api.duckdns.org/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    auth_basic "PRISM Observatory";
+    auth_basic_user_file /etc/nginx/.htpasswd-prism-observability;
+
+    client_max_body_size 10m;
+    location / {
+        proxy_pass http://127.0.0.1:18080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+    }
+}

--- a/deploy/observability/docker-compose.yml
+++ b/deploy/observability/docker-compose.yml
@@ -1,0 +1,22 @@
+name: prism-observability
+
+services:
+  clickstack:
+    image: docker.io/clickhouse/clickstack-all-in-one:2.21.0@sha256:867195e145d0f579c332716317acc2864729706c0dd120ca7fd9758c4237997a
+    container_name: prism-clickstack
+    restart: unless-stopped
+    cpus: 0.85
+    mem_limit: 1800m
+    pids_limit: 512
+    ports:
+      - "127.0.0.1:18080:8080"
+      - "127.0.0.1:14318:4318"
+    environment:
+      USAGE_STATS_ENABLED: "false"
+    volumes:
+      - /var/lib/prism-observability/clickhouse:/var/lib/clickhouse
+      - /var/lib/prism-observability/mongodb:/data/db
+      - /var/log/prism-observability/clickhouse:/var/log/clickhouse-server
+    stop_grace_period: 60s
+    security_opt:
+      - no-new-privileges:true

--- a/deploy/systemd/prism-observability-shipper.service.example
+++ b/deploy/systemd/prism-observability-shipper.service.example
@@ -1,0 +1,22 @@
+[Unit]
+Description=PRISM fail-open observability event shipper
+After=network-online.target prism-observability-tunnel.service
+Wants=network-online.target prism-observability-tunnel.service
+
+[Service]
+Type=simple
+WorkingDirectory=/root/prism-insight
+Environment=PRISM_ENV=production
+Environment=PRISM_OBSERVABILITY_SPOOL=/root/prism-insight/logs/prism_events.jsonl
+Environment=PRISM_OBSERVABILITY_CHECKPOINT=/root/prism-insight/logs/prism_events.checkpoint.json
+Environment=PRISM_OBSERVABILITY_OTLP_ENDPOINT=http://127.0.0.1:14318/v1/logs
+ExecStart=/root/.pyenv/shims/python -m observability.shipper --interval 5 --batch-size 100
+Restart=always
+RestartSec=10
+Nice=10
+CPUQuota=20%
+MemoryMax=96M
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/prism-observability-tunnel.service.example
+++ b/deploy/systemd/prism-observability-tunnel.service.example
@@ -1,0 +1,21 @@
+[Unit]
+Description=PRISM observability SSH tunnel to prism-backend
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/prism-observability/tunnel.env
+ExecStart=/usr/bin/ssh -NT \
+    -o BatchMode=yes \
+    -o ExitOnForwardFailure=yes \
+    -o ServerAliveInterval=30 \
+    -o ServerAliveCountMax=3 \
+    -L 127.0.0.1:14318:127.0.0.1:14318 \
+    root@${PRISM_BACKEND_HOST}
+Restart=always
+RestartSec=5
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/PRISM_OBSERVABILITY.md
+++ b/docs/PRISM_OBSERVABILITY.md
@@ -1,0 +1,51 @@
+# PRISM Trading Observatory
+
+## Contract
+
+Trading processes append versioned JSON events to `logs/prism_events.jsonl`.
+The append is fail-open and performs no network I/O. A separate shipper converts
+events to OTLP/HTTP and advances its checkpoint only after a successful batch.
+
+Required correlation fields:
+
+- `event_id`, `event_type`, `timestamp`
+- `trace_id`, `span_id`, optional `parent_event_id`
+- optional `decision_id`, `position_id`
+- `git_sha`, `policy_version`, `config_hash`
+- `market`, `ticker`, `service`, `environment`
+
+Sensitive attribute keys such as account, token, password, secret, cookie, and
+authorization are replaced with `[REDACTED]` before the local append.
+
+## Failure boundary
+
+- ClickStack, network, tunnel, or shipper failure never blocks trading.
+- Failed batches do not advance the checkpoint.
+- One corrupt JSONL record is skipped and cannot block later records.
+- ClickStack is not queried from any buy, sell, hard-stop, or fill path.
+
+## Deployment topology
+
+- `db-server`: PRISM pipeline, JSONL spool, shipper, SSH local-forward tunnel.
+- `prism-backend`: resource-limited ClickStack container.
+- ClickStack UI: backend localhost `18080`, proxied by authenticated Nginx `8443`.
+- OTLP/HTTP: backend localhost `14318`, reachable from db-server only through SSH.
+
+The tunnel target is supplied outside Git through
+`/etc/prism-observability/tunnel.env` as `PRISM_BACKEND_HOST=...`.
+
+## Initial events
+
+- `deployment.applied`
+- `trigger.performance_feedback`
+
+Decision, gate, execution, and position-outcome events are added incrementally
+after the end-to-end transport and resource envelope are verified.
+
+## Rollback
+
+1. Stop and disable `prism-observability-shipper` and tunnel units.
+2. The trading pipeline continues; local event appends remain harmless.
+3. Stop ClickStack with `docker compose down` without deleting its volumes.
+4. Remove the Nginx `8443` site and firewall rule if external UI access is no
+   longer needed.

--- a/observability/__init__.py
+++ b/observability/__init__.py
@@ -1,0 +1,5 @@
+"""Fail-open observability helpers for PRISM trading pipelines."""
+
+from .events import build_event, emit_event
+
+__all__ = ["build_event", "emit_event"]

--- a/observability/events.py
+++ b/observability/events.py
@@ -1,0 +1,230 @@
+"""Immutable, fail-open event recording for PRISM trading observability.
+
+The trading process only appends one JSON line to a local spool. Network I/O,
+ClickStack availability, and dashboard queries are deliberately kept outside
+the trading path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import socket
+import subprocess
+import uuid
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SPOOL_PATH = PROJECT_ROOT / "logs" / "prism_events.jsonl"
+MAX_EVENT_BYTES = 256 * 1024
+
+_SENSITIVE_KEY_PARTS = (
+    "account",
+    "api_key",
+    "authorization",
+    "cookie",
+    "credential",
+    "password",
+    "private_key",
+    "secret",
+    "session",
+    "token",
+)
+
+_CONFIG_KEYS = (
+    "MARKET_PULSE_MODE",
+    "REGIME_HIVOL_OVERRIDE",
+    "REGIME_MIN_SCORE_FLOOR",
+    "REGIME_WEAK_NO_TOPDOWN",
+    "REENTRY_COOLDOWN_ENABLED",
+    "REENTRY_COOLDOWN_LIVE",
+    "REENTRY_COOLDOWN_RISK_EXIT_LIVE",
+    "RS_RATING_ENABLED",
+    "TRIGGER_PERFORMANCE_FEEDBACK",
+)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _normalize_time(value: datetime | None) -> datetime:
+    current = value or _utc_now()
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    return current.astimezone(timezone.utc)
+
+
+def _normalize_hex_id(value: str | None, length: int) -> str:
+    raw = str(value or "").strip().lower()
+    if len(raw) == length and all(character in "0123456789abcdef" for character in raw):
+        return raw
+    if raw:
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:length]
+    return uuid.uuid4().hex[:length]
+
+
+def _redacted_key(key: str) -> bool:
+    lowered = key.lower()
+    return any(part in lowered for part in _SENSITIVE_KEY_PARTS)
+
+
+def _sanitize(value: Any, *, key: str = "", depth: int = 0) -> Any:
+    if _redacted_key(key):
+        return "[REDACTED]"
+    if depth >= 8:
+        return "[MAX_DEPTH]"
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, Mapping):
+        return {
+            str(item_key): _sanitize(item_value, key=str(item_key), depth=depth + 1)
+            for item_key, item_value in value.items()
+        }
+    if isinstance(value, (list, tuple, set)):
+        return [_sanitize(item, depth=depth + 1) for item in value]
+    return str(value)
+
+
+@lru_cache(maxsize=1)
+def _git_sha() -> str | None:
+    configured = os.getenv("PRISM_GIT_SHA")
+    if configured:
+        return configured.strip() or None
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=PROJECT_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=1.0,
+        )
+        return result.stdout.strip() or None
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def _config_snapshot() -> tuple[dict[str, str], str]:
+    values = {key: os.environ[key] for key in _CONFIG_KEYS if key in os.environ}
+    encoded = json.dumps(values, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+    return values, hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:16]
+
+
+def build_event(
+    event_type: str,
+    *,
+    service: str,
+    market: str | None = None,
+    ticker: str | None = None,
+    trace_id: str | None = None,
+    span_id: str | None = None,
+    parent_event_id: str | None = None,
+    decision_id: str | None = None,
+    position_id: str | None = None,
+    attributes: Mapping[str, Any] | None = None,
+    severity: str = "INFO",
+    event_time: datetime | None = None,
+) -> dict[str, Any]:
+    """Build a versioned event without performing I/O."""
+    normalized_type = str(event_type or "").strip()
+    normalized_service = str(service or "").strip()
+    if not normalized_type:
+        raise ValueError("event_type is required")
+    if not normalized_service:
+        raise ValueError("service is required")
+
+    timestamp = _normalize_time(event_time)
+    config, config_hash = _config_snapshot()
+    git_sha = _git_sha()
+    event = {
+        "schema_version": SCHEMA_VERSION,
+        "event_id": uuid.uuid4().hex,
+        "event_type": normalized_type,
+        "timestamp": timestamp.isoformat().replace("+00:00", "Z"),
+        "time_unix_nano": str(int(timestamp.timestamp() * 1_000_000_000)),
+        "severity": str(severity or "INFO").upper(),
+        "service": normalized_service,
+        "environment": os.getenv("PRISM_ENV", os.getenv("APP_ENV", "unknown")),
+        "host": socket.gethostname(),
+        "market": str(market).upper() if market else None,
+        "ticker": str(ticker) if ticker else None,
+        "trace_id": _normalize_hex_id(trace_id, 32),
+        "span_id": _normalize_hex_id(span_id, 16),
+        "parent_event_id": str(parent_event_id) if parent_event_id else None,
+        "decision_id": str(decision_id) if decision_id else None,
+        "position_id": str(position_id) if position_id else None,
+        "git_sha": git_sha,
+        "policy_version": os.getenv("PRISM_POLICY_VERSION") or (git_sha[:12] if git_sha else None),
+        "config_hash": config_hash,
+        "config": config,
+        "attributes": _sanitize(dict(attributes or {})),
+    }
+    return event
+
+
+def emit_event(
+    event_type: str,
+    *,
+    service: str,
+    market: str | None = None,
+    ticker: str | None = None,
+    trace_id: str | None = None,
+    span_id: str | None = None,
+    parent_event_id: str | None = None,
+    decision_id: str | None = None,
+    position_id: str | None = None,
+    attributes: Mapping[str, Any] | None = None,
+    severity: str = "INFO",
+    event_time: datetime | None = None,
+    spool_path: str | os.PathLike[str] | None = None,
+) -> dict[str, Any] | None:
+    """Append one event atomically; return ``None`` on every failure.
+
+    Observability must never block or fail a trading decision. Callers should
+    not retry synchronously.
+    """
+    try:
+        event = build_event(
+            event_type,
+            service=service,
+            market=market,
+            ticker=ticker,
+            trace_id=trace_id,
+            span_id=span_id,
+            parent_event_id=parent_event_id,
+            decision_id=decision_id,
+            position_id=position_id,
+            attributes=attributes,
+            severity=severity,
+            event_time=event_time,
+        )
+        encoded = (
+            json.dumps(event, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+            + "\n"
+        ).encode("utf-8")
+        if len(encoded) > MAX_EVENT_BYTES:
+            return None
+
+        path = Path(
+            spool_path
+            or os.getenv("PRISM_OBSERVABILITY_SPOOL", str(DEFAULT_SPOOL_PATH))
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        descriptor = os.open(path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
+        try:
+            os.write(descriptor, encoded)
+        finally:
+            os.close(descriptor)
+        return event
+    except Exception:  # noqa: BLE001 - this boundary must never fail trading
+        return None
+
+
+__all__ = ["build_event", "emit_event"]

--- a/observability/shipper.py
+++ b/observability/shipper.py
@@ -1,0 +1,270 @@
+"""Ship PRISM JSONL events to an OTLP/HTTP logs endpoint.
+
+The checkpoint advances only after a successful batch. Invalid local lines are
+skipped so one corrupt record cannot stop later trading telemetry.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .events import DEFAULT_SPOOL_PATH
+
+DEFAULT_ENDPOINT = "http://127.0.0.1:14318/v1/logs"
+DEFAULT_CHECKPOINT = DEFAULT_SPOOL_PATH.with_suffix(".checkpoint.json")
+MAX_LINE_BYTES = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class Checkpoint:
+    inode: int
+    offset: int
+
+
+def load_checkpoint(path: Path) -> Checkpoint | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+        return Checkpoint(inode=int(value["inode"]), offset=int(value["offset"]))
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError):
+        return None
+
+
+def save_checkpoint(path: Path, checkpoint: Checkpoint) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps({"inode": checkpoint.inode, "offset": checkpoint.offset}),
+        encoding="utf-8",
+    )
+    os.chmod(temporary, 0o600)
+    os.replace(temporary, path)
+
+
+def read_batch(
+    spool_path: Path,
+    checkpoint: Checkpoint | None,
+    *,
+    limit: int,
+) -> tuple[list[dict[str, Any]], Checkpoint | None]:
+    try:
+        stat = spool_path.stat()
+    except FileNotFoundError:
+        return [], checkpoint
+
+    offset = checkpoint.offset if checkpoint and checkpoint.inode == stat.st_ino else 0
+    if offset > stat.st_size:
+        offset = 0
+
+    events: list[dict[str, Any]] = []
+    final_offset = offset
+    with spool_path.open("rb") as stream:
+        stream.seek(offset)
+        while len(events) < limit:
+            raw = stream.readline(MAX_LINE_BYTES + 1)
+            if not raw:
+                break
+            final_offset = stream.tell()
+            if len(raw) > MAX_LINE_BYTES or not raw.endswith(b"\n"):
+                continue
+            try:
+                value = json.loads(raw)
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                continue
+            if isinstance(value, dict):
+                events.append(value)
+
+    return events, Checkpoint(inode=stat.st_ino, offset=final_offset)
+
+
+def _otel_value(value: Any) -> dict[str, Any]:
+    if isinstance(value, bool):
+        return {"boolValue": value}
+    if isinstance(value, int):
+        return {"intValue": str(value)}
+    if isinstance(value, float):
+        return {"doubleValue": value}
+    return {"stringValue": "" if value is None else str(value)}
+
+
+def _attributes(values: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {"key": key, "value": _otel_value(value)}
+        for key, value in values.items()
+        if value is not None
+    ]
+
+
+def build_otlp_payload(events: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    records = []
+    first: dict[str, Any] | None = None
+    for event in events:
+        if first is None:
+            first = event
+        payload_attributes = event.get("attributes") or {}
+        records.append(
+            {
+                "timeUnixNano": str(event.get("time_unix_nano") or "0"),
+                "observedTimeUnixNano": str(time.time_ns()),
+                "severityText": str(event.get("severity") or "INFO"),
+                "body": {
+                    "stringValue": json.dumps(
+                        event,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    )
+                },
+                "attributes": _attributes(
+                    {
+                        "event.name": event.get("event_type"),
+                        "event.id": event.get("event_id"),
+                        "prism.market": event.get("market"),
+                        "prism.ticker": event.get("ticker"),
+                        "prism.git_sha": event.get("git_sha"),
+                        "prism.policy_version": event.get("policy_version"),
+                        "prism.config_hash": event.get("config_hash"),
+                        "prism.decision_id": event.get("decision_id"),
+                        "prism.position_id": event.get("position_id"),
+                        "prism.trigger_type": payload_attributes.get("trigger_type"),
+                        "prism.feedback_mode": payload_attributes.get("mode"),
+                        "prism.applied_adjust": payload_attributes.get("applied_adjust"),
+                    }
+                ),
+                "traceId": event.get("trace_id"),
+                "spanId": event.get("span_id"),
+            }
+        )
+
+    resource = first or {}
+    return {
+        "resourceLogs": [
+            {
+                "resource": {
+                    "attributes": _attributes(
+                        {
+                            "service.name": resource.get("service", "prism-trading"),
+                            "service.version": resource.get("git_sha"),
+                            "deployment.environment": resource.get("environment"),
+                            "host.name": resource.get("host"),
+                        }
+                    )
+                },
+                "scopeLogs": [
+                    {
+                        "scope": {"name": "prism.observability", "version": "1"},
+                        "logRecords": records,
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def send_batch(
+    events: list[dict[str, Any]],
+    *,
+    endpoint: str,
+    timeout: float,
+    auth_token: str | None = None,
+) -> None:
+    encoded = json.dumps(build_otlp_payload(events), ensure_ascii=False).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if auth_token:
+        headers["Authorization"] = f"Bearer {auth_token}"
+    request = urllib.request.Request(endpoint, data=encoded, headers=headers, method="POST")
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        if not 200 <= response.status < 300:
+            raise RuntimeError(f"OTLP endpoint returned HTTP {response.status}")
+
+
+def run_once(
+    *,
+    spool_path: Path,
+    checkpoint_path: Path,
+    endpoint: str,
+    batch_size: int,
+    timeout: float,
+    auth_token: str | None = None,
+) -> int:
+    checkpoint = load_checkpoint(checkpoint_path)
+    events, next_checkpoint = read_batch(spool_path, checkpoint, limit=batch_size)
+    if next_checkpoint is None:
+        return 0
+    if events:
+        send_batch(events, endpoint=endpoint, timeout=timeout, auth_token=auth_token)
+    save_checkpoint(checkpoint_path, next_checkpoint)
+    return len(events)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--spool",
+        type=Path,
+        default=Path(os.getenv("PRISM_OBSERVABILITY_SPOOL", str(DEFAULT_SPOOL_PATH))),
+    )
+    parser.add_argument(
+        "--checkpoint",
+        type=Path,
+        default=Path(
+            os.getenv("PRISM_OBSERVABILITY_CHECKPOINT", str(DEFAULT_CHECKPOINT))
+        ),
+    )
+    parser.add_argument(
+        "--endpoint",
+        default=os.getenv("PRISM_OBSERVABILITY_OTLP_ENDPOINT", DEFAULT_ENDPOINT),
+    )
+    parser.add_argument("--batch-size", type=int, default=100)
+    parser.add_argument("--timeout", type=float, default=5.0)
+    parser.add_argument("--interval", type=float, default=5.0)
+    parser.add_argument("--once", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    auth_token = os.getenv("PRISM_OBSERVABILITY_OTLP_TOKEN")
+    stopping = False
+
+    def stop(_signum, _frame):
+        nonlocal stopping
+        stopping = True
+
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+
+    while True:
+        try:
+            shipped = run_once(
+                spool_path=args.spool,
+                checkpoint_path=args.checkpoint,
+                endpoint=args.endpoint,
+                batch_size=max(1, args.batch_size),
+                timeout=max(0.1, args.timeout),
+                auth_token=auth_token,
+            )
+            if shipped:
+                print(f"shipped={shipped}", flush=True)
+        except (OSError, RuntimeError, urllib.error.URLError) as error:
+            print(f"ship_failed={type(error).__name__}: {error}", file=sys.stderr, flush=True)
+            if args.once:
+                return 1
+
+        if args.once or stopping:
+            return 0
+        time.sleep(max(0.5, args.interval))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prism-us/tracking/journal.py
+++ b/prism-us/tracking/journal.py
@@ -62,6 +62,12 @@ format_trigger_feedback = _feedback_module.format_trigger_feedback
 get_trigger_feedback = _feedback_module.get_trigger_feedback
 resolve_actual_adjustment = _feedback_module.resolve_actual_adjustment
 
+_events_module = _import_from_main_cores(
+    "prism_observability_events",
+    "observability/events.py",
+)
+emit_event = _events_module.emit_event
+
 
 class USJournalManager:
     """Manages trading journal operations for US stocks."""
@@ -631,18 +637,26 @@ Please review the following completed US stock trade:
             if trigger_type:
                 feedback = get_trigger_feedback(self.cursor, "US", trigger_type)
                 trigger_adjustment = resolve_actual_adjustment(feedback)
+                event_payload = feedback_log_payload(
+                    feedback,
+                    trigger_adjustment,
+                    ticker=ticker,
+                    sector=sector,
+                )
                 logger.info(
                     "[TRIGGER_FEEDBACK] %s",
                     json.dumps(
-                        feedback_log_payload(
-                            feedback,
-                            trigger_adjustment,
-                            ticker=ticker,
-                            sector=sector,
-                        ),
+                        event_payload,
                         ensure_ascii=False,
                         sort_keys=True,
                     ),
+                )
+                emit_event(
+                    "trigger.performance_feedback",
+                    service="prism-us-trading",
+                    market="US",
+                    ticker=ticker,
+                    attributes=event_payload,
                 )
                 applied = int(trigger_adjustment["applied_adjust"])
                 if applied:

--- a/tests/test_observability_events.py
+++ b/tests/test_observability_events.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from observability.events import build_event, emit_event
+
+
+def test_build_event_has_correlation_and_provenance(monkeypatch):
+    monkeypatch.setenv("PRISM_ENV", "test")
+    monkeypatch.setenv("TRIGGER_PERFORMANCE_FEEDBACK", "shadow")
+    event = build_event(
+        "trade.decision",
+        service="prism-kr-trading",
+        market="kr",
+        ticker="005930",
+        trace_id="decision:005930",
+        decision_id="decision-1",
+        attributes={"score": 7},
+        event_time=datetime(2026, 8, 26, 3, 0, tzinfo=timezone.utc),
+    )
+
+    assert event["schema_version"] == 1
+    assert event["timestamp"] == "2026-08-26T03:00:00Z"
+    assert event["environment"] == "test"
+    assert event["market"] == "KR"
+    assert event["ticker"] == "005930"
+    assert event["decision_id"] == "decision-1"
+    assert len(event["trace_id"]) == 32
+    assert len(event["span_id"]) == 16
+    assert event["config"] == {"TRIGGER_PERFORMANCE_FEEDBACK": "shadow"}
+    assert len(event["config_hash"]) == 16
+
+
+def test_sensitive_attributes_are_redacted():
+    event = build_event(
+        "deployment.applied",
+        service="prism-operations",
+        attributes={
+            "token": "secret-token",
+            "nested": {"api_key": "secret-key", "safe": "visible"},
+            "account_key": "123-456",
+        },
+    )
+
+    assert event["attributes"]["token"] == "[REDACTED]"
+    assert event["attributes"]["nested"]["api_key"] == "[REDACTED]"
+    assert event["attributes"]["nested"]["safe"] == "visible"
+    assert event["attributes"]["account_key"] == "[REDACTED]"
+
+
+def test_emit_event_appends_json_lines(tmp_path):
+    spool = tmp_path / "events.jsonl"
+    first = emit_event("pipeline.run", service="prism-test", spool_path=spool)
+    second = emit_event("pipeline.done", service="prism-test", spool_path=spool)
+
+    assert first is not None
+    assert second is not None
+    rows = [json.loads(line) for line in spool.read_text().splitlines()]
+    assert [row["event_type"] for row in rows] == ["pipeline.run", "pipeline.done"]
+    assert len({row["event_id"] for row in rows}) == 2
+
+
+def test_emit_event_is_fail_open(tmp_path):
+    parent_file = tmp_path / "not-a-directory"
+    parent_file.write_text("occupied")
+    result = emit_event(
+        "pipeline.run",
+        service="prism-test",
+        spool_path=parent_file / "events.jsonl",
+    )
+    assert result is None

--- a/tests/test_observability_journal_integration.py
+++ b/tests/test_observability_journal_integration.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from tracking import journal as kr_journal
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_us_journal():
+    spec = importlib.util.spec_from_file_location(
+        "test_observability_us_journal",
+        PROJECT_ROOT / "prism-us" / "tracking" / "journal.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def _database(market: str):
+    connection = sqlite3.connect(":memory:")
+    cursor = connection.cursor()
+    cursor.execute(
+        """CREATE TABLE trading_journal (
+               ticker TEXT, market TEXT, trade_date TEXT,
+               profit_rate REAL, buy_scenario TEXT
+           )"""
+    )
+    if market == "KR":
+        cursor.execute(
+            """CREATE TABLE analysis_performance_tracker (
+                   trigger_type TEXT, was_traded INTEGER,
+                   tracked_7d_return REAL, tracked_14d_return REAL,
+                   tracked_30d_return REAL
+               )"""
+        )
+        cursor.execute(
+            """CREATE TABLE trading_history (
+                   id INTEGER PRIMARY KEY, trigger_type TEXT,
+                   profit_rate REAL, sell_date TEXT
+               )"""
+        )
+        candidate_table = "analysis_performance_tracker"
+        history_table = "trading_history"
+        return_columns = "tracked_7d_return, tracked_14d_return, tracked_30d_return"
+    else:
+        cursor.execute(
+            """CREATE TABLE us_analysis_performance_tracker (
+                   trigger_type TEXT, was_traded INTEGER,
+                   return_7d REAL, return_14d REAL, return_30d REAL
+               )"""
+        )
+        cursor.execute(
+            """CREATE TABLE us_trading_history (
+                   id INTEGER PRIMARY KEY, trigger_type TEXT,
+                   profit_rate REAL, sell_date TEXT
+               )"""
+        )
+        candidate_table = "us_analysis_performance_tracker"
+        history_table = "us_trading_history"
+        return_columns = "return_7d, return_14d, return_30d"
+
+    cursor.execute(
+        f"INSERT INTO {candidate_table} (trigger_type, was_traded, {return_columns}) "
+        "VALUES ('Gap', 0, 0.01, 0.02, 0.03)"
+    )
+    for row_id, profit in enumerate((-6.0, -5.0, -4.0, -3.0, 2.0), 1):
+        cursor.execute(
+            f"INSERT INTO {history_table} (id, trigger_type, profit_rate, sell_date) "
+            "VALUES (?, 'Gap', ?, '2026-08-01')",
+            (row_id, profit),
+        )
+    connection.commit()
+    return connection
+
+
+@pytest.mark.parametrize("market", ["KR", "US"])
+def test_journal_score_path_emits_fail_open_observability_event(
+    tmp_path,
+    monkeypatch,
+    market,
+):
+    spool = tmp_path / f"{market.lower()}-events.jsonl"
+    monkeypatch.setenv("PRISM_OBSERVABILITY_SPOOL", str(spool))
+    monkeypatch.setenv("TRIGGER_PERFORMANCE_FEEDBACK", "shadow")
+    connection = _database(market)
+    try:
+        if market == "KR":
+            monkeypatch.setattr(kr_journal, "JOURNAL_RECENT_LOSS_PENALTY", 0)
+            manager = kr_journal.JournalManager(
+                connection.cursor(), connection, enable_journal=True
+            )
+        else:
+            module = _load_us_journal()
+            monkeypatch.setattr(module, "JOURNAL_RECENT_LOSS_PENALTY", 0)
+            manager = module.USJournalManager(
+                connection.cursor(), connection, enable_journal=True
+            )
+
+        adjustment, reasons = manager.get_score_adjustment("TEST", trigger_type="Gap")
+        event = json.loads(spool.read_text(encoding="utf-8").strip())
+
+        assert adjustment == 0
+        assert reasons == []
+        assert event["event_type"] == "trigger.performance_feedback"
+        assert event["market"] == market
+        assert event["ticker"] == "TEST"
+        assert event["attributes"]["mode"] == "shadow"
+        assert event["attributes"]["would_adjust"] == -1
+        assert event["attributes"]["applied_adjust"] == 0
+    finally:
+        connection.close()

--- a/tests/test_observability_shipper.py
+++ b/tests/test_observability_shipper.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import ClassVar
+
+import pytest
+
+from observability.events import emit_event
+from observability.shipper import (
+    build_otlp_payload,
+    load_checkpoint,
+    run_once,
+)
+
+
+class _CollectorHandler(BaseHTTPRequestHandler):
+    payloads: ClassVar[list] = []
+    status = 200
+
+    def do_POST(self):
+        length = int(self.headers["Content-Length"])
+        self.__class__.payloads.append((self.path, json.loads(self.rfile.read(length))))
+        self.send_response(self.__class__.status)
+        self.end_headers()
+
+    def log_message(self, _format, *_args):
+        return
+
+
+@pytest.fixture
+def collector():
+    _CollectorHandler.payloads = []
+    _CollectorHandler.status = 200
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _CollectorHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/v1/logs"
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def test_otlp_payload_exposes_queryable_prism_attributes(tmp_path):
+    event = emit_event(
+        "trigger.performance_feedback",
+        service="prism-us-trading",
+        market="US",
+        ticker="AAPL",
+        attributes={
+            "trigger_type": "Gap Up Momentum Top",
+            "mode": "shadow",
+            "applied_adjust": 0,
+        },
+        spool_path=tmp_path / "events.jsonl",
+    )
+    payload = build_otlp_payload([event])
+    record = payload["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0]
+    attributes = {item["key"]: next(iter(item["value"].values())) for item in record["attributes"]}
+
+    assert record["traceId"] == event["trace_id"]
+    assert attributes["event.name"] == "trigger.performance_feedback"
+    assert attributes["prism.market"] == "US"
+    assert attributes["prism.trigger_type"] == "Gap Up Momentum Top"
+    assert attributes["prism.applied_adjust"] == "0"
+
+
+def test_success_advances_checkpoint_and_does_not_resend(tmp_path, collector):
+    spool = tmp_path / "events.jsonl"
+    checkpoint = tmp_path / "checkpoint.json"
+    emit_event("pipeline.run", service="prism-test", spool_path=spool)
+    emit_event("pipeline.done", service="prism-test", spool_path=spool)
+
+    assert run_once(
+        spool_path=spool,
+        checkpoint_path=checkpoint,
+        endpoint=collector,
+        batch_size=100,
+        timeout=2,
+    ) == 2
+    saved = load_checkpoint(checkpoint)
+    assert saved is not None
+    assert saved.offset == spool.stat().st_size
+    assert len(_CollectorHandler.payloads) == 1
+    assert _CollectorHandler.payloads[0][0] == "/v1/logs"
+
+    assert run_once(
+        spool_path=spool,
+        checkpoint_path=checkpoint,
+        endpoint=collector,
+        batch_size=100,
+        timeout=2,
+    ) == 0
+    assert len(_CollectorHandler.payloads) == 1
+
+
+def test_failed_delivery_does_not_advance_checkpoint(tmp_path, collector):
+    spool = tmp_path / "events.jsonl"
+    checkpoint = tmp_path / "checkpoint.json"
+    emit_event("pipeline.run", service="prism-test", spool_path=spool)
+    _CollectorHandler.status = 503
+
+    with pytest.raises(urllib.error.HTTPError):
+        run_once(
+            spool_path=spool,
+            checkpoint_path=checkpoint,
+            endpoint=collector,
+            batch_size=100,
+            timeout=2,
+        )
+    assert load_checkpoint(checkpoint) is None
+
+
+def test_corrupt_line_is_skipped_without_blocking_later_events(tmp_path, collector):
+    spool = tmp_path / "events.jsonl"
+    checkpoint = tmp_path / "checkpoint.json"
+    spool.write_text("not-json\n", encoding="utf-8")
+    emit_event("pipeline.done", service="prism-test", spool_path=spool)
+
+    assert run_once(
+        spool_path=spool,
+        checkpoint_path=checkpoint,
+        endpoint=collector,
+        batch_size=100,
+        timeout=2,
+    ) == 1
+    assert load_checkpoint(checkpoint).offset == spool.stat().st_size

--- a/tools/emit_observability_event.py
+++ b/tools/emit_observability_event.py
@@ -1,0 +1,66 @@
+"""Append one operational event to the PRISM observability spool."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from observability.events import emit_event
+
+
+def _value(raw: str):
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("event_type")
+    parser.add_argument("--service", default="prism-operations")
+    parser.add_argument("--market")
+    parser.add_argument("--ticker")
+    parser.add_argument("--trace-id")
+    parser.add_argument("--decision-id")
+    parser.add_argument("--position-id")
+    parser.add_argument(
+        "--attribute",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+    )
+    args = parser.parse_args()
+
+    attributes = {}
+    for item in args.attribute:
+        if "=" not in item:
+            parser.error(f"invalid --attribute {item!r}; expected KEY=VALUE")
+        key, raw = item.split("=", 1)
+        attributes[key] = _value(raw)
+
+    event = emit_event(
+        args.event_type,
+        service=args.service,
+        market=args.market,
+        ticker=args.ticker,
+        trace_id=args.trace_id,
+        decision_id=args.decision_id,
+        position_id=args.position_id,
+        attributes=attributes,
+    )
+    if event is None:
+        print("event append failed", file=sys.stderr)
+        return 1
+    print(event["event_id"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tracking/journal.py
+++ b/tracking/journal.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from cores.openai_error_logging import log_openai_error
 from cores.utils import parse_llm_json
+from observability.events import emit_event
 
 _feedback_spec = importlib.util.spec_from_file_location(
     "prism_root_performance_feedback",
@@ -708,18 +709,26 @@ Please review the following completed trade:
             if trigger_type:
                 feedback = get_trigger_feedback(self.cursor, "KR", trigger_type)
                 trigger_adjustment = resolve_actual_adjustment(feedback)
+                event_payload = feedback_log_payload(
+                    feedback,
+                    trigger_adjustment,
+                    ticker=ticker,
+                    sector=sector,
+                )
                 logger.info(
                     "[TRIGGER_FEEDBACK] %s",
                     json.dumps(
-                        feedback_log_payload(
-                            feedback,
-                            trigger_adjustment,
-                            ticker=ticker,
-                            sector=sector,
-                        ),
+                        event_payload,
                         ensure_ascii=False,
                         sort_keys=True,
                     ),
+                )
+                emit_event(
+                    "trigger.performance_feedback",
+                    service="prism-kr-trading",
+                    market="KR",
+                    ticker=ticker,
+                    attributes=event_payload,
                 )
                 applied = int(trigger_adjustment["applied_adjust"])
                 if applied:


### PR DESCRIPTION
## Summary
- add a versioned, secret-redacting PRISM event contract and atomic JSONL spool
- add an OTLP/HTTP shipper with durable checkpoint and retry semantics
- emit KR/US trigger feedback into the flight recorder without changing scores
- add resource-limited ClickStack, SSH tunnel, shipper and authenticated Nginx deployment templates

## Safety
- no network I/O in trading processes
- all observability failures are fail-open
- no DB schema or trading/order changes
- ClickStack and OTLP bind to backend localhost only
- image pinned by SHA256 digest

## Verification
- 72 related tests passed
- Ruff and py_compile passed
- Docker Compose config validated on prism-backend
- git diff --check passed