### PR TITLE
fix: harden ClickStack runtime ingestion

### DIFF
--- a/deploy/observability/docker-compose.yml
+++ b/deploy/observability/docker-compose.yml
@@ -7,16 +7,38 @@ services:
     restart: unless-stopped
     cpus: 0.85
     mem_limit: 1800m
-    pids_limit: 512
+    # ClickHouse initializes a 512-thread background pool. Keep headroom for
+    # the bundled collector/UI while CPU and memory remain strictly capped.
+    pids_limit: 2048
     ports:
       - "127.0.0.1:18080:8080"
-      - "127.0.0.1:14318:4318"
     environment:
       USAGE_STATS_ENABLED: "false"
     volumes:
       - /var/lib/prism-observability/clickhouse:/var/lib/clickhouse
       - /var/lib/prism-observability/mongodb:/data/db
       - /var/log/prism-observability/clickhouse:/var/log/clickhouse-server
+      - /etc/prism-observability/clickhouse-otel-user.xml:/etc/clickhouse-server/users.d/prism-otel.xml:ro
     stop_grace_period: 60s
+    security_opt:
+      - no-new-privileges:true
+
+  otel-ingest:
+    image: docker.clickhouse.com/clickhouse/clickstack-otel-collector:2@sha256:e859e89e548d7f26fa8b165da6970fa5e6af0bf9fdf93577cc13bfece8eb4994
+    container_name: prism-clickstack-otel
+    restart: unless-stopped
+    cpus: 0.15
+    mem_limit: 256m
+    pids_limit: 256
+    ports:
+      - "127.0.0.1:14318:4318"
+    env_file:
+      - /etc/prism-observability/clickstack.env
+    environment:
+      CLICKHOUSE_ENDPOINT: "tcp://clickstack:9000?dial_timeout=10s"
+      OPAMP_SERVER_URL: ""
+    depends_on:
+      clickstack:
+        condition: service_healthy
     security_opt:
       - no-new-privileges:true

--- a/docs/PRISM_OBSERVABILITY.md
+++ b/docs/PRISM_OBSERVABILITY.md
@@ -27,12 +27,21 @@ authorization are replaced with `[REDACTED]` before the local append.
 ## Deployment topology
 
 - `db-server`: PRISM pipeline, JSONL spool, shipper, SSH local-forward tunnel.
-- `prism-backend`: resource-limited ClickStack container.
+- `prism-backend`: resource-limited ClickStack container and an independent,
+  token-authenticated ClickStack OTel Collector.
 - ClickStack UI: backend localhost `18080`, proxied by authenticated Nginx `8443`.
 - OTLP/HTTP: backend localhost `14318`, reachable from db-server only through SSH.
 
 The tunnel target is supplied outside Git through
 `/etc/prism-observability/tunnel.env` as `PRISM_BACKEND_HOST=...`.
+The ingestion token is supplied outside Git through
+`/etc/prism-observability/clickstack.env` as `OTLP_AUTH_TOKEN=...` and is also
+configured on db-server as `PRISM_OBSERVABILITY_OTLP_TOKEN`.
+The shipper sends this exact value in the `Authorization` header, matching the
+ClickStack static bearer-token extension contract.
+The same environment file holds the dedicated `prism_otel` ClickHouse password;
+only its SHA-256 hash is written to the mounted ClickHouse user configuration.
+The XML user is restricted to the `default` observability database.
 
 ## Initial events
 

--- a/observability/shipper.py
+++ b/observability/shipper.py
@@ -181,7 +181,9 @@ def send_batch(
     encoded = json.dumps(build_otlp_payload(events), ensure_ascii=False).encode("utf-8")
     headers = {"Content-Type": "application/json"}
     if auth_token:
-        headers["Authorization"] = f"Bearer {auth_token}"
+        # ClickStack's static bearertokenauth extension compares the complete
+        # Authorization value to OTLP_AUTH_TOKEN (without a "Bearer " prefix).
+        headers["Authorization"] = auth_token
     request = urllib.request.Request(endpoint, data=encoded, headers=headers, method="POST")
     with urllib.request.urlopen(request, timeout=timeout) as response:
         if not 200 <= response.status < 300:

--- a/tests/test_observability_shipper.py
+++ b/tests/test_observability_shipper.py
@@ -22,7 +22,13 @@ class _CollectorHandler(BaseHTTPRequestHandler):
 
     def do_POST(self):
         length = int(self.headers["Content-Length"])
-        self.__class__.payloads.append((self.path, json.loads(self.rfile.read(length))))
+        self.__class__.payloads.append(
+            (
+                self.path,
+                json.loads(self.rfile.read(length)),
+                self.headers.get("Authorization"),
+            )
+        )
         self.send_response(self.__class__.status)
         self.end_headers()
 
@@ -80,12 +86,14 @@ def test_success_advances_checkpoint_and_does_not_resend(tmp_path, collector):
         endpoint=collector,
         batch_size=100,
         timeout=2,
+        auth_token="collector-secret",
     ) == 2
     saved = load_checkpoint(checkpoint)
     assert saved is not None
     assert saved.offset == spool.stat().st_size
     assert len(_CollectorHandler.payloads) == 1
     assert _CollectorHandler.payloads[0][0] == "/v1/logs"
+    assert _CollectorHandler.payloads[0][2] == "collector-secret"
 
     assert run_once(
         spool_path=spool,


### PR DESCRIPTION
## Summary
- raise ClickStack PID headroom while retaining CPU and memory caps
- add a separately pinned, token-authenticated ClickStack OTel collector
- mount a dedicated ClickHouse collector user configuration
- match the collector static Authorization token contract

## Production evidence
- ClickStack and collector healthy for 4 hours
- unauthenticated OTLP request returns 401
- authenticated OTLP request returns 200
- smoke log persisted in otel_logs with trace ID

## Verification
- 10 affected tests passed
- Ruff, py_compile, Compose config and git diff checks passed