### PR TITLE
docs: update Anthropic badge to Sonnet 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <img src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg" alt="License">
   <img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python">
   <img src="https://img.shields.io/badge/OpenAI-GPT--5-green.svg" alt="OpenAI">
-  <img src="https://img.shields.io/badge/Anthropic-Claude--Sonnet--4.6-green.svg" alt="Anthropic">
+  <img src="https://img.shields.io/badge/Anthropic-Claude--Sonnet--5-green.svg" alt="Anthropic Claude Sonnet 5">
   <img src="https://img.shields.io/badge/ChatGPT_Plus-Codex_OAuth-ff6b35.svg" alt="ChatGPT Plus">
 </div>
 
@@ -263,7 +263,7 @@ PRISM-INSIGHT is a **completely open-source, free** AI-powered stock analysis sy
 
 ### AI Models
 - **Analysis & Trading**: OpenAI GPT-5 / GPT-5.4-mini (via API or ChatGPT Plus subscription)
-- **Report Generation**: Anthropic Claude Sonnet 4.6
+- **Optional Compatibility Workflows**: Anthropic Claude Sonnet 5
 - **Translation**: OpenAI GPT-5 (EN, JA, ZH, ES support)
 
 ---

--- a/README_es.md
+++ b/README_es.md
@@ -10,7 +10,7 @@
   <img src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg" alt="Licencia">
   <img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python">
   <img src="https://img.shields.io/badge/OpenAI-GPT--5-green.svg" alt="OpenAI">
-  <img src="https://img.shields.io/badge/Anthropic-Claude--Sonnet--4.6-green.svg" alt="Anthropic">
+  <img src="https://img.shields.io/badge/Anthropic-Claude--Sonnet--5-green.svg" alt="Anthropic Claude Sonnet 5">
   <img src="https://img.shields.io/badge/ChatGPT_Plus-Codex_OAuth-ff6b35.svg" alt="ChatGPT Plus">
 </div>
 
@@ -261,7 +261,7 @@ PRISM-INSIGHT es un sistema de analisis bursatil impulsado por IA, **completamen
 
 ### Modelos de IA
 - **Analisis y Trading**: OpenAI GPT-5 / GPT-5.4-mini (via API o suscripcion ChatGPT Plus)
-- **Generacion de Informes**: Anthropic Claude Sonnet 4.6
+- **Flujos Opcionales de Compatibilidad**: Anthropic Claude Sonnet 5
 - **Traduccion**: OpenAI GPT-5 (soporte para EN, JA, ZH, ES)
 
 ---

--- a/README_ja.md
+++ b/README_ja.md
@@ -10,7 +10,7 @@
   <img src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg" alt="License">
   <img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python">
   <img src="https://img.shields.io/badge/OpenAI-GPT--5-green.svg" alt="OpenAI">
-  <img src="https://img.shields.io/badge/Anthropic-Claude--Sonnet--4.6-green.svg" alt="Anthropic">
+  <img src="https://img.shields.io/badge/Anthropic-Claude--Sonnet--5-green.svg" alt="Anthropic Claude Sonnet 5">
   <img src="https://img.shields.io/badge/ChatGPT_Plus-Codex_OAuth-ff6b35.svg" alt="ChatGPT Plus">
 </div>
 
@@ -261,7 +261,7 @@ PRISM-INSIGHTは、**韓国（KOSPI/KOSDAQ）** および **米国（NYSE/NASDAQ
 
 ### AIモデル
 - **分析・売買**: OpenAI GPT-5 / GPT-5.4-mini（APIまたはChatGPT Plusサブスクリプション経由）
-- **レポート生成**: Anthropic Claude Sonnet 4.6
+- **オプションの互換ワークフロー**: Anthropic Claude Sonnet 5
 - **翻訳**: OpenAI GPT-5（EN、JA、ZH、ES対応）
 
 ---

--- a/README_ko.md
+++ b/README_ko.md
@@ -10,7 +10,7 @@
   <img src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg" alt="License">
   <img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python">
   <img src="https://img.shields.io/badge/OpenAI-GPT--5-green.svg" alt="OpenAI">
-  <img src="https://img.shields.io/badge/Anthropic-Claude--Sonnet--4.6-green.svg" alt="Anthropic">
+  <img src="https://img.shields.io/badge/Anthropic-Claude--Sonnet--5-green.svg" alt="Anthropic Claude Sonnet 5">
   <img src="https://img.shields.io/badge/ChatGPT_Plus-Codex_OAuth-ff6b35.svg" alt="ChatGPT Plus">
 </div>
 
@@ -263,7 +263,7 @@ PRISM-INSIGHT는 **한국 (코스피/코스닥)** 및 **미국 (NYSE/NASDAQ)** �
 ### AI 실행 계층
 - **보고서·상담·매매**: OpenAI Agents 백엔드 (API 또는 ChatGPT Plus/Pro OAuth)
 - **역할별 모델**: 보고서, 매매, 거시경제, 번역, 저널이 서로 다른 기본 모델·추론 강도를 사용
-- **호환 경로**: 일부 레거시/선택 워크플로우는 mcp-agent 및 Anthropic 설정을 유지
+- **호환 경로**: 일부 레거시/선택 워크플로우는 mcp-agent 및 Anthropic Claude Sonnet 5 설정을 유지
 
 정확한 기본 모델과 호출 경로는 [AI 에이전트 시스템 문서](docs/CLAUDE_AGENTS_ko.md#4-기본-모델-매트릭스)를 참조하세요.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -10,7 +10,7 @@
   <img src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg" alt="License">
   <img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python">
   <img src="https://img.shields.io/badge/OpenAI-GPT--5-green.svg" alt="OpenAI">
-  <img src="https://img.shields.io/badge/Anthropic-Claude--Sonnet--4.6-green.svg" alt="Anthropic">
+  <img src="https://img.shields.io/badge/Anthropic-Claude--Sonnet--5-green.svg" alt="Anthropic Claude Sonnet 5">
   <img src="https://img.shields.io/badge/ChatGPT_Plus-Codex_OAuth-ff6b35.svg" alt="ChatGPT Plus">
 </div>
 
@@ -261,7 +261,7 @@ PRISM-INSIGHT 是一个**完全开源、免费**的 AI 驱动股票分析系统�
 
 ### AI 模型
 - **分析与交易**：OpenAI GPT-5 / GPT-5.4-mini（通过 API 或 ChatGPT Plus 订阅）
-- **报告生成**：Anthropic Claude Sonnet 4.6
+- **可选兼容工作流**：Anthropic Claude Sonnet 5
 - **翻译**：OpenAI GPT-5（支持英语、日语、中文、西班牙语）
 
 ---


### PR DESCRIPTION
## Summary
- update the Anthropic badge from Claude Sonnet 4.6 to Claude Sonnet 5 in all five language READMEs
- correct stale model descriptions: Anthropic is an optional compatibility workflow, while primary report execution now uses the role-specific OpenAI stack
- preserve historical 4.6 references in release/archive documents

## Verification
- Anthropic officially lists Claude Sonnet 5 and API model ID `claude-sonnet-5`
- repository PR #404 already upgraded report/bot Anthropic calls; Insight defaults to `claude-sonnet-5`
- all five READMEs render the Sonnet 5 badge through GitHub Markdown
- shields.io badge returns HTTP 200
- no Sonnet 4.6 reference remains in the five primary READMEs