### PR TITLE
fix: recover translated PDF timeouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -248,6 +248,13 @@ TELEGRAM_CHANNEL_ID=your_channel_id
 # REGIME_WEAK_NO_TOPDOWN=false
 # MICRO_SPLIT_SHADOW_ENABLED=false # US 신규 적격진입의 0→10% 예상 수량만 기록, 거래영향 0
 
+# KR/US translated-PDF delivery. Each timed-out LLM translation is retried once;
+# the whole translation batch remains bounded and cannot block trading decisions.
+# PRISM_TRANSLATED_PDF_MAX_CONCURRENCY=3
+# PRISM_TRANSLATED_PDF_ITEM_TIMEOUT_SECONDS=360
+# PRISM_TRANSLATED_PDF_BATCH_TIMEOUT_SECONDS=1800
+# PRISM_TRANSLATED_PDF_MAX_ATTEMPTS=2
+
 # loop_a 하드스탑 inflight SELL 레코드 TTL(초). 이보다 오래된 OPEN 레코드는 stale로 보고
 # 중복방지 대상에서 제외(fill-chaser 미정리로 손절이 영구 차단되던 버그 방지). tools/loop_a_hardstop.py.
 # INFLIGHT_TTL_SEC=900

--- a/cores/agents/telegram_translator_agent.py
+++ b/cores/agents/telegram_translator_agent.py
@@ -110,6 +110,7 @@ async def translate_telegram_message(
     to_lang: str = "en",
     *,
     raise_on_error: bool = False,
+    reasoning_effort: str = REPORT_AUX_EFFORT,
 ) -> str:
     """
     Translate a telegram message from source language to target language
@@ -121,6 +122,8 @@ async def translate_telegram_message(
         to_lang: Target language code (default: "en" for English)
         raise_on_error: Re-raise failures when callers must not send the source
             text as if it had been translated.
+        reasoning_effort: Reasoning effort for the translation request. PDF
+            translation callers use ``low`` because the task is single-pass.
 
     Returns:
         str: Translated message
@@ -145,7 +148,7 @@ async def translate_telegram_message(
             message=message,
             request_params=RequestParams(
                 model=model,
-                reasoning_effort=REPORT_AUX_EFFORT,
+                reasoning_effort=reasoning_effort,
                 maxTokens=100000,
                 temperature=0.3,  # Lower temperature for more consistent translations
                 max_iterations=1  # Single pass translation, no complex reasoning needed

--- a/docs/TRANSLATED_PDF_OPERATIONS_ko.md
+++ b/docs/TRANSLATED_PDF_OPERATIONS_ko.md
@@ -1,0 +1,31 @@
+# 번역 PDF 운영 계약
+
+KR·US 원문 보고서와 매매 처리가 끝난 뒤 다국어 PDF를 비동기 후속 작업으로 생성하고 전송한다. 번역 PDF 실패는 주문·포지션·원문 보고서 완료 상태를 변경하지 않는다.
+
+## 기본 정책
+
+- 동시 번역: 3건
+- 개별 번역 시도 제한: 360초
+- timeout 최대 시도: 2회
+- 전체 번역 배치 제한: 1,800초
+- PDF 번역 추론 강도: `low`
+
+환경변수로 각각 `PRISM_TRANSLATED_PDF_MAX_CONCURRENCY`, `PRISM_TRANSLATED_PDF_ITEM_TIMEOUT_SECONDS`, `PRISM_TRANSLATED_PDF_MAX_ATTEMPTS`, `PRISM_TRANSLATED_PDF_BATCH_TIMEOUT_SECONDS`를 조정할 수 있다.
+
+개별 timeout만 같은 번역을 한 번 더 시도한다. 일반 번역 오류와 쿼터 오류는 반복 호출하지 않고 기존 오류·알림 경로로 보낸다. 전체 배치 제한에 도달하면 남은 작업을 취소한다.
+
+## 로그 판정
+
+- `status=retry reason=item_timeout`: 복구 시도 중인 경고다.
+- 이후 같은 시장·언어·보고서에 `status=translated`와 `status=sent`가 있으면 복구 성공이다.
+- 최종 `status=skipped reason=item_timeout attempts=2`: 실제 산출물 누락이다.
+- `status=deadline_exceeded`: 배치 상한에 도달한 실제 장애다.
+- 성공 로그의 `queue_seconds`와 `request_seconds`를 분리해 대기열 포화와 LLM 지연을 구분한다.
+
+원시 오류 줄 수를 장애 건수로 사용하지 않는다. 시장·언어·원본 보고서를 키로 묶고 최종 상태로 판정한다.
+
+## 2026-09-01 KR 장애 기록
+
+최근 4개 KR 배치에서 일본어 번역은 12건 중 7건이 기존 360초 단일 시도 제한을 넘었다. 2026-09-01 오후 배치에서는 SK이노베이션과 아난티 일본어 PDF가 누락됐지만 다른 10개 번역 PDF와 원문 보고서·매매·tracking은 정상 완료됐다.
+
+번역 전용 요청이 공용 `medium` 추론 강도를 사용했고 timeout 재시도가 없던 것이 직접적인 취약점이었다. PDF 번역만 `low`로 낮추고 timeout 재시도 1회를 추가했으며, 재시도를 수용하도록 전체 상한을 1,800초로 늘렸다.

--- a/prism-us/tests/test_us_translated_pdf_delivery.py
+++ b/prism-us/tests/test_us_translated_pdf_delivery.py
@@ -11,12 +11,13 @@ from us_stock_analysis_orchestrator import (
 
 
 def test_us_translated_pdf_limits_match_kr_contract() -> None:
-    assert _translated_pdf_limits({}) == (3, 360, 1200)
+    assert _translated_pdf_limits({}) == (3, 360, 1800, 2)
     assert _translated_pdf_limits({
         "PRISM_TRANSLATED_PDF_MAX_CONCURRENCY": "2",
         "PRISM_TRANSLATED_PDF_ITEM_TIMEOUT_SECONDS": "90",
         "PRISM_TRANSLATED_PDF_BATCH_TIMEOUT_SECONDS": "600",
-    }) == (2, 90, 600)
+        "PRISM_TRANSLATED_PDF_MAX_ATTEMPTS": "3",
+    }) == (2, 90, 600, 3)
 
 
 def test_us_translated_pdfs_use_bounded_parallelism_and_skip_failures(
@@ -35,6 +36,7 @@ def test_us_translated_pdfs_use_bounded_parallelism_and_skip_failures(
     async def fake_translate(message, *, to_lang, raise_on_error, **_kwargs):
         nonlocal active, max_active
         assert raise_on_error is True
+        assert _kwargs["reasoning_effort"] == "low"
         active += 1
         max_active = max(max_active, active)
         await real_sleep(0.02)
@@ -88,3 +90,66 @@ def test_us_translated_pdfs_use_bounded_parallelism_and_skip_failures(
 
 async def _no_wait() -> None:
     return None
+
+
+def test_us_translated_pdf_retries_one_timeout_and_sends_once(
+    monkeypatch, tmp_path, caplog
+) -> None:
+    report = tmp_path / "AAA_Alpha_20260901_afternoon_gpt-5.6-luna.md"
+    report.write_text("flaky", encoding="utf-8")
+    real_sleep = asyncio.sleep
+    attempts = 0
+    sent = []
+
+    async def flaky_translate(message, *, reasoning_effort, **_kwargs):
+        nonlocal attempts
+        assert message == "flaky"
+        assert reasoning_effort == "low"
+        attempts += 1
+        if attempts == 1:
+            await real_sleep(0.03)
+        return "translated"
+
+    class FakeRenderer:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def render(self, _source, output):
+            return output
+
+    class FakeConfig:
+        broadcast_languages = ["ja"]
+
+        @staticmethod
+        def get_broadcast_channel_id(_lang):
+            return "channel-ja"
+
+    class FakeBot:
+        async def send_document(self, channel_id, path, **kwargs):
+            assert kwargs["market"] == "us"
+            sent.append((channel_id, path))
+            return True
+
+    monkeypatch.setattr(orchestrator_module, "translate_telegram_message", flaky_translate)
+    monkeypatch.setattr(pdf_converter, "PdfRenderer", FakeRenderer)
+    monkeypatch.setattr(orchestrator_module, "US_PDF_REPORTS_DIR", tmp_path)
+    monkeypatch.setattr(
+        orchestrator_module,
+        "_translated_pdf_limits",
+        lambda: (1, 0.01, 1, 2),
+    )
+    monkeypatch.setattr(orchestrator_module.asyncio, "sleep", lambda _delay: _no_wait())
+
+    orchestrator = USStockAnalysisOrchestrator.__new__(USStockAnalysisOrchestrator)
+    orchestrator.telegram_config = FakeConfig()
+
+    with caplog.at_level("INFO"):
+        asyncio.run(orchestrator._send_translated_pdfs(FakeBot(), [str(report)]))
+
+    assert attempts == 2
+    assert len(sent) == 1
+    assert "status=retry" in caplog.text
+    assert "attempt=1 next_attempt=2" in caplog.text

--- a/prism-us/us_stock_analysis_orchestrator.py
+++ b/prism-us/us_stock_analysis_orchestrator.py
@@ -199,8 +199,8 @@ _translator_module = _import_from_main_cores(
 translate_telegram_message = _translator_module.translate_telegram_message
 
 
-def _translated_pdf_limits(environ=None) -> tuple[int, int, int]:
-    """Return concurrency, per-report timeout, and whole-batch deadline."""
+def _translated_pdf_limits(environ=None) -> tuple[int, int, int, int]:
+    """Return concurrency, per-attempt timeout, batch deadline, and attempts."""
     environ = os.environ if environ is None else environ
 
     def positive_int(name: str, default: int) -> int:
@@ -212,7 +212,8 @@ def _translated_pdf_limits(environ=None) -> tuple[int, int, int]:
     return (
         positive_int("PRISM_TRANSLATED_PDF_MAX_CONCURRENCY", 3),
         positive_int("PRISM_TRANSLATED_PDF_ITEM_TIMEOUT_SECONDS", 360),
-        positive_int("PRISM_TRANSLATED_PDF_BATCH_TIMEOUT_SECONDS", 1200),
+        positive_int("PRISM_TRANSLATED_PDF_BATCH_TIMEOUT_SECONDS", 1800),
+        positive_int("PRISM_TRANSLATED_PDF_MAX_ATTEMPTS", 2),
     )
 
 
@@ -862,7 +863,9 @@ class USStockAnalysisOrchestrator:
         """
         from pdf_converter import PdfRenderer
 
-        concurrency, item_timeout, batch_timeout = _translated_pdf_limits()
+        concurrency, item_timeout, batch_timeout, max_attempts = (
+            _translated_pdf_limits()
+        )
         semaphore = asyncio.Semaphore(concurrency)
         jobs = []
         for lang in self.telegram_config.broadcast_languages:
@@ -874,8 +877,9 @@ class USStockAnalysisOrchestrator:
 
         logger.info(
             "[TRANSLATED_PDF] market=US status=start jobs=%d concurrency=%d "
-            "item_timeout_seconds=%d batch_timeout_seconds=%d",
-            len(jobs), concurrency, item_timeout, batch_timeout,
+            "item_timeout_seconds=%d batch_timeout_seconds=%d max_attempts=%d "
+            "reasoning_effort=low",
+            len(jobs), concurrency, item_timeout, batch_timeout, max_attempts,
         )
         if not jobs:
             return
@@ -887,17 +891,47 @@ class USStockAnalysisOrchestrator:
                     original_report = f.read()
                 text_for_translation, images = self._extract_base64_images(original_report)
 
-                async with semaphore:
-                    translated_report = await asyncio.wait_for(
-                        translate_telegram_message(
-                            text_for_translation,
-                            model=REPORT_AUX_MODEL,
-                            from_lang="ko",
-                            to_lang=lang,
-                            raise_on_error=True,
-                        ),
-                        timeout=item_timeout,
-                    )
+                translated_report = None
+                queue_seconds = 0.0
+                request_seconds = 0.0
+                attempts_used = 0
+                for attempt in range(1, max_attempts + 1):
+                    attempts_used = attempt
+                    queued_at = time.monotonic()
+                    try:
+                        async with semaphore:
+                            request_started = time.monotonic()
+                            queue_seconds += request_started - queued_at
+                            translated_report = await asyncio.wait_for(
+                                translate_telegram_message(
+                                    text_for_translation,
+                                    model=REPORT_AUX_MODEL,
+                                    from_lang="ko",
+                                    to_lang=lang,
+                                    raise_on_error=True,
+                                    reasoning_effort="low",
+                                ),
+                                timeout=item_timeout,
+                            )
+                            request_seconds += time.monotonic() - request_started
+                        break
+                    except asyncio.TimeoutError:
+                        request_seconds += time.monotonic() - request_started
+                        if attempt < max_attempts:
+                            logger.warning(
+                                "[TRANSLATED_PDF] market=US lang=%s report=%s "
+                                "status=retry reason=item_timeout attempt=%d "
+                                "next_attempt=%d timeout_seconds=%d",
+                                lang, report_path, attempt, attempt + 1, item_timeout,
+                            )
+                            continue
+                        logger.error(
+                            "[TRANSLATED_PDF] market=US lang=%s report=%s "
+                            "status=skipped reason=item_timeout timeout_seconds=%d "
+                            "attempts=%d",
+                            lang, report_path, item_timeout, max_attempts,
+                        )
+                        return None
 
                 translated_report = self._restore_base64_images(translated_report, images)
                 report_file = Path(report_path)
@@ -907,16 +941,12 @@ class USStockAnalysisOrchestrator:
 
                 logger.info(
                     "[TRANSLATED_PDF] market=US lang=%s report=%s status=translated "
-                    "duration_seconds=%.1f",
+                    "duration_seconds=%.1f queue_seconds=%.1f request_seconds=%.1f "
+                    "attempts=%d",
                     lang, report_path, time.monotonic() - started,
+                    queue_seconds, request_seconds, attempts_used,
                 )
                 return lang, channel_id, translated_report_path
-            except asyncio.TimeoutError:
-                logger.error(
-                    "[TRANSLATED_PDF] market=US lang=%s report=%s status=skipped "
-                    "reason=item_timeout timeout_seconds=%d",
-                    lang, report_path, item_timeout,
-                )
             except Exception as error:
                 logger.error(
                     "[TRANSLATED_PDF] market=US lang=%s report=%s status=skipped "

--- a/stock_analysis_orchestrator.py
+++ b/stock_analysis_orchestrator.py
@@ -74,8 +74,8 @@ def _batch_report_parallel_limit(job_count: int, environ=None) -> int:
     return min(job_count, max(1, configured))
 
 
-def _translated_pdf_limits(environ=None) -> tuple[int, int, int]:
-    """Return concurrency, per-report timeout, and whole-batch deadline."""
+def _translated_pdf_limits(environ=None) -> tuple[int, int, int, int]:
+    """Return concurrency, per-attempt timeout, batch deadline, and attempts."""
     environ = os.environ if environ is None else environ
 
     def positive_int(name: str, default: int) -> int:
@@ -87,7 +87,8 @@ def _translated_pdf_limits(environ=None) -> tuple[int, int, int]:
     return (
         positive_int("PRISM_TRANSLATED_PDF_MAX_CONCURRENCY", 3),
         positive_int("PRISM_TRANSLATED_PDF_ITEM_TIMEOUT_SECONDS", 360),
-        positive_int("PRISM_TRANSLATED_PDF_BATCH_TIMEOUT_SECONDS", 1200),
+        positive_int("PRISM_TRANSLATED_PDF_BATCH_TIMEOUT_SECONDS", 1800),
+        positive_int("PRISM_TRANSLATED_PDF_MAX_ATTEMPTS", 2),
     )
 
 
@@ -783,7 +784,9 @@ class StockAnalysisOrchestrator:
         from cores.agents.telegram_translator_agent import translate_telegram_message
         from pdf_converter import PdfRenderer
 
-        concurrency, item_timeout, batch_timeout = _translated_pdf_limits()
+        concurrency, item_timeout, batch_timeout, max_attempts = (
+            _translated_pdf_limits()
+        )
         semaphore = asyncio.Semaphore(concurrency)
         jobs = []
         for lang in self.telegram_config.broadcast_languages:
@@ -795,8 +798,9 @@ class StockAnalysisOrchestrator:
 
         logger.info(
             "[TRANSLATED_PDF] market=KR status=start jobs=%d concurrency=%d "
-            "item_timeout_seconds=%d batch_timeout_seconds=%d",
-            len(jobs), concurrency, item_timeout, batch_timeout,
+            "item_timeout_seconds=%d batch_timeout_seconds=%d max_attempts=%d "
+            "reasoning_effort=low",
+            len(jobs), concurrency, item_timeout, batch_timeout, max_attempts,
         )
         if not jobs:
             return
@@ -808,17 +812,47 @@ class StockAnalysisOrchestrator:
                     original_report = f.read()
                 text_for_translation, images = self._extract_base64_images(original_report)
 
-                async with semaphore:
-                    translated_report = await asyncio.wait_for(
-                        translate_telegram_message(
-                            text_for_translation,
-                            model=REPORT_AUX_MODEL,
-                            from_lang="ko",
-                            to_lang=lang,
-                            raise_on_error=True,
-                        ),
-                        timeout=item_timeout,
-                    )
+                translated_report = None
+                queue_seconds = 0.0
+                request_seconds = 0.0
+                attempts_used = 0
+                for attempt in range(1, max_attempts + 1):
+                    attempts_used = attempt
+                    queued_at = time.monotonic()
+                    try:
+                        async with semaphore:
+                            request_started = time.monotonic()
+                            queue_seconds += request_started - queued_at
+                            translated_report = await asyncio.wait_for(
+                                translate_telegram_message(
+                                    text_for_translation,
+                                    model=REPORT_AUX_MODEL,
+                                    from_lang="ko",
+                                    to_lang=lang,
+                                    raise_on_error=True,
+                                    reasoning_effort="low",
+                                ),
+                                timeout=item_timeout,
+                            )
+                            request_seconds += time.monotonic() - request_started
+                        break
+                    except asyncio.TimeoutError:
+                        request_seconds += time.monotonic() - request_started
+                        if attempt < max_attempts:
+                            logger.warning(
+                                "[TRANSLATED_PDF] market=KR lang=%s report=%s "
+                                "status=retry reason=item_timeout attempt=%d "
+                                "next_attempt=%d timeout_seconds=%d",
+                                lang, report_path, attempt, attempt + 1, item_timeout,
+                            )
+                            continue
+                        logger.error(
+                            "[TRANSLATED_PDF] market=KR lang=%s report=%s "
+                            "status=skipped reason=item_timeout timeout_seconds=%d "
+                            "attempts=%d",
+                            lang, report_path, item_timeout, max_attempts,
+                        )
+                        return None
 
                 translated_report = self._restore_base64_images(translated_report, images)
                 report_file = Path(report_path)
@@ -828,16 +862,12 @@ class StockAnalysisOrchestrator:
 
                 logger.info(
                     "[TRANSLATED_PDF] market=KR lang=%s report=%s status=translated "
-                    "duration_seconds=%.1f",
+                    "duration_seconds=%.1f queue_seconds=%.1f request_seconds=%.1f "
+                    "attempts=%d",
                     lang, report_path, time.monotonic() - started,
+                    queue_seconds, request_seconds, attempts_used,
                 )
                 return lang, channel_id, translated_report_path
-            except asyncio.TimeoutError:
-                logger.error(
-                    "[TRANSLATED_PDF] market=KR lang=%s report=%s status=skipped "
-                    "reason=item_timeout timeout_seconds=%d",
-                    lang, report_path, item_timeout,
-                )
             except Exception as error:
                 logger.error(
                     "[TRANSLATED_PDF] market=KR lang=%s report=%s status=skipped "

--- a/tests/test_translated_pdf_delivery.py
+++ b/tests/test_translated_pdf_delivery.py
@@ -15,16 +15,18 @@ from stock_analysis_orchestrator import (
 
 
 def test_translated_pdf_limits_are_bounded_and_configurable() -> None:
-    assert _translated_pdf_limits({}) == (3, 360, 1200)
+    assert _translated_pdf_limits({}) == (3, 360, 1800, 2)
     assert _translated_pdf_limits({
         "PRISM_TRANSLATED_PDF_MAX_CONCURRENCY": "2",
         "PRISM_TRANSLATED_PDF_ITEM_TIMEOUT_SECONDS": "90",
         "PRISM_TRANSLATED_PDF_BATCH_TIMEOUT_SECONDS": "600",
-    }) == (2, 90, 600)
+        "PRISM_TRANSLATED_PDF_MAX_ATTEMPTS": "3",
+    }) == (2, 90, 600, 3)
     assert _translated_pdf_limits({
         "PRISM_TRANSLATED_PDF_MAX_CONCURRENCY": "invalid",
         "PRISM_TRANSLATED_PDF_ITEM_TIMEOUT_SECONDS": "0",
-    }) == (3, 1, 1200)
+        "PRISM_TRANSLATED_PDF_MAX_ATTEMPTS": "0",
+    }) == (3, 1, 1800, 1)
 
 
 def test_translator_strict_mode_does_not_return_source_on_failure(monkeypatch) -> None:
@@ -52,6 +54,37 @@ def test_translator_strict_mode_does_not_return_source_on_failure(monkeypatch) -
         )
 
 
+def test_translator_uses_caller_reasoning_effort(monkeypatch) -> None:
+    captured = []
+
+    class CapturingLLM:
+        async def generate_str(self, **kwargs):
+            captured.append(kwargs["request_params"].reasoning_effort)
+            return "翻訳済み"
+
+    class CapturingAgent:
+        async def attach_llm(self, _llm_type):
+            return CapturingLLM()
+
+    monkeypatch.setattr(
+        telegram_translator_agent,
+        "create_telegram_translator_agent",
+        lambda **_kwargs: CapturingAgent(),
+    )
+
+    result = asyncio.run(
+        telegram_translator_agent.translate_telegram_message(
+            "원문",
+            to_lang="ja",
+            reasoning_effort="low",
+            raise_on_error=True,
+        )
+    )
+
+    assert result == "翻訳済み"
+    assert captured == ["low"]
+
+
 def test_kr_translated_pdfs_use_bounded_parallelism_and_skip_failures(
     monkeypatch, tmp_path
 ) -> None:
@@ -68,6 +101,7 @@ def test_kr_translated_pdfs_use_bounded_parallelism_and_skip_failures(
     async def fake_translate(message, *, to_lang, raise_on_error, **_kwargs):
         nonlocal active, max_active
         assert raise_on_error is True
+        assert _kwargs["reasoning_effort"] == "low"
         active += 1
         max_active = max(max_active, active)
         await real_sleep(0.02)
@@ -158,7 +192,11 @@ def test_kr_translated_pdf_batch_deadline_cancels_late_work(
 
     monkeypatch.setattr(telegram_translator_agent, "translate_telegram_message", slow_translate)
     monkeypatch.setattr(pdf_converter, "PdfRenderer", FakeRenderer)
-    monkeypatch.setattr(orchestrator_module, "_translated_pdf_limits", lambda: (1, 1, 0.03))
+    monkeypatch.setattr(
+        orchestrator_module,
+        "_translated_pdf_limits",
+        lambda: (1, 1, 0.03, 2),
+    )
 
     orchestrator = StockAnalysisOrchestrator.__new__(StockAnalysisOrchestrator)
     orchestrator.telegram_config = FakeConfig()
@@ -168,3 +206,69 @@ def test_kr_translated_pdf_batch_deadline_cancels_late_work(
 
     assert time.monotonic() - started < 0.5
     assert sent == []
+
+
+def test_kr_translated_pdf_retries_one_timeout_and_sends_once(
+    monkeypatch, tmp_path, caplog
+) -> None:
+    report = tmp_path / "001_회사_20260901_afternoon_gpt-5.6-luna.md"
+    report.write_text("flaky", encoding="utf-8")
+    real_sleep = asyncio.sleep
+    attempts = 0
+    sent = []
+
+    async def flaky_translate(message, *, reasoning_effort, **_kwargs):
+        nonlocal attempts
+        assert message == "flaky"
+        assert reasoning_effort == "low"
+        attempts += 1
+        if attempts == 1:
+            await real_sleep(0.03)
+        return "translated"
+
+    class FakeRenderer:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def render(self, _source, output):
+            return output
+
+    class FakeConfig:
+        broadcast_languages = ["ja"]
+
+        @staticmethod
+        def get_broadcast_channel_id(_lang):
+            return "channel-ja"
+
+    class FakeBot:
+        async def send_document(self, channel_id, path, **_kwargs):
+            sent.append((channel_id, path))
+            return True
+
+    async def fake_filename(report_file, lang):
+        return tmp_path / f"{report_file.stem}_{lang}.md"
+
+    monkeypatch.setattr(telegram_translator_agent, "translate_telegram_message", flaky_translate)
+    monkeypatch.setattr(pdf_converter, "PdfRenderer", FakeRenderer)
+    monkeypatch.setattr(orchestrator_module, "PDF_REPORTS_DIR", tmp_path)
+    monkeypatch.setattr(
+        orchestrator_module,
+        "_translated_pdf_limits",
+        lambda: (1, 0.01, 1, 2),
+    )
+    monkeypatch.setattr(orchestrator_module.asyncio, "sleep", lambda _delay: _no_wait())
+
+    orchestrator = StockAnalysisOrchestrator.__new__(StockAnalysisOrchestrator)
+    orchestrator.telegram_config = FakeConfig()
+    orchestrator._create_translated_filename = fake_filename
+
+    with caplog.at_level("INFO"):
+        asyncio.run(orchestrator._send_translated_pdfs(FakeBot(), [str(report)]))
+
+    assert attempts == 2
+    assert len(sent) == 1
+    assert "status=retry" in caplog.text
+    assert "attempt=1 next_attempt=2" in caplog.text


### PR DESCRIPTION
## Summary
- run translated-PDF LLM calls with low reasoning effort
- retry per-item timeouts once and extend the bounded batch deadline to 30 minutes
- log queue/request latency separately and document the incident/runbook

## Incident evidence
- KR recent 4 batches: Japanese PDF translations timed out 7/12 times
- 2026-09-01 afternoon: 2 Japanese PDFs missing; trading, original PDFs, tracking, and other 10 translations completed

## Verification
- Python 3.14: KR/Telegram 21 passed, US/orchestrator 31 passed
- Python 3.12: KR translated-PDF 6 passed, US translated-PDF 3 passed
- py_compile and git diff --check passed