### PR TITLE
fix(us): isolate malformed trigger snapshots

### DIFF
--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -62,6 +62,7 @@ SHADOW→LIVE **자동 승격**은 아래를 **모두** 충족할 때만:
 - **비전 매수게이트(S3)**: A/B 측정 설계 확정·데이터 축적 후 — **수익영향이라 사용자 확인 후**.
 
 ## 변경 이력
+- 2026-09-01: **US trigger fail-open 경계 복구** — yfinance가 일부 ticker의 OHLCV 셀을 중첩 Series로 반환하거나 현재·전일 라벨이 어긋나도 해당 ticker를 제거하고, 개별 trigger 예외는 빈 결과로 격리해 나머지 trigger와 전체 배치를 계속 실행한다. snapshot 자체를 가져오지 못한 경우의 배치 중단 계약은 유지한다.
 - 2026-09-01: **US 신규매수 위험 계약 정렬** — 레짐 slot tuple의 합계를 최종 후보 수 hard cap으로 적용해 post-FTD 1종목·약세/횡보 2종목 제한이 bottom-up refill로 무효화되지 않게 수정. US `max_portfolio_size`를 실제 신규매수·피라미딩 슬롯 한도에 연결하고, 최종 점수를 `buy_score + macro_adjustment + journal_adjustment`로 통일. 계정별 USD 주문예산으로 정수 1주를 살 수 없는 종목은 실주문·시뮬레이터 보유 생성 전에 watchlist로 전환한다.
 - 2026-07-19: **KR PENDING EXIT 배선 추가, gate OFF 유지** — batch/hardstop/trend에 broker-first lifecycle을 연결하고 `feature_status.py`에 `.env`와 모든 active cron inline gate 상태를 노출. 피라미딩 accepted-but-unfilled 재시작 방어 및 post-CLOSED 외부효과 복구 절차를 포함한 운영 reconciliation 완료 전 활성화 금지.
 - 2026-06-23: 레지스트리 신설. 현황 기록(Loop A LIVE / B·C SHADOW미스케줄 / 비전 SHADOW관측).

--- a/prism-us/tests/test_regime_weak_no_topdown_us.py
+++ b/prism-us/tests/test_regime_weak_no_topdown_us.py
@@ -80,3 +80,48 @@ def test_final_selection_does_not_refill_past_regime_total(monkeypatch):
     )
 
     assert sum(len(frame) for frame in result.values()) == 1
+
+
+def test_gap_trigger_drops_nested_series_cell_instead_of_raising():
+    nested_open = us_trigger_batch.pd.Series([100.0], index=["Open"])
+    nested_close = us_trigger_batch.pd.Series([102.0], index=["Close"])
+    snapshot = us_trigger_batch.pd.DataFrame(
+        {
+            "Open": [nested_open],
+            "High": [103.0],
+            "Low": [99.0],
+            "Close": [nested_close],
+            "Volume": [2_000_000],
+            "Amount": [204_000_000.0],
+        },
+        index=["BROKEN"],
+    )
+    previous = us_trigger_batch.pd.DataFrame(
+        {
+            "Open": [98.0],
+            "High": [100.0],
+            "Low": [97.0],
+            "Close": [99.0],
+            "Volume": [1_000_000],
+            "Amount": [99_000_000.0],
+        },
+        index=["BROKEN"],
+    )
+
+    result = us_trigger_batch.trigger_morning_gap_up_momentum(
+        "20260831", snapshot, previous
+    )
+
+    assert result.empty
+
+
+def test_trigger_boundary_fails_open_for_one_broken_trigger(caplog):
+    def broken_trigger():
+        raise ValueError("bad candidate labels")
+
+    result = us_trigger_batch._run_trigger_fail_open(
+        "Gap Up Momentum Top", broken_trigger
+    )
+
+    assert result.empty
+    assert "TRIGGER-FAIL-OPEN" in caplog.text

--- a/prism-us/us_trigger_batch.py
+++ b/prism-us/us_trigger_batch.py
@@ -81,6 +81,77 @@ MORNING_TARGET_CANDIDATES = 3
 MARKET_CAP_MIN_COVERAGE = 0.8
 MARKET_CAP_MAX_WORKERS = 8
 
+_SNAPSHOT_NUMERIC_COLUMNS = ("Open", "High", "Low", "Close", "Volume", "Amount")
+
+
+def _sanitize_numeric_snapshot(frame: pd.DataFrame, *, source: str) -> pd.DataFrame:
+    """Drop malformed ticker rows instead of letting nested yfinance cells abort a batch."""
+    if not isinstance(frame, pd.DataFrame) or frame.empty:
+        return pd.DataFrame()
+    missing = [column for column in _SNAPSHOT_NUMERIC_COLUMNS if column not in frame]
+    if missing:
+        logger.warning(
+            "[SNAPSHOT-SANITIZE] source=%s missing_columns=%s",
+            source,
+            ",".join(missing),
+        )
+        return pd.DataFrame()
+
+    clean = frame.loc[~frame.index.duplicated(keep="last")].copy()
+    invalid = pd.Series(False, index=clean.index)
+    nested_types = (pd.Series, pd.DataFrame, np.ndarray, list, tuple, dict, set)
+    for column in _SNAPSHOT_NUMERIC_COLUMNS:
+        values = clean[column]
+        if not isinstance(values, pd.Series):
+            logger.warning(
+                "[SNAPSHOT-SANITIZE] source=%s duplicate_column=%s",
+                source,
+                column,
+            )
+            return pd.DataFrame()
+        scalar_values = values.map(
+            lambda value: np.nan if isinstance(value, nested_types) else value
+        )
+        numeric = pd.to_numeric(scalar_values, errors="coerce")
+        invalid |= numeric.isna() | ~np.isfinite(numeric)
+        clean.loc[:, column] = numeric
+
+    if invalid.any():
+        logger.warning(
+            "[SNAPSHOT-SANITIZE] source=%s dropped_rows=%d total_rows=%d",
+            source,
+            int(invalid.sum()),
+            len(clean),
+        )
+    return clean.loc[~invalid].copy()
+
+
+def _aligned_trigger_inputs(
+    snapshot: pd.DataFrame, prev_snapshot: pd.DataFrame
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    current = _sanitize_numeric_snapshot(snapshot, source="current")
+    previous = _sanitize_numeric_snapshot(prev_snapshot, source="previous")
+    if current.empty or previous.empty:
+        return pd.DataFrame(), pd.DataFrame()
+    common = current.index.intersection(previous.index)
+    if common.empty:
+        return pd.DataFrame(), pd.DataFrame()
+    return current.loc[common].copy(), previous.loc[common].copy()
+
+
+def _run_trigger_fail_open(name: str, trigger, *args, **kwargs) -> pd.DataFrame:
+    """Isolate one trigger failure so other triggers and the batch keep running."""
+    try:
+        result = trigger(*args, **kwargs)
+        return result if isinstance(result, pd.DataFrame) else pd.DataFrame()
+    except Exception as error:  # noqa: BLE001 - explicit batch fail-open boundary
+        logger.exception(
+            "[TRIGGER-FAIL-OPEN] trigger=%s error=%s",
+            name,
+            type(error).__name__,
+        )
+        return pd.DataFrame()
+
 # --- #289 KR 다주 상대강도 스크리닝 US 이식 ---
 # Multi-week relative-strength lookback (trading days, ~3 months).
 SCREENING_SIGNAL_LOOKBACK_DAYS = 60
@@ -361,9 +432,9 @@ def trigger_morning_volume_surge(trade_date: str, snapshot: pd.DataFrame,
     """
     logger.debug("trigger_morning_volume_surge started")
 
-    common = snapshot.index.intersection(prev_snapshot.index)
-    snap = snapshot.loc[common].copy()
-    prev = prev_snapshot.loc[common].copy()
+    snap, prev = _aligned_trigger_inputs(snapshot, prev_snapshot)
+    if snap.empty:
+        return pd.DataFrame()
 
     # Market cap merge (for scoring, no minimum filter)
     if cap_df is not None and not cap_df.empty:
@@ -420,9 +491,9 @@ def trigger_morning_gap_up_momentum(trade_date: str, snapshot: pd.DataFrame,
     """
     logger.debug("trigger_morning_gap_up_momentum started")
 
-    common = snapshot.index.intersection(prev_snapshot.index)
-    snap = snapshot.loc[common].copy()
-    prev = prev_snapshot.loc[common].copy()
+    snap, prev = _aligned_trigger_inputs(snapshot, prev_snapshot)
+    if snap.empty:
+        return pd.DataFrame()
 
     # Market cap merge (for scoring, no minimum filter)
     if cap_df is not None and not cap_df.empty:
@@ -499,18 +570,24 @@ def trigger_morning_value_to_cap_ratio(trade_date: str, snapshot: pd.DataFrame,
         return pd.DataFrame()
 
     try:
+        clean_snapshot, clean_previous = _aligned_trigger_inputs(
+            snapshot, prev_snapshot
+        )
+        if clean_snapshot.empty:
+            return pd.DataFrame()
+
         # Merge market cap data
-        merged = snapshot.merge(cap_df[["MarketCap"]], left_index=True, right_index=True, how="inner").copy()
+        merged = clean_snapshot.merge(cap_df[["MarketCap"]], left_index=True, right_index=True, how="inner").copy()
         logger.info(f"Merged data: {len(merged)} stocks")
 
         # Common stocks with previous day
-        common = merged.index.intersection(prev_snapshot.index)
+        common = merged.index.intersection(clean_previous.index)
         if len(common) == 0:
             logger.error("No common stocks")
             return pd.DataFrame()
 
         merged = merged.loc[common].copy()
-        prev = prev_snapshot.loc[common].copy()
+        prev = clean_previous.loc[common].copy()
 
         # Absolute filters
         merged = apply_absolute_filters(merged, min_value=MIN_TRADING_VALUE)
@@ -582,9 +659,9 @@ def trigger_afternoon_daily_rise_top(trade_date: str, snapshot: pd.DataFrame,
     """
     logger.debug("trigger_afternoon_daily_rise_top started")
 
-    common = snapshot.index.intersection(prev_snapshot.index)
-    snap = snapshot.loc[common].copy()
-    prev = prev_snapshot.loc[common].copy()
+    snap, prev = _aligned_trigger_inputs(snapshot, prev_snapshot)
+    if snap.empty:
+        return pd.DataFrame()
 
     # Market cap filter
     if cap_df is not None and not cap_df.empty:
@@ -671,9 +748,9 @@ def trigger_afternoon_closing_strength(trade_date: str, snapshot: pd.DataFrame,
     """
     logger.debug("trigger_afternoon_closing_strength started")
 
-    common = snapshot.index.intersection(prev_snapshot.index)
-    snap = snapshot.loc[common].copy()
-    prev = prev_snapshot.loc[common].copy()
+    snap, prev = _aligned_trigger_inputs(snapshot, prev_snapshot)
+    if snap.empty:
+        return pd.DataFrame()
 
     # Market cap filter
     if cap_df is not None and not cap_df.empty:
@@ -764,9 +841,9 @@ def trigger_afternoon_volume_surge_flat(trade_date: str, snapshot: pd.DataFrame,
     """
     logger.debug("trigger_afternoon_volume_surge_flat started")
 
-    common = snapshot.index.intersection(prev_snapshot.index)
-    snap = snapshot.loc[common].copy()
-    prev = prev_snapshot.loc[common].copy()
+    snap, prev = _aligned_trigger_inputs(snapshot, prev_snapshot)
+    if snap.empty:
+        return pd.DataFrame()
 
     # Market cap filter
     if cap_df is not None and not cap_df.empty:
@@ -1511,8 +1588,22 @@ def run_batch(trigger_time: str, log_level: str = "INFO", output_file: str = Non
 
     if trigger_time == "morning":
         logger.info("=== Morning Batch Execution ===")
-        res1 = trigger_morning_volume_surge(trade_date, snapshot, prev_snapshot, None)
-        res2 = trigger_morning_gap_up_momentum(trade_date, snapshot, prev_snapshot, None)
+        res1 = _run_trigger_fail_open(
+            "Volume Surge Top",
+            trigger_morning_volume_surge,
+            trade_date,
+            snapshot,
+            prev_snapshot,
+            None,
+        )
+        res2 = _run_trigger_fail_open(
+            "Gap Up Momentum Top",
+            trigger_morning_gap_up_momentum,
+            trade_date,
+            snapshot,
+            prev_snapshot,
+            None,
+        )
         primary_tickers = set(res1.index).union(res2.index)
         primary_candidate_count = len(primary_tickers)
         needed = max(0, MORNING_TARGET_CANDIDATES - primary_candidate_count)
@@ -1520,12 +1611,20 @@ def run_batch(trigger_time: str, log_level: str = "INFO", output_file: str = Non
 
         if needed:
             cap_lookup_attempted = True
-            cap_universe = apply_absolute_filters(
-                snapshot.copy(), min_value=MIN_TRADING_VALUE
+            cap_source = _sanitize_numeric_snapshot(
+                snapshot, source="capacity_fill_current"
+            )
+            cap_universe = (
+                apply_absolute_filters(cap_source, min_value=MIN_TRADING_VALUE)
+                if not cap_source.empty
+                else pd.DataFrame()
             )
             cap_tickers = cap_universe.index.tolist()
-            cap_df = get_market_cap_df(
-                cap_tickers, max_workers=MARKET_CAP_MAX_WORKERS
+            cap_df = _run_trigger_fail_open(
+                "Market Cap Lookup",
+                get_market_cap_df,
+                cap_tickers,
+                max_workers=MARKET_CAP_MAX_WORKERS,
             )
             cap_lookup_coverage = (
                 len(cap_df) / len(cap_tickers) if cap_tickers else 0.0
@@ -1541,7 +1640,9 @@ def run_batch(trigger_time: str, log_level: str = "INFO", output_file: str = Non
                 cap_lookup_coverage * 100,
             )
             if cap_lookup_coverage >= MARKET_CAP_MIN_COVERAGE:
-                res3 = trigger_morning_value_to_cap_ratio(
+                res3 = _run_trigger_fail_open(
+                    "Value-to-Cap Ratio Top",
+                    trigger_morning_value_to_cap_ratio,
                     trade_date,
                     snapshot,
                     prev_snapshot,
@@ -1573,9 +1674,30 @@ def run_batch(trigger_time: str, log_level: str = "INFO", output_file: str = Non
         }
     elif trigger_time == "afternoon":
         logger.info("=== Afternoon Batch Execution ===")
-        res1 = trigger_afternoon_daily_rise_top(trade_date, snapshot, prev_snapshot, cap_df)
-        res2 = trigger_afternoon_closing_strength(trade_date, snapshot, prev_snapshot, cap_df)
-        res3 = trigger_afternoon_volume_surge_flat(trade_date, snapshot, prev_snapshot, cap_df)
+        res1 = _run_trigger_fail_open(
+            "Intraday Rise Top",
+            trigger_afternoon_daily_rise_top,
+            trade_date,
+            snapshot,
+            prev_snapshot,
+            cap_df,
+        )
+        res2 = _run_trigger_fail_open(
+            "Closing Strength Top",
+            trigger_afternoon_closing_strength,
+            trade_date,
+            snapshot,
+            prev_snapshot,
+            cap_df,
+        )
+        res3 = _run_trigger_fail_open(
+            "Volume Surge Sideways",
+            trigger_afternoon_volume_surge_flat,
+            trade_date,
+            snapshot,
+            prev_snapshot,
+            cap_df,
+        )
         triggers = {
             "Intraday Rise Top": res1,
             "Closing Strength Top": res2,
@@ -1591,14 +1713,29 @@ def run_batch(trigger_time: str, log_level: str = "INFO", output_file: str = Non
         market_regime = macro_context.get("market_regime", "sideways")
         # Macro sector trigger: active in all regimes except strong_bull (momentum is primary there)
         if market_regime not in ("strong_bull",):
-            res_macro = trigger_macro_sector_leader(trade_date, snapshot, prev_snapshot, cap_df, macro_context)
+            res_macro = _run_trigger_fail_open(
+                "Macro Sector Leader",
+                trigger_macro_sector_leader,
+                trade_date,
+                snapshot,
+                prev_snapshot,
+                cap_df,
+                macro_context,
+            )
             if not res_macro.empty:
                 triggers["Macro Sector Leader"] = res_macro
                 logger.info(f"Macro Sector Leader: {len(res_macro)} candidates")
 
         # Contrarian value: active in sideways, moderate_bear, strong_bear
         if market_regime in ("sideways", "moderate_bear", "strong_bear"):
-            res_value = trigger_contrarian_value(trade_date, snapshot, prev_snapshot, cap_df)
+            res_value = _run_trigger_fail_open(
+                "Contrarian Value Pick",
+                trigger_contrarian_value,
+                trade_date,
+                snapshot,
+                prev_snapshot,
+                cap_df,
+            )
             if not res_value.empty:
                 triggers["Contrarian Value Pick"] = res_value
                 logger.info(f"Contrarian Value Pick: {len(res_value)} candidates")


### PR DESCRIPTION
## Summary
- sanitize nested/non-numeric yfinance OHLCV cells per ticker
- align current and previous snapshots before trigger arithmetic
- isolate each US trigger behind an explicit fail-open boundary
- keep the batch running when one trigger fails

## Production incident
US morning aborted with `ValueError: Can only compare identically-labeled Series objects` after the previous snapshot returned only one usable ticker.

## Verification
- 27 screening regression tests passed
- 5 script-style bullish-candle checks passed
- py_compile, ruff (excluding pre-existing E402/E741/F841), and git diff --check passed