### PR TITLE
feat: integrate Codex Fast trading analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,4 +150,5 @@ prism-btc/state/
 prism-btc/backtest/results/
 !prism-btc/engine/config.py
 *.sqlite.migrate.lock
+*.sqlite.init.lock
 shadow_lifecycle_state.json

--- a/cores/llm/codex_oauth_fast_backend.py
+++ b/cores/llm/codex_oauth_fast_backend.py
@@ -1,0 +1,174 @@
+"""Isolated Codex CLI backend using ChatGPT-managed OAuth Fast mode.
+
+This is not a generic OpenAI SDK wrapper.  It invokes Codex non-interactively
+with a dedicated CODEX_HOME, read-only sandbox, ephemeral thread, and no repo
+rules.  Trading callers must retain an existing backend as fallback.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Literal
+
+
+class CodexFastError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class CodexMcpCall:
+    server: str
+    tool: str
+    arguments: dict
+    status: str | None
+    error: object | None
+
+
+@dataclass(frozen=True)
+class CodexFastResult:
+    text: str
+    latency_s: float
+    usage: dict | None
+    mcp_calls: tuple[CodexMcpCall, ...] = ()
+
+
+McpProfile = Literal["kr_trading", "us_trading"]
+
+
+def _command(
+    codex_bin: str,
+    model: str,
+    mcp_profile: McpProfile | None,
+) -> list[str]:
+    command = [
+        codex_bin,
+        "exec",
+        "--ephemeral",
+        "--sandbox", "read-only",
+        "--skip-git-repo-check",
+        "--ignore-rules",
+        "--model", model,
+        "-c", 'service_tier="fast"',
+        "-c", "features.fast_mode=true",
+        "--json",
+        "-",
+    ]
+    if mcp_profile:
+        command[2:2] = ["--profile", mcp_profile]
+    return command
+
+
+def _parse_stream(
+    stream: str,
+) -> tuple[str | None, dict | None, tuple[CodexMcpCall, ...]]:
+    final = None
+    usage = None
+    mcp_calls: list[CodexMcpCall] = []
+    for line in stream.splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if (
+            event.get("type") == "item.completed"
+            and event.get("item", {}).get("type") == "agent_message"
+        ):
+            final = event["item"].get("text")
+        if event.get("type") == "turn.completed":
+            usage = event.get("usage")
+        item = event.get("item", {})
+        if (
+            event.get("type") == "item.completed"
+            and item.get("type") == "mcp_tool_call"
+        ):
+            mcp_calls.append(
+                CodexMcpCall(
+                    server=str(item.get("server") or ""),
+                    tool=str(item.get("tool") or ""),
+                    arguments=item.get("arguments") or {},
+                    status=item.get("status"),
+                    error=item.get("error"),
+                )
+            )
+    return final, usage, tuple(mcp_calls)
+
+
+def _prompt(
+    system_prompt: str,
+    user_prompt: str,
+    mcp_profile: McpProfile | None,
+) -> str:
+    if mcp_profile:
+        execution_constraints = """- 설정된 MCP 조회 도구를 사용해 최신 데이터와 포트폴리오를 확인하세요.
+- 셸, 파일 읽기/쓰기, 내장 웹 검색은 사용하지 말고 MCP 도구만 사용하세요.
+- SQLite에는 조회 도구만 사용하고 어떤 데이터도 생성·수정·삭제하지 마세요.
+- 도구 조회를 마친 뒤 시스템 프롬프트가 요구하는 JSON 객체 하나만 출력하세요."""
+    else:
+        execution_constraints = """- 도구, 셸, 파일, 웹 검색을 사용하지 마세요.
+- 제공된 보고서·포트폴리오·결정적 사실만 사용하세요.
+- 시스템 프롬프트가 요구하는 JSON 객체 하나만 출력하세요."""
+    return f"""{system_prompt}
+
+[실행 제약]
+{execution_constraints}
+- 코드펜스나 JSON 밖의 설명을 쓰지 마세요.
+
+[사용자 메시지]
+{user_prompt}
+"""
+
+
+def generate_codex_fast(
+    *,
+    system_prompt: str,
+    user_prompt: str,
+    model: str = "gpt-5.6-sol",
+    timeout: int = 90,
+    codex_bin: str | None = None,
+    codex_home: str | None = None,
+    mcp_profile: McpProfile | None = None,
+    require_mcp_calls: bool = False,
+) -> CodexFastResult:
+    executable = codex_bin or os.environ.get("PRISM_CODEX_BIN", "codex")
+    home = codex_home or os.environ.get("PRISM_CODEX_HOME")
+    environment = os.environ.copy()
+    if home:
+        environment["CODEX_HOME"] = home
+    started = time.monotonic()
+    try:
+        process = subprocess.run(
+            _command(executable, model, mcp_profile),
+            input=_prompt(system_prompt, user_prompt, mcp_profile),
+            capture_output=True,
+            text=True,
+            cwd="/tmp",
+            env=environment,
+            timeout=timeout,
+            check=False,
+            # MCP stdio children are managed by Codex. Keep their shutdown
+            # signals out of the long-lived PRISM orchestrator process group.
+            start_new_session=True,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise CodexFastError(f"Codex Fast unavailable: {exc}") from exc
+    latency = time.monotonic() - started
+    if process.returncode != 0:
+        raise CodexFastError(
+            f"Codex Fast rc={process.returncode}: {process.stderr[-300:]}"
+        )
+    text, usage, mcp_calls = _parse_stream(process.stdout)
+    if not text:
+        raise CodexFastError("Codex Fast returned no final agent message")
+    if require_mcp_calls and not any(
+        call.status == "completed" and not call.error for call in mcp_calls
+    ):
+        raise CodexFastError("Codex Fast returned no MCP tool calls")
+    return CodexFastResult(
+        text=text,
+        latency_s=latency,
+        usage=usage,
+        mcp_calls=mcp_calls,
+    )

--- a/cores/llm/codex_oauth_fast_backend.py
+++ b/cores/llm/codex_oauth_fast_backend.py
@@ -8,9 +8,15 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
+import shutil
+import stat
+
+# Fixed argv, no shell, and a permission-checked executable.
+import subprocess  # nosec B404
+import tempfile
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal
 
 
@@ -36,6 +42,23 @@ class CodexFastResult:
 
 
 McpProfile = Literal["kr_trading", "us_trading"]
+
+
+def _resolve_codex_executable(candidate: str) -> str:
+    """Resolve an executable that cannot be replaced by another local user."""
+    located = candidate if os.path.isabs(candidate) else shutil.which(candidate)
+    if not located:
+        raise CodexFastError(f"Codex executable not found: {candidate}")
+    try:
+        executable = Path(located).resolve(strict=True)
+        mode = stat.S_IMODE(executable.stat().st_mode)
+    except OSError as exc:
+        raise CodexFastError(f"Codex executable is unavailable: {candidate}") from exc
+    if not executable.is_file() or not os.access(executable, os.X_OK):
+        raise CodexFastError(f"Codex executable is not runnable: {executable}")
+    if mode & (stat.S_IWGRP | stat.S_IWOTH):
+        raise CodexFastError(f"Codex executable has unsafe permissions: {executable}")
+    return str(executable)
 
 
 def _command(
@@ -132,26 +155,32 @@ def generate_codex_fast(
     mcp_profile: McpProfile | None = None,
     require_mcp_calls: bool = False,
 ) -> CodexFastResult:
-    executable = codex_bin or os.environ.get("PRISM_CODEX_BIN", "codex")
+    executable = _resolve_codex_executable(
+        codex_bin or os.environ.get("PRISM_CODEX_BIN", "codex")
+    )
     home = codex_home or os.environ.get("PRISM_CODEX_HOME")
     environment = os.environ.copy()
     if home:
         environment["CODEX_HOME"] = home
     started = time.monotonic()
     try:
-        process = subprocess.run(
-            _command(executable, model, mcp_profile),
-            input=_prompt(system_prompt, user_prompt, mcp_profile),
-            capture_output=True,
-            text=True,
-            cwd="/tmp",
-            env=environment,
-            timeout=timeout,
-            check=False,
-            # MCP stdio children are managed by Codex. Keep their shutdown
-            # signals out of the long-lived PRISM orchestrator process group.
-            start_new_session=True,
-        )
+        with tempfile.TemporaryDirectory(prefix="prism-codex-fast-") as run_dir:
+            # The executable is resolved, permission-checked, and invoked with a
+            # fixed argv list. No shell parsing or untrusted option expansion occurs.
+            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args, python.lang.security.audit.dangerous-subprocess-use-audit.dangerous-subprocess-use-audit
+            process = subprocess.run(  # nosec B603
+                _command(executable, model, mcp_profile),
+                input=_prompt(system_prompt, user_prompt, mcp_profile),
+                capture_output=True,
+                text=True,
+                cwd=run_dir,
+                env=environment,
+                timeout=timeout,
+                check=False,
+                # MCP stdio children are managed by Codex. Keep their shutdown
+                # signals out of the long-lived PRISM orchestrator process group.
+                start_new_session=True,
+            )
     except (OSError, subprocess.TimeoutExpired) as exc:
         raise CodexFastError(f"Codex Fast unavailable: {exc}") from exc
     latency = time.monotonic() - started

--- a/cores/llm/codex_oauth_fast_backend.py
+++ b/cores/llm/codex_oauth_fast_backend.py
@@ -42,6 +42,8 @@ class CodexFastResult:
 
 
 McpProfile = Literal["kr_trading", "us_trading"]
+SUPPORTED_MODELS = frozenset({"gpt-5.6-sol"})
+SUPPORTED_MCP_PROFILES = frozenset({"kr_trading", "us_trading"})
 
 
 def _resolve_codex_executable(candidate: str) -> str:
@@ -66,6 +68,10 @@ def _command(
     model: str,
     mcp_profile: McpProfile | None,
 ) -> list[str]:
+    if model not in SUPPORTED_MODELS:
+        raise CodexFastError(f"Unsupported Codex model: {model}")
+    if mcp_profile is not None and mcp_profile not in SUPPORTED_MCP_PROFILES:
+        raise CodexFastError(f"Unsupported Codex MCP profile: {mcp_profile}")
     command = [
         codex_bin,
         "exec",
@@ -169,7 +175,7 @@ def generate_codex_fast(
             # fixed argv list. No shell parsing or untrusted option expansion occurs.
             # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args, python.lang.security.audit.dangerous-subprocess-use-audit.dangerous-subprocess-use-audit
             process = subprocess.run(  # nosec B603
-                _command(executable, model, mcp_profile),
+                _command(executable, model, mcp_profile),  # nosemgrep
                 input=_prompt(system_prompt, user_prompt, mcp_profile),
                 capture_output=True,
                 text=True,

--- a/deploy/codex-prism-config.toml
+++ b/deploy/codex-prism-config.toml
@@ -1,0 +1,6 @@
+model = "gpt-5.6-sol"
+service_tier = "fast"
+cli_auth_credentials_store = "file"
+
+[features]
+fast_mode = true

--- a/deploy/kr_trading.config.toml
+++ b/deploy/kr_trading.config.toml
@@ -1,0 +1,56 @@
+# Codex OAuth Fast profile for KR buy/sell decisions on db-server.
+# Deploy to /root/.codex-prism/kr_trading.config.toml.
+
+[mcp_servers.time]
+command = "/root/.pyenv/shims/python"
+args = ["-m", "cores.llm.time_mcp_server"]
+cwd = "/root/prism-insight"
+env = { PYTHONPATH = "/root/prism-insight" }
+enabled_tools = ["get_current_time"]
+default_tools_approval_mode = "approve"
+required = true
+startup_timeout_sec = 15
+tool_timeout_sec = 30
+
+[mcp_servers.kospi_kosdaq]
+command = "/root/.pyenv/shims/python"
+args = ["-m", "cores.market_data.mcp_server"]
+cwd = "/root/prism-insight"
+env = { PYTHONPATH = "/root/prism-insight" }
+enabled_tools = [
+  "get_stock_ohlcv",
+  "get_stock_market_cap",
+  "get_stock_trading_volume",
+  "get_index_ohlcv",
+  "get_ticker_name",
+]
+default_tools_approval_mode = "approve"
+required = true
+startup_timeout_sec = 20
+tool_timeout_sec = 120
+
+[mcp_servers.sqlite]
+command = "/root/.local/bin/uv"
+args = [
+  "--directory",
+  "/root/prism-insight/sqlite",
+  "run",
+  "mcp-server-sqlite",
+  "--db-path",
+  "/root/prism-insight/stock_tracking_db.sqlite",
+]
+enabled_tools = ["list_tables", "describe_table", "read_query"]
+default_tools_approval_mode = "approve"
+required = true
+startup_timeout_sec = 30
+tool_timeout_sec = 30
+
+[mcp_servers.perplexity]
+command = "/root/.nvm/versions/node/v22.14.0/bin/npx"
+args = ["-y", "@perplexity-ai/mcp-server@1.2.0"]
+env_vars = ["PERPLEXITY_API_KEY"]
+enabled_tools = ["perplexity_ask"]
+default_tools_approval_mode = "approve"
+required = true
+startup_timeout_sec = 30
+tool_timeout_sec = 120

--- a/deploy/us_trading.config.toml
+++ b/deploy/us_trading.config.toml
@@ -1,0 +1,67 @@
+# Codex OAuth Fast profile for US buy/sell decisions on db-server.
+# Deploy to /root/.codex-prism/us_trading.config.toml.
+
+[mcp_servers.time]
+command = "/root/.pyenv/shims/python"
+args = ["-m", "cores.llm.time_mcp_server"]
+cwd = "/root/prism-insight"
+env = { PYTHONPATH = "/root/prism-insight" }
+enabled_tools = ["get_current_time"]
+default_tools_approval_mode = "approve"
+required = true
+startup_timeout_sec = 15
+tool_timeout_sec = 30
+
+[mcp_servers.yahoo_finance]
+command = "/root/.local/bin/uv"
+args = [
+  "tool",
+  "run",
+  "--from",
+  "yahoo-finance-mcp==0.1.2",
+  "--with",
+  "mcp==1.26.0",
+  "yahoo-finance-mcp",
+]
+cwd = "/tmp"
+enabled_tools = [
+  "get_historical_stock_prices",
+  "get_stock_info",
+  "get_yahoo_finance_news",
+  "get_stock_actions",
+  "get_financial_statement",
+  "get_holder_info",
+  "get_option_expiration_dates",
+  "get_option_chain",
+  "get_recommendations",
+]
+default_tools_approval_mode = "approve"
+required = true
+startup_timeout_sec = 30
+tool_timeout_sec = 120
+
+[mcp_servers.sqlite]
+command = "/root/.local/bin/uv"
+args = [
+  "--directory",
+  "/root/prism-insight/sqlite",
+  "run",
+  "mcp-server-sqlite",
+  "--db-path",
+  "/root/prism-insight/stock_tracking_db.sqlite",
+]
+enabled_tools = ["list_tables", "describe_table", "read_query"]
+default_tools_approval_mode = "approve"
+required = true
+startup_timeout_sec = 30
+tool_timeout_sec = 30
+
+[mcp_servers.perplexity]
+command = "/root/.nvm/versions/node/v22.14.0/bin/npx"
+args = ["-y", "@perplexity-ai/mcp-server@1.2.0"]
+env_vars = ["PERPLEXITY_API_KEY"]
+enabled_tools = ["perplexity_ask"]
+default_tools_approval_mode = "approve"
+required = true
+startup_timeout_sec = 30
+tool_timeout_sec = 120

--- a/docs/codex_oauth_fast_trading_rollout.md
+++ b/docs/codex_oauth_fast_trading_rollout.md
@@ -1,0 +1,229 @@
+# Codex OAuth Fast 매매 에이전트 단계적 전환 계획
+
+작성일: 2026-08-22
+목표: API key 과금 없이 ChatGPT OAuth Codex Fast를 US에서 먼저 검증하고,
+검증 후 KR 매수·KR/US 매도 판단까지 확대한다.
+
+## 1. 인증·표면 구분
+
+- 기존 PRISM 경로: mcp-agent → 일반 OpenAI SDK → ChatGPT OAuth proxy.
+  `service_tier=priority`를 전달해도 실제 응답은 `default`였다.
+- 파일럿 경로: Codex CLI/SDK → 저장된 ChatGPT 로그인 → Codex Fast.
+- Codex Fast 설정:
+
+```toml
+service_tier = "fast"
+
+[features]
+fast_mode = true
+```
+
+- GPT-5.6 Fast는 Standard보다 많은 ChatGPT 크레딧을 사용한다. API key 과금과는
+  별개다.
+
+## 2. Phase 0 결과: 로컬 가용성
+
+로컬 `codex-cli 0.144.1`, ChatGPT 로그인 상태에서 비대화식 실행 성공.
+
+- 짧은 동일 프롬프트:
+  - Fast 5.22초
+  - Standard 6.16초
+- production 프롬프트 + 실제 종결 거래 보고서:
+  - 손실 사례 산일전기 -16.31%:
+    - Fast: 39.39초, `미진입`, outcome +1, JSON 정상
+    - Standard: 69.10초, `진입`, outcome -1, JSON 정상
+  - 수익 사례 SK하이닉스 +12.48%:
+    - Fast: 42.99초, `진입`, outcome +1, JSON 정상
+- Fast 2건 합산: outcome +2/2, parse 2/2.
+
+해석 제한: 표본 2건이며 Standard 비교는 1건뿐이다. 품질 우위 일반화 금지.
+
+## 3. Phase 1: 12건 오프라인 평가
+
+기존 `tasks/eval/trading_ground_truth.json`의 8개 손실·4개 수익을 전부 평가한다.
+
+통과 기준:
+
+1. JSON parse 12/12.
+2. 기존 API `gpt-5.6-sol/high` net outcome +4 이상.
+3. 손실 회피 5/8 이상, 수익 포착 3/4 이상.
+4. p50 지연 55초 이하.
+5. timeout/CLI 오류 0건.
+
+Fast 크레딧 사용량을 먼저 계산·표시하고 실행한다.
+
+## 4. Phase 2: US 매수 시나리오 동등성 검증
+
+- 기존 mcp-agent 결과가 주문의 유일한 권위값이다.
+- Codex Fast는 기존 에이전트와 같은 MCP 서버·읽기 도구를 사용한다.
+- Codex timeout 90초, 동시성 1, 실패 시 기존 경로 유지.
+- 매수·매도 모두 실제 MCP 호출이 1건 이상 완료되어야 성공으로 인정한다.
+- SQLite는 `list_tables`, `describe_table`, `read_query`만 노출한다.
+- 셸·파일·내장 웹 검색은 금지하고 MCP 도구만 허용한다.
+
+승격 기준:
+
+- parse 100%
+- 기존 대비 손실 회피 악화 없음
+- 수익 포착 악화 없음
+- p50 지연 55초 이하
+- 결정 불일치 사례 사람 검토 완료
+
+## 5. Phase 3: US 매수 운영
+
+- Codex Fast를 1차 경로로 사용.
+- 기존 mcp-agent를 timeout/parse/CLI 실패 fallback으로 유지.
+- DB·주문·메시지 반영은 기존 순차 경로에서만 수행.
+- 10거래일 안정화 전에는 US 매도 판단으로 확대하지 않는다.
+
+## 6. Phase 4: KR 매수 shadow → 운영
+
+- US와 동일한 adapter·timeout·원장·fallback을 재사용한다.
+- KR 전용 production 시스템 프롬프트와 KRX sector constraint만 교체한다.
+- 기존 12건 realized-PnL 평가를 회귀 기준으로 유지한다.
+
+## 7. Phase 5: KR/US 매도 판단
+
+- 가장 마지막에 적용한다. 매도 판단은 보유 포지션과 실제 주문에 직접 영향을 준다.
+- Codex는 판단만 수행하고, broker/SQLite 적용은 반드시 기존 순차 chokepoint가 담당한다.
+- shadow에서 기존 결정과 불일치한 모든 `SELL`을 사람이 검토한 뒤 승격한다.
+
+## 8. 서버 준비 조건
+
+필요 조건과 현재 상태:
+
+1. 공식 Codex CLI 설치: 완료 (`/opt/prism-codex`, 0.144.1).
+2. 서버 전용 ChatGPT-managed Codex 로그인: 완료.
+3. `auth.json`·설정은 0600 권한·비추적 유지: 완료.
+4. Fast 설정을 `/root/.codex-prism`에 격리: 완료.
+5. 매매 adapter는 read-only sandbox와 ephemeral thread만 사용: 완료.
+6. KR/US 전용 MCP 프로필로 시장 도구를 격리: 완료.
+
+운영 primary 활성화는 MCP 도구와 판단 결과의 동등성 검증 뒤에만 한다.
+
+## 9. 평가 기록 보존
+
+초기 평가 하네스는 Git에 포함되지 않은 거래 표본과 로컬 보고서 아카이브에
+의존하는 일회성 도구였으므로 저장소에 포함하지 않는다. 검증된 기준과 결과는
+이 문서와 agentmemory에 보존하며, 운영 backend의 명령·격리·MCP 호출 계약은
+`tests/test_codex_oauth_fast_backend.py`에서 회귀 검증한다.
+
+## 10. 12건 전체 평가 결과
+
+사용자 승인에 따라 동시성 2로 전체 12건을 실행했다.
+
+- JSON parse: 12/12
+- net outcome score: +4
+- 손실 회피: 5/8
+- 수익 포착: 3/4
+- p50 latency: 48.11초
+- CLI/timeout 오류: 0
+- 사전등록 게이트: 전부 통과
+
+기존 direct API `gpt-5.6-sol/high` 결과(+4, 5/8, 3/4, p50 71.8초)와
+판단 품질이 같고 p50은 약 33% 짧았다.
+
+## 11. 운영 전환 시도와 즉시 롤백
+
+Rocky가 로컬 검증 통과 후 shadow를 생략하고 운영에 직접 적용하도록 승인했다.
+
+### 서버 Codex 격리
+
+- CLI: `/opt/prism-codex`, codex-cli 0.144.1
+- CODEX_HOME: `/root/.codex-prism`
+- 로컬 Mac 인증 파일을 복사하지 않고 서버 별도 device login
+- 서버와 로컬 모두 `Logged in using ChatGPT` 확인
+- `auth.json`·`config.toml` 권한 0600
+- 서버 Fast 최소 호출 6.29초, production backend JSON 호출 7.97초
+
+초기 무도구 파일럿은 사용자의 직접 운영 승인에 따라 KR/US 매수 primary로 잠시
+설정했으나, 기존 매수 에이전트도 MCP를 실제 사용한다는 점을 재확인한 직후 4개
+크론의 활성화 플래그를 모두 제거했다.
+
+### 롤백 직후 상태
+
+- KR/US 매수·매도: 기존 mcp-agent가 계속 primary
+- Codex Fast: 코드와 서버 프로필만 배치된 비활성 상태
+- timeout: 90초
+- 향후 활성화 시 Codex CLI/인증/timeout/MCP/parse 실패는 자동 fallback
+- US/한국의 DB·주문·메시지 순차 처리 불변
+
+### cron 환경
+
+- `PRISM_US_CODEX_FAST_TRADING`, `PRISM_KR_CODEX_FAST_TRADING`: 미설정
+- `PRISM_US_CODEX_FAST_SELL`, `PRISM_KR_CODEX_FAST_SELL`: 미설정
+- 따라서 롤백 직후 정규 배치는 Codex 경로를 실행하지 않았다.
+
+## 12. MCP 동등성 구현 및 서버 스모크
+
+전용 프로필:
+
+- `kr_trading.config.toml`: `time`, `kospi_kosdaq`, 읽기 전용 `sqlite`, `perplexity`
+- `us_trading.config.toml`: `time`, `yahoo_finance`, 읽기 전용 `sqlite`, `perplexity`
+- SQLite 쓰기 도구 `write_query`, `create_table`, `append_insight`는 미노출
+
+백엔드는 JSONL의 `mcp_tool_call`을 파싱하고, 완료된 MCP 호출이 0건이면 실패로
+처리해 기존 mcp-agent로 폴백한다. KR/US 매수와 매도에 같은 규칙을 적용했다.
+
+db-server 읽기 전용 스모크 결과:
+
+- KR: `time-get_current_time`, `kospi_kosdaq-get_index_ohlcv`,
+  `sqlite-list_tables` 성공 (16.30초)
+- US: `time-get_current_time`, `yahoo_finance-get_historical_stock_prices`,
+  `sqlite-list_tables` 성공 (18.49초)
+- 공통: `perplexity-perplexity_ask` 성공 (15.96초)
+- 스모크 중 주문·DB 수정·텔레그램 전송 없음
+
+실제 매매 프롬프트 메서드 단독 프로브:
+
+- US 매수(HOOD 최신 보고서): 57.66초, MCP 6회, JSON 성공
+- US 매도(PYPL 실제 보유 입력): 67.49초, MCP 9회, `보유`
+- KR 매수(삼성전자 최신 보고서): 79.69초, MCP 6회, JSON 성공
+- KR 매도(메모리 DB 가상 보유 입력): 46.16초, MCP 9회, `보유`
+- Codex 바이너리 강제 실패: 기존 US mcp-agent가 자동 기동해 70.68초에
+  MCP 조회와 JSON 반환, cleanup까지 성공
+- 모든 프로브는 시나리오/판단 메서드까지만 호출했다. 주문·프로덕션 DB 쓰기·
+  텔레그램 전송은 실행하지 않았다.
+
+## 13. 최종 운영 활성화
+
+위 검증 후 2026-08-22 03:32 KST에 KR/US morning·afternoon 4개 크론을
+다음 설정으로 활성화했다.
+
+- `PRISM_KR_CODEX_FAST_TRADING=1`, `PRISM_KR_CODEX_FAST_SELL=1`
+- `PRISM_US_CODEX_FAST_TRADING=1`, `PRISM_US_CODEX_FAST_SELL=1`
+- `PRISM_CODEX_HOME=/root/.codex-prism`
+- `PRISM_CODEX_BIN=/opt/prism-codex/node_modules/.bin/codex`
+- `PRISM_CODEX_FAST_TIMEOUT=120`
+
+활성화 당시 US afternoon 배치는 이미 14:30 EDT에 변경 전 환경으로 시작한
+상태였다. 중복 메시지·중간 작업 손실을 피하려고 재시작하지 않았으며, 그 실행은
+기존 mcp-agent로 완료한다. 새 설정은 다음 정규 배치부터 적용된다.
+
+## 14. 남은 단계
+
+1. 기존 mcp-agent와 Codex가 같은 고정 MCP 응답을 받는 replay 평가를 만든다.
+2. 매수 12건과 매도 realized-outcome 평가에서 JSON·판단·필수 도구 호출을 비교한다.
+3. 첫 정규 배치에서 `[CODEX_FAST]` latency·MCP 호출·fallback 로그를 확인한다.
+4. 나머지 production 직접 참조를 제거한 뒤 mcp-agent dependency/config를 삭제한다.
+
+## 15. US 매수 후보 병렬 pre-pass
+
+2026-08-22 US afternoon 회고에서 보고서 생성 3건은 이미 병렬이었지만, 추적 단계의
+매수 시나리오 3건은 직렬로 실행돼 약 9분이 걸렸다. KR에 있던 구조를 US에도
+포팅했다.
+
+- `US_TRADING_ANALYSIS_CONCURRENCY=2` (최대 4)
+- 공유 SQLite 조회만 `asyncio.Lock`으로 직렬화
+- Codex/LLM 구간은 lock을 해제해 동시 실행
+- 결과 적용, 보유 확인, 매수 주문은 기존 순서대로 직렬 유지
+- Codex 실패 시 legacy MCPApp fallback은 별도 lock으로 직렬화
+
+검증:
+
+- 관련 회귀 테스트 25개 통과, 알려진 기존 score-6 테스트 1개 제외
+- 서버 Codex+MCP 2개 동시 스모크: 각 21.97초/21.10초, 전체 21.97초
+- US morning/afternoon 크론에 동시성 2 명시
+
+매도 판단은 DB 갱신·주문 안전장치가 한 메서드에 함께 있어 즉시 병렬화하지 않았다.
+향후 `판단 준비 → LLM 판단 병렬 → 실행 순차`의 3단계로 분리한 뒤 적용한다.

--- a/prism-us/tests/test_phase7_orchestrator.py
+++ b/prism-us/tests/test_phase7_orchestrator.py
@@ -352,7 +352,10 @@ class TestOrchestratorIntegration:
             def __init__(self, telegram_token=None):
                 self.telegram_token = telegram_token
 
-            async def run(self, pdf_paths, chat_id, language, telegram_config=None, trigger_results_file=None):
+            async def run(
+                self, pdf_paths, chat_id, language, telegram_config=None,
+                trigger_results_file=None, **_kwargs,
+            ):
                 return False
 
         fake_tracking_module = SimpleNamespace(
@@ -377,7 +380,7 @@ class TestOrchestratorIntegration:
             caplog.set_level("INFO")
             await orchestrator.run_full_pipeline("afternoon", language="en", override_date="20260401")
 
-        assert "US tracking system batch execution failed" in caplog.text
+        assert "US full pipeline completed with tracking errors" in caplog.text
         assert "US full pipeline completed with tracking errors - mode: afternoon" in caplog.text
         assert "US full pipeline complete - mode: afternoon" not in caplog.text
 

--- a/prism-us/tests/test_us_batch_report_parallelism.py
+++ b/prism-us/tests/test_us_batch_report_parallelism.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from types import ModuleType
+
+import us_stock_analysis_orchestrator as orchestrator_module
+from us_stock_analysis_orchestrator import (
+    USStockAnalysisOrchestrator,
+    _batch_report_parallel_limit,
+)
+
+
+def test_us_batch_report_parallel_limit_matches_kr_contract() -> None:
+    key = "PRISM_BATCH_REPORT_MAX_CONCURRENCY"
+    assert _batch_report_parallel_limit(5, {}) == 3
+    assert _batch_report_parallel_limit(2, {}) == 2
+    assert _batch_report_parallel_limit(5, {key: "2"}) == 2
+    assert _batch_report_parallel_limit(5, {key: "0"}) == 1
+    assert _batch_report_parallel_limit(5, {key: "99"}) == 5
+    assert _batch_report_parallel_limit(5, {key: "invalid"}) == 3
+
+
+def test_us_generate_reports_uses_kr_bounded_parallelism_and_keeps_order(
+    monkeypatch, tmp_path
+) -> None:
+    active = 0
+    max_active = 0
+
+    async def fake_analyze_us_stock(ticker, **_kwargs):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep({"AAA": 0.03, "BBB": 0.02, "CCC": 0.01}[ticker])
+        active -= 1
+        return f"report-{ticker}"
+
+    fake_module = ModuleType("cores.us_analysis")
+    fake_module.analyze_us_stock = fake_analyze_us_stock
+    monkeypatch.setitem(sys.modules, "cores.us_analysis", fake_module)
+    monkeypatch.setattr(orchestrator_module, "US_REPORTS_DIR", tmp_path)
+    monkeypatch.setenv("PRISM_BATCH_REPORT_MAX_CONCURRENCY", "2")
+
+    orchestrator = USStockAnalysisOrchestrator.__new__(USStockAnalysisOrchestrator)
+    reports = asyncio.run(orchestrator.generate_reports(
+        [
+            {"ticker": "AAA", "name": "Alpha"},
+            {"ticker": "BBB", "name": "Beta"},
+            {"ticker": "CCC", "name": "Gamma"},
+        ],
+        "morning",
+        reference_date="20260821",
+    ))
+
+    assert max_active == 2
+    assert [path.split("/")[-1].split("_")[0] for path in reports] == [
+        "AAA", "BBB", "CCC",
+    ]

--- a/prism-us/tests/test_us_parallel_trading_analysis.py
+++ b/prism-us/tests/test_us_parallel_trading_analysis.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+TEST_DIR = Path(__file__).resolve().parent
+if str(TEST_DIR) not in sys.path:
+    sys.path.insert(0, str(TEST_DIR))
+
+import test_us_stock_tracking_agent_process_reports as base_tests
+
+agent_module = base_tests.us_agent_module
+USStockTrackingAgent = base_tests.USStockTrackingAgent
+
+
+def _make_agent() -> USStockTrackingAgent:
+    agent = USStockTrackingAgent.__new__(USStockTrackingAgent)
+    agent.account_configs = [
+        {
+            "name": "us-primary",
+            "account_key": "vps:us-primary:01",
+            "product": "01",
+        }
+    ]
+    agent.active_account = None
+    agent._safe_account_log_label = MagicMock(return_value="us-primary")
+    agent.update_holdings = AsyncMock(return_value=[])
+    return agent
+
+
+def test_us_trading_analysis_concurrency_defaults_to_two() -> None:
+    key = "US_TRADING_ANALYSIS_CONCURRENCY"
+    shared_key = "TRADING_ANALYSIS_CONCURRENCY"
+    assert agent_module._resolve_us_trading_analysis_concurrency({}) == 2
+    assert agent_module._resolve_us_trading_analysis_concurrency({key: "3"}) == 3
+    assert agent_module._resolve_us_trading_analysis_concurrency(
+        {shared_key: "4"}
+    ) == 4
+    assert agent_module._resolve_us_trading_analysis_concurrency({key: "0"}) == 2
+    assert agent_module._resolve_us_trading_analysis_concurrency(
+        {key: "invalid"}
+    ) == 2
+
+
+@pytest.mark.asyncio
+async def test_us_buy_analysis_prepass_is_bounded_and_preserves_input_order(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(agent_module, "US_TRADING_ANALYSIS_CONCURRENCY", 2)
+    agent = _make_agent()
+    paths = ["report-a.pdf", "report-b.pdf", "report-c.pdf"]
+    delays = {
+        "report-a.pdf": 0.04,
+        "report-b.pdf": 0.03,
+        "report-c.pdf": 0.01,
+    }
+    active = 0
+    peak = 0
+    failure_order: list[str] = []
+
+    async def fake_core(path: str) -> dict:
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(delays[path])
+        active -= 1
+        return {
+            "success": False,
+            "ticker": path,
+            "company_name": path,
+            "error": "probe",
+        }
+
+    original_error = agent_module.logger.error
+
+    def capture_error(message, *args, **kwargs):
+        text = str(message)
+        if text.startswith("[ANALYSIS_FAILED] Report analysis skipped"):
+            failure_order.append(text.rsplit(" — ", 1)[-1])
+        return original_error(message, *args, **kwargs)
+
+    agent._analyze_report_core = fake_core
+    monkeypatch.setattr(agent_module.logger, "error", capture_error)
+
+    assert await agent.process_reports(paths) == (0, 0)
+    assert peak == 2
+    assert failure_order == paths

--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -21,6 +21,7 @@ load_dotenv()
 
 import argparse
 import asyncio
+from contextlib import nullcontext
 import json
 import logging
 import os
@@ -225,6 +226,19 @@ US_REPORTS_DIR.mkdir(exist_ok=True)
 US_TELEGRAM_MSGS_DIR.mkdir(exist_ok=True)
 US_PDF_REPORTS_DIR.mkdir(exist_ok=True)
 (US_TELEGRAM_MSGS_DIR / "sent").mkdir(exist_ok=True)
+
+
+def _batch_report_parallel_limit(job_count: int, environ=None) -> int:
+    """Mirror the proven KR scheduled-report concurrency contract."""
+    if job_count <= 0:
+        return 1
+    environ = os.environ if environ is None else environ
+    raw_limit = environ.get("PRISM_BATCH_REPORT_MAX_CONCURRENCY", "3")
+    try:
+        configured = int(raw_limit)
+    except (TypeError, ValueError):
+        configured = 3
+    return min(job_count, max(1, configured))
 
 
 # Trigger type translation map (English -> Korean)
@@ -570,7 +584,7 @@ class USStockAnalysisOrchestrator:
         reference_date: str | None = None,
     ) -> list:
         """
-        Generate reports serially for all US stocks.
+        Generate US reports with the same bounded parallelism as KR.
 
         Args:
             tickers: List of stocks to analyze
@@ -581,11 +595,14 @@ class USStockAnalysisOrchestrator:
         Returns:
             list: List of successful report paths
         """
-        logger.info(f"Starting US report generation for {len(tickers)} stocks (serial processing)")
+        concurrency = _batch_report_parallel_limit(len(tickers))
+        logger.info(
+            f"Starting US report generation for {len(tickers)} stocks "
+            f"(bounded parallelism={concurrency})"
+        )
+        semaphore = asyncio.Semaphore(concurrency)
 
-        successful_reports = []
-
-        for idx, ticker_info in enumerate(tickers, 1):
+        async def generate_one(idx, ticker_info):
             if isinstance(ticker_info, dict):
                 ticker = ticker_info.get('ticker')
                 company_name = ticker_info.get('name', ticker)
@@ -604,20 +621,23 @@ class USStockAnalysisOrchestrator:
             try:
                 from cores.us_analysis import analyze_us_stock
 
-                logger.info(f"[{idx}/{len(tickers)}] Starting analyze_us_stock function call")
-                report = await analyze_us_stock(
-                    ticker=ticker,
-                    company_name=company_name,
-                    reference_date=report_date,
-                    language=language,
-                    macro_context=macro_context
-                )
+                async with semaphore:
+                    logger.info(
+                        f"[{idx}/{len(tickers)}] Starting analyze_us_stock function call"
+                    )
+                    report = await analyze_us_stock(
+                        ticker=ticker,
+                        company_name=company_name,
+                        reference_date=report_date,
+                        language=language,
+                        macro_context=macro_context
+                    )
 
                 if report and len(report.strip()) > 0:
                     with open(output_file, "w", encoding="utf-8") as f:
                         f.write(report)
                     logger.info(f"[{idx}/{len(tickers)}] Report generation complete: {company_name}({ticker}) - {len(report)} characters")
-                    successful_reports.append(output_file)
+                    return output_file
                 else:
                     logger.error(f"[{idx}/{len(tickers)}] Report generation failed: {company_name}({ticker}) - empty content")
 
@@ -626,6 +646,13 @@ class USStockAnalysisOrchestrator:
                 import traceback
                 logger.error(traceback.format_exc())
 
+            return None
+
+        reports = await asyncio.gather(*(
+            generate_one(idx, ticker_info)
+            for idx, ticker_info in enumerate(tickers, 1)
+        ))
+        successful_reports = [report for report in reports if report]
         logger.info(f"US report generation complete: {len(successful_reports)}/{len(tickers)} successful")
         return successful_reports
 
@@ -1348,7 +1375,11 @@ class USStockAnalysisOrchestrator:
                 try:
                     logger.info("Starting US stock tracking system batch execution")
 
-                    from us_stock_tracking_agent import USStockTrackingAgent, app as tracking_app
+                    from us_stock_tracking_agent import (
+                        USStockTrackingAgent,
+                        _us_codex_runtime_enabled,
+                        app as tracking_app,
+                    )
 
                     if self.telegram_config.use_telegram:
                         try:
@@ -1360,7 +1391,12 @@ class USStockAnalysisOrchestrator:
 
                     self.telegram_config.log_status()
 
-                    async with tracking_app.run():
+                    tracking_context = (
+                        nullcontext()
+                        if _us_codex_runtime_enabled()
+                        else tracking_app.run()
+                    )
+                    async with tracking_context:
                         tracking_agent = USStockTrackingAgent(
                             telegram_token=self.telegram_config.bot_token if self.telegram_config.use_telegram else None
                         )

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -22,6 +22,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 import asyncio
+from contextlib import asynccontextmanager
 import json
 import logging
 import os
@@ -105,7 +106,16 @@ assert _spec is not None and _spec.loader is not None
 _mod = _ilu.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)  # type: ignore[union-attr]
 OpenAIAugmentedLLM = _mod.OpenAIResponsesLLM
-del _ilu, _spec, _mod
+_codex_spec = _ilu.spec_from_file_location(
+    "codex_oauth_fast_backend",
+    Path(__file__).resolve().parent.parent / "cores" / "llm" / "codex_oauth_fast_backend.py",
+)
+assert _codex_spec is not None and _codex_spec.loader is not None
+_codex_mod = _ilu.module_from_spec(_codex_spec)
+sys.modules[_codex_spec.name] = _codex_mod
+_codex_spec.loader.exec_module(_codex_mod)  # type: ignore[union-attr]
+generate_codex_fast = _codex_mod.generate_codex_fast
+del _ilu, _spec, _mod, _codex_spec, _codex_mod
 
 # Import US-specific modules
 # Use explicit path to avoid conflicts with main project
@@ -153,6 +163,13 @@ translate_telegram_message = _translator_module.translate_telegram_message
 # (avoids prism-us/cores/ namespace collision)
 _utils_module = _import_from_main_cores("cores_utils", "cores/utils.py")
 parse_llm_json = _utils_module.parse_llm_json
+
+_feedback_module = _import_from_main_cores(
+    "prism_root_performance_feedback_agent",
+    "tracking/performance_feedback.py",
+)
+format_trigger_feedback = _feedback_module.format_trigger_feedback
+get_trigger_feedback = _feedback_module.get_trigger_feedback
 
 try:
     # First try direct import from prism-us directory
@@ -203,7 +220,53 @@ ka = _importlib_util.module_from_spec(_kis_auth_spec)
 _kis_auth_spec.loader.exec_module(ka)
 
 # Create MCPApp instance
-app = MCPApp(name="us_stock_tracking")
+class _LazyMCPApp:
+    """Construct mcp-agent only when legacy mode or fallback actually needs it."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    @asynccontextmanager
+    async def run(self):
+        instance = MCPApp(name=self.name)
+        async with instance.run():
+            yield
+
+
+app = _LazyMCPApp(name="us_stock_tracking")
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.environ.get(name, "0").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _us_codex_runtime_enabled() -> bool:
+    """Whether Codex MCP must run without an outer mcp-agent host."""
+    return _env_flag_enabled("PRISM_US_CODEX_FAST_TRADING") or _env_flag_enabled(
+        "PRISM_US_CODEX_FAST_SELL"
+    )
+
+
+def _resolve_us_trading_analysis_concurrency(environ=None) -> int:
+    """Bound concurrent US buy-scenario analyses without overloading db-server."""
+    environ = os.environ if environ is None else environ
+    raw = environ.get(
+        "US_TRADING_ANALYSIS_CONCURRENCY",
+        environ.get("TRADING_ANALYSIS_CONCURRENCY", "2"),
+    )
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return 2
+    return min(value, 4) if value > 0 else 2
+
+
+US_TRADING_ANALYSIS_CONCURRENCY = _resolve_us_trading_analysis_concurrency()
 
 
 # =============================================================================
@@ -894,6 +957,22 @@ class USStockTrackingAgent:
         account_key, _ = self._account_scope()
         return get_us_holdings_count(self.cursor, account_key=account_key)
 
+    def _get_db_lock(self) -> asyncio.Lock:
+        """Serialize the shared sqlite cursor around bounded parallel pre-pass reads."""
+        lock = getattr(self, "_db_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._db_lock = lock
+        return lock
+
+    def _get_legacy_fallback_lock(self) -> asyncio.Lock:
+        """Never start multiple legacy MCPApp fallbacks in the same process."""
+        lock = getattr(self, "_legacy_fallback_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._legacy_fallback_lock = lock
+        return lock
+
     async def _check_sector_diversity(self, sector: str, is_pyramiding_add: bool = False) -> bool:
         """Check for over-concentration in same sector.
 
@@ -1105,7 +1184,8 @@ class USStockTrackingAgent:
         ticker: str = None,
         sector: str = None,
         trigger_type: str = "",
-        trigger_mode: str = ""
+        trigger_mode: str = "",
+        db_lock: "asyncio.Lock" = None,
     ) -> Dict[str, Any]:
         """
         Extract trading scenario from report.
@@ -1121,7 +1201,13 @@ class USStockTrackingAgent:
         Returns:
             Dict: Trading scenario information
         """
+        if db_lock is None:
+            db_lock = self._get_db_lock()
+        _lock_held = False
         try:
+            await db_lock.acquire()
+            _lock_held = True
+
             # Get current holdings info
             current_slots = await self._get_current_slots_count()
 
@@ -1191,8 +1277,10 @@ class USStockTrackingAgent:
                 if trend_facts:
                     logger.debug(f"[TrendFacts] US injected for {ticker} ({len(trend_facts)} chars)")
 
-            # LLM call to generate trading scenario
-            llm = await self.trading_agent.attach_llm(OpenAIAugmentedLLM)
+            # The prompt now contains an immutable snapshot. Release the shared
+            # sqlite cursor before Codex/mcp-agent so independent candidates overlap.
+            db_lock.release()
+            _lock_held = False
 
             # Build trigger info section
             trigger_info_section = ""
@@ -1219,40 +1307,100 @@ class USStockTrackingAgent:
             {report_content}
             """
 
+            ticker_tag = ticker or "?"
+            scenario_json = None
+            codex_enabled = os.environ.get(
+                "PRISM_US_CODEX_FAST_TRADING", "0"
+            ).strip().lower() in {"1", "true", "yes", "on"}
+            if codex_enabled:
+                try:
+                    instruction = str(
+                        getattr(self.trading_agent, "instruction", "") or ""
+                    )
+                    if not instruction:
+                        raise RuntimeError("trading agent instruction unavailable")
+                    timeout = int(os.environ.get("PRISM_CODEX_FAST_TIMEOUT", "90"))
+                    codex_result = await asyncio.to_thread(
+                        generate_codex_fast,
+                        system_prompt=instruction,
+                        user_prompt=prompt_message,
+                        model="gpt-5.6-sol",
+                        timeout=timeout,
+                        mcp_profile="us_trading",
+                        require_mcp_calls=True,
+                    )
+                    scenario_json = parse_llm_json(
+                        codex_result.text,
+                        context="US Codex Fast trading scenario",
+                    )
+                    logger.info(
+                        "[CODEX_FAST] US scenario ticker=%s latency_s=%.2f "
+                        "parse_ok=%s mcp_calls=%s",
+                        ticker_tag,
+                        codex_result.latency_s,
+                        scenario_json is not None,
+                        len(codex_result.mcp_calls),
+                    )
+                    if scenario_json is None:
+                        logger.warning(
+                            "[%s] Codex Fast parse failed; falling back to mcp-agent",
+                            ticker_tag,
+                        )
+                except Exception as codex_err:  # noqa: BLE001 — mandatory fallback
+                    logger.warning(
+                        "[%s] Codex Fast unavailable (%s); falling back to mcp-agent",
+                        ticker_tag,
+                        type(codex_err).__name__,
+                    )
+                    scenario_json = None
+
             # LLM scenario generation with retry+backoff. Transient API/parse
             # failures (rate limits, truncated responses) were silently turning
             # into default_scenario() — i.e. a misleading "Analysis failed" skip.
             # Retry a couple of times before giving up.
-            ticker_tag = ticker or "?"
-            max_attempts = 3
-            response = None
-            scenario_json = None
-            for attempt in range(1, max_attempts + 1):
-                try:
-                    response = await llm.generate_str(
-                        message=prompt_message,
-                        request_params=RequestParams(
-                            model="gpt-5.6-sol",
-                            reasoning_effort="high",
-                            maxTokens=30000
-                        )
-                    )
-                    # JSON parsing (consolidated in cores/utils.py)
-                    scenario_json = parse_llm_json(response, context='US trading scenario')
-                    if scenario_json is not None:
-                        break
-                    logger.warning(
-                        f"[{ticker_tag}] US trading scenario parse returned None "
-                        f"(attempt {attempt}/{max_attempts})"
-                    )
-                except Exception as call_err:
-                    log_openai_error(logger, call_err, f"US trading scenario LLM call [{ticker_tag}]")
-                    logger.warning(
-                        f"[{ticker_tag}] US trading scenario LLM call failed "
-                        f"(attempt {attempt}/{max_attempts}): {call_err}"
-                    )
-                if attempt < max_attempts:
-                    await asyncio.sleep(2 * attempt)  # linear backoff: 2s, 4s
+            if scenario_json is None:
+                async def _legacy_scenario():
+                    llm = await self.trading_agent.attach_llm(OpenAIAugmentedLLM)
+                    max_attempts = 3
+                    legacy_scenario = None
+                    for attempt in range(1, max_attempts + 1):
+                        try:
+                            response = await llm.generate_str(
+                                message=prompt_message,
+                                request_params=RequestParams(
+                                    model="gpt-5.6-sol",
+                                    reasoning_effort="high",
+                                    maxTokens=30000
+                                )
+                            )
+                            legacy_scenario = parse_llm_json(
+                                response, context='US trading scenario'
+                            )
+                            if legacy_scenario is not None:
+                                break
+                            logger.warning(
+                                f"[{ticker_tag}] US trading scenario parse returned None "
+                                f"(attempt {attempt}/{max_attempts})"
+                            )
+                        except Exception as call_err:
+                            log_openai_error(
+                                logger, call_err,
+                                f"US trading scenario LLM call [{ticker_tag}]",
+                            )
+                            logger.warning(
+                                f"[{ticker_tag}] US trading scenario LLM call failed "
+                                f"(attempt {attempt}/{max_attempts}): {call_err}"
+                            )
+                        if attempt < max_attempts:
+                            await asyncio.sleep(2 * attempt)
+                    return legacy_scenario
+
+                if _us_codex_runtime_enabled():
+                    async with self._get_legacy_fallback_lock():
+                        async with app.run():
+                            scenario_json = await _legacy_scenario()
+                else:
+                    scenario_json = await _legacy_scenario()
 
             if scenario_json is not None:
                 scenario_json = self._stamp_scenario_market_regime(scenario_json)
@@ -1270,8 +1418,8 @@ class USStockTrackingAgent:
                 return scenario_json
 
             logger.error(
-                f"[ANALYSIS_FAILED][{ticker_tag}] US trading scenario unavailable after "
-                f"{max_attempts} attempts. Last response (truncated): {str(response)[:500]}"
+                f"[ANALYSIS_FAILED][{ticker_tag}] US trading scenario unavailable "
+                "after Codex primary and legacy fallback attempts"
             )
             return default_scenario()
 
@@ -1280,6 +1428,9 @@ class USStockTrackingAgent:
             logger.error(f"Error extracting trading scenario: {str(e)}")
             logger.error(traceback.format_exc())
             return default_scenario()
+        finally:
+            if _lock_held:
+                db_lock.release()
 
     async def _analyze_report_core(self, pdf_report_path: str) -> Dict[str, Any]:
         """Analyze a report once before per-account execution checks.
@@ -1299,7 +1450,9 @@ class USStockTrackingAgent:
                 logger.error(f"Failed to extract ticker info: {pdf_report_path}")
                 return {"success": False, "error": "Failed to extract ticker info"}
 
-            current_price = await self._get_current_stock_price(ticker)
+            db_lock = self._get_db_lock()
+            async with db_lock:
+                current_price = await self._get_current_stock_price(ticker)
             if current_price <= 0:
                 logger.error(f"{ticker} current price query failed")
                 return {"success": False, "error": "Current price query failed"}
@@ -1319,7 +1472,8 @@ class USStockTrackingAgent:
                 ticker=ticker,
                 sector=None,
                 trigger_type=trigger_type,
-                trigger_mode=trigger_mode
+                trigger_mode=trigger_mode,
+                db_lock=db_lock,
             )
 
             # Analysis/LLM failure sentinel: do NOT emit a misleading "매수 보류"
@@ -2038,9 +2192,6 @@ class USStockTrackingAgent:
             # Dynamic trailing stop threshold: min 1.5%, max 5%, scales with price appreciation
             trailing_stop_threshold_pct = max(1.5, min(5.0, (highest_price - buy_price) / buy_price * 100 * 0.3)) if buy_price > 0 else 3.0
 
-            # LLM call
-            llm = await self.sell_decision_agent.attach_llm(OpenAIAugmentedLLM)
-
             # 시스템이 사이클당 1회 계산한 LIVE 시장 레짐(S&P500/VIX 기반, OpenAI 무관).
             # 매수시점 동결값(scenario.market_condition)이 아닌 '현재' 레짐을 권위값으로 주입.
             live_regime_summary = getattr(self, "_live_regime_summary", None)
@@ -2083,10 +2234,72 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
 **Important**: If stop loss/target price adjustment is needed, return it via portfolio_adjustment JSON only. Do NOT directly UPDATE the DB.
 """
 
-            response = await llm.generate_str(
-                message=prompt_message,
-                request_params=RequestParams(model="gpt-5.6-sol", reasoning_effort="high", maxTokens=30000)
-            )
+            response = None
+            codex_sell_enabled = os.environ.get(
+                "PRISM_US_CODEX_FAST_SELL",
+                os.environ.get("PRISM_US_CODEX_FAST_TRADING", "0"),
+            ).strip().lower() in {"1", "true", "yes", "on"}
+            if codex_sell_enabled:
+                try:
+                    instruction = str(
+                        getattr(self.sell_decision_agent, "instruction", "") or ""
+                    )
+                    if not instruction:
+                        raise RuntimeError("sell agent instruction unavailable")
+                    timeout = int(os.environ.get("PRISM_CODEX_FAST_TIMEOUT", "90"))
+                    codex_result = await asyncio.to_thread(
+                        generate_codex_fast,
+                        system_prompt=instruction,
+                        user_prompt=prompt_message,
+                        model="gpt-5.6-sol",
+                        timeout=timeout,
+                        mcp_profile="us_trading",
+                        require_mcp_calls=True,
+                    )
+                    if parse_llm_json(
+                        codex_result.text,
+                        context=f"{ticker} US Codex Fast sell decision",
+                    ) is not None:
+                        response = codex_result.text
+                        logger.info(
+                            "[CODEX_FAST] US sell ticker=%s latency_s=%.2f "
+                            "mcp_calls=%s",
+                            ticker or "?",
+                            codex_result.latency_s,
+                            len(codex_result.mcp_calls),
+                        )
+                    else:
+                        logger.warning(
+                            "[%s] Codex Fast sell parse failed; falling back to mcp-agent",
+                            ticker or "?",
+                        )
+                except Exception as codex_err:  # noqa: BLE001 — mandatory fallback
+                    logger.warning(
+                        "[%s] Codex Fast sell unavailable (%s); "
+                        "falling back to mcp-agent",
+                        ticker or "?",
+                        type(codex_err).__name__,
+                    )
+
+            if response is None:
+                async def _legacy_sell_response():
+                    llm = await self.sell_decision_agent.attach_llm(
+                        OpenAIAugmentedLLM
+                    )
+                    return await llm.generate_str(
+                        message=prompt_message,
+                        request_params=RequestParams(
+                            model="gpt-5.6-sol",
+                            reasoning_effort="high",
+                            maxTokens=30000,
+                        ),
+                    )
+
+                if _us_codex_runtime_enabled():
+                    async with app.run():
+                        response = await _legacy_sell_response()
+                else:
+                    response = await _legacy_sell_response()
 
             if not response or not response.strip():
                 logger.warning(f"{ticker} Empty LLM response, falling back to rule-based decision")
@@ -3430,8 +3643,36 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
             signaled_tickers: set[str] = set()
             analysis_states: list[dict[str, Any]] = []
 
+            concurrency = max(
+                1,
+                min(US_TRADING_ANALYSIS_CONCURRENCY, len(pdf_report_paths) or 1),
+            )
+            semaphore = asyncio.Semaphore(concurrency)
+
+            async def _run_core(path: str) -> tuple[str, Dict[str, Any]]:
+                async with semaphore:
+                    try:
+                        return path, await self._analyze_report_core(path)
+                    except Exception as error:  # noqa: BLE001 — isolate one candidate
+                        logger.error(
+                            "Parallel US core analysis failed: %s (%s)",
+                            path,
+                            type(error).__name__,
+                        )
+                        return path, {"success": False, "error": str(error)}
+
+            logger.info(
+                "Parallel US buy-analysis pre-pass: %s reports, concurrency=%s",
+                len(pdf_report_paths),
+                concurrency,
+            )
+            core_pairs = await asyncio.gather(
+                *(_run_core(path) for path in pdf_report_paths)
+            )
+            core_results = dict(core_pairs)
+
             for pdf_report_path in pdf_report_paths:
-                analysis_result = await self._analyze_report_core(pdf_report_path)
+                analysis_result = core_results[pdf_report_path]
                 if not analysis_result.get("success", False):
                     logger.error(
                         f"[ANALYSIS_FAILED] Report analysis skipped "
@@ -4322,28 +4563,13 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
         return 0, []
 
     def _get_trigger_win_rate(self, trigger_type: str) -> str:
-        """Get trigger win rate string from us_analysis_performance_tracker.
-        Returns a formatted string like '(Trigger Win Rate: 63%)' or empty string if no data."""
+        """Return clearly separated actual-trade and Candidate trigger stats."""
         if not trigger_type or not self.conn:
             return ""
         try:
-            cursor = self.conn.cursor()
-            # Check table exists
-            table_check = cursor.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='us_analysis_performance_tracker'"
-            ).fetchone()
-            if not table_check:
-                return ""
-            row = cursor.execute("""
-                SELECT COUNT(*) as completed,
-                       SUM(CASE WHEN return_30d > 0 THEN 1 ELSE 0 END) as wins
-                FROM us_analysis_performance_tracker
-                WHERE trigger_type = ? AND return_30d IS NOT NULL
-            """, (trigger_type,)).fetchone()
-            if row and row[0] >= 3:
-                win_rate = int(row[1] / row[0] * 100)
-                return f"📡 Trigger Win Rate: {win_rate}% ({row[0]} trades)"
-            return ""
+            feedback = get_trigger_feedback(self.conn.cursor(), "US", trigger_type)
+            lines = format_trigger_feedback(feedback, language="en")
+            return f"📡 {' / '.join(lines)}" if lines else ""
         except Exception:
             return ""
 
@@ -4473,7 +4699,12 @@ async def main():
         logger.error("Report path not specified")
         return False
 
-    async with app.run():
+    from contextlib import nullcontext
+
+    tracking_context = (
+        nullcontext() if _us_codex_runtime_enabled() else app.run()
+    )
+    async with tracking_context:
         agent = USStockTrackingAgent(
             telegram_token=args.telegram_token,
             enable_journal=args.enable_journal

--- a/stock_analysis_orchestrator.py
+++ b/stock_analysis_orchestrator.py
@@ -15,6 +15,7 @@ load_dotenv()  # Load environment variables from .env file
 import cores.openai_debug  # noqa: F401 — OpenAI 400 error request body logging
 import argparse
 import asyncio
+from contextlib import nullcontext
 import json
 import logging
 import os
@@ -1276,7 +1277,10 @@ class StockAnalysisOrchestrator:
 
                     # Import tracking agent
                     from stock_tracking_enhanced_agent import EnhancedStockTrackingAgent as StockTrackingAgent
-                    from stock_tracking_agent import app as tracking_app
+                    from stock_tracking_agent import (
+                        _kr_codex_runtime_enabled,
+                        app as tracking_app,
+                    )
 
                     # Validate telegram configuration
                     if self.telegram_config.use_telegram:
@@ -1292,7 +1296,12 @@ class StockAnalysisOrchestrator:
                     self.telegram_config.log_status()
 
                     # Use MCPApp context manager
-                    async with tracking_app.run():
+                    tracking_context = (
+                        nullcontext()
+                        if _kr_codex_runtime_enabled()
+                        else tracking_app.run()
+                    )
+                    async with tracking_context:
                         # Pass telegram configuration to agent
                         tracking_agent = StockTrackingAgent(
                             telegram_token=self.telegram_config.bot_token if self.telegram_config.use_telegram else None

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -15,6 +15,7 @@ from dotenv import load_dotenv
 load_dotenv()  # Load environment variables from .env file
 
 import asyncio
+from contextlib import asynccontextmanager
 import json
 import logging
 import os
@@ -44,6 +45,7 @@ logger = logging.getLogger(__name__)
 from mcp_agent.app import MCPApp
 from mcp_agent.workflows.llm.augmented_llm import RequestParams
 from cores.llm.openai_responses_llm import OpenAIResponsesLLM as OpenAIAugmentedLLM
+from cores.llm.codex_oauth_fast_backend import generate_codex_fast
 
 # Core agent imports
 from cores.openai_error_logging import log_openai_error
@@ -104,9 +106,37 @@ from tracking import (
 )
 from trading import kis_auth as ka
 
-# Create MCPApp instance
-app = MCPApp(name="stock_tracking")
+# Delay MCPApp construction so a successful Codex+MCP path never nests two
+# MCP hosts in one process. Legacy mode still constructs the same app at run().
+class _LazyMCPApp:
+    def __init__(self, name: str):
+        self.name = name
+
+    @asynccontextmanager
+    async def run(self):
+        instance = MCPApp(name=self.name)
+        async with instance.run():
+            yield
+
+
+app = _LazyMCPApp(name="stock_tracking")
 _DEFAULT_KR_EXIT_LIMIT = object()
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.environ.get(name, "0").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _kr_codex_runtime_enabled() -> bool:
+    """Whether Codex MCP must run without an outer mcp-agent host."""
+    return _env_flag_enabled("PRISM_KR_CODEX_FAST_TRADING") or _env_flag_enabled(
+        "PRISM_KR_CODEX_FAST_SELL"
+    )
 
 
 @dataclass(frozen=True)
@@ -934,9 +964,6 @@ class StockTrackingAgent:
             db_lock.release()
             _lock_held = False
 
-            # LLM call to generate trading scenario
-            llm = await self.trading_agent.attach_llm(OpenAIAugmentedLLM)
-
             # Build trigger info section if available
             trigger_info_section = ""
             if trigger_type:
@@ -987,10 +1014,60 @@ class StockTrackingAgent:
                 {report_content}
                 """
 
-            scenario_json = await _generate_trading_scenario_json(
-                llm,
-                prompt_message,
-            )
+            scenario_json = None
+            codex_enabled = os.environ.get(
+                "PRISM_KR_CODEX_FAST_TRADING", "0"
+            ).strip().lower() in {"1", "true", "yes", "on"}
+            if codex_enabled:
+                try:
+                    instruction = str(
+                        getattr(self.trading_agent, "instruction", "") or ""
+                    )
+                    if not instruction:
+                        raise RuntimeError("trading agent instruction unavailable")
+                    timeout = int(os.environ.get("PRISM_CODEX_FAST_TIMEOUT", "90"))
+                    codex_result = await asyncio.to_thread(
+                        generate_codex_fast,
+                        system_prompt=instruction,
+                        user_prompt=prompt_message,
+                        model="gpt-5.6-sol",
+                        timeout=timeout,
+                        mcp_profile="kr_trading",
+                        require_mcp_calls=True,
+                    )
+                    scenario_json = parse_llm_json(
+                        codex_result.text,
+                        context="KR Codex Fast trading scenario",
+                    )
+                    logger.info(
+                        "[CODEX_FAST] KR scenario ticker=%s latency_s=%.2f "
+                        "parse_ok=%s mcp_calls=%s",
+                        ticker or "?",
+                        codex_result.latency_s,
+                        scenario_json is not None,
+                        len(codex_result.mcp_calls),
+                    )
+                except Exception as codex_err:  # noqa: BLE001 — fallback required
+                    logger.warning(
+                        "[%s] Codex Fast unavailable (%s); falling back to mcp-agent",
+                        ticker or "?",
+                        type(codex_err).__name__,
+                    )
+                    scenario_json = None
+
+            if scenario_json is None:
+                async def _legacy_scenario():
+                    llm = await self.trading_agent.attach_llm(OpenAIAugmentedLLM)
+                    return await _generate_trading_scenario_json(
+                        llm,
+                        prompt_message,
+                    )
+
+                if _kr_codex_runtime_enabled():
+                    async with app.run():
+                        scenario_json = await _legacy_scenario()
+                else:
+                    scenario_json = await _legacy_scenario()
             if scenario_json is not None:
                 scenario_json = self._stamp_scenario_market_regime(scenario_json)
                 # Preserve the deterministic facts used in the prompt so the
@@ -1229,22 +1306,18 @@ class StockTrackingAgent:
         return parse_price_value(value)
 
     def _get_trigger_win_rate(self, trigger_type: str) -> str:
-        """Get trigger win rate string from analysis_performance_tracker.
-        Returns a formatted string like '(이 트리거 과거 승률: 63%)' or empty string if no data."""
+        """Return clearly separated actual-trade and Candidate trigger stats."""
         if not trigger_type or not self.conn:
             return ""
         try:
-            cursor = self.conn.cursor()
-            row = cursor.execute("""
-                SELECT COUNT(*) as completed,
-                       SUM(CASE WHEN tracked_30d_return > 0 THEN 1 ELSE 0 END) as wins
-                FROM analysis_performance_tracker
-                WHERE trigger_type = ? AND tracking_status = 'completed'
-            """, (trigger_type,)).fetchone()
-            if row and row[0] >= 3:
-                win_rate = int(row[1] / row[0] * 100)
-                return f"📡 이 트리거 과거 승률: {win_rate}% ({row[0]}건)"
-            return ""
+            from tracking.performance_feedback import (
+                format_trigger_feedback,
+                get_trigger_feedback,
+            )
+
+            feedback = get_trigger_feedback(self.conn.cursor(), "KR", trigger_type)
+            lines = format_trigger_feedback(feedback, language="ko")
+            return f"📡 {' / '.join(lines)}" if lines else ""
         except Exception:
             return ""
 
@@ -4831,7 +4904,12 @@ async def main():
         local_logger.error("Report path not specified")
         return False
 
-    async with app.run():
+    from contextlib import nullcontext
+
+    tracking_context = (
+        nullcontext() if _kr_codex_runtime_enabled() else app.run()
+    )
+    async with tracking_context:
         agent = StockTrackingAgent(telegram_token=args.telegram_token)
         success = await agent.run(args.reports, args.chat_id)
 

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -5,7 +5,11 @@ import numpy as np
 from scipy import stats
 from typing import List, Tuple, Dict, Any
 from datetime import datetime, timedelta
-from stock_tracking_agent import StockTrackingAgent
+from stock_tracking_agent import (
+    StockTrackingAgent,
+    _kr_codex_runtime_enabled,
+    app,
+)
 from prism_core.positions import LegacyPositionWriteResult, legacy_position_id
 import asyncio
 import logging
@@ -14,6 +18,7 @@ import os
 import traceback
 
 from mcp_agent.workflows.llm.augmented_llm import RequestParams
+from cores.llm.codex_oauth_fast_backend import generate_codex_fast
 from cores.llm.openai_responses_llm import OpenAIResponsesLLM as OpenAIAugmentedLLM
 
 # Import core agents
@@ -1415,9 +1420,6 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
             # Dynamic trailing stop threshold: min 1.5%, max 5%, scales with price appreciation
             trailing_stop_threshold_pct = max(1.5, min(5.0, (highest_price - buy_price) / buy_price * 100 * 0.3)) if buy_price > 0 else 3.0
 
-            # LLM call to generate sell decision
-            llm = await self.sell_decision_agent.attach_llm(OpenAIAugmentedLLM)
-
             # Prepare prompt based on language (Korean text preserved for language == "ko" blocks)
             if self.language == "ko":
                 prompt_message = f"""
@@ -1479,14 +1481,72 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                 **Important**: If stop loss/target price adjustment is needed, return it via portfolio_adjustment JSON only. Do NOT directly UPDATE the DB.
                 """
 
-            response = await llm.generate_str(
-                message=prompt_message,
-                request_params=RequestParams(
-                    model="gpt-5.6-sol",
-                    reasoning_effort="high",
-                    maxTokens=30000
-                )
-            )
+            response = None
+            codex_sell_enabled = os.environ.get(
+                "PRISM_KR_CODEX_FAST_SELL",
+                os.environ.get("PRISM_KR_CODEX_FAST_TRADING", "0"),
+            ).strip().lower() in {"1", "true", "yes", "on"}
+            if codex_sell_enabled:
+                try:
+                    instruction = str(
+                        getattr(self.sell_decision_agent, "instruction", "") or ""
+                    )
+                    if not instruction:
+                        raise RuntimeError("sell agent instruction unavailable")
+                    timeout = int(os.environ.get("PRISM_CODEX_FAST_TIMEOUT", "90"))
+                    codex_result = await asyncio.to_thread(
+                        generate_codex_fast,
+                        system_prompt=instruction,
+                        user_prompt=prompt_message,
+                        model="gpt-5.6-sol",
+                        timeout=timeout,
+                        mcp_profile="kr_trading",
+                        require_mcp_calls=True,
+                    )
+                    if parse_llm_json(
+                        codex_result.text,
+                        context=f"{ticker} KR Codex Fast sell decision",
+                    ) is not None:
+                        response = codex_result.text
+                        logger.info(
+                            "[CODEX_FAST] KR sell ticker=%s latency_s=%.2f "
+                            "mcp_calls=%s",
+                            ticker or "?",
+                            codex_result.latency_s,
+                            len(codex_result.mcp_calls),
+                        )
+                    else:
+                        logger.warning(
+                            "[%s] Codex Fast sell parse failed; falling back to mcp-agent",
+                            ticker or "?",
+                        )
+                except Exception as codex_err:  # noqa: BLE001 — mandatory fallback
+                    logger.warning(
+                        "[%s] Codex Fast sell unavailable (%s); "
+                        "falling back to mcp-agent",
+                        ticker or "?",
+                        type(codex_err).__name__,
+                    )
+
+            if response is None:
+                async def _legacy_sell_response():
+                    llm = await self.sell_decision_agent.attach_llm(
+                        OpenAIAugmentedLLM
+                    )
+                    return await llm.generate_str(
+                        message=prompt_message,
+                        request_params=RequestParams(
+                            model="gpt-5.6-sol",
+                            reasoning_effort="high",
+                            maxTokens=30000
+                        )
+                    )
+
+                if _kr_codex_runtime_enabled():
+                    async with app.run():
+                        response = await _legacy_sell_response()
+                else:
+                    response = await _legacy_sell_response()
 
             # JSON parsing (consolidated in cores/utils.py)
             try:

--- a/tests/test_codex_oauth_fast_backend.py
+++ b/tests/test_codex_oauth_fast_backend.py
@@ -34,6 +34,13 @@ def test_resolve_codex_executable_rejects_unsafe_permissions(
         backend._resolve_codex_executable("codex")
 
 
+def test_command_rejects_unapproved_model_and_profile() -> None:
+    with pytest.raises(backend.CodexFastError, match="Unsupported Codex model"):
+        backend._command("/trusted/codex", "attacker-model", None)
+    with pytest.raises(backend.CodexFastError, match="Unsupported Codex MCP profile"):
+        backend._command("/trusted/codex", "gpt-5.6-sol", "attacker-profile")
+
+
 def test_codex_fast_backend_uses_isolated_ephemeral_command(
     monkeypatch,
     _trusted_codex,

--- a/tests/test_codex_oauth_fast_backend.py
+++ b/tests/test_codex_oauth_fast_backend.py
@@ -9,11 +9,43 @@ import pytest
 import cores.llm.codex_oauth_fast_backend as backend
 
 
-def test_codex_fast_backend_uses_isolated_ephemeral_command(monkeypatch) -> None:
+@pytest.fixture
+def _trusted_codex(monkeypatch) -> None:
+    monkeypatch.setattr(
+        backend,
+        "_resolve_codex_executable",
+        lambda _candidate: "/trusted/codex",
+    )
+
+
+def test_resolve_codex_executable_rejects_unsafe_permissions(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    executable = tmp_path / "codex"
+    executable.write_text("#!/bin/sh\nexit 0\n")
+    executable.chmod(0o755)
+    monkeypatch.setattr(backend.shutil, "which", lambda _candidate: str(executable))
+
+    assert backend._resolve_codex_executable("codex") == str(executable.resolve())
+
+    executable.chmod(0o775)
+    with pytest.raises(backend.CodexFastError, match="unsafe permissions"):
+        backend._resolve_codex_executable("codex")
+
+
+def test_codex_fast_backend_uses_isolated_ephemeral_command(
+    monkeypatch,
+    _trusted_codex,
+) -> None:
     seen = {}
 
     def fake_run(command, **kwargs):
-        seen.update(command=command, kwargs=kwargs)
+        seen.update(
+            command=command,
+            kwargs=kwargs,
+            run_dir_existed=Path(kwargs["cwd"]).is_dir(),
+        )
         stream = "\n".join([
             json.dumps({
                 "type": "item.completed",
@@ -42,11 +74,12 @@ def test_codex_fast_backend_uses_isolated_ephemeral_command(monkeypatch) -> None
         require_mcp_calls=True,
     )
     command = seen["command"]
-    assert command[:2] == ["codex", "exec"]
+    assert command[:2] == ["/trusted/codex", "exec"]
     assert "--ephemeral" in command and "read-only" in command
     assert 'service_tier="fast"' in command
     assert command[command.index("--profile") + 1] == "kr_trading"
-    assert seen["kwargs"]["cwd"] == "/tmp"
+    assert seen["run_dir_existed"] is True
+    assert not Path(seen["kwargs"]["cwd"]).exists()
     assert seen["kwargs"]["env"]["CODEX_HOME"] == "/secure/codex-home"
     assert seen["kwargs"]["start_new_session"] is True
     assert "도구를 사용하지 마세요" not in seen["kwargs"]["input"]
@@ -57,7 +90,10 @@ def test_codex_fast_backend_uses_isolated_ephemeral_command(monkeypatch) -> None
     ]
 
 
-def test_codex_fast_backend_requires_mcp_call_when_requested(monkeypatch) -> None:
+def test_codex_fast_backend_requires_mcp_call_when_requested(
+    monkeypatch,
+    _trusted_codex,
+) -> None:
     stream = "\n".join([
         json.dumps({
             "type": "item.completed",
@@ -82,7 +118,10 @@ def test_codex_fast_backend_requires_mcp_call_when_requested(monkeypatch) -> Non
         )
 
 
-def test_codex_fast_backend_raises_on_cli_failure(monkeypatch) -> None:
+def test_codex_fast_backend_raises_on_cli_failure(
+    monkeypatch,
+    _trusted_codex,
+) -> None:
     monkeypatch.setattr(
         backend.subprocess,
         "run",

--- a/tests/test_codex_oauth_fast_backend.py
+++ b/tests/test_codex_oauth_fast_backend.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import cores.llm.codex_oauth_fast_backend as backend
+
+
+def test_codex_fast_backend_uses_isolated_ephemeral_command(monkeypatch) -> None:
+    seen = {}
+
+    def fake_run(command, **kwargs):
+        seen.update(command=command, kwargs=kwargs)
+        stream = "\n".join([
+            json.dumps({
+                "type": "item.completed",
+                "item": {
+                    "type": "mcp_tool_call",
+                    "server": "time",
+                    "tool": "get_current_time",
+                    "arguments": {"timezone": "Asia/Seoul"},
+                    "status": "completed",
+                },
+            }),
+            json.dumps({
+                "type": "item.completed",
+                "item": {"type": "agent_message", "text": '{"decision":"미진입"}'},
+            }),
+            json.dumps({"type": "turn.completed", "usage": {"output_tokens": 10}}),
+        ])
+        return SimpleNamespace(returncode=0, stdout=stream, stderr="")
+
+    monkeypatch.setattr(backend.subprocess, "run", fake_run)
+    result = backend.generate_codex_fast(
+        system_prompt="system",
+        user_prompt="user",
+        codex_home="/secure/codex-home",
+        mcp_profile="kr_trading",
+        require_mcp_calls=True,
+    )
+    command = seen["command"]
+    assert command[:2] == ["codex", "exec"]
+    assert "--ephemeral" in command and "read-only" in command
+    assert 'service_tier="fast"' in command
+    assert command[command.index("--profile") + 1] == "kr_trading"
+    assert seen["kwargs"]["cwd"] == "/tmp"
+    assert seen["kwargs"]["env"]["CODEX_HOME"] == "/secure/codex-home"
+    assert seen["kwargs"]["start_new_session"] is True
+    assert "도구를 사용하지 마세요" not in seen["kwargs"]["input"]
+    assert result.text == '{"decision":"미진입"}'
+    assert result.usage == {"output_tokens": 10}
+    assert [(call.server, call.tool) for call in result.mcp_calls] == [
+        ("time", "get_current_time")
+    ]
+
+
+def test_codex_fast_backend_requires_mcp_call_when_requested(monkeypatch) -> None:
+    stream = "\n".join([
+        json.dumps({
+            "type": "item.completed",
+            "item": {"type": "agent_message", "text": '{"decision":"미진입"}'},
+        }),
+        json.dumps({"type": "turn.completed", "usage": {"output_tokens": 10}}),
+    ])
+    monkeypatch.setattr(
+        backend.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=0, stdout=stream, stderr=""
+        ),
+    )
+
+    with pytest.raises(backend.CodexFastError, match="no MCP tool calls"):
+        backend.generate_codex_fast(
+            system_prompt="s",
+            user_prompt="u",
+            mcp_profile="us_trading",
+            require_mcp_calls=True,
+        )
+
+
+def test_codex_fast_backend_raises_on_cli_failure(monkeypatch) -> None:
+    monkeypatch.setattr(
+        backend.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=1, stdout="", stderr="auth failed"
+        ),
+    )
+    with pytest.raises(backend.CodexFastError, match="auth failed"):
+        backend.generate_codex_fast(system_prompt="s", user_prompt="u")
+
+
+def test_us_trading_wires_codex_primary_before_legacy_fallback() -> None:
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "prism-us" / "us_stock_tracking_agent.py"
+    ).read_text("utf-8")
+    method = source[source.index("    async def _extract_trading_scenario("):]
+    method = method[:method.index("    async def ", 20_000)]
+    assert "PRISM_US_CODEX_FAST_TRADING" in method
+    assert "await asyncio.to_thread(" in method
+    assert "generate_codex_fast" in method
+    assert 'mcp_profile="us_trading"' in method
+    assert "require_mcp_calls=True" in method
+    assert "falling back to mcp-agent" in method
+    assert "async with app.run()" in method
+    assert method.index("generate_codex_fast") < method.index("attach_llm(")
+
+
+def test_kr_trading_wires_same_codex_primary_and_legacy_fallback() -> None:
+    source = (
+        Path(__file__).resolve().parents[1] / "stock_tracking_agent.py"
+    ).read_text("utf-8")
+    method = source[source.index("    async def _extract_trading_scenario("):]
+    method = method[:method.index("    def _default_scenario")]
+    assert "PRISM_KR_CODEX_FAST_TRADING" in method
+    assert "await asyncio.to_thread(" in method
+    assert "generate_codex_fast" in method
+    assert 'mcp_profile="kr_trading"' in method
+    assert "require_mcp_calls=True" in method
+    assert "falling back to mcp-agent" in method
+    assert "async with app.run()" in method
+    assert method.index("generate_codex_fast") < method.index("attach_llm(")
+
+
+def test_us_sell_wires_codex_mcp_before_legacy_fallback() -> None:
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "prism-us"
+        / "us_stock_tracking_agent.py"
+    ).read_text("utf-8")
+    method = source[source.index("    async def _analyze_sell_decision("):]
+    method = method[:method.index("    async def ", 20_000)]
+    assert "PRISM_US_CODEX_FAST_SELL" in method
+    assert 'mcp_profile="us_trading"' in method
+    assert "require_mcp_calls=True" in method
+    assert "falling back to mcp-agent" in method
+    assert "async with app.run()" in method
+    assert method.index("generate_codex_fast") < method.index("attach_llm(")
+
+
+def test_kr_sell_wires_codex_mcp_before_legacy_fallback() -> None:
+    source = (
+        Path(__file__).resolve().parents[1] / "stock_tracking_enhanced_agent.py"
+    ).read_text("utf-8")
+    method = source[source.index("    async def _analyze_sell_decision("):]
+    method = method[:method.index("    async def ", 20_000)]
+    assert "PRISM_KR_CODEX_FAST_SELL" in method
+    assert 'mcp_profile="kr_trading"' in method
+    assert "require_mcp_calls=True" in method
+    assert "falling back to mcp-agent" in method
+    assert "async with app.run()" in method
+    assert method.index("generate_codex_fast") < method.index("attach_llm(")
+
+
+@pytest.mark.parametrize(
+    ("profile_name", "market_server"),
+    [
+        ("kr_trading.config.toml", "kospi_kosdaq"),
+        ("us_trading.config.toml", "yahoo_finance"),
+    ],
+)
+def test_trading_mcp_profiles_allow_only_read_only_sqlite_tools(
+    profile_name: str,
+    market_server: str,
+) -> None:
+    import tomllib
+
+    profile_path = Path(__file__).resolve().parents[1] / "deploy" / profile_name
+    config = tomllib.loads(profile_path.read_text("utf-8"))
+    servers = config["mcp_servers"]
+
+    assert market_server in servers
+    assert servers["sqlite"]["enabled_tools"] == [
+        "list_tables",
+        "describe_table",
+        "read_query",
+    ]
+    assert not {
+        "write_query",
+        "create_table",
+        "append_insight",
+    }.intersection(servers["sqlite"]["enabled_tools"])
+    assert servers["time"]["enabled_tools"] == ["get_current_time"]
+    assert servers["perplexity"]["enabled_tools"] == ["perplexity_ask"]
+
+
+@pytest.mark.parametrize(
+    ("path", "runtime_helper"),
+    [
+        ("stock_analysis_orchestrator.py", "_kr_codex_runtime_enabled"),
+        (
+            "prism-us/us_stock_analysis_orchestrator.py",
+            "_us_codex_runtime_enabled",
+        ),
+    ],
+)
+def test_orchestrator_avoids_nested_mcp_host_for_codex_runtime(
+    path: str,
+    runtime_helper: str,
+) -> None:
+    source = (Path(__file__).resolve().parents[1] / path).read_text("utf-8")
+    assert "nullcontext" in source
+    assert runtime_helper in source
+    assert "tracking_app.run()" in source
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["stock_tracking_agent.py", "prism-us/us_stock_tracking_agent.py"],
+)
+def test_tracking_mcp_app_is_lazy_for_codex_runtime(path: str) -> None:
+    source = (Path(__file__).resolve().parents[1] / path).read_text("utf-8")
+    assert "class _LazyMCPApp" in source
+    assert "app = _LazyMCPApp(" in source
+    assert "app = MCPApp(" not in source


### PR DESCRIPTION
## Summary
- add isolated ChatGPT OAuth Codex Fast backend with read-only MCP profiles
- wire KR/US buy and sell analysis as Codex primary with existing mcp-agent fallback
- preserve sequential broker/DB application while bounding US analysis concurrency
- parallelize US report generation with bounded, order-preserving execution
- ignore persistent SQLite init lock artifacts

## Cleanup
- exclude machine-local one-off benchmark scripts that depended on ignored fixtures and absolute archive paths
- preserve verified evaluation results in the rollout document and agentmemory

## Verification
- Codex/performance/context/KR tests: 34 passed
- US parallel/orchestrator tests: 32 passed
- expanded KR/US suites: 91 passed excluding two stale rebound-pilot tests that also fail unchanged on origin/main
- Ruff passed for new files
- py_compile, TOML parsing, secret-pattern and diff checks passed