### PR TITLE
feat: align report models and expose swing regime

### DIFF
--- a/cores/agents/telegram_translator_agent.py
+++ b/cores/agents/telegram_translator_agent.py
@@ -1,6 +1,7 @@
 from mcp_agent.agents.agent import Agent
 
 from cores.openai_error_logging import log_openai_error
+from report_model_config import REPORT_AUX_EFFORT, REPORT_AUX_MODEL
 
 
 def create_telegram_translator_agent(from_lang: str = "ko", to_lang: str = "en"):
@@ -104,7 +105,7 @@ Only return the translated text without any explanations or metadata.
 
 async def translate_telegram_message(
     message: str,
-    model: str = "gpt-5.6-luna",
+    model: str = REPORT_AUX_MODEL,
     from_lang: str = "ko",
     to_lang: str = "en"
 ) -> str:
@@ -140,6 +141,7 @@ async def translate_telegram_message(
             message=message,
             request_params=RequestParams(
                 model=model,
+                reasoning_effort=REPORT_AUX_EFFORT,
                 maxTokens=100000,
                 temperature=0.3,  # Lower temperature for more consistent translations
                 max_iterations=1  # Single pass translation, no complex reasoning needed

--- a/cores/agents/trading_agents.py
+++ b/cores/agents/trading_agents.py
@@ -64,8 +64,11 @@ def create_trading_scenario_agent(language: str = "ko", sector_names: list = Non
 
         ## Market Regime Classification (5 levels)
 
-        A) Prefer the regime from the report's 'Market Analysis' / 'Macro Intelligence Summary' if present.
-        B) Otherwise derive from KOSPI 20-day data (kospi_kosdaq-get_index_ohlcv):
+        A) The provided deterministic `market_regime` is authoritative. Copy its exact enum into
+           the scenario; do not rename or reclassify it from prose. `swing_state`, when present,
+           is descriptive context and does not replace the execution regime.
+        B) Only when the deterministic value is explicitly unavailable, derive from KOSPI 20-day data
+           (kospi_kosdaq-get_index_ohlcv):
            - **strong_bull**:    KOSPI > 20d MA AND last 2 weeks ≥ +5%
            - **moderate_bull**:  KOSPI > 20d MA AND positive trend
            - **sideways**:       KOSPI ≈ 20d MA, mixed signals
@@ -398,8 +401,11 @@ def create_trading_scenario_agent(language: str = "ko", sector_names: list = Non
 
         ## 시장 체제 진단 (5단계)
 
-        A) 보고서의 '시장 분석' / '거시경제 인텔리전스 요약'에 regime이 있으면 우선 사용하십시오.
-        B) 없으면 KOSPI 20일 데이터(kospi_kosdaq-get_index_ohlcv)로 직접 판단하십시오:
+        A) 제공된 결정론적 `market_regime`이 유일한 실행 기준입니다. enum을 그대로 scenario에
+           복사하고 설명 문구를 보고 다시 이름 붙이거나 재분류하지 마십시오. `swing_state`가 있으면
+           보조 설명일 뿐 실행 regime을 대체하지 않습니다.
+        B) 결정론적 값이 명시적으로 없을 때만 KOSPI 20일 데이터
+           (kospi_kosdaq-get_index_ohlcv)로 직접 판단하십시오:
            - **strong_bull**:    KOSPI > 20일선 AND 최근 2주 +5% 이상
            - **moderate_bull**:  KOSPI > 20일선 AND 양의 추세
            - **sideways**:       KOSPI ≈ 20일선, 혼재 신호

--- a/cores/company_name_translator.py
+++ b/cores/company_name_translator.py
@@ -10,6 +10,7 @@ import re
 from typing import Any, Dict
 
 from cores.openai_error_logging import log_openai_error
+from report_model_config import REPORT_AUX_EFFORT, REPORT_AUX_MODEL
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +67,7 @@ async def translate_company_name(korean_name: str) -> str:
     """
     Translate Korean company name to English.
 
-    Uses GPT-5-nano for cost-efficient translation with caching
+    Uses the shared low-reasoning report auxiliary model with caching
     to prevent duplicate API calls.
 
     Args:
@@ -128,7 +129,8 @@ Return ONLY the English company name, nothing else. No quotes, no explanation.
         english_name = await llm.generate_str(
             message=f"Translate this Korean company name to English: {korean_name}",
             request_params=RequestParams(
-                model="gpt-5.4-mini",
+                model=REPORT_AUX_MODEL,
+                reasoning_effort=REPORT_AUX_EFFORT,
                 maxTokens=1000,
                 temperature=0.1,
                 max_iterations=1

--- a/cores/llm/features/insight_broadcast.py
+++ b/cores/llm/features/insight_broadcast.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 def _parse_ticker_company(pdf_stem: str) -> tuple[str, str | None]:
     """Best-effort ticker/company extraction from a report PDF filename stem.
 
-    Expected stem format: ``{ticker}_{company}_{date}_{mode}_gpt5.4-mini``.
+    Expected stem format: ``{ticker}_{company}_{date}_{mode}_{model-slug}``.
     Returns (ticker, company_name|None). Never raises.
     """
     try:

--- a/cores/llm/models.py
+++ b/cores/llm/models.py
@@ -22,8 +22,8 @@ _DEFAULT_MAPPING: dict[str, tuple[str, LLMParams]] = {
         LLMParams(reasoning_effort="none", max_tokens=16000),
     ),
     "summary": (
-        "gpt-5.4-mini",
-        LLMParams(reasoning_effort="none", max_tokens=16000),
+        "gpt-5.6-luna",
+        LLMParams(reasoning_effort="low", max_tokens=16000),
     ),
 }
 

--- a/cores/llm/tests/test_models.py
+++ b/cores/llm/tests/test_models.py
@@ -23,7 +23,8 @@ class TestModelRegistryDefaults:
     def test_resolve_summary(self):
         reg = ModelRegistry.defaults()
         model_id, params = reg.resolve("summary")
-        assert model_id == "gpt-5.4-mini"
+        assert model_id == "gpt-5.6-luna"
+        assert params.reasoning_effort == "low"
 
     def test_resolve_trading(self):
         reg = ModelRegistry.defaults()

--- a/cores/main.py
+++ b/cores/main.py
@@ -4,6 +4,7 @@ import threading
 import os
 import signal
 from datetime import datetime
+from report_model_config import REPORT_MODEL, report_model_slug
 
 from cores.analysis import analyze_stock
 
@@ -24,7 +25,11 @@ if __name__ == "__main__":
     result = asyncio.run(analyze_stock(company_code="036570", company_name="엔씨소프트", reference_date="20260209"))
 
     # Save results
-    with open(f"엔씨소프트_분석보고서_{datetime.now().strftime('%Y%m%d')}_gpt5.4-mini.md", "w", encoding="utf-8") as f:
+    with open(
+        f"엔씨소프트_분석보고서_{datetime.now().strftime('%Y%m%d')}_{report_model_slug(REPORT_MODEL)}.md",
+        "w",
+        encoding="utf-8",
+    ) as f:
         f.write(result)
 
     end = time.time()

--- a/cores/regime_policy.py
+++ b/cores/regime_policy.py
@@ -333,7 +333,15 @@ def enforce_computed_regime(
 
     if "market_regime" in merged:
         merged["llm_market_regime"] = merged.get("market_regime")
-    for key in ("market_regime", "regime_confidence", "simple_ma_regime", "index_summary"):
+    for key in (
+        "market_regime",
+        "primary_trend_regime",
+        "effective_entry_regime",
+        "swing_state",
+        "regime_confidence",
+        "simple_ma_regime",
+        "index_summary",
+    ):
         if key in computed:
             merged[key] = computed[key]
     merged["computed_regime"] = computed

--- a/cores/report_generation.py
+++ b/cores/report_generation.py
@@ -4,15 +4,12 @@ from cores.llm.agent_bridge import ensure_openai_agents_configured
 from cores.llm.backends.openai_agents_backend import OpenAIAgentsBackend
 from cores.llm.config_loader import load_report_mcp_registry
 from cores.llm.ports import AgentSpec, LLMParams
-
-import os
+from report_model_config import REPORT_EFFORT, REPORT_MODEL
 from cores.openai_error_logging import log_openai_error
 
-# Report LLM model/effort (env-overridable). gpt-5.6-terra + reasoning_effort="medium"
-# selected 2026-07-16 (report-quality eval, see tasks/eval). Requires the Responses API
-# path above: gpt-5.6 rejects function tools + reasoning_effort on chat.completions.
-REPORT_MODEL = os.environ.get("REPORT_MODEL", "gpt-5.6-terra")
-REPORT_EFFORT = os.environ.get("REPORT_EFFORT", "medium")
+# Report LLM model/effort are shared with macro, summaries and artifact names.
+# Luna with low reasoning keeps the evidence-gathering tool path while reducing
+# latency; the Responses API backend remains required for gpt-5.6 tool calls.
 
 _report_backend = None
 

--- a/prism-us/cores/agents/trading_agents.py
+++ b/prism-us/cores/agents/trading_agents.py
@@ -68,8 +68,11 @@ def create_us_trading_scenario_agent(language: str = "ko", sector_names: list = 
 
 ## 시장 체제 진단 (5단계)
 
-A) 보고서의 '시장 분석' / '거시경제 인텔리전스 요약'에 regime이 있으면 우선 사용하십시오.
-B) 없으면 S&P 500 (^GSPC) + VIX 최근 20일 데이터(yahoo_finance-get_historical_stock_prices)로 직접 판단하십시오:
+A) 제공된 결정론적 `market_regime`이 유일한 실행 기준입니다. enum을 그대로 scenario에
+   복사하고 설명 문구를 보고 다시 이름 붙이거나 재분류하지 마십시오. `swing_state`가 있으면
+   보조 설명일 뿐 실행 regime을 대체하지 않습니다.
+B) 결정론적 값이 명시적으로 없을 때만 S&P 500 (^GSPC) + VIX 최근 20일 데이터
+   (yahoo_finance-get_historical_stock_prices)로 직접 판단하십시오:
    - **strong_bull**:    S&P 500 > 20일선 AND 최근 4주 +3% 초과 AND VIX < 18
    - **moderate_bull**:  S&P 500 > 20일선 AND 양의 추세
    - **sideways**:       S&P 500 ≈ 20일선, 혼재 신호
@@ -392,8 +395,11 @@ confirm momentum via N·S·I, validate trend via L·M.
 
 ## Market Regime Classification (5 levels)
 
-A) Prefer the regime from the report's 'Market Analysis' / 'Macro Intelligence Summary' if present.
-B) Otherwise derive from S&P 500 (^GSPC) + VIX 20-day data (yahoo_finance-get_historical_stock_prices):
+A) The provided deterministic `market_regime` is authoritative. Copy its exact enum into the
+   scenario; do not rename or reclassify it from prose. `swing_state`, when present, is descriptive
+   context and does not replace the execution regime.
+B) Only when the deterministic value is explicitly unavailable, derive from S&P 500 (^GSPC) + VIX
+   20-day data (yahoo_finance-get_historical_stock_prices):
    - **strong_bull**:    S&P 500 > 20d MA AND 4-week change > +3% AND VIX < 18
    - **moderate_bull**:  S&P 500 > 20d MA AND positive trend
    - **sideways**:       S&P 500 ≈ 20d MA, mixed signals

--- a/prism-us/cores/data_prefetch.py
+++ b/prism-us/cores/data_prefetch.py
@@ -896,6 +896,9 @@ def _log_regime_snapshot(market: str, computed: dict) -> None:
             "ts": _dt.now().strftime("%Y-%m-%d %H:%M:%S"),
             "market": market,
             "regime": computed.get("market_regime"),
+            "primary_trend_regime": computed.get("primary_trend_regime"),
+            "effective_entry_regime": computed.get("effective_entry_regime"),
+            "swing_state": computed.get("swing_state"),
             "confidence": computed.get("regime_confidence"),
         }
         s = computed.get("index_summary") or {}
@@ -1137,6 +1140,72 @@ def _inject_distribution_days(index_summary, df, close_col) -> None:
     index_summary["distribution_days"] = None if dist is None else dist["count"]
 
 
+def _compute_us_swing_state(
+    sp500_df: pd.DataFrame,
+    close_col: str,
+    nasdaq_df: pd.DataFrame | None = None,
+) -> dict:
+    """Describe the entry timeframe without changing the execution regime.
+
+    A 2018~2026 replay showed that mechanically downgrading structural bull
+    regimes during these pauses would often suppress profitable rebound days.
+    The state is therefore additive observability/prompt context only.
+    """
+    closes = sp500_df[close_col].dropna()
+    if len(closes) < 20:
+        return {"swing_state": "unknown"}
+
+    sp_current = float(closes.iloc[-1])
+    sp_ma20 = float(closes.tail(20).mean())
+    sp_return10 = (
+        (sp_current / float(closes.iloc[-11]) - 1.0) * 100
+        if len(closes) >= 11
+        else None
+    )
+    sp_confirmed = sp_current > sp_ma20 and (sp_return10 or 0.0) > 0
+
+    nasdaq_above20 = None
+    nasdaq_return10 = None
+    if nasdaq_df is not None and not nasdaq_df.empty:
+        nd_close_col = next(
+            (name for name in ("Close", "close", "Adj Close") if name in nasdaq_df.columns),
+            None,
+        )
+        if nd_close_col:
+            nd_closes = nasdaq_df.sort_index()[nd_close_col].dropna()
+            if len(nd_closes) >= 20:
+                nd_current = float(nd_closes.iloc[-1])
+                nasdaq_above20 = nd_current > float(nd_closes.tail(20).mean())
+                if len(nd_closes) >= 11:
+                    nasdaq_return10 = (
+                        nd_current / float(nd_closes.iloc[-11]) - 1.0
+                    ) * 100
+
+    nasdaq_confirmed = (
+        True
+        if nasdaq_above20 is None
+        else nasdaq_above20 and (nasdaq_return10 or 0.0) > 0
+    )
+    if sp_current < sp_ma20 and (sp_return10 or 0.0) <= -2.0:
+        state = "pullback"
+    elif sp_confirmed and nasdaq_confirmed:
+        state = "trend_up"
+    else:
+        state = "consolidation"
+
+    return {
+        "swing_state": state,
+        "sp500_return_10d_pct": round(sp_return10, 2) if sp_return10 is not None else None,
+        "sp500_vs_20d_ma_pct": round((sp_current / sp_ma20 - 1.0) * 100, 2),
+        "nasdaq_return_10d_pct": (
+            round(nasdaq_return10, 2) if nasdaq_return10 is not None else None
+        ),
+        "nasdaq_vs_20d_ma": (
+            "above" if nasdaq_above20 else "below"
+        ) if nasdaq_above20 is not None else None,
+    }
+
+
 def _compute_us_regime(sp500_df: pd.DataFrame, nasdaq_df: pd.DataFrame = None, vix_df: pd.DataFrame = None) -> dict:
     """Compute US market regime programmatically from index data.
 
@@ -1298,6 +1367,8 @@ def _compute_us_regime(sp500_df: pd.DataFrame, nasdaq_df: pd.DataFrame = None, v
         "sp500_20d_ma": round(ma_20d, 2),
         "nasdaq_20d_trend": nasdaq_trend,
     }
+    swing_context = _compute_us_swing_state(sp500_df, close_col, nasdaq_df)
+    index_summary.update(swing_context)
     # Trend MA fields (additive — present only when enough history)
     if ma_50 is not None:
         index_summary["sp500_50d_ma"] = round(ma_50, 2)
@@ -1335,8 +1406,14 @@ def _compute_us_regime(sp500_df: pd.DataFrame, nasdaq_df: pd.DataFrame = None, v
             else:
                 logger.info(f"[regime] US HIVOL override SHADOW(관찰,미적용): would {_reason}")
 
+    index_summary["primary_trend_regime"] = regime
+    index_summary["effective_entry_regime"] = regime
+
     return {
         "market_regime": regime,
+        "primary_trend_regime": regime,
+        "effective_entry_regime": regime,
+        "swing_state": swing_context["swing_state"],
         "regime_confidence": confidence,
         "simple_ma_regime": simple_ma_regime,
         "index_summary": index_summary,

--- a/prism-us/cores/us_analysis.py
+++ b/prism-us/cores/us_analysis.py
@@ -582,7 +582,12 @@ if __name__ == "__main__":
     ))
 
     # Save result
-    output_path = f"AAPL_Apple Inc_{datetime.now().strftime('%Y%m%d')}_gpt5.4-mini.md"
+    from report_model_config import REPORT_MODEL, report_model_slug
+
+    output_path = (
+        f"AAPL_Apple Inc_{datetime.now().strftime('%Y%m%d')}_"
+        f"{report_model_slug(REPORT_MODEL)}.md"
+    )
     with open(output_path, "w", encoding="utf-8") as f:
         f.write(result)
 

--- a/prism-us/tests/test_us_swing_state_contract.py
+++ b/prism-us/tests/test_us_swing_state_contract.py
@@ -1,0 +1,60 @@
+"""US structural regime stays authoritative while swing context is additive."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cores.data_prefetch import _compute_us_regime  # noqa: E402
+
+
+def _frame(values):
+    index = pd.date_range("2025-01-01", periods=len(values), freq="B")
+    close = np.asarray(values, dtype=float)
+    return pd.DataFrame(
+        {
+            "Open": close * 0.999,
+            "High": close * 1.005,
+            "Low": close * 0.995,
+            "Close": close,
+            "Volume": np.arange(len(close), dtype=float) + 1_000_000,
+        },
+        index=index,
+    )
+
+
+def test_strong_structural_bull_can_report_swing_consolidation():
+    base = list(np.linspace(3000, 6000, 210))
+    # Strong first half of the 20-day window keeps 4-week return above 3%,
+    # while the last ten sessions cool off for both S&P and Nasdaq.
+    tail = [6050, 6120, 6200, 6280, 6360, 6440, 6520, 6600, 6680, 6760,
+            6740, 6720, 6700, 6680, 6660, 6640, 6620, 6600, 6580, 6560]
+    sp500 = _frame(base + tail)
+    nasdaq = _frame([value * 3.0 for value in base + tail])
+    vix = _frame([15.0] * len(sp500))
+
+    result = _compute_us_regime(sp500, nasdaq, vix)
+
+    assert result["market_regime"] == "strong_bull"
+    assert result["primary_trend_regime"] == "strong_bull"
+    assert result["effective_entry_regime"] == "strong_bull"
+    assert result["swing_state"] == "consolidation"
+    assert result["index_summary"]["swing_state"] == "consolidation"
+
+
+def test_calm_bull_with_short_term_confirmation_reports_trend_up():
+    closes = list(np.linspace(3000, 6500, 230))
+    sp500 = _frame(closes)
+    nasdaq = _frame([value * 3.0 for value in closes])
+    vix = _frame([14.0] * len(sp500))
+
+    result = _compute_us_regime(sp500, nasdaq, vix)
+
+    assert result["market_regime"] == "strong_bull"
+    assert result["swing_state"] == "trend_up"

--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -37,6 +37,13 @@ PRISM_US_DIR = Path(__file__).parent
 sys.path.insert(0, str(PROJECT_ROOT))
 sys.path.insert(0, str(PRISM_US_DIR))
 
+from report_model_config import (  # noqa: E402
+    REPORT_AUX_EFFORT,
+    REPORT_AUX_MODEL,
+    REPORT_MODEL,
+    report_model_slug,
+)
+from regime_display import regime_label, swing_label  # noqa: E402
 from messaging.batch_campaign_publisher import (  # noqa: E402
     COLLECTING,
     SKIPPED,
@@ -377,8 +384,8 @@ class USStockAnalysisOrchestrator:
                 result = await llm.generate_str(
                     message=f"Execute US stock market macro analysis for {reference_date} and output JSON.",
                     request_params=RequestParams(
-                        model="gpt-5.4-mini",
-                        reasoning_effort="none",
+                        model=REPORT_AUX_MODEL,
+                        reasoning_effort=REPORT_AUX_EFFORT,
                         maxTokens=16000,
                         parallel_tool_calls=True,
                         use_history=True
@@ -570,7 +577,10 @@ class USStockAnalysisOrchestrator:
             logger.info(f"[{idx}/{len(tickers)}] Starting US stock analysis: {company_name}({ticker})")
 
             report_date = reference_date or resolve_us_trade_date()
-            output_file = str(US_REPORTS_DIR / f"{ticker}_{company_name}_{report_date}_{mode}_gpt5.4-mini.md")
+            output_file = str(
+                US_REPORTS_DIR
+                / f"{ticker}_{company_name}_{report_date}_{mode}_{report_model_slug(REPORT_MODEL)}.md"
+            )
 
             try:
                 from cores.us_analysis import analyze_us_stock
@@ -1013,19 +1023,13 @@ class USStockAnalysisOrchestrator:
         # Extract metadata for hybrid selection info
         metadata = results.get("metadata", {})
         market_regime = metadata.get("market_regime")
+        primary_trend_regime = metadata.get("primary_trend_regime") or market_regime
+        swing_state = metadata.get("swing_state")
         selection_strategy = metadata.get("selection_strategy", "")
         topdown_count = metadata.get("topdown_count", 0)
         bottomup_count = metadata.get("bottomup_count", 0)
 
         # Regime display names
-        REGIME_KO = {
-            "strong_bull": "강세장", "moderate_bull": "온건 강세",
-            "sideways": "횡보장", "moderate_bear": "온건 약세", "strong_bear": "약세장",
-        }
-        REGIME_EN = {
-            "strong_bull": "Strong Bull", "moderate_bull": "Moderate Bull",
-            "sideways": "Sideways", "moderate_bear": "Moderate Bear", "strong_bear": "Strong Bear",
-        }
         CHANNEL_KO = {"top-down": "탑다운 (주도섹터)", "bottom-up": "바텀업 (개별종목)"}
         CHANNEL_EN = {"top-down": "Top-Down (Leading Sector)", "bottom-up": "Bottom-Up (Individual)"}
 
@@ -1049,7 +1053,6 @@ class USStockAnalysisOrchestrator:
                 "※ 가상 운용 과정 공유이며 투자 리딩 또는 실제 매수 권유가 아닙니다."
             )
             channel_map = CHANNEL_KO
-            regime_map = REGIME_KO
             score_label = "점수"
             rr_label = "R/R"
             sl_label = "손절"
@@ -1072,7 +1075,6 @@ class USStockAnalysisOrchestrator:
                 "※ Virtual-operation disclosure only; not investment guidance or a buy recommendation."
             )
             channel_map = CHANNEL_EN
-            regime_map = REGIME_EN
             score_label = "Score"
             rr_label = "R/R"
             sl_label = "SL"
@@ -1081,11 +1083,18 @@ class USStockAnalysisOrchestrator:
 
         # Hybrid selection summary (regime + strategy)
         if market_regime and "hybrid" in selection_strategy:
-            regime_display = regime_map.get(market_regime, market_regime)
             if language == "ko":
-                message += f"🧭 시장국면: {regime_display} | 선정: 탑다운 {topdown_count}종목 + 바텀업 {bottomup_count}종목\n"
+                message += f"🧭 장기추세: {regime_label(primary_trend_regime)}"
+                if swing_state:
+                    message += f" | 스윙: {swing_label(swing_state)}"
+                message += f" | 실행기준: {regime_label(market_regime)}"
+                message += f" | 선정: 탑다운 {topdown_count}종목 + 바텀업 {bottomup_count}종목\n"
             else:
-                message += f"🧭 Regime: {regime_display} | Selection: Top-Down {topdown_count} + Bottom-Up {bottomup_count}\n"
+                message += f"🧭 Primary Trend: {regime_label(primary_trend_regime, 'en')}"
+                if swing_state:
+                    message += f" | Swing: {swing_label(swing_state, 'en')}"
+                message += f" | Execution: {regime_label(market_regime, 'en')}"
+                message += f" | Selection: Top-Down {topdown_count} + Bottom-Up {bottomup_count}\n"
 
         message += "\n"
 

--- a/prism-us/us_telegram_summary_agent.py
+++ b/prism-us/us_telegram_summary_agent.py
@@ -13,6 +13,7 @@ import logging
 import importlib.util as _ilu
 from datetime import datetime
 from pathlib import Path
+from report_model_config import REPORT_AUX_EFFORT, REPORT_AUX_MODEL
 
 from mcp_agent.agents.agent import Agent
 from mcp_agent.app import MCPApp
@@ -88,7 +89,7 @@ class USTelegramSummaryGenerator:
         """
         Extract ticker, company name, and date from filename.
 
-        US filename format: AAPL_Apple Inc_20260118_gpt5.4-mini.pdf
+        US filename format: AAPL_Apple Inc_20260118_gpt-5.6-luna.pdf
 
         Args:
             filename: Report filename
@@ -490,8 +491,8 @@ Report Content:
         response = await evaluator_optimizer.generate_str(
             message=prompt_message,
             request_params=RequestParams(
-                model="gpt-5.4-mini",
-                reasoning_effort="none",
+                model=REPORT_AUX_MODEL,
+                reasoning_effort=REPORT_AUX_EFFORT,
                 maxTokens=6000,
                 max_iterations=2
             )

--- a/prism-us/us_trigger_batch.py
+++ b/prism-us/us_trigger_batch.py
@@ -1665,6 +1665,9 @@ def run_batch(trigger_time: str, log_level: str = "INFO", output_file: str = Non
 
         # Derive hybrid metadata from final_results
         _market_regime = macro_context.get("market_regime", "sideways") if macro_context else None
+        _primary_trend_regime = macro_context.get("primary_trend_regime") if macro_context else None
+        _effective_entry_regime = macro_context.get("effective_entry_regime") if macro_context else None
+        _swing_state = macro_context.get("swing_state") if macro_context else None
         _topdown_slots, _bottomup_slots = _get_regime_slots(_market_regime) if _market_regime else (0, 3)
         _topdown_count = sum(
             1 for _, stocks_df in final_results.items()
@@ -1689,6 +1692,9 @@ def run_batch(trigger_time: str, log_level: str = "INFO", output_file: str = Non
             "min_trading_value_usd": MIN_TRADING_VALUE,
             "selection_strategy": "hybrid_topdown_bottomup" if macro_context else "pure_bottomup",
             "market_regime": _market_regime,
+            "primary_trend_regime": _primary_trend_regime or _market_regime,
+            "effective_entry_regime": _effective_entry_regime or _market_regime,
+            "swing_state": _swing_state,
             "topdown_slots": _topdown_slots,
             "bottomup_slots": _bottomup_slots,
             "topdown_count": _topdown_count,

--- a/regime_display.py
+++ b/regime_display.py
@@ -1,0 +1,48 @@
+"""Human-readable labels for the authoritative regime and swing context."""
+
+from __future__ import annotations
+
+
+REGIME_KO = {
+    "parabolic": "폭주 강세",
+    "strong_bull": "강한 강세",
+    "moderate_bull": "온건 강세",
+    "sideways": "횡보",
+    "moderate_bear": "온건 약세",
+    "strong_bear": "강한 약세",
+}
+REGIME_EN = {
+    "parabolic": "Parabolic Bull",
+    "strong_bull": "Strong Bull",
+    "moderate_bull": "Moderate Bull",
+    "sideways": "Sideways",
+    "moderate_bear": "Moderate Bear",
+    "strong_bear": "Strong Bear",
+}
+SWING_KO = {
+    "trend_up": "상승 지속",
+    "consolidation": "횡보·숨고르기",
+    "pullback": "단기 조정",
+    "unknown": "판단 보류",
+}
+SWING_EN = {
+    "trend_up": "Trend Up",
+    "consolidation": "Consolidation",
+    "pullback": "Pullback",
+    "unknown": "Unknown",
+}
+
+
+def regime_label(value: str | None, language: str = "ko") -> str:
+    token = str(value or "unknown")
+    labels = REGIME_KO if language == "ko" else REGIME_EN
+    return f"{labels.get(token, token)}({token})"
+
+
+def swing_label(value: str | None, language: str = "ko") -> str:
+    token = str(value or "unknown")
+    labels = SWING_KO if language == "ko" else SWING_EN
+    return f"{labels.get(token, token)}({token})"
+
+
+__all__ = ["regime_label", "swing_label"]

--- a/report_model_config.py
+++ b/report_model_config.py
@@ -1,0 +1,28 @@
+"""One report-pipeline model contract shared by KR and US entry points."""
+
+from __future__ import annotations
+
+import os
+import re
+
+
+REPORT_MODEL = os.environ.get("REPORT_MODEL", "gpt-5.6-luna")
+REPORT_EFFORT = os.environ.get("REPORT_EFFORT", "low")
+REPORT_AUX_MODEL = os.environ.get("REPORT_AUX_MODEL", REPORT_MODEL)
+REPORT_AUX_EFFORT = os.environ.get("REPORT_AUX_EFFORT", "low")
+
+
+def report_model_slug(model: str | None = None) -> str:
+    """Return a stable filename-safe slug that reflects the actual model."""
+    value = str(model or REPORT_MODEL).strip().lower()
+    value = re.sub(r"[^a-z0-9.]+", "-", value).strip("-")
+    return value or "unknown-model"
+
+
+__all__ = [
+    "REPORT_AUX_EFFORT",
+    "REPORT_AUX_MODEL",
+    "REPORT_EFFORT",
+    "REPORT_MODEL",
+    "report_model_slug",
+]

--- a/stock_analysis_orchestrator.py
+++ b/stock_analysis_orchestrator.py
@@ -24,6 +24,8 @@ from datetime import datetime
 from pathlib import Path
 
 from cores.openai_error_logging import log_openai_error
+from report_model_config import REPORT_AUX_EFFORT, REPORT_AUX_MODEL, REPORT_MODEL, report_model_slug
+from regime_display import regime_label, swing_label
 from messaging.batch_campaign_publisher import (  # noqa: E402
     COLLECTING,
     SKIPPED,
@@ -92,8 +94,8 @@ class StockAnalysisOrchestrator:
         """
         Parse report filename to extract components.
 
-        Expected format: {ticker}_{company_name}_{date}_{mode}_gpt5.4-mini
-        Example: 005930_삼성전자_20250127_morning_gpt5.4-mini
+        Expected format: {ticker}_{company_name}_{date}_{mode}_{model-slug}
+        Example: 005930_삼성전자_20250127_morning_gpt-5.6-luna
 
         Args:
             filename_stem: Filename without extension
@@ -360,8 +362,8 @@ class StockAnalysisOrchestrator:
                 result = await llm.generate_str(
                     message=f"{reference_date} 기준 한국 주식시장 거시경제 분석을 수행하고 JSON으로 출력하세요.",
                     request_params=RequestParams(
-                        model="gpt-5.4-mini",
-                        reasoning_effort="none",
+                        model=REPORT_AUX_MODEL,
+                        reasoning_effort=REPORT_AUX_EFFORT,
                         maxTokens=16000,
                         parallel_tool_calls=True,
                         use_history=True
@@ -983,14 +985,12 @@ class StockAnalysisOrchestrator:
         # Extract metadata for hybrid selection info
         metadata = results.get("metadata", {})
         market_regime = metadata.get("market_regime")
+        primary_trend_regime = metadata.get("primary_trend_regime") or market_regime
+        swing_state = metadata.get("swing_state")
         selection_strategy = metadata.get("selection_strategy", "")
         topdown_count = metadata.get("topdown_count", 0)
         bottomup_count = metadata.get("bottomup_count", 0)
 
-        REGIME_KO = {
-            "strong_bull": "강세장", "moderate_bull": "온건 강세",
-            "sideways": "횡보장", "moderate_bear": "온건 약세", "strong_bear": "약세장",
-        }
         CHANNEL_KO = {"top-down": "탑다운 (주도섹터)", "bottom-up": "바텀업 (개별종목)"}
 
         # Set title based on mode
@@ -1011,8 +1011,11 @@ class StockAnalysisOrchestrator:
 
         # Hybrid selection summary (regime + strategy)
         if market_regime and "hybrid" in selection_strategy:
-            regime_display = REGIME_KO.get(market_regime, market_regime)
-            message += f"🧭 시장국면: {regime_display} | 선정: 탑다운 {topdown_count}종목 + 바텀업 {bottomup_count}종목\n"
+            message += f"🧭 장기추세: {regime_label(primary_trend_regime)}"
+            if swing_state:
+                message += f" | 스윙: {swing_label(swing_state)}"
+            message += f" | 실행기준: {regime_label(market_regime)}"
+            message += f" | 선정: 탑다운 {topdown_count}종목 + 바텀업 {bottomup_count}종목\n"
 
         message += "\n"
 
@@ -1324,7 +1327,10 @@ class StockAnalysisOrchestrator:
 
             # Set output file path
             reference_date = datetime.now().strftime("%Y%m%d")
-            output_file = str(REPORTS_DIR / f"{ticker}_{company_name}_{reference_date}_{mode}_gpt5.4-mini.md")
+            output_file = str(
+                REPORTS_DIR
+                / f"{ticker}_{company_name}_{reference_date}_{mode}_{report_model_slug(REPORT_MODEL)}.md"
+            )
 
             try:
                 # Import function directly from main.py

--- a/telegram_summary_agent.py
+++ b/telegram_summary_agent.py
@@ -5,6 +5,7 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
+from report_model_config import REPORT_AUX_EFFORT, REPORT_AUX_MODEL
 
 import cores.openai_debug  # noqa: F401 — OpenAI 400/429 request metadata logging
 from mcp_agent.app import MCPApp
@@ -292,8 +293,8 @@ class TelegramSummaryGenerator:
         response = await evaluator_optimizer.generate_str(
             message=prompt_message,
             request_params=RequestParams(
-                model="gpt-5.4-mini",
-                reasoning_effort="none",
+                model=REPORT_AUX_MODEL,
+                reasoning_effort=REPORT_AUX_EFFORT,
                 maxTokens=6000,
                 max_iterations=2
             )

--- a/tests/test_regime_snapshot_contract.py
+++ b/tests/test_regime_snapshot_contract.py
@@ -15,6 +15,9 @@ def test_computed_regime_overrides_llm_label_but_preserves_audit_value():
         },
         {
             "market_regime": "moderate_bear",
+            "primary_trend_regime": "moderate_bear",
+            "effective_entry_regime": "moderate_bear",
+            "swing_state": "pullback",
             "regime_confidence": 0.78,
             "simple_ma_regime": "bear",
             "index_summary": {"distribution_days": 6},
@@ -22,6 +25,9 @@ def test_computed_regime_overrides_llm_label_but_preserves_audit_value():
     )
 
     assert result["market_regime"] == "moderate_bear"
+    assert result["primary_trend_regime"] == "moderate_bear"
+    assert result["effective_entry_regime"] == "moderate_bear"
+    assert result["swing_state"] == "pullback"
     assert result["llm_market_regime"] == "strong_bull"
     assert result["index_summary"]["distribution_days"] == 6
     assert result["leading_sectors"] == [{"sector": "Semiconductors"}]

--- a/tests/test_report_model_and_regime_display.py
+++ b/tests/test_report_model_and_regime_display.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+
+import report_model_config
+from regime_display import regime_label, swing_label
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_report_model_defaults_to_luna_low(monkeypatch):
+    monkeypatch.delenv("REPORT_MODEL", raising=False)
+    monkeypatch.delenv("REPORT_EFFORT", raising=False)
+    monkeypatch.delenv("REPORT_AUX_MODEL", raising=False)
+    monkeypatch.delenv("REPORT_AUX_EFFORT", raising=False)
+    module = importlib.reload(report_model_config)
+
+    assert module.REPORT_MODEL == "gpt-5.6-luna"
+    assert module.REPORT_EFFORT == "low"
+    assert module.REPORT_AUX_MODEL == "gpt-5.6-luna"
+    assert module.REPORT_AUX_EFFORT == "low"
+    assert module.report_model_slug() == "gpt-5.6-luna"
+
+
+def test_regime_labels_expose_enum_and_swing_timeframe():
+    assert regime_label("strong_bull") == "강한 강세(strong_bull)"
+    assert regime_label("moderate_bull") == "온건 강세(moderate_bull)"
+    assert swing_label("consolidation") == "횡보·숨고르기(consolidation)"
+    assert regime_label("strong_bull", "en") == "Strong Bull(strong_bull)"
+
+
+def test_batch_report_filenames_are_not_hardcoded_to_mini():
+    for relative in (
+        "stock_analysis_orchestrator.py",
+        "prism-us/us_stock_analysis_orchestrator.py",
+    ):
+        source = (ROOT / relative).read_text()
+        assert "_gpt5.4-mini.md" not in source
+        assert "report_model_slug" in source
+
+
+def test_kr_trigger_alert_displays_authoritative_enum_and_swing_state():
+    from stock_analysis_orchestrator import StockAnalysisOrchestrator
+
+    orchestrator = StockAnalysisOrchestrator.__new__(StockAnalysisOrchestrator)
+    message = orchestrator._create_trigger_alert_message(
+        "morning",
+        {
+            "metadata": {
+                "market_regime": "strong_bull",
+                "primary_trend_regime": "strong_bull",
+                "swing_state": "consolidation",
+                "selection_strategy": "hybrid_topdown_bottomup",
+                "topdown_count": 1,
+                "bottomup_count": 2,
+            }
+        },
+        "20260827",
+    )
+
+    assert "강한 강세(strong_bull)" in message
+    assert "횡보·숨고르기(consolidation)" in message
+    assert "실행기준: 강한 강세(strong_bull)" in message
+
+
+def test_us_trigger_alert_uses_the_same_regime_contract():
+    script = r'''
+import os
+import sys
+sys.path.insert(0, os.path.join(os.getcwd(), "prism-us"))
+from us_stock_analysis_orchestrator import USStockAnalysisOrchestrator
+
+orchestrator = USStockAnalysisOrchestrator.__new__(USStockAnalysisOrchestrator)
+message = orchestrator._create_trigger_alert_message(
+    "afternoon",
+    {"metadata": {
+        "market_regime": "strong_bull",
+        "primary_trend_regime": "strong_bull",
+        "swing_state": "consolidation",
+        "selection_strategy": "hybrid_topdown_bottomup",
+        "topdown_count": 2,
+        "bottomup_count": 1,
+    }},
+    "20260826",
+    "ko",
+)
+assert "강한 강세(strong_bull)" in message
+assert "횡보·숨고르기(consolidation)" in message
+'''
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr

--- a/trigger_batch.py
+++ b/trigger_batch.py
@@ -1959,6 +1959,9 @@ def run_batch(trigger_time: str, log_level: str = "INFO", output_file: str = Non
 
         # Derive hybrid metadata from final_results
         _market_regime = macro_context.get("market_regime", "sideways") if macro_context else None
+        _primary_trend_regime = macro_context.get("primary_trend_regime") if macro_context else None
+        _effective_entry_regime = macro_context.get("effective_entry_regime") if macro_context else None
+        _swing_state = macro_context.get("swing_state") if macro_context else None
         _topdown_slots, _bottomup_slots = _get_regime_slots(_market_regime) if _market_regime else (0, 3)
         _topdown_count = sum(
             1 for _, stocks_df in final_results.items()
@@ -1980,6 +1983,9 @@ def run_batch(trigger_time: str, log_level: str = "INFO", output_file: str = Non
             "lookback_days": 10,
             "selection_strategy": "hybrid_topdown_bottomup" if macro_context else "pure_bottomup",
             "market_regime": _market_regime,
+            "primary_trend_regime": _primary_trend_regime or _market_regime,
+            "effective_entry_regime": _effective_entry_regime or _market_regime,
+            "swing_state": _swing_state,
             "topdown_slots": _topdown_slots,
             "bottomup_slots": _bottomup_slots,
             "topdown_count": _topdown_count,


### PR DESCRIPTION
## Summary
- centralize the KR/US report pipeline on `gpt-5.6-luna` with low reasoning for reports, macro, summaries, evaluation, translation and company-name translation
- derive report artifact suffixes from the actual configured model instead of hardcoding `_gpt5.4-mini`
- keep the deterministic structural `market_regime` authoritative
- add an informational US `swing_state` (`trend_up`, `consolidation`, `pullback`) without mechanically downgrading entry gates
- show explicit enum values in KR/US trigger alerts: primary trend, swing context and execution regime
- instruct KR/US buy agents not to reclassify the provided deterministic enum

## Regime evidence
2018-2026 replay of 399 baseline strong-bull sessions did not support mechanical downgrade. Short-term weak/consolidating subsets generally rebounded as well as or better than retained strong-bull days. The execution regime therefore remains unchanged; swing state is additive context only.

Current 2026-08-26 result:
- market_regime: strong_bull
- primary_trend_regime: strong_bull
- effective_entry_regime: strong_bull
- swing_state: consolidation
- S&P 10d: -0.94%, Nasdaq 10d: -1.72%, distribution days: 2

## Validation
- 77 report/model/prompt/regime tests passed
- 15 US swing/high-vol/distribution tests passed
- earlier focused suite: 102 + 15 passed
- current-market deterministic smoke passed
- py_compile and diff check passed
- Ruff reports only pre-existing E741/E712 in touched legacy files; new modules pass