### PR TITLE
fix: keep medium reasoning for long reports

### DIFF
--- a/cores/report_generation.py
+++ b/cores/report_generation.py
@@ -8,8 +8,9 @@ from report_model_config import REPORT_EFFORT, REPORT_MODEL
 from cores.openai_error_logging import log_openai_error
 
 # Report LLM model/effort are shared with macro, summaries and artifact names.
-# Luna with low reasoning keeps the evidence-gathering tool path while reducing
-# latency; the Responses API backend remains required for gpt-5.6 tool calls.
+# Long-form reports keep medium reasoning for cross-source reconciliation and
+# numeric strategy synthesis. Auxiliary report tasks use the separate low-effort
+# contract; the Responses API backend remains required for gpt-5.6 tool calls.
 
 _report_backend = None
 

--- a/report_model_config.py
+++ b/report_model_config.py
@@ -7,7 +7,7 @@ import re
 
 
 REPORT_MODEL = os.environ.get("REPORT_MODEL", "gpt-5.6-luna")
-REPORT_EFFORT = os.environ.get("REPORT_EFFORT", "low")
+REPORT_EFFORT = os.environ.get("REPORT_EFFORT", "medium")
 REPORT_AUX_MODEL = os.environ.get("REPORT_AUX_MODEL", REPORT_MODEL)
 REPORT_AUX_EFFORT = os.environ.get("REPORT_AUX_EFFORT", "low")
 

--- a/tests/test_report_model_and_regime_display.py
+++ b/tests/test_report_model_and_regime_display.py
@@ -12,7 +12,7 @@ from regime_display import regime_label, swing_label
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_report_model_defaults_to_luna_low(monkeypatch):
+def test_report_model_defaults_to_luna_medium_with_low_auxiliary(monkeypatch):
     monkeypatch.delenv("REPORT_MODEL", raising=False)
     monkeypatch.delenv("REPORT_EFFORT", raising=False)
     monkeypatch.delenv("REPORT_AUX_MODEL", raising=False)
@@ -20,7 +20,7 @@ def test_report_model_defaults_to_luna_low(monkeypatch):
     module = importlib.reload(report_model_config)
 
     assert module.REPORT_MODEL == "gpt-5.6-luna"
-    assert module.REPORT_EFFORT == "low"
+    assert module.REPORT_EFFORT == "medium"
     assert module.REPORT_AUX_MODEL == "gpt-5.6-luna"
     assert module.REPORT_AUX_EFFORT == "low"
     assert module.report_model_slug() == "gpt-5.6-luna"


### PR DESCRIPTION
## Summary
- keep long-form `gpt-5.6-luna` reports on medium reasoning
- retain low reasoning for macro, summary, evaluation, translation and filename translation
- document the quality/latency split in the shared report contract

## Evidence
The 2026-08-27 KR morning run already produced three ~230K-246K character reports with Luna medium in 4m31s under bounded parallelism=3. Long reports reconcile multiple MCP sources and synthesize financial, flow, technical, target and stop calculations, so the quality margin is worth keeping.

## Validation
- 11 focused tests passed
- py_compile, Ruff and diff check passed