### PR TITLE
fix(us): preserve ledger and execution separation

### DIFF
--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -63,7 +63,7 @@ SHADOW→LIVE **자동 승격**은 아래를 **모두** 충족할 때만:
 
 ## 변경 이력
 - 2026-09-01: **US trigger fail-open 경계 복구** — yfinance가 일부 ticker의 OHLCV 셀을 중첩 Series로 반환하거나 현재·전일 라벨이 어긋나도 해당 ticker를 제거하고, 개별 trigger 예외는 빈 결과로 격리해 나머지 trigger와 전체 배치를 계속 실행한다. snapshot 자체를 가져오지 못한 경우의 배치 중단 계약은 유지한다.
-- 2026-09-01: **US 신규매수 위험 계약 정렬** — 레짐 slot tuple의 합계를 최종 후보 수 hard cap으로 적용해 post-FTD 1종목·약세/횡보 2종목 제한이 bottom-up refill로 무효화되지 않게 수정. US `max_portfolio_size`를 실제 신규매수·피라미딩 슬롯 한도에 연결하고, 최종 점수를 `buy_score + macro_adjustment + journal_adjustment`로 통일. 계정별 USD 주문예산으로 정수 1주를 살 수 없는 종목은 실주문·시뮬레이터 보유 생성 전에 watchlist로 전환한다.
+- 2026-09-01: **US 신규매수 위험 계약 정렬** — 레짐 slot tuple의 합계를 최종 후보 수 hard cap으로 적용해 post-FTD 1종목·약세/횡보 2종목 제한이 bottom-up refill로 무효화되지 않게 수정. US `max_portfolio_size`를 실제 신규매수·피라미딩 슬롯 한도에 연결하고, 최종 점수를 `buy_score + macro_adjustment + journal_adjustment`로 통일. 내부 원장·시뮬레이터는 KIS 실주문 가능 수량·성공 여부와 독립된 기존 계약을 유지한다.
 - 2026-07-19: **KR PENDING EXIT 배선 추가, gate OFF 유지** — batch/hardstop/trend에 broker-first lifecycle을 연결하고 `feature_status.py`에 `.env`와 모든 active cron inline gate 상태를 노출. 피라미딩 accepted-but-unfilled 재시작 방어 및 post-CLOSED 외부효과 복구 절차를 포함한 운영 reconciliation 완료 전 활성화 금지.
 - 2026-06-23: 레지스트리 신설. 현황 기록(Loop A LIVE / B·C SHADOW미스케줄 / 비전 SHADOW관측).
 - 2026-06-24: S6 발행 게이트 갱신 — 배선 구현 완료 반영. 게이트 `PRISM_FEATURE_INSIGHT_IMAGE=on` + `vision_available()`(이전 "발행 배선 미구현" 기재 정정). `feature_status.py`도 동일 로직으로 LIVE/OFF 보고.

--- a/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
+++ b/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
@@ -151,19 +151,6 @@ def test_us_entry_risk_contract_helpers() -> None:
         "effective_score": 6.0,
     }
 
-    assert us_agent_module._whole_share_affordability(
-        {"buy_amount_usd": 1100.0}, current_price=1200.0
-    ) == {
-        "known": True,
-        "allowed": False,
-        "cash_amount": 1100.0,
-        "whole_share_quantity": 0,
-    }
-    assert us_agent_module._whole_share_affordability(
-        {"buy_amount_usd": 1100.0}, current_price=500.0
-    )["whole_share_quantity"] == 2
-
-
 class _FakeAsyncUSTradingContext:
     def __init__(self, account_name=None, **kwargs):
         self.account_name = account_name
@@ -862,80 +849,6 @@ async def test_sideways_uptrend_score_six_uses_half_size_us_order(monkeypatch, t
         "SELECT cash_amount FROM order_intents"
     ).fetchone()[0]
     assert float(cash_amount) == 1000.0
-
-
-@pytest.mark.asyncio
-async def test_process_reports_blocks_unaffordable_entry_before_simulator(
-    monkeypatch, tmp_path
-):
-    agent = USStockTrackingAgent.__new__(USStockTrackingAgent)
-    agent.db_path = str(tmp_path / "unaffordable.sqlite")
-    _ensure_reentry_schema(agent.db_path)
-    agent.account_configs = [{
-        "name": "us-primary",
-        "account_key": "prod:us-primary:01",
-        "product": "01",
-        "buy_amount_usd": 1100.0,
-    }]
-    agent.active_account = None
-    agent.max_slots = 10
-    agent.enable_journal = False
-    agent.conn = sqlite3.connect(":memory:")
-    agent.cursor = agent.conn.cursor()
-
-    async def fake_core(_report_path):
-        return {
-            "success": True,
-            "ticker": "EXPENSIVE",
-            "company_name": "Expensive Inc.",
-            "current_price": 1200.0,
-            "scenario": {
-                "buy_score": 8,
-                "macro_adjustment": 0,
-                "min_score": 7,
-                "sector": "Technology",
-                "target_price": 1400.0,
-                "stop_loss": 1140.0,
-                "risk_reward_ratio": 3.3,
-                "max_portfolio_size": 6,
-            },
-            "decision": "entry",
-            "raw_decision": "Enter",
-            "sector": "Technology",
-            "rank_change_msg": "Up",
-        }
-
-    watchlist_calls = []
-
-    async def fake_save_watchlist_item(**kwargs):
-        watchlist_calls.append(kwargs)
-        return True
-
-    agent._analyze_report_core = fake_core
-    agent.update_holdings = AsyncMock(return_value=[])
-    agent._is_ticker_in_holdings = AsyncMock(return_value=False)
-    agent._get_current_slots_count = AsyncMock(return_value=0)
-    agent._check_sector_diversity = AsyncMock(return_value=True)
-    agent._buy_floor_regime = lambda: "strong_bull"
-    agent._regime_policy_mod = lambda: None
-    agent._evaluate_production_buy_gate = lambda *args, **kwargs: {
-        "allowed": True,
-        "reason": "",
-        "findings": [],
-    }
-    agent._buy_stock_with_position = AsyncMock(
-        side_effect=AssertionError("unaffordable entry must not reach simulator")
-    )
-    agent._save_watchlist_item = fake_save_watchlist_item
-
-    buy_count, sell_count = await USStockTrackingAgent.process_reports(
-        agent, ["report-a.pdf"]
-    )
-
-    assert (buy_count, sell_count) == (0, 0)
-    agent._buy_stock_with_position.assert_not_awaited()
-    assert len(watchlist_calls) == 1
-    assert "whole-share affordability" in watchlist_calls[0]["skip_reason"]
 
 
 @pytest.mark.asyncio

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -479,34 +479,6 @@ def _effective_buy_score(
     }
 
 
-def _whole_share_affordability(
-    account: Dict[str, Any] | None,
-    *,
-    current_price: float,
-    cash_amount_override: float | None = None,
-) -> Dict[str, Any]:
-    """Fail open only when configured cash is unknown; otherwise require one share."""
-    configured = cash_amount_override
-    if configured is None and account:
-        configured = account.get("buy_amount_usd")
-    cash_amount = _safe_number(configured, default=0.0)
-    price = _safe_number(current_price, default=0.0)
-    if cash_amount <= 0:
-        return {
-            "known": False,
-            "allowed": True,
-            "cash_amount": None,
-            "whole_share_quantity": None,
-        }
-    quantity = int(cash_amount / price) if price > 0 else 0
-    return {
-        "known": True,
-        "allowed": quantity >= 1,
-        "cash_amount": cash_amount,
-        "whole_share_quantity": quantity,
-    }
-
-
 def check_sector_diversity(cursor, sector: str, max_same_sector: int, concentration_ratio: float, account_key: str | None = None) -> bool:
     """
     Check for over-concentration in same sector.
@@ -1722,18 +1694,6 @@ class USStockTrackingAgent:
             slot_limit = _scenario_slot_limit(scenario, hard_max=self.max_slots)
             if current_slots >= slot_limit:
                 logger.warning(f"Holdings already at scenario maximum ({slot_limit})")
-                return LegacyPositionWriteResult(False, None)
-
-            affordability = _whole_share_affordability(
-                getattr(self, "active_account", None),
-                current_price=current_price,
-            )
-            if affordability["known"] and not affordability["allowed"]:
-                logger.warning(
-                    "%s entry blocked before simulator: configured amount cannot buy "
-                    "one whole share",
-                    ticker,
-                )
                 return LegacyPositionWriteResult(False, None)
 
             # Current time
@@ -4010,19 +3970,6 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                                     entry_cash_amount,
                                 )
 
-                    affordability = _whole_share_affordability(
-                        account,
-                        current_price=current_price,
-                        cash_amount_override=entry_cash_amount,
-                    )
-                    if affordability["known"] and not affordability["allowed"]:
-                        logger.warning(
-                            "[BUY_GATE][US] %s(%s) blocked: configured amount "
-                            "cannot buy one whole share",
-                            company_name,
-                            ticker,
-                        )
-
                     rationale = scenario.get("rationale", "") or ""
                     logger.info(
                         f"Scenario decision: {company_name} ({ticker}) - "
@@ -4049,11 +3996,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     # re-entry — longer cooldown after a loss). Fresh entries only;
                     # pyramiding adds (is_add) are exempt.
                     _cd_block = False
-                    if (
-                        normalized_decision == "entry"
-                        and not is_add
-                        and affordability["allowed"]
-                    ):
+                    if normalized_decision == "entry" and not is_add:
                         try:
                             from reentry_cooldown import reentry_block, COOLDOWN_LIVE, COOLDOWN_RISK_EXIT_LIVE
                             _account_key, _ = self._account_scope()
@@ -4111,10 +4054,6 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                         "slots_used": current_slots,
                         "slots_max": scenario_slot_limit,
                         "is_add": bool(is_add),
-                        "affordability_known": bool(affordability["known"]),
-                        "whole_share_quantity": affordability[
-                            "whole_share_quantity"
-                        ],
                     }
                     analysis_result["scenario"] = scenario
 
@@ -4124,7 +4063,6 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                         and sector_diverse
                         and not _cd_block
                         and _buy_gate.get("allowed", False)
-                        and affordability["allowed"]
                     )
                     if entry_eligible:
                         emit_trading_context(
@@ -4324,11 +4262,6 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                             )
                         if _cd_block:
                             reason_parts.append("Recent risk-exit re-entry cooldown")
-                        if affordability["known"] and not affordability["allowed"]:
-                            reason_parts.append(
-                                "whole-share affordability: configured amount "
-                                "cannot buy 1 share"
-                            )
                         reason = " / ".join(reason_parts) if reason_parts else "Other"
                         logger.info(f"Purchase deferred: {company_name} ({ticker}) - {reason}")
                         state["should_save_watchlist"] = True


### PR DESCRIPTION
## Summary
- remove KIS whole-share affordability from the internal ledger decision path
- preserve simulator holdings independently of real-order feasibility/outcome
- retain regime slot, max portfolio size, and effective-score fixes
- document the ledger/execution separation contract

## Verification
- 21 focused US tests passed
- py_compile, ruff with pre-existing ignores, and git diff --check passed