### PR TITLE
docs: place Priso beside the project logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 <div align="center">
-  <img src="docs/images/prism-insight-logo.jpeg" alt="PRISM-INSIGHT Logo" width="300">
+  <img src="docs/images/prism-insight-logo.jpeg" alt="PRISM-INSIGHT Logo" width="240">
+  &nbsp;&nbsp;
+  <a href="assets/characters/priso/README.md">
+    <img src="assets/characters/priso/v1.0/priso_master_transparent.png" alt="Priso, the PRISM mascot" width="240">
+  </a>
+  <br>
+  <sub><strong>Priso</strong> · Official PRISM Mascot</sub>
   <br><br>
   <img src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg" alt="License">
   <img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python">
@@ -27,14 +33,6 @@
   <a href="README_zh.md">中文</a> |
   <a href="README_es.md">Español</a>
 </p>
-
-### Meet Priso, the PRISM Mascot
-
-<p align="center">
-  <img src="assets/characters/priso/v1.0/priso_master_transparent.png" alt="Priso, the PRISM mascot" width="260">
-</p>
-
-**Priso** is the official mascot of PRISM-INSIGHT. See the [Priso asset guide](assets/characters/priso/README.md) for the approved reference images and version policy.
 
 ### Platinum Sponsor
 

--- a/README_es.md
+++ b/README_es.md
@@ -1,5 +1,11 @@
 <div align="center">
-  <img src="docs/images/prism-insight-logo.jpeg" alt="PRISM-INSIGHT Logo" width="300">
+  <img src="docs/images/prism-insight-logo.jpeg" alt="PRISM-INSIGHT Logo" width="240">
+  &nbsp;&nbsp;
+  <a href="assets/characters/priso/README.md">
+    <img src="assets/characters/priso/v1.0/priso_master_transparent.png" alt="Priso, la mascota de PRISM" width="240">
+  </a>
+  <br>
+  <sub><strong>Priso</strong> · Mascota oficial de PRISM</sub>
   <br><br>
   <img src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg" alt="Licencia">
   <img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python">

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,5 +1,11 @@
 <div align="center">
-  <img src="docs/images/prism-insight-logo.jpeg" alt="PRISM-INSIGHT ロゴ" width="300">
+  <img src="docs/images/prism-insight-logo.jpeg" alt="PRISM-INSIGHT ロゴ" width="240">
+  &nbsp;&nbsp;
+  <a href="assets/characters/priso/README.md">
+    <img src="assets/characters/priso/v1.0/priso_master_transparent.png" alt="PRISMのマスコット、プリソ" width="240">
+  </a>
+  <br>
+  <sub><strong>プリソ（Priso）</strong> · PRISM公式マスコット</sub>
   <br><br>
   <img src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg" alt="License">
   <img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python">

--- a/README_ko.md
+++ b/README_ko.md
@@ -1,5 +1,11 @@
 <div align="center">
-  <img src="docs/images/prism-insight-logo.jpeg" alt="PRISM-INSIGHT Logo" width="300">
+  <img src="docs/images/prism-insight-logo.jpeg" alt="PRISM-INSIGHT Logo" width="240">
+  &nbsp;&nbsp;
+  <a href="assets/characters/priso/README.md">
+    <img src="assets/characters/priso/v1.0/priso_master_transparent.png" alt="PRISM 마스코트 프리소" width="240">
+  </a>
+  <br>
+  <sub><strong>프리소(Priso)</strong> · PRISM 공식 마스코트</sub>
   <br><br>
   <img src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg" alt="License">
   <img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python">
@@ -27,14 +33,6 @@
   <a href="README_zh.md">中文</a> |
   <a href="README_es.md">Español</a>
 </p>
-
-### PRISM 마스코트, 프리소
-
-<p align="center">
-  <img src="assets/characters/priso/v1.0/priso_master_transparent.png" alt="PRISM 마스코트 프리소" width="260">
-</p>
-
-**프리소(Priso)**는 PRISM-INSIGHT의 공식 마스코트입니다. 검수를 마친 기준 이미지와 버전 정책은 [프리소 에셋 안내](assets/characters/priso/README.md)에서 확인할 수 있습니다.
 
 ### 플래티넘 스폰서
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,5 +1,11 @@
 <div align="center">
-  <img src="docs/images/prism-insight-logo.jpeg" alt="PRISM-INSIGHT Logo" width="300">
+  <img src="docs/images/prism-insight-logo.jpeg" alt="PRISM-INSIGHT Logo" width="240">
+  &nbsp;&nbsp;
+  <a href="assets/characters/priso/README.md">
+    <img src="assets/characters/priso/v1.0/priso_master_transparent.png" alt="PRISM 吉祥物 Priso" width="240">
+  </a>
+  <br>
+  <sub><strong>Priso</strong> · PRISM 官方吉祥物</sub>
   <br><br>
   <img src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg" alt="License">
   <img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python">


### PR DESCRIPTION
## Summary
- place the PRISM logo and Priso side by side in the top brand block
- use equal 240px sizing and link Priso to the asset guide
- add localized mascot captions to English, Korean, Japanese, Chinese, and Spanish READMEs
- remove the duplicated standalone mascot sections from English and Korean

## Verification
- all five files rendered through the GitHub Markdown API
- each render contains exactly one logo and one linked Priso image at 240px
- source structure and git diff checks passed