### PR TITLE
fix: load observability shipper token securely

### DIFF
--- a/deploy/systemd/prism-observability-shipper.service.example
+++ b/deploy/systemd/prism-observability-shipper.service.example
@@ -6,6 +6,7 @@ Wants=network-online.target prism-observability-tunnel.service
 [Service]
 Type=simple
 WorkingDirectory=/root/prism-insight
+EnvironmentFile=/etc/prism-observability/shipper.env
 Environment=PRISM_ENV=production
 Environment=PRISM_OBSERVABILITY_SPOOL=/root/prism-insight/logs/prism_events.jsonl
 Environment=PRISM_OBSERVABILITY_CHECKPOINT=/root/prism-insight/logs/prism_events.checkpoint.json

--- a/docs/PRISM_OBSERVABILITY.md
+++ b/docs/PRISM_OBSERVABILITY.md
@@ -39,9 +39,13 @@ The ingestion token is supplied outside Git through
 configured on db-server as `PRISM_OBSERVABILITY_OTLP_TOKEN`.
 The shipper sends this exact value in the `Authorization` header, matching the
 ClickStack static bearer-token extension contract.
+db-server loads the value from `/etc/prism-observability/shipper.env`, which
+must remain mode `0600`.
 The same environment file holds the dedicated `prism_otel` ClickHouse password;
 only its SHA-256 hash is written to the mounted ClickHouse user configuration.
 The XML user is restricted to the `default` observability database.
+The mounted XML contains no plaintext password and must be readable by the
+ClickHouse process (mode `0644`).
 
 ## Initial events
 


### PR DESCRIPTION
## Summary
- load the OTLP token from a root-only systemd EnvironmentFile
- document permissions for the shipper secret and ClickHouse hash-only user file

## Safety
- no token value enters Git, process arguments, or logs
- documentation/unit-only change

## Verification
- git diff --check passed