### PR TITLE
fix: bound translated report delivery latency

### DIFF
--- a/cores/agents/telegram_translator_agent.py
+++ b/cores/agents/telegram_translator_agent.py
@@ -107,7 +107,9 @@ async def translate_telegram_message(
     message: str,
     model: str = REPORT_AUX_MODEL,
     from_lang: str = "ko",
-    to_lang: str = "en"
+    to_lang: str = "en",
+    *,
+    raise_on_error: bool = False,
 ) -> str:
     """
     Translate a telegram message from source language to target language
@@ -117,6 +119,8 @@ async def translate_telegram_message(
         model: OpenAI model to use (default: gpt-5.6-luna for cost efficiency)
         from_lang: Source language code (default: "ko" for Korean)
         to_lang: Target language code (default: "en" for English)
+        raise_on_error: Re-raise failures when callers must not send the source
+            text as if it had been translated.
 
     Returns:
         str: Translated message
@@ -151,9 +155,10 @@ async def translate_telegram_message(
         return translated.strip()
 
     except Exception as e:
-        # If translation fails, return original message with error note
         import logging
         logger = logging.getLogger(__name__)
         log_openai_error(logger, e, "telegram translation")
         logger.error(f"Translation failed: {str(e)}")
+        if raise_on_error:
+            raise
         return message  # Fallback to original message

--- a/prism-us/tests/test_us_translated_pdf_delivery.py
+++ b/prism-us/tests/test_us_translated_pdf_delivery.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import asyncio
+
+import pdf_converter
+import us_stock_analysis_orchestrator as orchestrator_module
+from us_stock_analysis_orchestrator import (
+    USStockAnalysisOrchestrator,
+    _translated_pdf_limits,
+)
+
+
+def test_us_translated_pdf_limits_match_kr_contract() -> None:
+    assert _translated_pdf_limits({}) == (3, 360, 1200)
+    assert _translated_pdf_limits({
+        "PRISM_TRANSLATED_PDF_MAX_CONCURRENCY": "2",
+        "PRISM_TRANSLATED_PDF_ITEM_TIMEOUT_SECONDS": "90",
+        "PRISM_TRANSLATED_PDF_BATCH_TIMEOUT_SECONDS": "600",
+    }) == (2, 90, 600)
+
+
+def test_us_translated_pdfs_use_bounded_parallelism_and_skip_failures(
+    monkeypatch, tmp_path
+) -> None:
+    active = 0
+    max_active = 0
+    sent = []
+    real_sleep = asyncio.sleep
+
+    report_a = tmp_path / "AAA_Alpha_20260827_morning_gpt-5.6-luna.md"
+    report_b = tmp_path / "BBB_Beta_20260827_morning_gpt-5.6-luna.md"
+    report_a.write_text("good", encoding="utf-8")
+    report_b.write_text("bad", encoding="utf-8")
+
+    async def fake_translate(message, *, to_lang, raise_on_error, **_kwargs):
+        nonlocal active, max_active
+        assert raise_on_error is True
+        active += 1
+        max_active = max(max_active, active)
+        await real_sleep(0.02)
+        active -= 1
+        if message == "bad" and to_lang == "ja":
+            raise RuntimeError("cannot translate")
+        return f"{to_lang}:{message}"
+
+    class FakeRenderer:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def render(self, _source, output):
+            return output
+
+    class FakeConfig:
+        broadcast_languages = ["en", "ja"]
+
+        @staticmethod
+        def get_broadcast_channel_id(lang):
+            return f"channel-{lang}"
+
+    class FakeBot:
+        async def send_document(self, channel_id, path, **kwargs):
+            assert kwargs["market"] == "us"
+            sent.append((channel_id, path))
+            return True
+
+    monkeypatch.setenv("PRISM_TRANSLATED_PDF_MAX_CONCURRENCY", "2")
+    monkeypatch.setenv("PRISM_TRANSLATED_PDF_ITEM_TIMEOUT_SECONDS", "2")
+    monkeypatch.setenv("PRISM_TRANSLATED_PDF_BATCH_TIMEOUT_SECONDS", "5")
+    monkeypatch.setattr(orchestrator_module, "translate_telegram_message", fake_translate)
+    monkeypatch.setattr(pdf_converter, "PdfRenderer", FakeRenderer)
+    monkeypatch.setattr(orchestrator_module, "US_PDF_REPORTS_DIR", tmp_path)
+    monkeypatch.setattr(orchestrator_module.asyncio, "sleep", lambda _delay: _no_wait())
+
+    orchestrator = USStockAnalysisOrchestrator.__new__(USStockAnalysisOrchestrator)
+    orchestrator.telegram_config = FakeConfig()
+
+    asyncio.run(
+        orchestrator._send_translated_pdfs(FakeBot(), [str(report_a), str(report_b)])
+    )
+
+    assert max_active == 2
+    assert len(sent) == 3
+    assert not (tmp_path / f"{report_b.stem}_ja.md").exists()
+
+
+async def _no_wait() -> None:
+    return None

--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -26,6 +26,7 @@ import logging
 import os
 import re
 import sys
+import time
 from datetime import datetime
 from pathlib import Path
 import importlib.util as _ilu
@@ -195,6 +196,24 @@ _translator_module = _import_from_main_cores(
     "cores/agents/telegram_translator_agent.py"
 )
 translate_telegram_message = _translator_module.translate_telegram_message
+
+
+def _translated_pdf_limits(environ=None) -> tuple[int, int, int]:
+    """Return concurrency, per-report timeout, and whole-batch deadline."""
+    environ = os.environ if environ is None else environ
+
+    def positive_int(name: str, default: int) -> int:
+        try:
+            return max(1, int(environ.get(name, str(default))))
+        except (TypeError, ValueError):
+            return default
+
+    return (
+        positive_int("PRISM_TRANSLATED_PDF_MAX_CONCURRENCY", 3),
+        positive_int("PRISM_TRANSLATED_PDF_ITEM_TIMEOUT_SECONDS", 360),
+        positive_int("PRISM_TRANSLATED_PDF_BATCH_TIMEOUT_SECONDS", 1200),
+    )
+
 
 # Directory configuration
 US_REPORTS_DIR = PRISM_US_DIR / "reports"
@@ -814,81 +833,132 @@ class USStockAnalysisOrchestrator:
             bot_agent: TelegramBotAgent instance
             report_paths: List of original markdown report file paths
         """
-        try:
-            from pdf_converter import PdfRenderer
+        from pdf_converter import PdfRenderer
 
-            async def _translate_pdfs_for_lang(lang, channel_id, renderer):
-                for report_path in report_paths:
-                    try:
-                        logger.info(f"Translating US markdown report {report_path} to {lang}")
+        concurrency, item_timeout, batch_timeout = _translated_pdf_limits()
+        semaphore = asyncio.Semaphore(concurrency)
+        jobs = []
+        for lang in self.telegram_config.broadcast_languages:
+            channel_id = self.telegram_config.get_broadcast_channel_id(lang)
+            if not channel_id:
+                logger.warning(f"No channel ID configured for language: {lang}")
+                continue
+            jobs.extend((lang, channel_id, report_path) for report_path in report_paths)
 
-                        with open(report_path, 'r', encoding='utf-8') as f:
-                            original_report = f.read()
+        logger.info(
+            "[TRANSLATED_PDF] market=US status=start jobs=%d concurrency=%d "
+            "item_timeout_seconds=%d batch_timeout_seconds=%d",
+            len(jobs), concurrency, item_timeout, batch_timeout,
+        )
+        if not jobs:
+            return
 
-                        text_for_translation, images = self._extract_base64_images(original_report)
-                        logger.info(f"Prepared US report for translation: {len(text_for_translation)} chars (extracted {len(images)} images)")
+        async def _translate_one(lang, channel_id, report_path):
+            started = time.monotonic()
+            try:
+                with open(report_path, 'r', encoding='utf-8') as f:
+                    original_report = f.read()
+                text_for_translation, images = self._extract_base64_images(original_report)
 
-                        translated_report = await translate_telegram_message(
+                async with semaphore:
+                    translated_report = await asyncio.wait_for(
+                        translate_telegram_message(
                             text_for_translation,
-                            model="gpt-5.6-luna",
+                            model=REPORT_AUX_MODEL,
                             from_lang="ko",
-                            to_lang=lang
-                        )
+                            to_lang=lang,
+                            raise_on_error=True,
+                        ),
+                        timeout=item_timeout,
+                    )
 
-                        translated_report = self._restore_base64_images(translated_report, images)
-                        logger.info(f"Restored images to translated US report: {len(translated_report)} chars")
+                translated_report = self._restore_base64_images(translated_report, images)
+                report_file = Path(report_path)
+                translated_report_path = report_file.parent / f"{report_file.stem}_{lang}.md"
+                with open(translated_report_path, 'w', encoding='utf-8') as f:
+                    f.write(translated_report)
 
-                        report_file = Path(report_path)
-                        translated_report_path = report_file.parent / f"{report_file.stem}_{lang}.md"
+                logger.info(
+                    "[TRANSLATED_PDF] market=US lang=%s report=%s status=translated "
+                    "duration_seconds=%.1f",
+                    lang, report_path, time.monotonic() - started,
+                )
+                return lang, channel_id, translated_report_path
+            except asyncio.TimeoutError:
+                logger.error(
+                    "[TRANSLATED_PDF] market=US lang=%s report=%s status=skipped "
+                    "reason=item_timeout timeout_seconds=%d",
+                    lang, report_path, item_timeout,
+                )
+            except Exception as error:
+                logger.error(
+                    "[TRANSLATED_PDF] market=US lang=%s report=%s status=skipped "
+                    "reason=translation_failed error=%s",
+                    lang, report_path, error,
+                )
+                from telegram_config import is_openai_quota_error, send_openai_quota_alert
+                if is_openai_quota_error(error):
+                    await send_openai_quota_alert(self.telegram_config, market="US")
+            return None
 
-                        with open(translated_report_path, 'w', encoding='utf-8') as f:
-                            f.write(translated_report)
+        tasks = [asyncio.create_task(_translate_one(*job)) for job in jobs]
 
-                        logger.info(f"Translated US report saved: {translated_report_path}")
-
+        async def _deliver_completed():
+            async with PdfRenderer() as renderer:
+                for completed in asyncio.as_completed(tasks):
+                    result = await completed
+                    if result is None:
+                        continue
+                    lang, channel_id, translated_report_path = result
+                    try:
                         translated_pdf_file = US_PDF_REPORTS_DIR / f"{Path(translated_report_path).stem}.pdf"
                         translated_pdf_path = await renderer.render(
                             str(translated_report_path), str(translated_pdf_file)
                         )
+                        if not translated_pdf_path:
+                            logger.error(
+                                "[TRANSLATED_PDF] market=US lang=%s report=%s "
+                                "status=skipped reason=pdf_render_failed",
+                                lang, translated_report_path,
+                            )
+                            continue
 
-                        if translated_pdf_path:
-                            logger.info(f"Sending translated US PDF {translated_pdf_path} to {lang} channel")
-                            success = await bot_agent.send_document(channel_id, str(translated_pdf_path), msg_type="pdf", market="us")
+                        success = await bot_agent.send_document(
+                            channel_id,
+                            str(translated_pdf_path),
+                            msg_type="pdf",
+                            market="us",
+                        )
+                        logger.log(
+                            logging.INFO if success else logging.ERROR,
+                            "[TRANSLATED_PDF] market=US lang=%s report=%s status=%s",
+                            lang, translated_report_path, "sent" if success else "send_failed",
+                        )
+                        await asyncio.sleep(1)
+                    except Exception as error:
+                        logger.error(
+                            "[TRANSLATED_PDF] market=US lang=%s report=%s "
+                            "status=skipped reason=delivery_failed error=%s",
+                            lang, translated_report_path, error,
+                        )
 
-                            if success:
-                                logger.info(f"Translated US PDF sent successfully to {lang} channel")
-                            else:
-                                logger.error(f"Failed to send translated US PDF to {lang} channel")
-
-                            await asyncio.sleep(1)
-                        else:
-                            logger.error(f"Failed to convert translated US report to PDF: {translated_report_path}")
-
-                    except Exception as e:
-                        logger.error(f"Error processing US report {report_path} for {lang}: {str(e)}")
-                        from telegram_config import is_openai_quota_error, send_openai_quota_alert
-                        if is_openai_quota_error(e):
-                            await send_openai_quota_alert(self.telegram_config, market="US")
-                            return
-
-            # Languages are still processed one page at a time (memory ceiling stays
-            # at a single Chromium), but a SHARED browser is reused across all of
-            # them so the Chromium launch cost is paid ONCE instead of once per file
-            # (previously N launches for N PDFs — the batch's main slow tail).
-            async with PdfRenderer() as renderer:
-                for lang in self.telegram_config.broadcast_languages:
-                    channel_id = self.telegram_config.get_broadcast_channel_id(lang)
-                    if not channel_id:
-                        logger.warning(f"No channel ID configured for language: {lang}")
-                        continue
-                    logger.info(f"Processing PDF translation for US {lang} channel (shared browser)")
-                    try:
-                        await _translate_pdfs_for_lang(lang, channel_id, renderer)
-                    except Exception as lang_err:
-                        logger.error(f"US PDF translation failed for {lang}: {lang_err}")
-
-        except Exception as e:
-            logger.error(f"Error in _send_translated_pdfs: {str(e)}")
+        try:
+            await asyncio.wait_for(_deliver_completed(), timeout=batch_timeout)
+            logger.info("[TRANSLATED_PDF] market=US status=complete jobs=%d", len(jobs))
+        except asyncio.TimeoutError:
+            logger.error(
+                "[TRANSLATED_PDF] market=US status=deadline_exceeded "
+                "batch_timeout_seconds=%d pending_jobs=%d",
+                batch_timeout, sum(not task.done() for task in tasks),
+            )
+        except Exception as error:
+            logger.error(f"Error in _send_translated_pdfs: {str(error)}")
+        finally:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
 
     async def send_trigger_alert(self, mode: str, trigger_results_file: str, language: str = "ko"):
         """

--- a/stock_analysis_orchestrator.py
+++ b/stock_analysis_orchestrator.py
@@ -20,6 +20,7 @@ import logging
 import os
 import re
 import sys
+import time
 from datetime import datetime
 from pathlib import Path
 
@@ -70,6 +71,23 @@ def _batch_report_parallel_limit(job_count: int, environ=None) -> int:
         configured = 3
 
     return min(job_count, max(1, configured))
+
+
+def _translated_pdf_limits(environ=None) -> tuple[int, int, int]:
+    """Return concurrency, per-report timeout, and whole-batch deadline."""
+    environ = os.environ if environ is None else environ
+
+    def positive_int(name: str, default: int) -> int:
+        try:
+            return max(1, int(environ.get(name, str(default))))
+        except (TypeError, ValueError):
+            return default
+
+    return (
+        positive_int("PRISM_TRANSLATED_PDF_MAX_CONCURRENCY", 3),
+        positive_int("PRISM_TRANSLATED_PDF_ITEM_TIMEOUT_SECONDS", 360),
+        positive_int("PRISM_TRANSLATED_PDF_BATCH_TIMEOUT_SECONDS", 1200),
+    )
 
 
 class StockAnalysisOrchestrator:
@@ -761,82 +779,130 @@ class StockAnalysisOrchestrator:
             bot_agent: TelegramBotAgent instance
             report_paths: List of original markdown report file paths
         """
-        try:
-            from cores.agents.telegram_translator_agent import translate_telegram_message
-            from pdf_converter import PdfRenderer
+        from cores.agents.telegram_translator_agent import translate_telegram_message
+        from pdf_converter import PdfRenderer
 
-            async def _translate_pdfs_for_lang(lang, channel_id, renderer):
-                for report_path in report_paths:
-                    try:
-                        logger.info(f"Translating markdown report {report_path} to {lang}")
+        concurrency, item_timeout, batch_timeout = _translated_pdf_limits()
+        semaphore = asyncio.Semaphore(concurrency)
+        jobs = []
+        for lang in self.telegram_config.broadcast_languages:
+            channel_id = self.telegram_config.get_broadcast_channel_id(lang)
+            if not channel_id:
+                logger.warning(f"No channel ID configured for language: {lang}")
+                continue
+            jobs.extend((lang, channel_id, report_path) for report_path in report_paths)
 
-                        with open(report_path, 'r', encoding='utf-8') as f:
-                            original_report = f.read()
+        logger.info(
+            "[TRANSLATED_PDF] market=KR status=start jobs=%d concurrency=%d "
+            "item_timeout_seconds=%d batch_timeout_seconds=%d",
+            len(jobs), concurrency, item_timeout, batch_timeout,
+        )
+        if not jobs:
+            return
 
-                        text_for_translation, images = self._extract_base64_images(original_report)
-                        logger.info(f"Prepared report for translation: {len(text_for_translation)} chars (extracted {len(images)} images)")
+        async def _translate_one(lang, channel_id, report_path):
+            started = time.monotonic()
+            try:
+                with open(report_path, 'r', encoding='utf-8') as f:
+                    original_report = f.read()
+                text_for_translation, images = self._extract_base64_images(original_report)
 
-                        translated_report = await translate_telegram_message(
+                async with semaphore:
+                    translated_report = await asyncio.wait_for(
+                        translate_telegram_message(
                             text_for_translation,
-                            model="gpt-5.6-luna",
+                            model=REPORT_AUX_MODEL,
                             from_lang="ko",
-                            to_lang=lang
-                        )
+                            to_lang=lang,
+                            raise_on_error=True,
+                        ),
+                        timeout=item_timeout,
+                    )
 
-                        translated_report = self._restore_base64_images(translated_report, images)
-                        logger.info(f"Restored images to translated report: {len(translated_report)} chars")
+                translated_report = self._restore_base64_images(translated_report, images)
+                report_file = Path(report_path)
+                translated_report_path = await self._create_translated_filename(report_file, lang)
+                with open(translated_report_path, 'w', encoding='utf-8') as f:
+                    f.write(translated_report)
 
-                        report_file = Path(report_path)
-                        translated_report_path = await self._create_translated_filename(report_file, lang)
+                logger.info(
+                    "[TRANSLATED_PDF] market=KR lang=%s report=%s status=translated "
+                    "duration_seconds=%.1f",
+                    lang, report_path, time.monotonic() - started,
+                )
+                return lang, channel_id, translated_report_path
+            except asyncio.TimeoutError:
+                logger.error(
+                    "[TRANSLATED_PDF] market=KR lang=%s report=%s status=skipped "
+                    "reason=item_timeout timeout_seconds=%d",
+                    lang, report_path, item_timeout,
+                )
+            except Exception as error:
+                logger.error(
+                    "[TRANSLATED_PDF] market=KR lang=%s report=%s status=skipped "
+                    "reason=translation_failed error=%s",
+                    lang, report_path, error,
+                )
+                from telegram_config import is_openai_quota_error, send_openai_quota_alert
+                if is_openai_quota_error(error):
+                    await send_openai_quota_alert(self.telegram_config, market="KR")
+            return None
 
-                        with open(translated_report_path, 'w', encoding='utf-8') as f:
-                            f.write(translated_report)
+        tasks = [asyncio.create_task(_translate_one(*job)) for job in jobs]
 
-                        logger.info(f"Translated report saved: {translated_report_path}")
-
+        async def _deliver_completed():
+            async with PdfRenderer() as renderer:
+                for completed in asyncio.as_completed(tasks):
+                    result = await completed
+                    if result is None:
+                        continue
+                    lang, channel_id, translated_report_path = result
+                    try:
                         translated_pdf_file = PDF_REPORTS_DIR / f"{Path(translated_report_path).stem}.pdf"
                         translated_pdf_path = await renderer.render(
                             str(translated_report_path), str(translated_pdf_file)
                         )
+                        if not translated_pdf_path:
+                            logger.error(
+                                "[TRANSLATED_PDF] market=KR lang=%s report=%s "
+                                "status=skipped reason=pdf_render_failed",
+                                lang, translated_report_path,
+                            )
+                            continue
 
-                        if translated_pdf_path:
-                            logger.info(f"Sending translated PDF {translated_pdf_path} to {lang} channel")
-                            success = await bot_agent.send_document(channel_id, str(translated_pdf_path), msg_type="pdf")
+                        success = await bot_agent.send_document(
+                            channel_id, str(translated_pdf_path), msg_type="pdf"
+                        )
+                        logger.log(
+                            logging.INFO if success else logging.ERROR,
+                            "[TRANSLATED_PDF] market=KR lang=%s report=%s status=%s",
+                            lang, translated_report_path, "sent" if success else "send_failed",
+                        )
+                        await asyncio.sleep(1)
+                    except Exception as error:
+                        logger.error(
+                            "[TRANSLATED_PDF] market=KR lang=%s report=%s "
+                            "status=skipped reason=delivery_failed error=%s",
+                            lang, translated_report_path, error,
+                        )
 
-                            if success:
-                                logger.info(f"Translated PDF sent successfully to {lang} channel")
-                            else:
-                                logger.error(f"Failed to send translated PDF to {lang} channel")
-
-                            await asyncio.sleep(1)
-                        else:
-                            logger.error(f"Failed to convert translated report to PDF: {translated_report_path}")
-
-                    except Exception as e:
-                        logger.error(f"Error processing report {report_path} for {lang}: {str(e)}")
-                        from telegram_config import is_openai_quota_error, send_openai_quota_alert
-                        if is_openai_quota_error(e):
-                            await send_openai_quota_alert(self.telegram_config, market="KR")
-                            return
-
-            # Languages are still processed one page at a time (memory ceiling stays
-            # at a single Chromium), but a SHARED browser is reused across all of
-            # them so the Chromium launch cost is paid ONCE instead of once per file
-            # (previously N launches for N PDFs — the batch's main slow tail).
-            async with PdfRenderer() as renderer:
-                for lang in self.telegram_config.broadcast_languages:
-                    channel_id = self.telegram_config.get_broadcast_channel_id(lang)
-                    if not channel_id:
-                        logger.warning(f"No channel ID configured for language: {lang}")
-                        continue
-                    logger.info(f"Processing PDF translation for {lang} channel (shared browser)")
-                    try:
-                        await _translate_pdfs_for_lang(lang, channel_id, renderer)
-                    except Exception as lang_err:
-                        logger.error(f"PDF translation failed for {lang}: {lang_err}")
-
-        except Exception as e:
-            logger.error(f"Error in _send_translated_pdfs: {str(e)}")
+        try:
+            await asyncio.wait_for(_deliver_completed(), timeout=batch_timeout)
+            logger.info("[TRANSLATED_PDF] market=KR status=complete jobs=%d", len(jobs))
+        except asyncio.TimeoutError:
+            logger.error(
+                "[TRANSLATED_PDF] market=KR status=deadline_exceeded "
+                "batch_timeout_seconds=%d pending_jobs=%d",
+                batch_timeout, sum(not task.done() for task in tasks),
+            )
+        except Exception as error:
+            logger.error(f"Error in _send_translated_pdfs: {str(error)}")
+        finally:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
 
     async def send_trigger_alert(self, mode, trigger_results_file, language: str = "ko"):
         """

--- a/tests/test_translated_pdf_delivery.py
+++ b/tests/test_translated_pdf_delivery.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+import pdf_converter
+import stock_analysis_orchestrator as orchestrator_module
+from cores.agents import telegram_translator_agent
+from stock_analysis_orchestrator import (
+    StockAnalysisOrchestrator,
+    _translated_pdf_limits,
+)
+
+
+def test_translated_pdf_limits_are_bounded_and_configurable() -> None:
+    assert _translated_pdf_limits({}) == (3, 360, 1200)
+    assert _translated_pdf_limits({
+        "PRISM_TRANSLATED_PDF_MAX_CONCURRENCY": "2",
+        "PRISM_TRANSLATED_PDF_ITEM_TIMEOUT_SECONDS": "90",
+        "PRISM_TRANSLATED_PDF_BATCH_TIMEOUT_SECONDS": "600",
+    }) == (2, 90, 600)
+    assert _translated_pdf_limits({
+        "PRISM_TRANSLATED_PDF_MAX_CONCURRENCY": "invalid",
+        "PRISM_TRANSLATED_PDF_ITEM_TIMEOUT_SECONDS": "0",
+    }) == (3, 1, 1200)
+
+
+def test_translator_strict_mode_does_not_return_source_on_failure(monkeypatch) -> None:
+    class BrokenLLM:
+        async def generate_str(self, **_kwargs):
+            raise RuntimeError("translation unavailable")
+
+    class BrokenAgent:
+        async def attach_llm(self, _llm_type):
+            return BrokenLLM()
+
+    monkeypatch.setattr(
+        telegram_translator_agent,
+        "create_telegram_translator_agent",
+        lambda **_kwargs: BrokenAgent(),
+    )
+    monkeypatch.setattr(telegram_translator_agent, "log_openai_error", lambda *_args: None)
+
+    assert asyncio.run(telegram_translator_agent.translate_telegram_message("원문")) == "원문"
+    with pytest.raises(RuntimeError, match="translation unavailable"):
+        asyncio.run(
+            telegram_translator_agent.translate_telegram_message(
+                "원문", raise_on_error=True
+            )
+        )
+
+
+def test_kr_translated_pdfs_use_bounded_parallelism_and_skip_failures(
+    monkeypatch, tmp_path
+) -> None:
+    active = 0
+    max_active = 0
+    sent = []
+    real_sleep = asyncio.sleep
+
+    report_a = tmp_path / "001_회사A_20260827_morning_gpt-5.6-luna.md"
+    report_b = tmp_path / "002_회사B_20260827_morning_gpt-5.6-luna.md"
+    report_a.write_text("good", encoding="utf-8")
+    report_b.write_text("bad", encoding="utf-8")
+
+    async def fake_translate(message, *, to_lang, raise_on_error, **_kwargs):
+        nonlocal active, max_active
+        assert raise_on_error is True
+        active += 1
+        max_active = max(max_active, active)
+        await real_sleep(0.02)
+        active -= 1
+        if message == "bad" and to_lang == "ja":
+            raise RuntimeError("cannot translate")
+        return f"{to_lang}:{message}"
+
+    class FakeRenderer:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def render(self, _source, output):
+            return output
+
+    class FakeConfig:
+        broadcast_languages = ["en", "ja"]
+
+        @staticmethod
+        def get_broadcast_channel_id(lang):
+            return f"channel-{lang}"
+
+    class FakeBot:
+        async def send_document(self, channel_id, path, **_kwargs):
+            sent.append((channel_id, path))
+            return True
+
+    async def fake_filename(report_file, lang):
+        return tmp_path / f"{report_file.stem}_{lang}.md"
+
+    monkeypatch.setenv("PRISM_TRANSLATED_PDF_MAX_CONCURRENCY", "2")
+    monkeypatch.setenv("PRISM_TRANSLATED_PDF_ITEM_TIMEOUT_SECONDS", "2")
+    monkeypatch.setenv("PRISM_TRANSLATED_PDF_BATCH_TIMEOUT_SECONDS", "5")
+    monkeypatch.setattr(telegram_translator_agent, "translate_telegram_message", fake_translate)
+    monkeypatch.setattr(pdf_converter, "PdfRenderer", FakeRenderer)
+    monkeypatch.setattr(orchestrator_module, "PDF_REPORTS_DIR", tmp_path)
+    monkeypatch.setattr(orchestrator_module.asyncio, "sleep", lambda _delay: _no_wait())
+
+    orchestrator = StockAnalysisOrchestrator.__new__(StockAnalysisOrchestrator)
+    orchestrator.telegram_config = FakeConfig()
+    orchestrator._create_translated_filename = fake_filename
+
+    asyncio.run(
+        orchestrator._send_translated_pdfs(FakeBot(), [str(report_a), str(report_b)])
+    )
+
+    assert max_active == 2
+    assert len(sent) == 3
+    assert not (tmp_path / f"{report_b.stem}_ja.md").exists()
+
+
+async def _no_wait() -> None:
+    return None
+
+
+def test_kr_translated_pdf_batch_deadline_cancels_late_work(
+    monkeypatch, tmp_path
+) -> None:
+    report = tmp_path / "001_회사_20260827_morning_gpt-5.6-luna.md"
+    report.write_text("slow", encoding="utf-8")
+    sent = []
+
+    async def slow_translate(*_args, **_kwargs):
+        await asyncio.sleep(1)
+        return "translated"
+
+    class FakeRenderer:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+    class FakeConfig:
+        broadcast_languages = ["en"]
+
+        @staticmethod
+        def get_broadcast_channel_id(_lang):
+            return "channel-en"
+
+    class FakeBot:
+        async def send_document(self, *_args, **_kwargs):
+            sent.append(True)
+            return True
+
+    monkeypatch.setattr(telegram_translator_agent, "translate_telegram_message", slow_translate)
+    monkeypatch.setattr(pdf_converter, "PdfRenderer", FakeRenderer)
+    monkeypatch.setattr(orchestrator_module, "_translated_pdf_limits", lambda: (1, 1, 0.03))
+
+    orchestrator = StockAnalysisOrchestrator.__new__(StockAnalysisOrchestrator)
+    orchestrator.telegram_config = FakeConfig()
+
+    started = time.monotonic()
+    asyncio.run(orchestrator._send_translated_pdfs(FakeBot(), [str(report)]))
+
+    assert time.monotonic() - started < 0.5
+    assert sent == []


### PR DESCRIPTION
## Summary
- translate KR/US long-form PDFs with bounded concurrency (default 3) while reusing one renderer
- cap each translation at 6 minutes and the full translated-PDF tail at 20 minutes
- skip failed translations instead of sending the Korean source as a translated PDF
- add structured per-job delivery logs and regression tests

## Verification
- KR focused tests: 12 passed
- US focused tests: 4 passed
- py_compile: passed
- Ruff (excluding pre-existing E402/E741/F841): passed
- git diff --check: passed