### PR TITLE
test: align rebound pilot fixtures with final gate

### DIFF
--- a/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
+++ b/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
@@ -714,6 +714,7 @@ async def test_sideways_uptrend_score_six_uses_half_size_us_order(monkeypatch, t
 
     agent = USStockTrackingAgent.__new__(USStockTrackingAgent)
     agent.db_path = str(tmp_path / "us-rebound-pilot.sqlite")
+    _ensure_reentry_schema(agent.db_path)
     agent.account_configs = [{
         "name": "us-primary",
         "account_key": "vps:us-primary:01",
@@ -732,7 +733,15 @@ async def test_sideways_uptrend_score_six_uses_half_size_us_order(monkeypatch, t
             "ticker": "AAPL",
             "company_name": "Apple Inc.",
             "current_price": 180.5,
-            "scenario": {"buy_score": 6, "min_score": 5, "sector": "Technology"},
+            "scenario": {
+                "buy_score": 6,
+                "min_score": 5,
+                "sector": "Technology",
+                "target_price": 200.0,
+                "stop_loss": 170.0,
+                "risk_reward_ratio": 2.0,
+                "_deterministic_market_regime": "moderate_bull",
+            },
             "decision": "entry",
             "raw_decision": "Enter",
             "sector": "Technology",

--- a/tests/test_regime_min_score_floor.py
+++ b/tests/test_regime_min_score_floor.py
@@ -109,7 +109,7 @@ def test_rebound_pilot_remains_narrow(
 
 
 def test_rebound_pilot_is_disabled_with_floor_flag(monkeypatch):
-    monkeypatch.delenv("REGIME_MIN_SCORE_FLOOR", raising=False)
+    monkeypatch.setenv("REGIME_MIN_SCORE_FLOOR", "false")
 
     assert not is_rebound_pilot_entry(6, 5, "sideways", "UPTREND", "Enter")
 

--- a/tests/test_stock_tracking_agent_process_reports.py
+++ b/tests/test_stock_tracking_agent_process_reports.py
@@ -440,6 +440,7 @@ async def test_sideways_uptrend_score_six_uses_half_size_kr_order(monkeypatch, t
 
     agent = StockTrackingAgent.__new__(StockTrackingAgent)
     agent.db_path = str(tmp_path / "kr-rebound-pilot.sqlite")
+    _ensure_reentry_schema(agent.db_path)
     agent.account_configs = [{
         "name": "kr-primary",
         "account_key": "vps:kr-primary:01",
@@ -455,7 +456,15 @@ async def test_sideways_uptrend_score_six_uses_half_size_kr_order(monkeypatch, t
             "ticker": "005930",
             "company_name": "Samsung Electronics",
             "current_price": 70000,
-            "scenario": {"buy_score": 6, "min_score": 5, "sector": "Technology"},
+            "scenario": {
+                "buy_score": 6,
+                "min_score": 5,
+                "sector": "Technology",
+                "target_price": 77000,
+                "stop_loss": 65000,
+                "risk_reward_ratio": 1.4,
+                "_deterministic_market_regime": "moderate_bull",
+            },
             "decision": "Enter",
             "sector": "Technology",
             "rank_change_msg": "Up",


### PR DESCRIPTION
## Summary
- supply the actual-history schema required by fail-closed re-entry checks
- distinguish score-floor `sideways` from analysis-time deterministic `moderate_bull`
- provide valid target/stop/R-R facts required by the final deterministic buy gate
- explicitly set the rollback flag to `false` when testing disabled behavior

No production code changes.

## Verification
- KR rebound/floor suite: 44 passed
- US rebound integration: 1 passed
- Ruff F/E9 and git diff checks passed