### PR TITLE
feat: add observability insights dashboard and backfill

### DIFF
--- a/deploy/observability/docker-compose.yml
+++ b/deploy/observability/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     pids_limit: 2048
     ports:
       - "127.0.0.1:18080:8080"
+      - "127.0.0.1:18123:8123"
     environment:
       USAGE_STATS_ENABLED: "false"
     volumes:

--- a/deploy/systemd/prism-observability-dashboard-export.service.example
+++ b/deploy/systemd/prism-observability-dashboard-export.service.example
@@ -1,0 +1,17 @@
+[Unit]
+Description=Publish curated PRISM observability insights to app-server
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/prism-observability/dashboard-export.env
+WorkingDirectory=/opt/prism-observability
+ExecStart=/usr/bin/python3 /opt/prism-observability/publish_observability_insights.py --days 180
+Nice=10
+CPUQuota=30%
+MemoryMax=128M
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/prism-observability-dashboard-export.service.example
+++ b/deploy/systemd/prism-observability-dashboard-export.service.example
@@ -6,6 +6,7 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 EnvironmentFile=/etc/prism-observability/dashboard-export.env
+EnvironmentFile=/etc/prism-observability/clickstack.env
 WorkingDirectory=/opt/prism-observability
 ExecStart=/usr/bin/python3 /opt/prism-observability/publish_observability_insights.py --days 180
 Nice=10

--- a/deploy/systemd/prism-observability-dashboard-export.timer.example
+++ b/deploy/systemd/prism-observability-dashboard-export.timer.example
@@ -1,0 +1,12 @@
+[Unit]
+Description=Refresh PRISM observability dashboard snapshot every five minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+AccuracySec=30s
+Persistent=true
+Unit=prism-observability-dashboard-export.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/PRISM_OBSERVABILITY.md
+++ b/docs/PRISM_OBSERVABILITY.md
@@ -75,6 +75,10 @@ credential-free JSON snapshot. tools/publish_observability_insights.py
 publishes it atomically to app-server every five minutes through the systemd
 timer template.
 
+The publisher uses a dedicated SSH identity and the unprivileged prism account
+on app-server. Host, port, user, identity path, and destination stay outside Git
+in /etc/prism-observability/dashboard-export.env.
+
 The existing dashboard reads /observability_insights.json independently from
 its portfolio JSON. Missing or delayed observability data hides only the new
 panel and never breaks the existing dashboard.

--- a/docs/PRISM_OBSERVABILITY.md
+++ b/docs/PRISM_OBSERVABILITY.md
@@ -55,6 +55,30 @@ ClickHouse process (mode `0644`).
 Decision, gate, execution, and position-outcome events are added incrementally
 after the end-to-end transport and resource envelope are verified.
 
+## Historical baseline
+
+tools/backfill_observability.py backfills only verifiable facts:
+
+- realized KR/US rows from the production trading-history tables
+- completed watched-candidate 7/14/30-day outcomes
+- recorded regime snapshots
+- actual db-server pull timestamps from Git reflog
+
+Every row is marked ingestion_mode=backfill, includes its source table or
+reflog provenance, and receives a deterministic event ID. Historical prompts,
+gates, and decision traces are not reconstructed.
+
+## Curated dashboard snapshot
+
+tools/export_observability_insights.py aggregates ClickHouse events into a
+credential-free JSON snapshot. tools/publish_observability_insights.py
+publishes it atomically to app-server every five minutes through the systemd
+timer template.
+
+The existing dashboard reads /observability_insights.json independently from
+its portfolio JSON. Missing or delayed observability data hides only the new
+panel and never breaks the existing dashboard.
+
 ## Rollback
 
 1. Stop and disable `prism-observability-shipper` and tunnel units.

--- a/examples/dashboard/app/page.tsx
+++ b/examples/dashboard/app/page.tsx
@@ -17,7 +17,7 @@ import { ProjectFooter } from "@/components/project-footer"
 import { useLanguage } from "@/components/language-provider"
 import { useMarket } from "@/components/market-selector"
 import { TriggerReliabilityBadge } from "@/components/trigger-reliability-badge"
-import type { DashboardData, Holding, Market } from "@/types/dashboard"
+import type { DashboardData, Holding, Market, ObservabilityInsightsSnapshot } from "@/types/dashboard"
 
 type TabType = "dashboard" | "ai-decisions" | "trading" | "watchlist" | "insights" | "stance"
 const VALID_TABS: TabType[] = ["dashboard", "ai-decisions", "trading", "watchlist", "insights", "stance"]
@@ -50,6 +50,7 @@ function DashboardContent() {
   const searchParams = useSearchParams()
   const router = useRouter()
   const [data, setData] = useState<DashboardData | null>(null)
+  const [observability, setObservability] = useState<ObservabilityInsightsSnapshot | null>(null)
   const [selectedStock, setSelectedStock] = useState<Holding | null>(null)
   const [isRealTrading, setIsRealTrading] = useState(false)
   const [dataError, setDataError] = useState<string | null>(null)
@@ -97,6 +98,19 @@ function DashboardContent() {
 
         const jsonData = await response.json()
         setData(jsonData)
+        try {
+          const observabilityResponse = await fetch("/observability_insights.json", {
+            cache: "no-store",
+          })
+          if (observabilityResponse.ok) {
+            setObservability(await observabilityResponse.json())
+          } else {
+            setObservability(null)
+          }
+        } catch {
+          // Observability is an optional, independent data plane.
+          setObservability(null)
+        }
       } catch (error) {
         console.error("[v0] Failed to fetch dashboard data:", error)
         if (market === "US") {
@@ -268,7 +282,13 @@ function DashboardContent() {
 
         {activeTab === "watchlist" && <WatchlistPage watchlist={data.watchlist} market={market} />}
 
-        {activeTab === "insights" && data.trading_insights && <TradingInsightsPage data={data.trading_insights} market={market} />}
+        {activeTab === "insights" && data.trading_insights && (
+          <TradingInsightsPage
+            data={data.trading_insights}
+            market={market}
+            observability={observability}
+          />
+        )}
 
       </main>
 

--- a/examples/dashboard/components/observability-insights-panel.tsx
+++ b/examples/dashboard/components/observability-insights-panel.tsx
@@ -1,0 +1,372 @@
+"use client"
+
+import {
+  Activity,
+  ArrowDownRight,
+  ArrowUpRight,
+  Clock3,
+  Database,
+  GitCommitHorizontal,
+  Radar,
+  ShieldCheck,
+} from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { useLanguage } from "@/components/language-provider"
+import { cn } from "@/lib/utils"
+import type {
+  Market,
+  ObservabilityInsightsSnapshot,
+  ObservabilityTradeMetrics,
+} from "@/types/dashboard"
+
+interface Props {
+  data: ObservabilityInsightsSnapshot
+  market: Market
+}
+
+const pct = (value: number | null, digits = 1) =>
+  value === null || value === undefined
+    ? "—"
+    : (value * 100).toFixed(digits) + "%"
+
+const pctDirect = (value: number | null, digits = 1) =>
+  value === null || value === undefined
+    ? "—"
+    : (value >= 0 ? "+" : "") + value.toFixed(digits) + "%"
+
+const number = (value: number | null, digits = 2) =>
+  value === null || value === undefined ? "—" : value.toFixed(digits)
+
+function SampleBadge({
+  sufficient,
+  language,
+}: {
+  sufficient: boolean
+  language: string
+}) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        sufficient
+          ? "border-emerald-500/30 text-emerald-600"
+          : "border-amber-500/30 text-amber-600",
+      )}
+    >
+      {sufficient
+        ? language === "ko" ? "표본 확보" : "Sample ready"
+        : language === "ko" ? "표본 부족" : "Low sample"}
+    </Badge>
+  )
+}
+
+function metricDelta(
+  pre: ObservabilityTradeMetrics,
+  post: ObservabilityTradeMetrics,
+) {
+  if (pre.avg_return_pct === null || post.avg_return_pct === null) return null
+  return post.avg_return_pct - pre.avg_return_pct
+}
+
+export function ObservabilityInsightsPanel({ data, market }: Props) {
+  const { language } = useLanguage()
+  const current = data.markets[market]
+  const latestEvent = data.generated_at ? new Date(data.generated_at) : null
+  const staleMinutes = latestEvent
+    ? Math.max(0, (Date.now() - latestEvent.getTime()) / 60_000)
+    : Number.POSITIVE_INFINITY
+  const impacts = data.deployment_impacts.slice().reverse().slice(0, 8)
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Radar className="h-5 w-5 text-cyan-500" />
+          <div>
+            <h3 className="font-semibold">
+              {language === "ko" ? "PRISM 관측 센터" : "PRISM Observatory"}
+            </h3>
+            <p className="text-xs text-muted-foreground">
+              {language === "ko"
+                ? "ClickHouse 원본 이벤트를 정제한 매매 성과와 배포 영향"
+                : "Curated trading performance and deployment impact from ClickHouse events"}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Badge
+            variant="outline"
+            className={cn(
+              staleMinutes <= 30
+                ? "border-emerald-500/30 text-emerald-600"
+                : "border-red-500/30 text-red-600",
+            )}
+          >
+            <Activity className="mr-1 h-3 w-3" />
+            {staleMinutes <= 30
+              ? language === "ko" ? "수집 정상" : "Fresh"
+              : language === "ko" ? "갱신 지연" : "Stale"}
+          </Badge>
+          <Badge variant="secondary">{market}</Badge>
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>
+              {language === "ko" ? "실제 매매" : "Actual trades"}
+            </CardDescription>
+            <CardTitle className="text-2xl">{current.actual.count}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1 text-sm">
+            <div className="flex justify-between">
+              <span>{language === "ko" ? "승률" : "Win rate"}</span>
+              <strong>{pct(current.actual.win_rate)}</strong>
+            </div>
+            <div className="flex justify-between">
+              <span>PF</span>
+              <strong>{number(current.actual.profit_factor)}</strong>
+            </div>
+            <div className="flex justify-between">
+              <span>{language === "ko" ? "평균" : "Average"}</span>
+              <strong>{pctDirect(current.actual.avg_return_pct)}</strong>
+            </div>
+            <SampleBadge
+              sufficient={current.actual.sample_sufficient}
+              language={language}
+            />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>
+              {language === "ko" ? "관찰 후보" : "Watched candidates"}
+            </CardDescription>
+            <CardTitle className="text-2xl">{current.candidate.count}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1 text-sm">
+            <div className="flex justify-between">
+              <span>{language === "ko" ? "30일 상승" : "30d positive"}</span>
+              <strong>{pct(current.candidate.positive_rate_30d)}</strong>
+            </div>
+            <div className="flex justify-between">
+              <span>{language === "ko" ? "30일 평균" : "30d average"}</span>
+              <strong>{pctDirect(current.candidate.avg_30d_pct)}</strong>
+            </div>
+            <div className="flex justify-between">
+              <span>{language === "ko" ? "30일 중앙값" : "30d median"}</span>
+              <strong>{pctDirect(current.candidate.median_30d_pct)}</strong>
+            </div>
+            <SampleBadge
+              sufficient={current.candidate.sample_sufficient}
+              language={language}
+            />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>
+              {language === "ko" ? "현재 시장 국면" : "Latest regime"}
+            </CardDescription>
+            <CardTitle className="text-xl capitalize">
+              {current.latest_regime?.regime || "—"}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <span>{language === "ko" ? "신뢰도" : "Confidence"}</span>
+              <strong>{pct(current.latest_regime?.confidence ?? null)}</strong>
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {current.latest_regime?.observed_at
+                ? new Date(current.latest_regime.observed_at).toLocaleString(
+                    language === "ko" ? "ko-KR" : "en-US",
+                  )
+                : "—"}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>
+              {language === "ko" ? "관측 데이터" : "Telemetry"}
+            </CardDescription>
+            <CardTitle className="text-2xl">
+              {data.data_quality.total_events.toLocaleString()}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1 text-sm">
+            <div className="flex justify-between">
+              <span>Live</span>
+              <strong>{data.data_quality.live_events}</strong>
+            </div>
+            <div className="flex justify-between">
+              <span>Backfill</span>
+              <strong>{data.data_quality.backfill_events}</strong>
+            </div>
+            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Database className="h-3 w-3" />
+              {language === "ko"
+                ? data.retention_days + "일 보존"
+                : data.retention_days + "d retention"}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <ShieldCheck className="h-4 w-4 text-emerald-500" />
+            {language === "ko"
+              ? "트리거별 Candidate vs Actual"
+              : "Candidate vs Actual by trigger"}
+          </CardTitle>
+          <CardDescription>
+            {language === "ko"
+              ? "관찰 후보의 30일 성과와 실제 청산 성과는 서로 다른 지표로 표시합니다."
+              : "Watched 30-day outcomes and realized trade outcomes remain separate."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          <table className="w-full min-w-[760px] text-sm">
+            <thead>
+              <tr className="border-b text-left text-muted-foreground">
+                <th className="p-2">{language === "ko" ? "트리거" : "Trigger"}</th>
+                <th className="p-2 text-right">Actual n</th>
+                <th className="p-2 text-right">
+                  {language === "ko" ? "실제 승률" : "Actual WR"}
+                </th>
+                <th className="p-2 text-right">PF</th>
+                <th className="p-2 text-right">
+                  {language === "ko" ? "실제 평균" : "Actual avg"}
+                </th>
+                <th className="p-2 text-right">Candidate n</th>
+                <th className="p-2 text-right">
+                  {language === "ko" ? "30일 상승" : "30d positive"}
+                </th>
+                <th className="p-2 text-right">
+                  {language === "ko" ? "후보 평균" : "Candidate avg"}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {current.triggers.slice(0, 12).map((row) => (
+                <tr key={row.trigger_type} className="border-b border-border/40">
+                  <td className="p-2 font-medium">{row.trigger_type}</td>
+                  <td className="p-2 text-right">{row.actual.count}</td>
+                  <td className="p-2 text-right">{pct(row.actual.win_rate, 0)}</td>
+                  <td className="p-2 text-right">{number(row.actual.profit_factor)}</td>
+                  <td className="p-2 text-right">{pctDirect(row.actual.avg_return_pct)}</td>
+                  <td className="p-2 text-right">{row.candidate.count}</td>
+                  <td className="p-2 text-right">
+                    {pct(row.candidate.positive_rate_30d, 0)}
+                  </td>
+                  <td className="p-2 text-right">
+                    {pctDirect(row.candidate.avg_30d_pct)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <GitCommitHorizontal className="h-4 w-4 text-violet-500" />
+            {language === "ko" ? "배포 전후 14일 영향" : "14-day deployment impact"}
+          </CardTitle>
+          <CardDescription>
+            {language === "ko"
+              ? "매수일 기준 전후 코호트 비교입니다. 인과관계가 아니라 관측된 변화입니다."
+              : "Buy-date cohort comparison. This is observed association, not proof of causality."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {impacts.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              {language === "ko" ? "배포 기록이 없습니다." : "No deployment records."}
+            </p>
+          )}
+          {impacts.map((impact) => {
+            const currentImpact = impact.markets[market]
+            const delta = metricDelta(currentImpact.pre, currentImpact.post)
+            return (
+              <div
+                key={impact.git_sha + "-" + impact.target}
+                className="grid gap-2 rounded-lg border p-3 md:grid-cols-[1.5fr_1fr_1fr_1fr] md:items-center"
+              >
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <code className="text-xs">{impact.git_sha.slice(0, 8)}</code>
+                    <Badge variant="outline">{impact.target}</Badge>
+                    {!impact.post_window_complete && (
+                      <Badge variant="secondary">
+                        {language === "ko" ? "관측 중" : "In progress"}
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+                    <Clock3 className="h-3 w-3" />
+                    {new Date(impact.timestamp).toLocaleString(
+                      language === "ko" ? "ko-KR" : "en-US",
+                    )}
+                  </div>
+                  {impact.subject && (
+                    <p className="mt-1 line-clamp-1 text-xs text-muted-foreground">
+                      {impact.subject}
+                    </p>
+                  )}
+                </div>
+                <div className="text-sm">
+                  <span className="text-muted-foreground">
+                    {language === "ko" ? "이전 " : "Pre "}
+                  </span>
+                  <strong>
+                    {currentImpact.pre.count} / {pctDirect(currentImpact.pre.avg_return_pct)}
+                  </strong>
+                </div>
+                <div className="text-sm">
+                  <span className="text-muted-foreground">
+                    {language === "ko" ? "이후 " : "Post "}
+                  </span>
+                  <strong>
+                    {currentImpact.post.count} / {pctDirect(currentImpact.post.avg_return_pct)}
+                  </strong>
+                </div>
+                <div
+                  className={cn(
+                    "flex items-center justify-end gap-1 font-semibold",
+                    delta === null
+                      ? "text-muted-foreground"
+                      : delta >= 0
+                        ? "text-emerald-600"
+                        : "text-red-600",
+                  )}
+                >
+                  {delta === null ? null : delta >= 0
+                    ? <ArrowUpRight className="h-4 w-4" />
+                    : <ArrowDownRight className="h-4 w-4" />}
+                  {delta === null ? "—" : pctDirect(delta)}
+                </div>
+              </div>
+            )
+          })}
+        </CardContent>
+      </Card>
+    </section>
+  )
+}

--- a/examples/dashboard/components/trading-insights-page.tsx
+++ b/examples/dashboard/components/trading-insights-page.tsx
@@ -37,14 +37,16 @@ import {
   Globe
 } from "lucide-react"
 import { useLanguage } from "@/components/language-provider"
-import type { TradingInsightsData, TradingPrinciple, TradingJournal, TradingIntuition, SituationAnalysis, JudgmentEvaluation, Market, TriggerReliabilityData } from "@/types/dashboard"
+import type { TradingInsightsData, TradingPrinciple, TradingJournal, TradingIntuition, SituationAnalysis, JudgmentEvaluation, Market, TriggerReliabilityData, ObservabilityInsightsSnapshot } from "@/types/dashboard"
 import { TriggerReliabilityCard } from "./trigger-reliability-card"
+import { ObservabilityInsightsPanel } from "./observability-insights-panel"
 
 type MarketFilter = "all" | "KR" | "US"
 
 interface TradingInsightsPageProps {
   data: TradingInsightsData
   market?: Market
+  observability?: ObservabilityInsightsSnapshot | null
 }
 
 // Helper to safely parse JSON
@@ -57,7 +59,7 @@ function tryParseJSON<T>(str: string | T): T | null {
   }
 }
 
-export function TradingInsightsPage({ data, market = "KR" }: TradingInsightsPageProps) {
+export function TradingInsightsPage({ data, market = "KR", observability }: TradingInsightsPageProps) {
   const { t, language } = useLanguage()
   const [marketFilter, setMarketFilter] = useState<MarketFilter>("all")
 
@@ -203,6 +205,10 @@ export function TradingInsightsPage({ data, market = "KR" }: TradingInsightsPage
           </div>
         </div>
       </div>
+
+      {observability && (
+        <ObservabilityInsightsPanel data={observability} market={market} />
+      )}
 
       {/* Trigger Reliability Card */}
       {data.trigger_reliability && data.trigger_reliability.trigger_reliability.length > 0 && (

--- a/examples/dashboard/types/dashboard.ts
+++ b/examples/dashboard/types/dashboard.ts
@@ -471,6 +471,83 @@ export interface TradingInsightsData {
   trigger_reliability?: TriggerReliabilityData
 }
 
+export interface ObservabilityTradeMetrics {
+  count: number
+  win_rate: number | null
+  avg_return_pct: number | null
+  median_return_pct: number | null
+  avg_win_pct: number | null
+  avg_loss_pct: number | null
+  profit_factor: number | null
+  stop_rate: number | null
+  sample_sufficient: boolean
+}
+
+export interface ObservabilityCandidateMetrics {
+  count: number
+  positive_rate_30d: number | null
+  avg_7d_pct: number | null
+  median_7d_pct: number | null
+  avg_14d_pct: number | null
+  median_14d_pct: number | null
+  avg_30d_pct: number | null
+  median_30d_pct: number | null
+  sample_sufficient: boolean
+}
+
+export interface ObservabilityTriggerRow {
+  trigger_type: string
+  actual: ObservabilityTradeMetrics
+  candidate: ObservabilityCandidateMetrics
+}
+
+export interface ObservabilityMarketSnapshot {
+  actual: ObservabilityTradeMetrics
+  candidate: ObservabilityCandidateMetrics
+  triggers: ObservabilityTriggerRow[]
+  latest_regime: {
+    regime: string | null
+    confidence: number | null
+    observed_at: string
+  } | null
+  regime_distribution: Array<{ regime: string; count: number }>
+}
+
+export interface ObservabilityDeployment {
+  timestamp: string
+  git_sha: string
+  target: string
+  prs: number[]
+  subject?: string | null
+  ingestion_mode: "live" | "backfill"
+  verified_actual_deployment: boolean
+}
+
+export interface ObservabilityDeploymentImpact extends ObservabilityDeployment {
+  window_days: number
+  post_window_complete: boolean
+  markets: Record<Market, {
+    pre: ObservabilityTradeMetrics
+    post: ObservabilityTradeMetrics
+  }>
+}
+
+export interface ObservabilityInsightsSnapshot {
+  schema_version: number
+  generated_at: string
+  retention_days: number
+  data_quality: {
+    total_events: number
+    backfill_events: number
+    live_events: number
+    coverage_start: string | null
+    last_event_at: string | null
+  }
+  markets: Record<Market, ObservabilityMarketSnapshot>
+  deployments: ObservabilityDeployment[]
+  deployment_impacts: ObservabilityDeploymentImpact[]
+}
+
 // ── Stance 프로토콜 리더보드 ──────────────────────────────────────
 // 대시보드 데이터와 별도 파일(/stance_leaderboard.json)로 제공된다.
 // 원장을 재생해 만든 계산 결과이므로 언제든 다시 만들 수 있다.

--- a/observability/events.py
+++ b/observability/events.py
@@ -121,6 +121,7 @@ def build_event(
     event_type: str,
     *,
     service: str,
+    event_id: str | None = None,
     market: str | None = None,
     ticker: str | None = None,
     trace_id: str | None = None,
@@ -145,7 +146,7 @@ def build_event(
     git_sha = _git_sha()
     event = {
         "schema_version": SCHEMA_VERSION,
-        "event_id": uuid.uuid4().hex,
+        "event_id": _normalize_hex_id(event_id, 32),
         "event_type": normalized_type,
         "timestamp": timestamp.isoformat().replace("+00:00", "Z"),
         "time_unix_nano": str(int(timestamp.timestamp() * 1_000_000_000)),
@@ -173,6 +174,7 @@ def emit_event(
     event_type: str,
     *,
     service: str,
+    event_id: str | None = None,
     market: str | None = None,
     ticker: str | None = None,
     trace_id: str | None = None,
@@ -194,6 +196,7 @@ def emit_event(
         event = build_event(
             event_type,
             service=service,
+            event_id=event_id,
             market=market,
             ticker=ticker,
             trace_id=trace_id,

--- a/tests/test_observability_backfill.py
+++ b/tests/test_observability_backfill.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+
+from observability.events import build_event
+from tools.backfill_observability import (
+    emit_backfill,
+    iter_actual_events,
+    iter_candidate_events,
+    iter_regime_events,
+    load_state,
+    save_state,
+)
+
+
+def _database():
+    connection = sqlite3.connect(":memory:")
+    connection.executescript(
+        """
+        CREATE TABLE trading_history (
+          id INTEGER, ticker TEXT, company_name TEXT, buy_price REAL,
+          buy_date TEXT, sell_price REAL, sell_date TEXT, profit_rate REAL,
+          holding_days INTEGER, scenario TEXT, trigger_type TEXT,
+          trigger_mode TEXT, sector TEXT, exit_kind TEXT
+        );
+        CREATE TABLE us_trading_history AS SELECT * FROM trading_history WHERE 0;
+        CREATE TABLE analysis_performance_tracker (
+          id INTEGER, ticker TEXT, company_name TEXT, trigger_type TEXT,
+          trigger_mode TEXT, analyzed_date TEXT, decision TEXT,
+          was_traded INTEGER, skip_reason TEXT, buy_score REAL,
+          min_score REAL, target_price REAL, stop_loss REAL,
+          risk_reward_ratio REAL, tracked_7d_return REAL,
+          tracked_14d_return REAL, tracked_30d_return REAL,
+          tracked_30d_date TEXT
+        );
+        CREATE TABLE us_analysis_performance_tracker (
+          id INTEGER, ticker TEXT, company_name TEXT, trigger_type TEXT,
+          trigger_mode TEXT, analysis_date TEXT, decision TEXT,
+          was_traded INTEGER, skip_reason TEXT, buy_score REAL,
+          target_price REAL, stop_loss REAL, risk_reward_ratio REAL,
+          return_7d REAL, return_14d REAL, return_30d REAL,
+          last_updated TEXT, hit_target INTEGER, hit_stop_loss INTEGER,
+          sector TEXT
+        );
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO trading_history VALUES (
+          1, '005930', 'Samsung', 70000, '2026-08-01 09:00:00',
+          68000, '2026-08-10 09:00:00', -2.857, 9, '{"score": 7}',
+          'Gap', 'topdown', 'Semiconductor', 'hard_stop'
+        )
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO us_trading_history VALUES (
+          2, 'AAPL', 'Apple', 200, '2026-08-02 09:00:00',
+          210, '2026-08-11 09:00:00', 5.0, 9, '{"score": 8}',
+          'Closing', 'bottomup', 'Technology', 'target'
+        )
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO analysis_performance_tracker VALUES (
+          10, '000660', 'SK Hynix', 'Gap', 'topdown',
+          '2026-08-01 10:00:00', 'watch', 0, 'score',
+          6, 7, 150000, 130000, 2.0, 0.01, 0.02, -0.03,
+          '2026-08-31 10:00:00'
+        )
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO us_analysis_performance_tracker VALUES (
+          20, 'MSFT', 'Microsoft', 'Closing', 'bottomup',
+          '2026-08-02 10:00:00', 'watch', 0, 'score',
+          7, 500, 440, 2.5, 0.02, 0.03, 0.04,
+          '2026-09-01 10:00:00', 0, 0, 'Technology'
+        )
+        """
+    )
+    connection.commit()
+    return connection
+
+
+def test_explicit_event_id_is_deterministic():
+    first = build_event("test", service="test", event_id="source:1")
+    second = build_event("test", service="test", event_id="source:1")
+    assert first["event_id"] == second["event_id"]
+    assert len(first["event_id"]) == 32
+
+
+def test_actual_and_candidate_backfill_keep_units_and_provenance():
+    connection = _database()
+    since = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    try:
+        actual = list(iter_actual_events(connection, "KR", since=since))
+        candidate = list(iter_candidate_events(connection, "US", since=since))
+    finally:
+        connection.close()
+
+    assert actual[0]["event_type"] == "trade.outcome"
+    assert actual[0]["attributes"]["profit_rate_pct"] == -2.857
+    assert actual[0]["attributes"]["scenario_hash"] != '{"score": 7}'
+    assert actual[0]["attributes"]["ingestion_mode"] == "backfill"
+    assert candidate[0]["event_type"] == "candidate.outcome"
+    assert candidate[0]["attributes"]["return_30d_pct"] == 4.0
+    assert candidate[0]["attributes"]["was_traded"] == 0
+
+
+def test_regime_backfill_skips_invalid_lines(tmp_path):
+    path = tmp_path / "regime.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                "not-json",
+                json.dumps(
+                    {
+                        "ts": "2026-08-01 09:00:00",
+                        "market": "KR",
+                        "regime": "sideways",
+                        "confidence": 0.55,
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    events = list(
+        iter_regime_events(
+            path,
+            since=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        )
+    )
+    assert len(events) == 1
+    assert events[0]["attributes"]["regime"] == "sideways"
+    assert events[0]["attributes"]["source"] == "regime_history_jsonl"
+
+
+def test_state_and_emit_backfill_are_idempotent(tmp_path, monkeypatch):
+    state_path = tmp_path / "state.json"
+    event = {
+        "event_type": "trade.outcome",
+        "event_id": "a" * 32,
+        "service": "test",
+        "attributes": {},
+    }
+    emitted_ids: set[str] = set()
+    monkeypatch.setattr(
+        "tools.backfill_observability.emit_event",
+        lambda **kwargs: kwargs,
+    )
+
+    first = emit_backfill([event], emitted_ids=emitted_ids, dry_run=False)
+    second = emit_backfill([event], emitted_ids=emitted_ids, dry_run=False)
+    save_state(state_path, emitted_ids)
+
+    assert first["emitted"] == 1
+    assert second["skipped"] == 1
+    assert load_state(state_path) == {"a" * 32}

--- a/tests/test_observability_insights_export.py
+++ b/tests/test_observability_insights_export.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tools import publish_observability_insights as publisher
+from tools.export_observability_insights import build_snapshot
+
+
+def _event(
+    event_id,
+    event_type,
+    timestamp,
+    *,
+    market=None,
+    ticker=None,
+    attributes=None,
+    git_sha="abc123",
+):
+    return {
+        "event_id": event_id,
+        "event_type": event_type,
+        "timestamp": timestamp,
+        "market": market,
+        "ticker": ticker,
+        "git_sha": git_sha,
+        "attributes": attributes or {},
+    }
+
+
+def test_snapshot_separates_actual_candidate_and_market():
+    events = [
+        _event(
+            "trade-kr-1",
+            "trade.outcome",
+            "2026-08-10T00:00:00Z",
+            market="KR",
+            attributes={
+                "profit_rate_pct": -5.0,
+                "buy_date": "2026-08-01 09:00:00",
+                "trigger_type": "Gap",
+                "exit_kind": "hard_stop",
+                "ingestion_mode": "backfill",
+            },
+        ),
+        _event(
+            "trade-us-1",
+            "trade.outcome",
+            "2026-08-11T00:00:00Z",
+            market="US",
+            attributes={
+                "profit_rate_pct": 10.0,
+                "buy_date": "2026-08-02 09:00:00",
+                "trigger_type": "Closing",
+                "exit_kind": "target",
+                "ingestion_mode": "backfill",
+            },
+        ),
+        _event(
+            "candidate-kr-1",
+            "candidate.outcome",
+            "2026-08-01T00:00:00Z",
+            market="KR",
+            attributes={
+                "return_7d_pct": 1.0,
+                "return_14d_pct": 2.0,
+                "return_30d_pct": 3.0,
+                "was_traded": 0,
+                "trigger_type": "Gap",
+                "ingestion_mode": "backfill",
+            },
+        ),
+    ]
+    snapshot = build_snapshot(
+        events,
+        now=datetime(2026, 8, 26, tzinfo=timezone.utc),
+    )
+
+    assert snapshot["markets"]["KR"]["actual"]["count"] == 1
+    assert snapshot["markets"]["KR"]["actual"]["stop_rate"] == 1.0
+    assert snapshot["markets"]["US"]["actual"]["win_rate"] == 1.0
+    assert snapshot["markets"]["KR"]["candidate"]["avg_30d_pct"] == 3.0
+    assert snapshot["markets"]["KR"]["triggers"][0]["trigger_type"] == "Gap"
+    assert snapshot["data_quality"]["backfill_events"] == 3
+
+
+def test_snapshot_deduplicates_event_ids_and_deployments():
+    deployment = _event(
+        "deploy-live",
+        "deployment.applied",
+        "2026-08-10T00:00:00Z",
+        attributes={"target": "db-server", "prs": [1]},
+        git_sha="same-sha",
+    )
+    deployment_backfill = _event(
+        "deploy-backfill",
+        "deployment.applied",
+        "2026-08-10T00:00:01Z",
+        attributes={
+            "target": "db-server",
+            "git_sha": "same-sha",
+            "ingestion_mode": "backfill",
+        },
+    )
+    duplicate = dict(deployment)
+    snapshot = build_snapshot(
+        [deployment, duplicate, deployment_backfill],
+        now=datetime(2026, 8, 26, tzinfo=timezone.utc),
+    )
+    assert snapshot["data_quality"]["total_events"] == 2
+    assert len(snapshot["deployments"]) == 1
+    assert snapshot["deployments"][0]["ingestion_mode"] == "live"
+
+
+def test_deployment_impact_uses_buy_date_cohorts():
+    deployment = _event(
+        "deploy",
+        "deployment.applied",
+        "2026-08-10T00:00:00Z",
+        attributes={"target": "db-server"},
+    )
+    trades = []
+    for index, buy_date in enumerate(
+        ("2026-08-01 09:00:00", "2026-08-12 09:00:00"),
+        1,
+    ):
+        trades.append(
+            _event(
+                f"trade-{index}",
+                "trade.outcome",
+                f"2026-08-{15 + index}T00:00:00Z",
+                market="KR",
+                attributes={
+                    "profit_rate_pct": -2.0 if index == 1 else 4.0,
+                    "buy_date": buy_date,
+                    "trigger_type": "Gap",
+                    "exit_kind": "normal",
+                },
+            )
+        )
+    snapshot = build_snapshot(
+        [deployment, *trades],
+        now=datetime(2026, 8, 30, tzinfo=timezone.utc),
+    )
+    impact = snapshot["deployment_impacts"][0]
+    assert impact["markets"]["KR"]["pre"]["count"] == 1
+    assert impact["markets"]["KR"]["post"]["count"] == 1
+    assert impact["post_window_complete"] is True
+
+
+def test_publisher_validates_remote_destination_before_execution(tmp_path):
+    with pytest.raises(ValueError, match="destination"):
+        publisher.publish(
+            container="clickstack",
+            local_output=tmp_path / "snapshot.json",
+            days=180,
+            host="app.example",
+            port=22,
+            user="root",
+            destination="/tmp/good path.json",
+        )
+
+
+def test_publisher_generates_then_installs_atomically(tmp_path, monkeypatch):
+    snapshot = {
+        "generated_at": "2026-08-26T00:00:00Z",
+        "data_quality": {"total_events": 3},
+    }
+    calls = []
+    monkeypatch.setattr(publisher, "load_clickhouse_events", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(publisher, "build_snapshot", lambda *_args, **_kwargs: snapshot)
+    monkeypatch.setattr(
+        publisher,
+        "write_snapshot",
+        lambda path, value: path.write_text(str(value), encoding="utf-8"),
+    )
+    monkeypatch.setattr(
+        publisher.subprocess,
+        "run",
+        lambda command, **kwargs: calls.append((command, kwargs)),
+    )
+
+    result = publisher.publish(
+        container="clickstack",
+        local_output=tmp_path / "snapshot.json",
+        days=180,
+        host="app.example",
+        port=2222,
+        user="root",
+        destination="/srv/dashboard/observability_insights.json",
+    )
+
+    assert result["events"] == 3
+    assert calls[0][0][0] == "scp"
+    assert calls[0][0][-1].endswith("observability_insights.json.tmp")
+    assert calls[1][0][0] == "ssh"
+    assert "/usr/bin/install" in calls[1][0]
+    assert calls[2][0][0] == "ssh"

--- a/tests/test_observability_insights_export.py
+++ b/tests/test_observability_insights_export.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 import pytest
 
 from tools import publish_observability_insights as publisher
-from tools.export_observability_insights import build_snapshot
+from tools.export_observability_insights import build_snapshot, load_clickhouse_events
 
 
 def _event(
@@ -85,6 +85,16 @@ def test_snapshot_separates_actual_candidate_and_market():
     assert snapshot["data_quality"]["backfill_events"] == 3
 
 
+def test_clickhouse_exporter_rejects_non_local_endpoint():
+    with pytest.raises(ValueError, match="local HTTP"):
+        load_clickhouse_events(
+            "https://clickhouse.example",
+            user="user",
+            password="secret",
+            days=180,
+        )
+
+
 def test_snapshot_deduplicates_event_ids_and_deployments():
     deployment = _event(
         "deploy-live",
@@ -152,7 +162,7 @@ def test_deployment_impact_uses_buy_date_cohorts():
 def test_publisher_validates_remote_destination_before_execution(tmp_path):
     with pytest.raises(ValueError, match="destination"):
         publisher.publish(
-            container="clickstack",
+            endpoint="http://127.0.0.1:18123",
             local_output=tmp_path / "snapshot.json",
             days=180,
             host="app.example",
@@ -169,6 +179,8 @@ def test_publisher_generates_then_installs_atomically(tmp_path, monkeypatch):
         "data_quality": {"total_events": 3},
     }
     calls = []
+    monkeypatch.setenv("CLICKHOUSE_USER", "prism_otel")
+    monkeypatch.setenv("CLICKHOUSE_PASSWORD", "test-password")
     monkeypatch.setattr(publisher, "load_clickhouse_events", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(publisher, "build_snapshot", lambda *_args, **_kwargs: snapshot)
     monkeypatch.setattr(
@@ -183,7 +195,7 @@ def test_publisher_generates_then_installs_atomically(tmp_path, monkeypatch):
     )
 
     result = publisher.publish(
-        container="clickstack",
+        endpoint="http://127.0.0.1:18123",
         local_output=tmp_path / "snapshot.json",
         days=180,
         host="app.example",
@@ -194,12 +206,12 @@ def test_publisher_generates_then_installs_atomically(tmp_path, monkeypatch):
     )
 
     assert result["events"] == 3
-    assert calls[0][0][0] == "scp"
+    assert calls[0][0][0].endswith("/scp")
     assert "-P" in calls[0][0]
     assert "2222" in calls[0][0]
     assert "/etc/prism-observability/dashboard-publisher" in calls[0][0]
     assert calls[0][0][-1].endswith("observability_insights.json.tmp")
-    assert calls[1][0][0] == "ssh"
+    assert calls[1][0][0].endswith("/ssh")
     assert "-p" in calls[1][0]
     assert "/usr/bin/install" in calls[1][0]
-    assert calls[2][0][0] == "ssh"
+    assert calls[2][0][0].endswith("/ssh")

--- a/tests/test_observability_insights_export.py
+++ b/tests/test_observability_insights_export.py
@@ -159,6 +159,7 @@ def test_publisher_validates_remote_destination_before_execution(tmp_path):
             port=22,
             user="root",
             destination="/tmp/good path.json",
+            identity_file=None,
         )
 
 
@@ -189,11 +190,16 @@ def test_publisher_generates_then_installs_atomically(tmp_path, monkeypatch):
         port=2222,
         user="root",
         destination="/srv/dashboard/observability_insights.json",
+        identity_file="/etc/prism-observability/dashboard-publisher",
     )
 
     assert result["events"] == 3
     assert calls[0][0][0] == "scp"
+    assert "-P" in calls[0][0]
+    assert "2222" in calls[0][0]
+    assert "/etc/prism-observability/dashboard-publisher" in calls[0][0]
     assert calls[0][0][-1].endswith("observability_insights.json.tmp")
     assert calls[1][0][0] == "ssh"
+    assert "-p" in calls[1][0]
     assert "/usr/bin/install" in calls[1][0]
     assert calls[2][0][0] == "ssh"

--- a/tools/backfill_observability.py
+++ b/tools/backfill_observability.py
@@ -11,9 +11,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import re
 import sqlite3
-import subprocess
 import sys
 from collections.abc import Iterable, Iterator, Mapping
 from datetime import datetime, timedelta, timezone
@@ -32,6 +30,57 @@ BACKFILL_VERSION = 1
 DEFAULT_DB = PROJECT_ROOT / "stock_tracking_db.sqlite"
 DEFAULT_REGIME_LOG = PROJECT_ROOT / "logs" / "regime_history.jsonl"
 DEFAULT_STATE = PROJECT_ROOT / "logs" / "observability_backfill_state.json"
+
+_ACTUAL_TABLES = {
+    "KR": "trading_history",
+    "US": "us_trading_history",
+}
+_ACTUAL_QUERIES = {
+    "KR": """
+        SELECT id, ticker, company_name, buy_price, buy_date, sell_price,
+               sell_date, profit_rate, holding_days, scenario, trigger_type,
+               trigger_mode, sector, exit_kind
+        FROM trading_history
+        ORDER BY id
+    """,
+    "US": """
+        SELECT id, ticker, company_name, buy_price, buy_date, sell_price,
+               sell_date, profit_rate, holding_days, scenario, trigger_type,
+               trigger_mode, sector, exit_kind
+        FROM us_trading_history
+        ORDER BY id
+    """,
+}
+_CANDIDATE_TABLES = {
+    "KR": "analysis_performance_tracker",
+    "US": "us_analysis_performance_tracker",
+}
+_CANDIDATE_QUERIES = {
+    "KR": """
+        SELECT id, ticker, company_name, trigger_type, trigger_mode,
+               analyzed_date AS analysis_date, decision, was_traded,
+               skip_reason, buy_score, min_score, target_price, stop_loss,
+               risk_reward_ratio, tracked_7d_return AS return_7d,
+               tracked_14d_return AS return_14d,
+               tracked_30d_return AS return_30d,
+               tracked_30d_date AS outcome_observed_at,
+               NULL AS hit_target, NULL AS hit_stop_loss, NULL AS sector
+        FROM analysis_performance_tracker
+        WHERE tracked_30d_return IS NOT NULL
+        ORDER BY id
+    """,
+    "US": """
+        SELECT id, ticker, company_name, trigger_type, trigger_mode,
+               analysis_date, decision, was_traded, skip_reason, buy_score,
+               NULL AS min_score, target_price, stop_loss,
+               risk_reward_ratio, return_7d, return_14d, return_30d,
+               last_updated AS outcome_observed_at,
+               hit_target, hit_stop_loss, sector
+        FROM us_analysis_performance_tracker
+        WHERE return_30d IS NOT NULL
+        ORDER BY id
+    """,
+}
 
 
 def _event_id(source_key: str) -> str:
@@ -73,14 +122,9 @@ def iter_actual_events(
     *,
     since: datetime,
 ) -> Iterator[dict[str, Any]]:
-    table = "trading_history" if market == "KR" else "us_trading_history"
-    columns = (
-        "id, ticker, company_name, buy_price, buy_date, sell_price, sell_date, "
-        "profit_rate, holding_days, scenario, trigger_type, trigger_mode, "
-        "sector, exit_kind"
-    )
+    table = _ACTUAL_TABLES[market]
     connection.row_factory = sqlite3.Row
-    for row in connection.execute(f"SELECT {columns} FROM {table} ORDER BY id"):
+    for row in connection.execute(_ACTUAL_QUERIES[market]):
         event_time = _parse_time(row["sell_date"])
         if event_time is None or event_time < since:
             continue
@@ -121,36 +165,8 @@ def iter_candidate_events(
     since: datetime,
 ) -> Iterator[dict[str, Any]]:
     connection.row_factory = sqlite3.Row
-    if market == "KR":
-        table = "analysis_performance_tracker"
-        query = f"""
-            SELECT id, ticker, company_name, trigger_type, trigger_mode,
-                   analyzed_date AS analysis_date, decision, was_traded,
-                   skip_reason, buy_score, min_score, target_price, stop_loss,
-                   risk_reward_ratio, tracked_7d_return AS return_7d,
-                   tracked_14d_return AS return_14d,
-                   tracked_30d_return AS return_30d,
-                   tracked_30d_date AS outcome_observed_at,
-                   NULL AS hit_target, NULL AS hit_stop_loss, NULL AS sector
-            FROM {table}
-            WHERE tracked_30d_return IS NOT NULL
-            ORDER BY id
-        """
-    else:
-        table = "us_analysis_performance_tracker"
-        query = f"""
-            SELECT id, ticker, company_name, trigger_type, trigger_mode,
-                   analysis_date, decision, was_traded, skip_reason, buy_score,
-                   NULL AS min_score, target_price, stop_loss,
-                   risk_reward_ratio, return_7d, return_14d, return_30d,
-                   last_updated AS outcome_observed_at,
-                   hit_target, hit_stop_loss, sector
-            FROM {table}
-            WHERE return_30d IS NOT NULL
-            ORDER BY id
-        """
-
-    for row in connection.execute(query):
+    table = _CANDIDATE_TABLES[market]
+    for row in connection.execute(_CANDIDATE_QUERIES[market]):
         event_time = _parse_time(row["analysis_date"])
         if event_time is None or event_time < since:
             continue
@@ -242,53 +258,48 @@ def iter_deployment_events(
     *,
     since: datetime,
 ) -> Iterator[dict[str, Any]]:
-    subjects_result = subprocess.run(
-        ["git", "log", "--all", "--format=%H%x1f%s"],
-        cwd=repo,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    subjects = {}
-    for row in subjects_result.stdout.splitlines():
-        sha, separator, subject = row.partition("\x1f")
-        if separator:
-            subjects[sha] = subject
-    result = subprocess.run(
-        [
-            "git",
-            "reflog",
-            "--date=iso",
-            "--format=%gd%x1f%H%x1f%gs",
-        ],
-        cwd=repo,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    for raw in result.stdout.splitlines():
-        parts = raw.split("\x1f", 2)
-        if len(parts) != 3:
+    dot_git = repo / ".git"
+    if dot_git.is_dir():
+        git_dir = dot_git
+    elif dot_git.is_file():
+        marker = dot_git.read_text(encoding="utf-8").strip()
+        if not marker.startswith("gitdir:"):
+            return
+        git_dir = (repo / marker.split(":", 1)[1].strip()).resolve()
+    else:
+        return
+    reflog = git_dir / "logs" / "HEAD"
+    if not reflog.exists():
+        return
+
+    for raw in reflog.read_text(encoding="utf-8").splitlines():
+        metadata, separator, message = raw.partition("\t")
+        fields = metadata.split()
+        if not separator or len(fields) < 4:
             continue
-        selector, git_sha, message = parts
+        git_sha = fields[1]
         if "pull" not in message and "merge origin/main" not in message:
             continue
-        if "@{" not in selector or not selector.endswith("}"):
+        try:
+            epoch_seconds = int(fields[-2])
+            offset_text = fields[-1]
+            sign = 1 if offset_text.startswith("+") else -1
+            offset = timedelta(
+                hours=int(offset_text[1:3]),
+                minutes=int(offset_text[3:5]),
+            )
+            reflog_timezone = timezone(sign * offset)
+            event_time = datetime.fromtimestamp(
+                epoch_seconds,
+                tz=reflog_timezone,
+            ).astimezone(timezone.utc)
+        except (ValueError, IndexError):
             continue
-        event_time = _parse_time(selector.split("@{", 1)[1][:-1])
-        if event_time is None or event_time < since:
+        if event_time < since:
             continue
-        source_key = f"reflog:{selector}:{git_sha}:v{BACKFILL_VERSION}"
-        subject = subjects.get(git_sha, "")
-        prs = sorted(
-            {
-                int(match)
-                for match in re.findall(
-                    r"(?:pull request |PR\s*)#(\d+)",
-                    subject,
-                    re.IGNORECASE,
-                )
-            }
+        source_key = (
+            f"reflog:{epoch_seconds}:{git_sha}:{message}:"
+            f"v{BACKFILL_VERSION}"
         )
         yield {
             "event_type": "deployment.applied",
@@ -302,8 +313,6 @@ def iter_deployment_events(
                 "verified_actual_deployment": True,
                 "target": "db-server",
                 "git_sha": git_sha,
-                "commit_subject": subject,
-                "prs": prs,
                 "reflog_message": message,
             },
         }

--- a/tools/backfill_observability.py
+++ b/tools/backfill_observability.py
@@ -1,0 +1,412 @@
+"""Backfill trustworthy PRISM facts into the observability JSONL spool.
+
+This intentionally does not reconstruct historical prompts, gates, or traces.
+Only immutable SQLite outcomes, recorded regime snapshots, and server reflog
+deployments are emitted. Every event is marked as a backfill and receives a
+deterministic ID so repeated runs are safe with the local state file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sqlite3
+import subprocess
+import sys
+from collections.abc import Iterable, Iterator, Mapping
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from observability.events import emit_event
+
+KST = ZoneInfo("Asia/Seoul")
+BACKFILL_VERSION = 1
+DEFAULT_DB = PROJECT_ROOT / "stock_tracking_db.sqlite"
+DEFAULT_REGIME_LOG = PROJECT_ROOT / "logs" / "regime_history.jsonl"
+DEFAULT_STATE = PROJECT_ROOT / "logs" / "observability_backfill_state.json"
+
+
+def _event_id(source_key: str) -> str:
+    return hashlib.sha256(source_key.encode("utf-8")).hexdigest()[:32]
+
+
+def _parse_time(value: Any, *, default_timezone=KST) -> datetime | None:
+    if not value:
+        return None
+    text = str(value).strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=default_timezone)
+    return parsed.astimezone(timezone.utc)
+
+
+def _hash_text(value: Any) -> str | None:
+    if value in (None, ""):
+        return None
+    return hashlib.sha256(str(value).encode("utf-8")).hexdigest()[:16]
+
+
+def _base_attributes(source_table: str, source_id: Any) -> dict[str, Any]:
+    return {
+        "ingestion_mode": "backfill",
+        "backfill_version": BACKFILL_VERSION,
+        "source": "production_sqlite",
+        "source_table": source_table,
+        "source_id": str(source_id),
+    }
+
+
+def iter_actual_events(
+    connection: sqlite3.Connection,
+    market: str,
+    *,
+    since: datetime,
+) -> Iterator[dict[str, Any]]:
+    table = "trading_history" if market == "KR" else "us_trading_history"
+    columns = (
+        "id, ticker, company_name, buy_price, buy_date, sell_price, sell_date, "
+        "profit_rate, holding_days, scenario, trigger_type, trigger_mode, "
+        "sector, exit_kind"
+    )
+    connection.row_factory = sqlite3.Row
+    for row in connection.execute(f"SELECT {columns} FROM {table} ORDER BY id"):
+        event_time = _parse_time(row["sell_date"])
+        if event_time is None or event_time < since:
+            continue
+        source_key = f"sqlite:{table}:{row['id']}:v{BACKFILL_VERSION}"
+        attributes = _base_attributes(table, row["id"])
+        attributes.update(
+            {
+                "company_name": row["company_name"],
+                "buy_price": row["buy_price"],
+                "buy_date": row["buy_date"],
+                "sell_price": row["sell_price"],
+                "sell_date": row["sell_date"],
+                "profit_rate_pct": row["profit_rate"],
+                "holding_days": row["holding_days"],
+                "scenario_hash": _hash_text(row["scenario"]),
+                "trigger_type": row["trigger_type"],
+                "trigger_mode": row["trigger_mode"],
+                "sector": row["sector"],
+                "exit_kind": row["exit_kind"],
+            }
+        )
+        yield {
+            "event_type": "trade.outcome",
+            "event_id": _event_id(source_key),
+            "service": f"prism-{market.lower()}-history",
+            "market": market,
+            "ticker": row["ticker"],
+            "position_id": f"legacy:{market}:{row['id']}",
+            "event_time": event_time,
+            "attributes": attributes,
+        }
+
+
+def iter_candidate_events(
+    connection: sqlite3.Connection,
+    market: str,
+    *,
+    since: datetime,
+) -> Iterator[dict[str, Any]]:
+    connection.row_factory = sqlite3.Row
+    if market == "KR":
+        table = "analysis_performance_tracker"
+        query = f"""
+            SELECT id, ticker, company_name, trigger_type, trigger_mode,
+                   analyzed_date AS analysis_date, decision, was_traded,
+                   skip_reason, buy_score, min_score, target_price, stop_loss,
+                   risk_reward_ratio, tracked_7d_return AS return_7d,
+                   tracked_14d_return AS return_14d,
+                   tracked_30d_return AS return_30d,
+                   tracked_30d_date AS outcome_observed_at,
+                   NULL AS hit_target, NULL AS hit_stop_loss, NULL AS sector
+            FROM {table}
+            WHERE tracked_30d_return IS NOT NULL
+            ORDER BY id
+        """
+    else:
+        table = "us_analysis_performance_tracker"
+        query = f"""
+            SELECT id, ticker, company_name, trigger_type, trigger_mode,
+                   analysis_date, decision, was_traded, skip_reason, buy_score,
+                   NULL AS min_score, target_price, stop_loss,
+                   risk_reward_ratio, return_7d, return_14d, return_30d,
+                   last_updated AS outcome_observed_at,
+                   hit_target, hit_stop_loss, sector
+            FROM {table}
+            WHERE return_30d IS NOT NULL
+            ORDER BY id
+        """
+
+    for row in connection.execute(query):
+        event_time = _parse_time(row["analysis_date"])
+        if event_time is None or event_time < since:
+            continue
+        source_key = f"sqlite:{table}:{row['id']}:v{BACKFILL_VERSION}"
+        attributes = _base_attributes(table, row["id"])
+        attributes.update(
+            {
+                "company_name": row["company_name"],
+                "analysis_date": row["analysis_date"],
+                "outcome_observed_at": row["outcome_observed_at"],
+                "trigger_type": row["trigger_type"],
+                "trigger_mode": row["trigger_mode"],
+                "sector": row["sector"],
+                "decision": row["decision"],
+                "was_traded": int(row["was_traded"] or 0),
+                "skip_reason": row["skip_reason"],
+                "buy_score": row["buy_score"],
+                "min_score": row["min_score"],
+                "target_price": row["target_price"],
+                "stop_loss": row["stop_loss"],
+                "risk_reward_ratio": row["risk_reward_ratio"],
+                "return_7d_pct": (
+                    float(row["return_7d"]) * 100
+                    if row["return_7d"] is not None
+                    else None
+                ),
+                "return_14d_pct": (
+                    float(row["return_14d"]) * 100
+                    if row["return_14d"] is not None
+                    else None
+                ),
+                "return_30d_pct": float(row["return_30d"]) * 100,
+                "hit_target": row["hit_target"],
+                "hit_stop_loss": row["hit_stop_loss"],
+            }
+        )
+        yield {
+            "event_type": "candidate.outcome",
+            "event_id": _event_id(source_key),
+            "service": f"prism-{market.lower()}-candidate-history",
+            "market": market,
+            "ticker": row["ticker"],
+            "decision_id": f"legacy-candidate:{market}:{row['id']}",
+            "event_time": event_time,
+            "attributes": attributes,
+        }
+
+
+def iter_regime_events(path: Path, *, since: datetime) -> Iterator[dict[str, Any]]:
+    if not path.exists():
+        return
+    for line_number, raw in enumerate(
+        path.read_text(encoding="utf-8").splitlines(),
+        1,
+    ):
+        try:
+            row = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        event_time = _parse_time(row.get("ts"))
+        market = str(row.get("market") or "").upper()
+        if event_time is None or event_time < since or market not in {"KR", "US"}:
+            continue
+        digest = hashlib.sha256(raw.encode()).hexdigest()
+        source_key = f"regime:{digest}:v{BACKFILL_VERSION}"
+        attributes = {
+            "ingestion_mode": "backfill",
+            "backfill_version": BACKFILL_VERSION,
+            "source": "regime_history_jsonl",
+            "source_line": line_number,
+            **{
+                key: value
+                for key, value in row.items()
+                if key not in {"ts", "market"}
+            },
+        }
+        yield {
+            "event_type": "market.regime_snapshot",
+            "event_id": _event_id(source_key),
+            "service": "prism-regime-history",
+            "market": market,
+            "event_time": event_time,
+            "attributes": attributes,
+        }
+
+
+def iter_deployment_events(
+    repo: Path,
+    *,
+    since: datetime,
+) -> Iterator[dict[str, Any]]:
+    subjects_result = subprocess.run(
+        ["git", "log", "--all", "--format=%H%x1f%s"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subjects = {}
+    for row in subjects_result.stdout.splitlines():
+        sha, separator, subject = row.partition("\x1f")
+        if separator:
+            subjects[sha] = subject
+    result = subprocess.run(
+        [
+            "git",
+            "reflog",
+            "--date=iso",
+            "--format=%gd%x1f%H%x1f%gs",
+        ],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    for raw in result.stdout.splitlines():
+        parts = raw.split("\x1f", 2)
+        if len(parts) != 3:
+            continue
+        selector, git_sha, message = parts
+        if "pull" not in message and "merge origin/main" not in message:
+            continue
+        if "@{" not in selector or not selector.endswith("}"):
+            continue
+        event_time = _parse_time(selector.split("@{", 1)[1][:-1])
+        if event_time is None or event_time < since:
+            continue
+        source_key = f"reflog:{selector}:{git_sha}:v{BACKFILL_VERSION}"
+        subject = subjects.get(git_sha, "")
+        prs = sorted(
+            {
+                int(match)
+                for match in re.findall(
+                    r"(?:pull request |PR\s*)#(\d+)",
+                    subject,
+                    re.IGNORECASE,
+                )
+            }
+        )
+        yield {
+            "event_type": "deployment.applied",
+            "event_id": _event_id(source_key),
+            "service": "prism-deployment-history",
+            "event_time": event_time,
+            "attributes": {
+                "ingestion_mode": "backfill",
+                "backfill_version": BACKFILL_VERSION,
+                "source": "git_reflog",
+                "verified_actual_deployment": True,
+                "target": "db-server",
+                "git_sha": git_sha,
+                "commit_subject": subject,
+                "prs": prs,
+                "reflog_message": message,
+            },
+        }
+
+
+def load_state(path: Path) -> set[str]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+        return {str(item) for item in value.get("emitted_event_ids", [])}
+    except (OSError, TypeError, json.JSONDecodeError):
+        return set()
+
+
+def save_state(path: Path, event_ids: set[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "backfill_version": BACKFILL_VERSION,
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+                "emitted_event_ids": sorted(event_ids),
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    temporary.chmod(0o600)
+    temporary.replace(path)
+
+
+def emit_backfill(
+    events: Iterable[Mapping[str, Any]],
+    *,
+    emitted_ids: set[str],
+    dry_run: bool,
+) -> dict[str, int]:
+    counts = {"discovered": 0, "emitted": 0, "skipped": 0, "failed": 0}
+    for event in events:
+        counts["discovered"] += 1
+        event_id = str(event["event_id"])
+        if event_id in emitted_ids:
+            counts["skipped"] += 1
+            continue
+        if dry_run:
+            counts["emitted"] += 1
+            continue
+        result = emit_event(**event)
+        if result is None:
+            counts["failed"] += 1
+            continue
+        emitted_ids.add(event_id)
+        counts["emitted"] += 1
+    return counts
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB)
+    parser.add_argument("--regime-log", type=Path, default=DEFAULT_REGIME_LOG)
+    parser.add_argument("--repo", type=Path, default=PROJECT_ROOT)
+    parser.add_argument("--state", type=Path, default=DEFAULT_STATE)
+    parser.add_argument("--days", type=int, default=180)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    since = datetime.now(timezone.utc) - timedelta(days=max(1, args.days))
+    emitted_ids = load_state(args.state)
+    connection = sqlite3.connect(f"file:{args.db}?mode=ro", uri=True)
+    try:
+        groups = {
+            "kr_actual": iter_actual_events(connection, "KR", since=since),
+            "us_actual": iter_actual_events(connection, "US", since=since),
+            "kr_candidate": iter_candidate_events(connection, "KR", since=since),
+            "us_candidate": iter_candidate_events(connection, "US", since=since),
+            "regime": iter_regime_events(args.regime_log, since=since),
+            "deployment": iter_deployment_events(args.repo, since=since),
+        }
+        summary = {
+            name: emit_backfill(
+                events,
+                emitted_ids=emitted_ids,
+                dry_run=args.dry_run,
+            )
+            for name, events in groups.items()
+        }
+    finally:
+        connection.close()
+    if not args.dry_run:
+        save_state(args.state, emitted_ids)
+    print(
+        json.dumps(
+            {
+                "since": since.isoformat(),
+                "dry_run": args.dry_run,
+                "groups": summary,
+            },
+            indent=2,
+        )
+    )
+    return 1 if any(group["failed"] for group in summary.values()) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/export_observability_insights.py
+++ b/tools/export_observability_insights.py
@@ -1,0 +1,414 @@
+"""Build a sanitized dashboard snapshot from PRISM ClickHouse events."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+from collections import Counter
+from collections.abc import Iterable, Mapping
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+KST = ZoneInfo("Asia/Seoul")
+EVENT_TYPES = {
+    "candidate.outcome",
+    "deployment.applied",
+    "market.regime_snapshot",
+    "trade.outcome",
+    "trigger.performance_feedback",
+}
+
+
+def _parse_time(value: Any, *, default_timezone=KST) -> datetime | None:
+    if not value:
+        return None
+    text = str(value).strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=default_timezone)
+    return parsed.astimezone(timezone.utc)
+
+
+def _mean(values: list[float]) -> float | None:
+    return statistics.mean(values) if values else None
+
+
+def _median(values: list[float]) -> float | None:
+    return statistics.median(values) if values else None
+
+
+def _rounded(value: float | None, digits: int = 3) -> float | None:
+    return round(value, digits) if value is not None else None
+
+
+def _profit_factor(values: list[float]) -> float | None:
+    wins = sum(value for value in values if value > 0)
+    gross_loss = abs(sum(value for value in values if value < 0))
+    return wins / gross_loss if gross_loss else None
+
+
+def _trade_metrics(events: list[dict[str, Any]]) -> dict[str, Any]:
+    returns = [
+        float(event["attributes"]["profit_rate_pct"])
+        for event in events
+        if event.get("attributes", {}).get("profit_rate_pct") is not None
+    ]
+    wins = [value for value in returns if value > 0]
+    losses = [value for value in returns if value < 0]
+    stop_count = sum(
+        any(
+            marker in str(event.get("attributes", {}).get("exit_kind") or "").lower()
+            for marker in ("stop", "hard", "risk", "손절")
+        )
+        for event in events
+    )
+    return {
+        "count": len(returns),
+        "win_rate": _rounded(len(wins) / len(returns) if returns else None),
+        "avg_return_pct": _rounded(_mean(returns)),
+        "median_return_pct": _rounded(_median(returns)),
+        "avg_win_pct": _rounded(_mean(wins)),
+        "avg_loss_pct": _rounded(_mean(losses)),
+        "profit_factor": _rounded(_profit_factor(returns)),
+        "stop_rate": _rounded(stop_count / len(events) if events else None),
+        "sample_sufficient": len(returns) >= 5,
+    }
+
+
+def _candidate_metrics(events: list[dict[str, Any]]) -> dict[str, Any]:
+    watched = [
+        event
+        for event in events
+        if int(event.get("attributes", {}).get("was_traded") or 0) == 0
+    ]
+
+    def values(key: str) -> list[float]:
+        return [
+            float(event["attributes"][key])
+            for event in watched
+            if event.get("attributes", {}).get(key) is not None
+        ]
+
+    returns_7 = values("return_7d_pct")
+    returns_14 = values("return_14d_pct")
+    returns_30 = values("return_30d_pct")
+    return {
+        "count": len(returns_30),
+        "positive_rate_30d": _rounded(
+            sum(value > 0 for value in returns_30) / len(returns_30)
+            if returns_30
+            else None
+        ),
+        "avg_7d_pct": _rounded(_mean(returns_7)),
+        "median_7d_pct": _rounded(_median(returns_7)),
+        "avg_14d_pct": _rounded(_mean(returns_14)),
+        "median_14d_pct": _rounded(_median(returns_14)),
+        "avg_30d_pct": _rounded(_mean(returns_30)),
+        "median_30d_pct": _rounded(_median(returns_30)),
+        "sample_sufficient": len(returns_30) >= 5,
+    }
+
+
+def _deduplicate(events: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    by_id: dict[str, dict[str, Any]] = {}
+    for raw in events:
+        event = dict(raw)
+        event_id = str(event.get("event_id") or "")
+        if not event_id or event.get("event_type") not in EVENT_TYPES:
+            continue
+        existing = by_id.get(event_id)
+        if existing is None or str(event.get("timestamp") or "") > str(
+            existing.get("timestamp") or ""
+        ):
+            by_id[event_id] = event
+    return list(by_id.values())
+
+
+def _deployment_records(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    records: dict[tuple[str, str], dict[str, Any]] = {}
+    for event in events:
+        if event.get("event_type") != "deployment.applied":
+            continue
+        attributes = event.get("attributes") or {}
+        git_sha = str(attributes.get("git_sha") or event.get("git_sha") or "")
+        target = str(attributes.get("target") or "unknown")
+        timestamp = _parse_time(event.get("timestamp"))
+        if not git_sha or timestamp is None:
+            continue
+        record = {
+            "timestamp": timestamp.isoformat().replace("+00:00", "Z"),
+            "git_sha": git_sha,
+            "target": target,
+            "prs": attributes.get("prs") or [],
+            "subject": attributes.get("commit_subject") or attributes.get("subject"),
+            "ingestion_mode": attributes.get("ingestion_mode", "live"),
+            "verified_actual_deployment": bool(
+                attributes.get("verified_actual_deployment")
+                or attributes.get("ingestion_mode") != "backfill"
+            ),
+        }
+        key = (git_sha, target)
+        existing = records.get(key)
+        if existing is None:
+            records[key] = record
+            continue
+        if existing["ingestion_mode"] == "backfill" and record["ingestion_mode"] != "backfill":
+            records[key] = record
+    return sorted(records.values(), key=lambda item: item["timestamp"])
+
+
+def _market_snapshot(
+    events: list[dict[str, Any]],
+    market: str,
+) -> dict[str, Any]:
+    actual = [
+        event
+        for event in events
+        if event.get("event_type") == "trade.outcome" and event.get("market") == market
+    ]
+    candidates = [
+        event
+        for event in events
+        if event.get("event_type") == "candidate.outcome"
+        and event.get("market") == market
+    ]
+    regimes = [
+        event
+        for event in events
+        if event.get("event_type") == "market.regime_snapshot"
+        and event.get("market") == market
+    ]
+    triggers = sorted(
+        {
+            str(event.get("attributes", {}).get("trigger_type"))
+            for event in actual + candidates
+            if event.get("attributes", {}).get("trigger_type")
+        }
+    )
+    trigger_rows = []
+    for trigger in triggers:
+        trigger_actual = [
+            event
+            for event in actual
+            if event.get("attributes", {}).get("trigger_type") == trigger
+        ]
+        trigger_candidates = [
+            event
+            for event in candidates
+            if event.get("attributes", {}).get("trigger_type") == trigger
+        ]
+        trigger_rows.append(
+            {
+                "trigger_type": trigger,
+                "actual": _trade_metrics(trigger_actual),
+                "candidate": _candidate_metrics(trigger_candidates),
+            }
+        )
+    trigger_rows.sort(
+        key=lambda row: (
+            -(row["actual"]["count"] + row["candidate"]["count"]),
+            row["trigger_type"],
+        )
+    )
+
+    regime_counts = Counter(
+        str(event.get("attributes", {}).get("regime") or "unknown")
+        for event in regimes
+    )
+    latest_regime = None
+    if regimes:
+        latest = max(regimes, key=lambda event: str(event.get("timestamp") or ""))
+        latest_regime = {
+            "regime": latest.get("attributes", {}).get("regime"),
+            "confidence": latest.get("attributes", {}).get("confidence"),
+            "observed_at": latest.get("timestamp"),
+        }
+
+    return {
+        "actual": _trade_metrics(actual),
+        "candidate": _candidate_metrics(candidates),
+        "triggers": trigger_rows,
+        "latest_regime": latest_regime,
+        "regime_distribution": [
+            {"regime": regime, "count": count}
+            for regime, count in regime_counts.most_common()
+        ],
+    }
+
+
+def _deployment_impacts(
+    events: list[dict[str, Any]],
+    deployments: list[dict[str, Any]],
+    *,
+    now: datetime,
+    window_days: int = 14,
+) -> list[dict[str, Any]]:
+    actual_by_market = {
+        market: [
+            event
+            for event in events
+            if event.get("event_type") == "trade.outcome"
+            and event.get("market") == market
+        ]
+        for market in ("KR", "US")
+    }
+    window = timedelta(days=window_days)
+    impacts = []
+    for deployment in deployments[-20:]:
+        deployed_at = _parse_time(deployment["timestamp"])
+        if deployed_at is None:
+            continue
+        markets = {}
+        for market, trades in actual_by_market.items():
+            pre = []
+            post = []
+            for trade in trades:
+                buy_at = _parse_time(trade.get("attributes", {}).get("buy_date"))
+                if buy_at is None:
+                    continue
+                if deployed_at - window <= buy_at < deployed_at:
+                    pre.append(trade)
+                elif deployed_at <= buy_at < deployed_at + window:
+                    post.append(trade)
+            markets[market] = {
+                "pre": _trade_metrics(pre),
+                "post": _trade_metrics(post),
+            }
+        impacts.append(
+            {
+                **deployment,
+                "window_days": window_days,
+                "post_window_complete": now >= deployed_at + window,
+                "markets": markets,
+            }
+        )
+    return impacts
+
+
+def build_snapshot(
+    raw_events: Iterable[Mapping[str, Any]],
+    *,
+    now: datetime | None = None,
+    retention_days: int = 180,
+) -> dict[str, Any]:
+    current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    events = _deduplicate(raw_events)
+    timestamps = [
+        parsed
+        for parsed in (_parse_time(event.get("timestamp")) for event in events)
+        if parsed is not None
+    ]
+    deployments = _deployment_records(events)
+    backfill_count = sum(
+        event.get("attributes", {}).get("ingestion_mode") == "backfill"
+        for event in events
+    )
+    return {
+        "schema_version": 1,
+        "generated_at": current.isoformat().replace("+00:00", "Z"),
+        "retention_days": retention_days,
+        "data_quality": {
+            "total_events": len(events),
+            "backfill_events": backfill_count,
+            "live_events": len(events) - backfill_count,
+            "coverage_start": min(timestamps).isoformat().replace("+00:00", "Z")
+            if timestamps
+            else None,
+            "last_event_at": max(timestamps).isoformat().replace("+00:00", "Z")
+            if timestamps
+            else None,
+        },
+        "markets": {
+            market: _market_snapshot(events, market)
+            for market in ("KR", "US")
+        },
+        "deployments": deployments[-50:],
+        "deployment_impacts": _deployment_impacts(
+            events,
+            deployments,
+            now=current,
+        ),
+    }
+
+
+def load_clickhouse_events(container: str, *, days: int) -> list[dict[str, Any]]:
+    event_list = ", ".join(f"'{value}'" for value in sorted(EVENT_TYPES))
+    query = f"""
+        SELECT Body
+        FROM otel_logs
+        WHERE TimestampTime >= now() - INTERVAL {max(1, days)} DAY
+          AND LogAttributes['event.name'] IN ({event_list})
+        FORMAT JSONEachRow
+    """
+    result = subprocess.run(
+        [
+            "docker",
+            "exec",
+            container,
+            "clickhouse-client",
+            "--query",
+            query,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    events = []
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        body = json.loads(row["Body"])
+        if isinstance(body, dict):
+            events.append(body)
+    return events
+
+
+def write_snapshot(path: Path, snapshot: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(snapshot, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    temporary.chmod(0o644)
+    temporary.replace(path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--container", default="prism-clickstack")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path(
+            "/var/lib/prism-observability/exports/observability_insights.json"
+        ),
+    )
+    parser.add_argument("--days", type=int, default=180)
+    args = parser.parse_args(argv)
+
+    events = load_clickhouse_events(args.container, days=args.days)
+    snapshot = build_snapshot(events, retention_days=max(1, args.days))
+    write_snapshot(args.output, snapshot)
+    print(
+        json.dumps(
+            {
+                "output": str(args.output),
+                "events": snapshot["data_quality"]["total_events"],
+                "generated_at": snapshot["generated_at"],
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/export_observability_insights.py
+++ b/tools/export_observability_insights.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import http.client
 import json
 import os
 import statistics
 import urllib.parse
-import urllib.request
 from collections import Counter
 from collections.abc import Iterable, Mapping
 from datetime import datetime, timedelta, timezone
@@ -364,19 +364,29 @@ def load_clickhouse_events(
     if parsed.scheme != "http" or parsed.hostname not in {"127.0.0.1", "localhost"}:
         raise ValueError("ClickHouse dashboard endpoint must be local HTTP")
     query = urllib.parse.urlencode({"param_days": max(1, days)})
-    url = endpoint.rstrip("/") + "/?" + query
-    request = urllib.request.Request(
-        url,
-        data=_CLICKHOUSE_EVENTS_QUERY.encode("utf-8"),
-        headers={
+    path = (parsed.path.rstrip("/") or "") + "/?" + query
+    connection = http.client.HTTPConnection(
+        parsed.hostname,
+        parsed.port or 80,
+        timeout=15,
+    )
+    try:
+        connection.request(
+            "POST",
+            path,
+            body=_CLICKHOUSE_EVENTS_QUERY.encode("utf-8"),
+            headers={
             "Content-Type": "text/plain; charset=utf-8",
             "X-ClickHouse-User": user,
             "X-ClickHouse-Key": password,
-        },
-        method="POST",
-    )
-    with urllib.request.urlopen(request, timeout=15) as response:
+            },
+        )
+        response = connection.getresponse()
+        if not 200 <= response.status < 300:
+            raise RuntimeError(f"ClickHouse HTTP {response.status}")
         output = response.read().decode("utf-8")
+    finally:
+        connection.close()
     events = []
     for line in output.splitlines():
         if not line.strip():

--- a/tools/export_observability_insights.py
+++ b/tools/export_observability_insights.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import statistics
-import subprocess
+import urllib.parse
+import urllib.request
 from collections import Counter
 from collections.abc import Iterable, Mapping
 from datetime import datetime, timedelta, timezone
@@ -21,6 +23,19 @@ EVENT_TYPES = {
     "trade.outcome",
     "trigger.performance_feedback",
 }
+_CLICKHOUSE_EVENTS_QUERY = """
+    SELECT Body
+    FROM otel_logs
+    WHERE TimestampTime >= now() - INTERVAL {days:UInt16} DAY
+      AND LogAttributes['event.name'] IN (
+        'candidate.outcome',
+        'deployment.applied',
+        'market.regime_snapshot',
+        'trade.outcome',
+        'trigger.performance_feedback'
+      )
+    FORMAT JSONEachRow
+"""
 
 
 def _parse_time(value: Any, *, default_timezone=KST) -> datetime | None:
@@ -338,30 +353,32 @@ def build_snapshot(
     }
 
 
-def load_clickhouse_events(container: str, *, days: int) -> list[dict[str, Any]]:
-    event_list = ", ".join(f"'{value}'" for value in sorted(EVENT_TYPES))
-    query = f"""
-        SELECT Body
-        FROM otel_logs
-        WHERE TimestampTime >= now() - INTERVAL {max(1, days)} DAY
-          AND LogAttributes['event.name'] IN ({event_list})
-        FORMAT JSONEachRow
-    """
-    result = subprocess.run(
-        [
-            "docker",
-            "exec",
-            container,
-            "clickhouse-client",
-            "--query",
-            query,
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
+def load_clickhouse_events(
+    endpoint: str,
+    *,
+    user: str,
+    password: str,
+    days: int,
+) -> list[dict[str, Any]]:
+    parsed = urllib.parse.urlparse(endpoint)
+    if parsed.scheme != "http" or parsed.hostname not in {"127.0.0.1", "localhost"}:
+        raise ValueError("ClickHouse dashboard endpoint must be local HTTP")
+    query = urllib.parse.urlencode({"param_days": max(1, days)})
+    url = endpoint.rstrip("/") + "/?" + query
+    request = urllib.request.Request(
+        url,
+        data=_CLICKHOUSE_EVENTS_QUERY.encode("utf-8"),
+        headers={
+            "Content-Type": "text/plain; charset=utf-8",
+            "X-ClickHouse-User": user,
+            "X-ClickHouse-Key": password,
+        },
+        method="POST",
     )
+    with urllib.request.urlopen(request, timeout=15) as response:
+        output = response.read().decode("utf-8")
     events = []
-    for line in result.stdout.splitlines():
+    for line in output.splitlines():
         if not line.strip():
             continue
         row = json.loads(line)
@@ -384,7 +401,10 @@ def write_snapshot(path: Path, snapshot: Mapping[str, Any]) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--container", default="prism-clickstack")
+    parser.add_argument(
+        "--endpoint",
+        default=os.getenv("CLICKHOUSE_HTTP_ENDPOINT", "http://127.0.0.1:18123"),
+    )
     parser.add_argument(
         "--output",
         type=Path,
@@ -395,7 +415,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--days", type=int, default=180)
     args = parser.parse_args(argv)
 
-    events = load_clickhouse_events(args.container, days=args.days)
+    events = load_clickhouse_events(
+        args.endpoint,
+        user=os.getenv("CLICKHOUSE_USER", "prism_otel"),
+        password=os.getenv("CLICKHOUSE_PASSWORD", ""),
+        days=args.days,
+    )
     snapshot = build_snapshot(events, retention_days=max(1, args.days))
     write_snapshot(args.output, snapshot)
     print(

--- a/tools/publish_observability_insights.py
+++ b/tools/publish_observability_insights.py
@@ -43,6 +43,7 @@ def publish(
     port: int,
     user: str,
     destination: str,
+    identity_file: str | None = None,
 ) -> dict[str, object]:
     if not _SAFE_HOST.fullmatch(host):
         raise ValueError("invalid dashboard host")
@@ -52,6 +53,8 @@ def publish(
         raise ValueError("invalid dashboard destination")
     if not 1 <= port <= 65535:
         raise ValueError("invalid dashboard SSH port")
+    if identity_file and not Path(identity_file).is_absolute():
+        raise ValueError("dashboard identity file must be absolute")
 
     events = load_clickhouse_events(container, days=days)
     snapshot = build_snapshot(events, retention_days=days)
@@ -59,18 +62,20 @@ def publish(
 
     remote = f"{user}@{host}"
     remote_temporary = destination + ".tmp"
-    common_ssh = [
+    common_options = [
         "-o",
         "BatchMode=yes",
         "-o",
         "ConnectTimeout=10",
-        "-p",
-        str(port),
     ]
+    if identity_file:
+        common_options.extend(["-i", identity_file])
+    scp_options = [*common_options, "-P", str(port)]
+    ssh_options = [*common_options, "-p", str(port)]
     subprocess.run(
         [
             "scp",
-            *common_ssh,
+            *scp_options,
             str(local_output),
             f"{remote}:{remote_temporary}",
         ],
@@ -80,7 +85,7 @@ def publish(
     subprocess.run(
         [
             "ssh",
-            *common_ssh,
+            *ssh_options,
             remote,
             "/usr/bin/install",
             "-m",
@@ -93,7 +98,7 @@ def publish(
         timeout=30,
     )
     subprocess.run(
-        ["ssh", *common_ssh, remote, "/usr/bin/rm", "-f", "--", remote_temporary],
+        ["ssh", *ssh_options, remote, "/usr/bin/rm", "-f", "--", remote_temporary],
         check=True,
         timeout=30,
     )
@@ -125,6 +130,7 @@ def main(argv: list[str] | None = None) -> int:
         port=int(os.getenv("PRISM_DASHBOARD_PORT", "22")),
         user=os.getenv("PRISM_DASHBOARD_USER", "root"),
         destination=_required_env("PRISM_DASHBOARD_DESTINATION"),
+        identity_file=os.getenv("PRISM_DASHBOARD_IDENTITY") or None,
     )
     print(json.dumps(result))
     return 0

--- a/tools/publish_observability_insights.py
+++ b/tools/publish_observability_insights.py
@@ -1,0 +1,134 @@
+"""Generate the curated observability snapshot and publish it atomically."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+if __package__:
+    from .export_observability_insights import (
+        build_snapshot,
+        load_clickhouse_events,
+        write_snapshot,
+    )
+else:
+    from export_observability_insights import (
+        build_snapshot,
+        load_clickhouse_events,
+        write_snapshot,
+    )
+
+_SAFE_REMOTE_PATH = re.compile(r"^/[A-Za-z0-9_./-]+$")
+_SAFE_HOST = re.compile(r"^[A-Za-z0-9_.:-]+$")
+_SAFE_USER = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _required_env(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if not value:
+        raise ValueError(f"{name} is required")
+    return value
+
+
+def publish(
+    *,
+    container: str,
+    local_output: Path,
+    days: int,
+    host: str,
+    port: int,
+    user: str,
+    destination: str,
+) -> dict[str, object]:
+    if not _SAFE_HOST.fullmatch(host):
+        raise ValueError("invalid dashboard host")
+    if not _SAFE_USER.fullmatch(user):
+        raise ValueError("invalid dashboard user")
+    if not _SAFE_REMOTE_PATH.fullmatch(destination):
+        raise ValueError("invalid dashboard destination")
+    if not 1 <= port <= 65535:
+        raise ValueError("invalid dashboard SSH port")
+
+    events = load_clickhouse_events(container, days=days)
+    snapshot = build_snapshot(events, retention_days=days)
+    write_snapshot(local_output, snapshot)
+
+    remote = f"{user}@{host}"
+    remote_temporary = destination + ".tmp"
+    common_ssh = [
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=10",
+        "-p",
+        str(port),
+    ]
+    subprocess.run(
+        [
+            "scp",
+            *common_ssh,
+            str(local_output),
+            f"{remote}:{remote_temporary}",
+        ],
+        check=True,
+        timeout=30,
+    )
+    subprocess.run(
+        [
+            "ssh",
+            *common_ssh,
+            remote,
+            "/usr/bin/install",
+            "-m",
+            "0644",
+            "--",
+            remote_temporary,
+            destination,
+        ],
+        check=True,
+        timeout=30,
+    )
+    subprocess.run(
+        ["ssh", *common_ssh, remote, "/usr/bin/rm", "-f", "--", remote_temporary],
+        check=True,
+        timeout=30,
+    )
+    return {
+        "generated_at": snapshot["generated_at"],
+        "events": snapshot["data_quality"]["total_events"],
+        "destination": destination,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--container", default="prism-clickstack")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path(
+            "/var/lib/prism-observability/exports/observability_insights.json"
+        ),
+    )
+    parser.add_argument("--days", type=int, default=180)
+    args = parser.parse_args(argv)
+
+    result = publish(
+        container=args.container,
+        local_output=args.output,
+        days=max(1, args.days),
+        host=_required_env("PRISM_DASHBOARD_HOST"),
+        port=int(os.getenv("PRISM_DASHBOARD_PORT", "22")),
+        user=os.getenv("PRISM_DASHBOARD_USER", "root"),
+        destination=_required_env("PRISM_DASHBOARD_DESTINATION"),
+    )
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/publish_observability_insights.py
+++ b/tools/publish_observability_insights.py
@@ -6,7 +6,7 @@ import argparse
 import json
 import os
 import re
-import subprocess
+import subprocess  # nosec B404 - fixed absolute binaries with validated arguments
 from pathlib import Path
 
 if __package__:
@@ -25,6 +25,8 @@ else:
 _SAFE_REMOTE_PATH = re.compile(r"^/[A-Za-z0-9_./-]+$")
 _SAFE_HOST = re.compile(r"^[A-Za-z0-9_.:-]+$")
 _SAFE_USER = re.compile(r"^[A-Za-z0-9_-]+$")
+_SCP = "/usr/bin/scp"
+_SSH = "/usr/bin/ssh"
 
 
 def _required_env(name: str) -> str:
@@ -36,7 +38,7 @@ def _required_env(name: str) -> str:
 
 def publish(
     *,
-    container: str,
+    endpoint: str,
     local_output: Path,
     days: int,
     host: str,
@@ -56,7 +58,12 @@ def publish(
     if identity_file and not Path(identity_file).is_absolute():
         raise ValueError("dashboard identity file must be absolute")
 
-    events = load_clickhouse_events(container, days=days)
+    events = load_clickhouse_events(
+        endpoint,
+        user=_required_env("CLICKHOUSE_USER"),
+        password=_required_env("CLICKHOUSE_PASSWORD"),
+        days=days,
+    )
     snapshot = build_snapshot(events, retention_days=days)
     write_snapshot(local_output, snapshot)
 
@@ -72,9 +79,9 @@ def publish(
         common_options.extend(["-i", identity_file])
     scp_options = [*common_options, "-P", str(port)]
     ssh_options = [*common_options, "-p", str(port)]
-    subprocess.run(
+    subprocess.run(  # nosec B603 - all inputs are validated and shell=False
         [
-            "scp",
+            _SCP,
             *scp_options,
             str(local_output),
             f"{remote}:{remote_temporary}",
@@ -82,9 +89,9 @@ def publish(
         check=True,
         timeout=30,
     )
-    subprocess.run(
+    subprocess.run(  # nosec B603 - all inputs are validated and shell=False
         [
-            "ssh",
+            _SSH,
             *ssh_options,
             remote,
             "/usr/bin/install",
@@ -97,8 +104,8 @@ def publish(
         check=True,
         timeout=30,
     )
-    subprocess.run(
-        ["ssh", *ssh_options, remote, "/usr/bin/rm", "-f", "--", remote_temporary],
+    subprocess.run(  # nosec B603 - all inputs are validated and shell=False
+        [_SSH, *ssh_options, remote, "/usr/bin/rm", "-f", "--", remote_temporary],
         check=True,
         timeout=30,
     )
@@ -111,7 +118,10 @@ def publish(
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--container", default="prism-clickstack")
+    parser.add_argument(
+        "--endpoint",
+        default=os.getenv("CLICKHOUSE_HTTP_ENDPOINT", "http://127.0.0.1:18123"),
+    )
     parser.add_argument(
         "--output",
         type=Path,
@@ -123,7 +133,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     result = publish(
-        container=args.container,
+        endpoint=args.endpoint,
         local_output=args.output,
         days=max(1, args.days),
         host=_required_env("PRISM_DASHBOARD_HOST"),


### PR DESCRIPTION
## Summary
- backfill only verified KR/US trades, watched-candidate outcomes, regime snapshots, and actual server deploy reflog entries
- use deterministic event IDs and a local state file for idempotency
- aggregate ClickHouse events into a credential-free observability_insights.json snapshot
- extend the existing dashboard Insights tab with market health, Candidate vs Actual, regime, data quality, and deployment-impact views
- publish snapshots atomically from prism-backend to app-server every five minutes

## Safety
- no historical prompts or gates are reconstructed
- all backfill rows are explicitly marked ingestion_mode=backfill
- browser/app-server receive no ClickHouse credentials
- missing observability JSON hides only the new panel
- dashboard publisher validates host/user/path and does not use shell=True

## Verification
- production dry-run: 2,140 records, 0 failures
- observability tests: 19 passed
- Ruff, py_compile, git diff checks passed
- Next.js production build passed
- standalone tsc remains blocked by pre-existing dashboard type errors; no new component errors reported