### PR TITLE
fix(us): enforce entry risk contracts

### DIFF
--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -62,6 +62,7 @@ SHADOW→LIVE **자동 승격**은 아래를 **모두** 충족할 때만:
 - **비전 매수게이트(S3)**: A/B 측정 설계 확정·데이터 축적 후 — **수익영향이라 사용자 확인 후**.
 
 ## 변경 이력
+- 2026-09-01: **US 신규매수 위험 계약 정렬** — 레짐 slot tuple의 합계를 최종 후보 수 hard cap으로 적용해 post-FTD 1종목·약세/횡보 2종목 제한이 bottom-up refill로 무효화되지 않게 수정. US `max_portfolio_size`를 실제 신규매수·피라미딩 슬롯 한도에 연결하고, 최종 점수를 `buy_score + macro_adjustment + journal_adjustment`로 통일. 계정별 USD 주문예산으로 정수 1주를 살 수 없는 종목은 실주문·시뮬레이터 보유 생성 전에 watchlist로 전환한다.
 - 2026-07-19: **KR PENDING EXIT 배선 추가, gate OFF 유지** — batch/hardstop/trend에 broker-first lifecycle을 연결하고 `feature_status.py`에 `.env`와 모든 active cron inline gate 상태를 노출. 피라미딩 accepted-but-unfilled 재시작 방어 및 post-CLOSED 외부효과 복구 절차를 포함한 운영 reconciliation 완료 전 활성화 금지.
 - 2026-06-23: 레지스트리 신설. 현황 기록(Loop A LIVE / B·C SHADOW미스케줄 / 비전 SHADOW관측).
 - 2026-06-24: S6 발행 게이트 갱신 — 배선 구현 완료 반영. 게이트 `PRISM_FEATURE_INSIGHT_IMAGE=on` + `vision_available()`(이전 "발행 배선 미구현" 기재 정정). `feature_status.py`도 동일 로직으로 LIVE/OFF 보고.

--- a/prism-us/tests/test_regime_weak_no_topdown_us.py
+++ b/prism-us/tests/test_regime_weak_no_topdown_us.py
@@ -38,3 +38,45 @@ def test_on_does_not_touch_bull_or_strong_bear():
     assert _slots("moderate_bull", "true") == (1, 2)
     assert _slots("strong_bull", "true") == (2, 1)
     assert _slots("strong_bear", "true") == (0, 3)  # 이미 top-down 0
+
+
+def test_selection_plan_uses_slot_sum_as_hard_total(monkeypatch):
+    monkeypatch.setattr(
+        us_trigger_batch, "_get_regime_slots", lambda _regime: (1, 0)
+    )
+
+    assert us_trigger_batch._get_regime_selection_plan("moderate_bull") == (
+        1,
+        0,
+        1,
+    )
+
+
+def test_final_selection_does_not_refill_past_regime_total(monkeypatch):
+    monkeypatch.setattr(
+        us_trigger_batch, "_get_regime_slots", lambda _regime: (1, 0)
+    )
+    monkeypatch.setattr(
+        us_trigger_batch,
+        "get_us_sector_map",
+        lambda tickers: {ticker: "Technology" for ticker in tickers},
+    )
+    triggers = {
+        "Trigger A": us_trigger_batch.pd.DataFrame(
+            {"CompositeScore": [3.0], "CompanyName": ["A"]}, index=["AAA"]
+        ),
+        "Trigger B": us_trigger_batch.pd.DataFrame(
+            {"CompositeScore": [2.0], "CompanyName": ["B"]}, index=["BBB"]
+        ),
+        "Trigger C": us_trigger_batch.pd.DataFrame(
+            {"CompositeScore": [1.0], "CompanyName": ["C"]}, index=["CCC"]
+        ),
+    }
+
+    result = us_trigger_batch.select_final_tickers(
+        triggers,
+        use_hybrid=False,
+        macro_context={"market_regime": "moderate_bull", "leading_sectors": []},
+    )
+
+    assert sum(len(frame) for frame in result.values()) == 1

--- a/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
+++ b/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
@@ -131,6 +131,39 @@ USStockTrackingAgent = us_agent_module.USStockTrackingAgent
 from prism_core.positions import LegacyPositionWriteResult
 
 
+def test_us_entry_risk_contract_helpers() -> None:
+    assert us_agent_module._scenario_slot_limit(
+        {"max_portfolio_size": "6"}, hard_max=10
+    ) == 6
+    assert us_agent_module._scenario_slot_limit(
+        {"max_portfolio_size": 99}, hard_max=10
+    ) == 10
+    assert us_agent_module._scenario_slot_limit({}, hard_max=10) == 10
+
+    score = us_agent_module._effective_buy_score(
+        {"buy_score": 6, "macro_adjustment": -1},
+        journal_adjustment=1,
+    )
+    assert score == {
+        "buy_score": 6.0,
+        "macro_adjustment": -1.0,
+        "journal_adjustment": 1.0,
+        "effective_score": 6.0,
+    }
+
+    assert us_agent_module._whole_share_affordability(
+        {"buy_amount_usd": 1100.0}, current_price=1200.0
+    ) == {
+        "known": True,
+        "allowed": False,
+        "cash_amount": 1100.0,
+        "whole_share_quantity": 0,
+    }
+    assert us_agent_module._whole_share_affordability(
+        {"buy_amount_usd": 1100.0}, current_price=500.0
+    )["whole_share_quantity"] == 2
+
+
 class _FakeAsyncUSTradingContext:
     def __init__(self, account_name=None, **kwargs):
         self.account_name = account_name
@@ -829,6 +862,156 @@ async def test_sideways_uptrend_score_six_uses_half_size_us_order(monkeypatch, t
         "SELECT cash_amount FROM order_intents"
     ).fetchone()[0]
     assert float(cash_amount) == 1000.0
+
+
+@pytest.mark.asyncio
+async def test_process_reports_blocks_unaffordable_entry_before_simulator(
+    monkeypatch, tmp_path
+):
+    agent = USStockTrackingAgent.__new__(USStockTrackingAgent)
+    agent.db_path = str(tmp_path / "unaffordable.sqlite")
+    _ensure_reentry_schema(agent.db_path)
+    agent.account_configs = [{
+        "name": "us-primary",
+        "account_key": "prod:us-primary:01",
+        "product": "01",
+        "buy_amount_usd": 1100.0,
+    }]
+    agent.active_account = None
+    agent.max_slots = 10
+    agent.enable_journal = False
+    agent.conn = sqlite3.connect(":memory:")
+    agent.cursor = agent.conn.cursor()
+
+    async def fake_core(_report_path):
+        return {
+            "success": True,
+            "ticker": "EXPENSIVE",
+            "company_name": "Expensive Inc.",
+            "current_price": 1200.0,
+            "scenario": {
+                "buy_score": 8,
+                "macro_adjustment": 0,
+                "min_score": 7,
+                "sector": "Technology",
+                "target_price": 1400.0,
+                "stop_loss": 1140.0,
+                "risk_reward_ratio": 3.3,
+                "max_portfolio_size": 6,
+            },
+            "decision": "entry",
+            "raw_decision": "Enter",
+            "sector": "Technology",
+            "rank_change_msg": "Up",
+        }
+
+    watchlist_calls = []
+
+    async def fake_save_watchlist_item(**kwargs):
+        watchlist_calls.append(kwargs)
+        return True
+
+    agent._analyze_report_core = fake_core
+    agent.update_holdings = AsyncMock(return_value=[])
+    agent._is_ticker_in_holdings = AsyncMock(return_value=False)
+    agent._get_current_slots_count = AsyncMock(return_value=0)
+    agent._check_sector_diversity = AsyncMock(return_value=True)
+    agent._buy_floor_regime = lambda: "strong_bull"
+    agent._regime_policy_mod = lambda: None
+    agent._evaluate_production_buy_gate = lambda *args, **kwargs: {
+        "allowed": True,
+        "reason": "",
+        "findings": [],
+    }
+    agent._buy_stock_with_position = AsyncMock(
+        side_effect=AssertionError("unaffordable entry must not reach simulator")
+    )
+    agent._save_watchlist_item = fake_save_watchlist_item
+
+    buy_count, sell_count = await USStockTrackingAgent.process_reports(
+        agent, ["report-a.pdf"]
+    )
+
+    assert (buy_count, sell_count) == (0, 0)
+    agent._buy_stock_with_position.assert_not_awaited()
+    assert len(watchlist_calls) == 1
+    assert "whole-share affordability" in watchlist_calls[0]["skip_reason"]
+
+
+@pytest.mark.asyncio
+async def test_process_reports_applies_macro_adjustment_to_final_score(
+    monkeypatch, tmp_path
+):
+    agent = USStockTrackingAgent.__new__(USStockTrackingAgent)
+    agent.db_path = str(tmp_path / "macro-score.sqlite")
+    _ensure_reentry_schema(agent.db_path)
+    agent.account_configs = [{
+        "name": "us-primary",
+        "account_key": "prod:us-primary:01",
+        "product": "01",
+        "buy_amount_usd": 1100.0,
+    }]
+    agent.active_account = None
+    agent.max_slots = 10
+    agent.enable_journal = False
+    agent.conn = sqlite3.connect(":memory:")
+    agent.cursor = agent.conn.cursor()
+
+    async def fake_core(_report_path):
+        return {
+            "success": True,
+            "ticker": "LAGGING",
+            "company_name": "Lagging Inc.",
+            "current_price": 100.0,
+            "scenario": {
+                "buy_score": 5,
+                "macro_adjustment": -1,
+                "effective_score": 4,
+                "min_score": 5,
+                "sector": "Utilities",
+                "target_price": 115.0,
+                "stop_loss": 95.0,
+                "risk_reward_ratio": 3.0,
+                "max_portfolio_size": 6,
+            },
+            "decision": "entry",
+            "raw_decision": "Enter",
+            "sector": "Utilities",
+            "rank_change_msg": "Flat",
+        }
+
+    gate_scores = []
+    watchlist_calls = []
+
+    def fake_gate(*args, **kwargs):
+        gate_scores.append(kwargs["score_override"])
+        return {"allowed": True, "reason": "", "findings": []}
+
+    async def fake_save_watchlist_item(**kwargs):
+        watchlist_calls.append(kwargs)
+        return True
+
+    agent._analyze_report_core = fake_core
+    agent.update_holdings = AsyncMock(return_value=[])
+    agent._is_ticker_in_holdings = AsyncMock(return_value=False)
+    agent._get_current_slots_count = AsyncMock(return_value=0)
+    agent._check_sector_diversity = AsyncMock(return_value=True)
+    agent._buy_floor_regime = lambda: "strong_bull"
+    agent._regime_policy_mod = lambda: None
+    agent._evaluate_production_buy_gate = fake_gate
+    agent._buy_stock_with_position = AsyncMock(
+        side_effect=AssertionError("macro-adjusted score must block simulator")
+    )
+    agent._save_watchlist_item = fake_save_watchlist_item
+
+    buy_count, sell_count = await USStockTrackingAgent.process_reports(
+        agent, ["report-a.pdf"]
+    )
+
+    assert (buy_count, sell_count) == (0, 0)
+    assert gate_scores == [4.0]
+    agent._buy_stock_with_position.assert_not_awaited()
+    assert "Insufficient score (4/5)" in watchlist_calls[0]["skip_reason"]
 
 
 @pytest.mark.asyncio

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -442,6 +442,71 @@ async def get_trading_value_rank_change(ticker: str) -> Tuple[float, str]:
 MIN_HOLDINGS_FOR_RATIO_CHECK = 4
 
 
+def _safe_number(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or isinstance(value, bool):
+            return default
+        return float(str(value).replace(",", "").strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _scenario_slot_limit(scenario: Dict[str, Any], *, hard_max: int) -> int:
+    """Resolve the report's portfolio cap without allowing it to exceed hard max."""
+    hard_limit = max(1, int(hard_max))
+    raw = (scenario or {}).get("max_portfolio_size")
+    try:
+        requested = int(float(raw))
+    except (TypeError, ValueError):
+        return hard_limit
+    if requested <= 0:
+        return hard_limit
+    return min(requested, hard_limit)
+
+
+def _effective_buy_score(
+    scenario: Dict[str, Any], *, journal_adjustment: float = 0.0
+) -> Dict[str, float]:
+    """Recompute the score contract used by both the prompt and final gate."""
+    buy_score = _safe_number((scenario or {}).get("buy_score"))
+    macro_adjustment = _safe_number((scenario or {}).get("macro_adjustment"))
+    journal_value = _safe_number(journal_adjustment)
+    return {
+        "buy_score": buy_score,
+        "macro_adjustment": macro_adjustment,
+        "journal_adjustment": journal_value,
+        "effective_score": buy_score + macro_adjustment + journal_value,
+    }
+
+
+def _whole_share_affordability(
+    account: Dict[str, Any] | None,
+    *,
+    current_price: float,
+    cash_amount_override: float | None = None,
+) -> Dict[str, Any]:
+    """Fail open only when configured cash is unknown; otherwise require one share."""
+    configured = cash_amount_override
+    if configured is None and account:
+        configured = account.get("buy_amount_usd")
+    cash_amount = _safe_number(configured, default=0.0)
+    price = _safe_number(current_price, default=0.0)
+    if cash_amount <= 0:
+        return {
+            "known": False,
+            "allowed": True,
+            "cash_amount": None,
+            "whole_share_quantity": None,
+        }
+    quantity = int(cash_amount / price) if price > 0 else 0
+    return {
+        "known": True,
+        "allowed": quantity >= 1,
+        "cash_amount": cash_amount,
+        "whole_share_quantity": quantity,
+    }
+
+
 def check_sector_diversity(cursor, sector: str, max_same_sector: int, concentration_ratio: float, account_key: str | None = None) -> bool:
     """
     Check for over-concentration in same sector.
@@ -1654,8 +1719,21 @@ class USStockTrackingAgent:
 
             # Check available slots
             current_slots = await self._get_current_slots_count()
-            if current_slots >= self.max_slots:
-                logger.warning(f"Holdings already at maximum ({self.max_slots})")
+            slot_limit = _scenario_slot_limit(scenario, hard_max=self.max_slots)
+            if current_slots >= slot_limit:
+                logger.warning(f"Holdings already at scenario maximum ({slot_limit})")
+                return LegacyPositionWriteResult(False, None)
+
+            affordability = _whole_share_affordability(
+                getattr(self, "active_account", None),
+                current_price=current_price,
+            )
+            if affordability["known"] and not affordability["allowed"]:
+                logger.warning(
+                    "%s entry blocked before simulator: configured amount cannot buy "
+                    "one whole share",
+                    ticker,
+                )
                 return LegacyPositionWriteResult(False, None)
 
             # Current time
@@ -1737,7 +1815,7 @@ class USStockTrackingAgent:
                 portfolio_context={
                     "slots_before": current_slots,
                     "slots_after": current_slots + 1,
-                    "slots_max": getattr(self, "max_slots", 10),
+                    "slots_max": slot_limit,
                 },
                 execution_context=entry_execution_context,
                 source="us_batch_entry",
@@ -3807,11 +3885,20 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                         is_add = True
 
                     current_slots = await self._get_current_slots_count()
-                    if current_slots >= self.max_slots:
+                    scenario_slot_limit = _scenario_slot_limit(
+                        scenario, hard_max=self.max_slots
+                    )
+                    if current_slots >= scenario_slot_limit:
                         # User-facing reason must NOT include the account label (leaks
                         # masked account number to broadcast channels). Keep detail in logs only.
-                        reason = "Max slots reached (portfolio full)"
-                        logger.info(f"Purchase deferred: {company_name} ({ticker}) - Max slots reached for {label}")
+                        reason = (
+                            "Scenario max portfolio size reached "
+                            f"({current_slots}/{scenario_slot_limit})"
+                        )
+                        logger.info(
+                            f"Purchase deferred: {company_name} ({ticker}) - "
+                            f"scenario slots {current_slots}/{scenario_slot_limit} for {label}"
+                        )
                         state["should_save_watchlist"] = True
                         state["skip_reason"] = state["skip_reason"] or reason
                         continue
@@ -3822,7 +3909,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     sector_diverse = await self._check_sector_diversity(sector, is_pyramiding_add=is_add)
 
                     buy_score = scenario.get("buy_score", 0)
-                    min_score = scenario.get("min_score", 0)
+                    min_score = _safe_number(scenario.get("min_score", 0))
                     llm_min_score = min_score
                     floor_regime = None
                     pulse_state = None
@@ -3865,10 +3952,18 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                                 f"(reasons: {', '.join(adjustment_reasons)})"
                             )
 
-                    adjusted_score = buy_score + score_adjustment
+                    score_parts = _effective_buy_score(
+                        scenario, journal_adjustment=score_adjustment
+                    )
+                    macro_adjustment = score_parts["macro_adjustment"]
+                    score_before_journal = (
+                        score_parts["buy_score"] + macro_adjustment
+                    )
+                    adjusted_score = score_parts["effective_score"]
                     logger.info(
                         f"Buy score: {company_name} ({ticker}) - Original: {buy_score}, "
-                        f"Adjusted: {adjusted_score}, Min: {min_score}"
+                        f"Macro: {macro_adjustment:+g}, Journal: {score_adjustment:+d}, "
+                        f"Effective: {adjusted_score:g}, Min: {min_score:g}"
                     )
 
                     raw_decision = analysis_result.get("raw_decision", "")
@@ -3915,6 +4010,19 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                                     entry_cash_amount,
                                 )
 
+                    affordability = _whole_share_affordability(
+                        account,
+                        current_price=current_price,
+                        cash_amount_override=entry_cash_amount,
+                    )
+                    if affordability["known"] and not affordability["allowed"]:
+                        logger.warning(
+                            "[BUY_GATE][US] %s(%s) blocked: configured amount "
+                            "cannot buy one whole share",
+                            company_name,
+                            ticker,
+                        )
+
                     rationale = scenario.get("rationale", "") or ""
                     logger.info(
                         f"Scenario decision: {company_name} ({ticker}) - "
@@ -3941,7 +4049,11 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     # re-entry — longer cooldown after a loss). Fresh entries only;
                     # pyramiding adds (is_add) are exempt.
                     _cd_block = False
-                    if normalized_decision == "entry" and not is_add:
+                    if (
+                        normalized_decision == "entry"
+                        and not is_add
+                        and affordability["allowed"]
+                    ):
                         try:
                             from reentry_cooldown import reentry_block, COOLDOWN_LIVE, COOLDOWN_RISK_EXIT_LIVE
                             _account_key, _ = self._account_scope()
@@ -3975,7 +4087,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     scenario = dict(scenario)
                     scenario["_journal_influence_context"] = attach_deterministic_score_effect(
                         scenario.get("_journal_influence_context"),
-                        score_before=buy_score,
+                        score_before=score_before_journal,
                         score_after=adjusted_score,
                         min_score=min_score,
                         applied_adjustment=score_adjustment,
@@ -3986,6 +4098,8 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                         "decision": normalized_decision,
                         "raw_decision": raw_decision,
                         "buy_score": buy_score,
+                        "macro_adjustment": macro_adjustment,
+                        "journal_adjustment": score_adjustment,
                         "adjusted_score": adjusted_score,
                         "min_score": min_score,
                         "gate_allowed": bool(_buy_gate.get("allowed")),
@@ -3995,8 +4109,12 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                         "sector_diverse": bool(sector_diverse),
                         "rebound_pilot": bool(rebound_pilot),
                         "slots_used": current_slots,
-                        "slots_max": self.max_slots,
+                        "slots_max": scenario_slot_limit,
                         "is_add": bool(is_add),
+                        "affordability_known": bool(affordability["known"]),
+                        "whole_share_quantity": affordability[
+                            "whole_share_quantity"
+                        ],
                     }
                     analysis_result["scenario"] = scenario
 
@@ -4006,6 +4124,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                         and sector_diverse
                         and not _cd_block
                         and _buy_gate.get("allowed", False)
+                        and affordability["allowed"]
                     )
                     if entry_eligible:
                         emit_trading_context(
@@ -4024,7 +4143,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                             },
                             portfolio_context={
                                 "slots_used": current_slots,
-                                "slots_max": self.max_slots,
+                                "slots_max": scenario_slot_limit,
                             },
                             entry_quality_context=_capture_entry_quality_context(
                                 cursor=self.cursor,
@@ -4194,7 +4313,9 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                         if normalized_decision != "entry":
                             reason_parts.append(f"AI judgment: {normalized_decision}")
                         if adjusted_score < min_score and not rebound_pilot:
-                            reason_parts.append(f"Insufficient score ({adjusted_score}/{min_score})")
+                            reason_parts.append(
+                                f"Insufficient score ({adjusted_score:g}/{min_score:g})"
+                            )
                         if not sector_diverse:
                             reason_parts.append(f"Sector concentration ({sector})")
                         if normalized_decision == "entry" and not _buy_gate.get("allowed", False):
@@ -4203,6 +4324,11 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                             )
                         if _cd_block:
                             reason_parts.append("Recent risk-exit re-entry cooldown")
+                        if affordability["known"] and not affordability["allowed"]:
+                            reason_parts.append(
+                                "whole-share affordability: configured amount "
+                                "cannot buy 1 share"
+                            )
                         reason = " / ".join(reason_parts) if reason_parts else "Other"
                         logger.info(f"Purchase deferred: {company_name} ({ticker}) - {reason}")
                         state["should_save_watchlist"] = True

--- a/prism-us/us_trigger_batch.py
+++ b/prism-us/us_trigger_batch.py
@@ -1127,6 +1127,16 @@ def _get_regime_slots(market_regime: str) -> tuple:
     return (td, bu)
 
 
+def _get_regime_selection_plan(market_regime: str) -> tuple[int, int, int]:
+    """Return top-down, bottom-up, and their hard total selection limit."""
+    topdown_slots, bottomup_slots = _get_regime_slots(market_regime)
+    return (
+        topdown_slots,
+        bottomup_slots,
+        max(0, int(topdown_slots) + int(bottomup_slots)),
+    )
+
+
 def _build_topdown_pool(trigger_candidates: dict, macro_context: dict, score_column: str, sector_map: dict = None) -> list:
     """Build top-down candidate pool from leading sectors.
 
@@ -1322,9 +1332,6 @@ def select_final_tickers(triggers: dict, trade_date: str = None, use_hybrid: boo
     selected_tickers = set()
     score_column = "FinalScore" if use_hybrid and trade_date else "CompositeScore"
 
-    # Fixed max_selections=3 regardless of regime (user preference for consistent selection count)
-    max_selections = 3
-
     # Build sector map once for all candidate tickers (used by both top-down and logging)
     candidate_tickers = []
     for name, df in trigger_candidates.items():
@@ -1334,7 +1341,14 @@ def select_final_tickers(triggers: dict, trade_date: str = None, use_hybrid: boo
 
     # Determine regime and slot allocation
     market_regime = macro_context.get("market_regime", "sideways") if macro_context else "sideways"
-    topdown_slots, bottomup_slots = _get_regime_slots(market_regime)
+    if macro_context:
+        topdown_slots, bottomup_slots, max_selections = (
+            _get_regime_selection_plan(market_regime)
+        )
+    else:
+        # No macro context means there is no trustworthy regime throttle.
+        # Preserve the legacy three-candidate, pure bottom-up fallback.
+        topdown_slots, bottomup_slots, max_selections = (0, 3, 3)
 
     # Build top-down pool from leading sectors (empty when macro_context is None)
     topdown_pool = _build_topdown_pool(trigger_candidates, macro_context, score_column, sector_map)


### PR DESCRIPTION
## Summary
- respect regime slot totals in final US candidate selection
- enforce scenario max_portfolio_size in US buy paths
- recompute effective score with macro and journal adjustments
- block unaffordable whole-share entries before simulator holdings are created

## Verification
- 20 focused regression tests passed
- 69 root regime-policy tests passed
- 92 isolated US policy/trading tests passed
- py_compile, ruff (excluding pre-existing E402/E741/F841), and git diff --check passed

## Known pre-existing test debt
- full prism-us collection includes script-style sys.exit tests and stale legacy tests; isolated changed-path suites pass.