### PR TITLE
fix(ops): detect micro-split cron shadow gate

### DIFF
--- a/tests/test_feature_status.py
+++ b/tests/test_feature_status.py
@@ -189,6 +189,15 @@ def test_micro_split_shadow_enabled_is_never_live():
     assert "거래영향 0" in r["micro_split_shadow"]["evidence"]
 
 
+def test_micro_split_shadow_reads_us_cron_inline_gate():
+    cron = """
+15 10 * * 1-5 cd /opt/prism && MICRO_SPLIT_SHADOW_ENABLED=true python prism-us/us_stock_analysis_orchestrator.py --mode morning
+"""
+    r = _results_by_id(fs.evaluate_all(env={}, crontab=cron))
+    assert r["micro_split_shadow"]["state"] == "SHADOW"
+    assert "crontab inline" in r["micro_split_shadow"]["evidence"]
+
+
 # ── Vision pipeline (S1/S2) ───────────────────────────────────────────────────
 
 def test_vision_pipeline_live_on_no_shadow():

--- a/tools/feature_status.py
+++ b/tools/feature_status.py
@@ -181,11 +181,15 @@ def _decide_loop_c(env: dict, crontab: str):
 
 
 def _decide_micro_split_shadow(env: dict, crontab: str):
-    enabled = str(env.get("MICRO_SPLIT_SHADOW_ENABLED", "")).strip().lower()
+    env_value = str(env.get("MICRO_SPLIT_SHADOW_ENABLED", "")).strip().lower()
+    cron_value = _cron_get_inline_env(crontab, "MICRO_SPLIT_SHADOW_ENABLED").lower()
+    enabled = env_value or cron_value
     if enabled in {"1", "true", "yes", "on"}:
+        source = "env" if env_value else "crontab inline"
         return (
             "SHADOW",
-            "MICRO_SPLIT_SHADOW_ENABLED=true, 신규 US 적격진입 0→10% projection만 기록, 거래영향 0",
+            "MICRO_SPLIT_SHADOW_ENABLED=true "
+            f"({source}), 신규 US 적격진입 0→10% projection만 기록, 거래영향 0",
         )
     return "OFF", f"MICRO_SPLIT_SHADOW_ENABLED={enabled or '(unset)'}"
 


### PR DESCRIPTION
## Summary
- detect MICRO_SPLIT_SHADOW_ENABLED from active cron inline assignments
- report SHADOW rather than OFF when only US batch cron enables capture

## Verification
- 42 feature-status tests passed
- Ruff, py_compile, and git diff --check passed