### PR TITLE
fix: restore effective fill-chaser LIVE state

### DIFF
--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -35,7 +35,7 @@
 | TIER0 이벤트 강제청산(뉴스 자율매도 + KIS 51 관리종목) | **LIVE** | 코드 상시 | 더존 등 실증 | KR+US 매도 프롬프트 핵심-0 |
 | Loop A — 고빈도 하드스톱(−7%/시나리오손절) | **LIVE** | `.env HARDSTOP_LIVE=true` (구 `LOOP_A_LIVE`, alias 유효) + cron 10분 | SHADOW 관측 후 승격(06-20) | KR 9–15 / US 9–16. 킬: `HARDSTOP_ENABLED=false` |
 | Loop B — 50MA 종가확인 추세이탈 | **LIVE** | `.env TREND_EXIT_LIVE=true` (구 `LOOP_B_LIVE`) + cron(KR 9–15 / US 9–16) | 백테스트 KR/US 순효과(휩쏘0·추가DD0) + 사용자 승인(06-24) | 코드: `tools/trend_exit_seller.py` (구 `tools/loop_b_trend_exit.py` shim 유효). 킬: `TREND_EXIT_ENABLED=false` |
-| Loop C — 미체결 추격 + KIS TR 래퍼 | **SHADOW** | cron(KR/US */2분, `FILL_CHASER_LIVE` 미설정; 구 `LOOP_C_LIVE` alias) | **신규 KIS 정정/취소 TR 실 KIS 수락 검증**(dry-run/`--selftest`로 페이로드 필드는 검증됨) | 코드: `tools/fill_chaser.py` (구 `tools/loop_c_fill_chaser.py` shim 유효). 매수=체결우선 cross(예산 `FILL_CHASER_BUY_MAX_PREMIUM_PCT`=3%, `FILL_CHASER_BUY_CROSS`=on). 상세로깅 `[LOOP_C][SHADOW]` |
+| Loop C — 미체결 추격 + KIS TR 래퍼 | **LIVE** | cron(KR/US */2분) + `.env FILL_CHASER_LIVE=true` + lifecycle `fill_chaser=live` | US 실제 정정 성공 27개 고유 주문·SHADOW 579액션·payload/중복 오류 0 확인 후 2026-09-02 수동 승격 | 코드: `tools/fill_chaser.py` (구 `tools/loop_c_fill_chaser.py` shim 유효). 매수=체결우선 cross(예산 `FILL_CHASER_BUY_MAX_PREMIUM_PCT`=3%, `FILL_CHASER_BUY_CROSS`=on). 두 게이트 중 하나라도 내려가면 SHADOW/OFF |
 | KR 주문 선기록(PENDING ENTRY/EXIT) | **OFF** | `.env` 또는 cron inline `POSITION_PENDING_KR_ENABLED=true` (기본 off) | 피라미딩 fill reconciliation + post-CLOSED 외부효과 복구 검증/사용자 승인 | gate OFF 배포만 허용. gate=true에서 피라미딩은 주문 전 차단. 활성화 전 `failed_exit_linked_open_positions`, PENDING/EXIT_UNKNOWN 0 확인 필수 |
 | 재진입 쿨다운 게이트(매수측) | **LIVE** | `REENTRY_COOLDOWN_LIVE=true` (기본값) | SHADOW 관측 및 prod 이력검증 완료 | 코드: `reentry_cooldown.py` (KR/US 매수 caller 훅). 손실·stop/trend-exit 후 24h 재매수 차단(승리후 0h). 계좌별 DB 경로·account_key로 조회 |
 | 고변동·급락 레짐 강등 | **LIVE** | `REGIME_HIVOL_OVERRIDE=active` (기본값) | KR/US 합성데이터 회귀 완료 | 장기 이평 위에 남은 급락형 휩쏘를 sideways로 강등. `shadow/off`는 긴급 롤백용 |
@@ -59,10 +59,11 @@ SHADOW→LIVE **자동 승격**은 아래를 **모두** 충족할 때만:
 
 ## 승격 대기열 (다음 LIVE 후보)
 - ✅ **Loop B**: LIVE 승격 완료(06-24, 백테스트 KR/US 통과 + 사용자 승인).
-- **Loop C**: 실 KIS 수락 검증(소액 왕복 1회) → 통과 시 후보. (SHADOW 상세로깅·`--selftest`로 페이로드는 검증됨.)
+- ✅ **Loop C**: LIVE 승격 완료(09-02, US 실제 정정 성공 27건 + SHADOW 579액션 + 오류 0). `.env`와 lifecycle 이중 게이트를 모두 확인한다.
 - **비전 매수게이트(S3)**: A/B 측정 설계 확정·데이터 축적 후 — **수익영향이라 사용자 확인 후**.
 
 ## 변경 이력
+- 2026-09-02: **Fill-chaser lifecycle LIVE 복구** — 08-19 lifecycle 도입 때 기존 `.env FILL_CHASER_LIVE=true`가 유지됐지만 명시적 lifecycle 승격이 없어 실제 cron이 SHADOW로 강등됐다. `feature_status.py`가 lifecycle을 보지 않아 LIVE로 오보한 결함도 함께 수정했다. 영향 전수조회에서 US 매수 COP/OXY/LITE/RJF는 자연 체결, HOOD/WDAY는 체결 0·장종료 취소, 관련 US 매도 5건은 전량 체결이었다. 과거 US 실제 정정 성공 27개 고유 주문, 이후 SHADOW 579액션·payload/중복 오류 0을 근거로 lifecycle을 수동 LIVE 승격했다. SHADOW와 LIVE chase 예산을 분리하고 브로커 거절을 성공 액션으로 기록하지 않도록 보강했다.
 - 2026-09-01: **US trigger fail-open 경계 복구** — yfinance가 일부 ticker의 OHLCV 셀을 중첩 Series로 반환하거나 현재·전일 라벨이 어긋나도 해당 ticker를 제거하고, 개별 trigger 예외는 빈 결과로 격리해 나머지 trigger와 전체 배치를 계속 실행한다. snapshot 자체를 가져오지 못한 경우의 배치 중단 계약은 유지한다.
 - 2026-09-01: **US 신규매수 위험 계약 정렬** — 레짐 slot tuple의 합계를 최종 후보 수 hard cap으로 적용해 post-FTD 1종목·약세/횡보 2종목 제한이 bottom-up refill로 무효화되지 않게 수정. US `max_portfolio_size`를 실제 신규매수·피라미딩 슬롯 한도에 연결하고, 최종 점수를 `buy_score + macro_adjustment + journal_adjustment`로 통일. 내부 원장·시뮬레이터는 KIS 실주문 가능 수량·성공 여부와 독립된 기존 계약을 유지한다.
 - 2026-07-19: **KR PENDING EXIT 배선 추가, gate OFF 유지** — batch/hardstop/trend에 broker-first lifecycle을 연결하고 `feature_status.py`에 `.env`와 모든 active cron inline gate 상태를 노출. 피라미딩 accepted-but-unfilled 재시작 방어 및 post-CLOSED 외부효과 복구 절차를 포함한 운영 reconciliation 완료 전 활성화 금지.

--- a/examples/messaging/SUBSCRIBER_OPS_HARNESS.md
+++ b/examples/messaging/SUBSCRIBER_OPS_HARNESS.md
@@ -150,7 +150,9 @@ env -i date                    # 셸 TZ 오염 없이 시스템 시간 확인
 기본값은 SHADOW(관측만, 주문 없음)다. 운영 순서:
 
 1. SHADOW로 최소 하루 이상 장중 구동. 로그에서 `mode=SHADOW` 와 `Fill-chaser done` 요약 확인.
-2. 사용자 승인 후 `.env`에 `FILL_CHASER_LIVE=true` 추가.
+2. 사용자 승인 후 `.env`에 `FILL_CHASER_LIVE=true`를 추가하고
+   `python tools/shadow_lifecycle.py --set-mode fill_chaser live --reason "검증 근거"`로
+   lifecycle을 명시적으로 승격한다. 두 게이트 중 하나라도 빠지면 SHADOW다.
 3. 수동 1회 실행으로 LIVE 확인:
    ```bash
    .venv/bin/python tools/fill_chaser.py --market us --once

--- a/prism-us/tests/test_fill_chaser_us.py
+++ b/prism-us/tests/test_fill_chaser_us.py
@@ -203,6 +203,29 @@ def test_sell_chase_amends_live(tmp_db, monkeypatch):
     assert trader.calls[0].endswith(":NASD")
 
 
+def test_us_live_amend_rejection_does_not_consume_chase_budget(
+    tmp_db, monkeypatch
+):
+    monkeypatch.setattr(lc, "FILL_CHASER_LIVE", True)
+    trader = FakeTrader(
+        [_row("O1", "AAPL", "01", 10, 190.00)],
+        {"AAPL": 189.00},
+        amend_result={"success": False, "message": "broker rejected"},
+    )
+    _patch_ctx(monkeypatch, trader)
+    _seed_seen(tmp_db, "O1")
+
+    summary = _run()
+
+    assert summary["amended"] == 0
+    assert summary["skipped"] == 1
+    assert _logs(tmp_db, "AMEND") == []
+    assert len(_logs(tmp_db, "SKIP")) == 1
+    conn = sqlite3.connect(tmp_db)
+    assert lc.chase_count_for(conn, "O1", "US", mode="LIVE") == 0
+    conn.close()
+
+
 def test_buy_within_ceiling_chases(tmp_db, monkeypatch):
     monkeypatch.setattr(lc, "FILL_CHASER_LIVE", True)
     # ceiling = 100 * 1.02 = 102; market 101 < ceiling => chase up.

--- a/tests/test_feature_status.py
+++ b/tests/test_feature_status.py
@@ -158,10 +158,27 @@ def test_loop_c_misscheduled_no_cron():
     assert r["loop_c"]["state"] == "미스케줄"
 
 
-def test_loop_c_live_when_env_and_cron():
+def test_loop_c_live_when_env_and_cron(monkeypatch):
+    monkeypatch.setattr(fs, "_fill_chaser_lifecycle_mode", lambda: "live")
     env = {"LOOP_C_LIVE": "true"}
     r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_WITH_ALL))
     assert r["loop_c"]["state"] == "LIVE"
+
+
+def test_loop_c_shadow_when_env_live_but_lifecycle_shadow(monkeypatch):
+    monkeypatch.setattr(fs, "_fill_chaser_lifecycle_mode", lambda: "shadow")
+    env = {"FILL_CHASER_LIVE": "true"}
+    r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_WITH_ALL))
+    assert r["loop_c"]["state"] == "SHADOW"
+    assert "lifecycle=shadow" in r["loop_c"]["evidence"]
+
+
+def test_loop_c_off_when_lifecycle_off(monkeypatch):
+    monkeypatch.setattr(fs, "_fill_chaser_lifecycle_mode", lambda: "off")
+    env = {"FILL_CHASER_LIVE": "true"}
+    r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_WITH_ALL))
+    assert r["loop_c"]["state"] == "OFF"
+    assert "lifecycle=off" in r["loop_c"]["evidence"]
 
 
 def test_loop_c_shadow_cron_no_live_flag():
@@ -363,9 +380,10 @@ def test_cron_active_line_counted():
 
 # ── Rename compat: new descriptive script names must also count as scheduled ────
 
-def test_loops_detected_with_new_script_names():
+def test_loops_detected_with_new_script_names(monkeypatch):
     """A crontab using the renamed scripts (hardstop_seller / trend_exit_seller /
     fill_chaser) must resolve LIVE exactly like the old loop_* names."""
+    monkeypatch.setattr(fs, "_fill_chaser_lifecycle_mode", lambda: "live")
     env = {"HARDSTOP_LIVE": "true", "TREND_EXIT_LIVE": "true", "FILL_CHASER_LIVE": "true"}
     r = _results_by_id(fs.evaluate_all(env=env, crontab=CRON_WITH_NEW_NAMES))
     assert r["loop_a"]["state"] == "LIVE"

--- a/tests/test_fill_chaser.py
+++ b/tests/test_fill_chaser.py
@@ -215,6 +215,27 @@ def test_sell_chase_amends_live(tmp_db, monkeypatch):
     assert len(trader.calls) == 1 and trader.calls[0].startswith("amend:005930:O1:")
 
 
+def test_live_amend_rejection_does_not_consume_chase_budget(tmp_db, monkeypatch):
+    monkeypatch.setattr(lc, "FILL_CHASER_LIVE", True)
+    trader = FakeTrader(
+        [_row("O1", "005930", "01", 10, 70000)],
+        {"005930": 69000},
+        amend_result={"success": False, "message": "broker rejected"},
+    )
+    _patch_ctx(monkeypatch, trader)
+    _seed_seen(tmp_db, "O1")
+
+    summary = _run()
+
+    assert summary["amended"] == 0
+    assert summary["skipped"] == 1
+    assert _logs(tmp_db, "AMEND") == []
+    assert len(_logs(tmp_db, "SKIP")) == 1
+    conn = sqlite3.connect(tmp_db)
+    assert lc.chase_count_for(conn, "O1", "KR", mode="LIVE") == 0
+    conn.close()
+
+
 def test_buy_within_ceiling_chases(tmp_db, monkeypatch):
     """BUY: market just under the 2% ceiling => chase UP (no cancel)."""
     monkeypatch.setattr(lc, "FILL_CHASER_LIVE", True)
@@ -241,6 +262,46 @@ def test_buy_ceiling_hit_cancels_instead_of_overpaying(tmp_db, monkeypatch):
     assert not any(c.startswith("amend") for c in trader.calls)
     reason = _logs(tmp_db, "CANCEL")[0]
     assert reason[3] == "CANCEL"
+
+
+def test_live_cancel_rejection_is_not_recorded_as_cancel(tmp_db, monkeypatch):
+    monkeypatch.setattr(lc, "FILL_CHASER_LIVE", True)
+    trader = FakeTrader(
+        [_row("O1", "005930", "02", 5, 10000)],
+        {"005930": 11000},
+        cancel_result={"success": False, "message": "broker rejected"},
+    )
+    _patch_ctx(monkeypatch, trader)
+    _seed_seen(tmp_db, "O1", ticker="005930", side="BUY")
+
+    summary = _run()
+
+    assert summary["cancelled"] == 0
+    assert summary["skipped"] == 1
+    assert _logs(tmp_db, "CANCEL") == []
+    assert len(_logs(tmp_db, "SKIP")) == 1
+
+
+def test_chase_count_isolated_by_runtime_mode(tmp_db):
+    conn = sqlite3.connect(tmp_db)
+    lc._ensure_schema(conn)
+    for mode in ("SHADOW", "LIVE"):
+        conn.execute(
+            "INSERT INTO loop_c_chase_log "
+            "(ticker,market,side,order_no,action,mode,old_price,new_price,"
+            "unfilled_qty,chase_count,reason,loop_run_id,logged_ts) "
+            "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                "005930", "KR", "BUY", "O1", "AMEND", mode, 10000, 10100,
+                1, 1, "test", f"run-{mode}", "2000-01-01T00:00:00+00:00",
+            ),
+        )
+    conn.commit()
+
+    assert lc.chase_count_for(conn, "O1", "KR", mode="SHADOW") == 1
+    assert lc.chase_count_for(conn, "O1", "KR", mode="LIVE") == 1
+    assert lc.chase_count_for(conn, "O1", "KR") == 2
+    conn.close()
 
 
 def test_buy_ceiling_shadow_no_real_call(tmp_db, monkeypatch):

--- a/tools/feature_status.py
+++ b/tools/feature_status.py
@@ -163,21 +163,40 @@ def _decide_loop_b(env: dict, crontab: str):
     return "SHADOW", f"TREND_EXIT_LIVE={live or '(unset)'}, cron=있음"
 
 
+def _fill_chaser_lifecycle_mode() -> str:
+    """Return the effective lifecycle gate; fail closed to SHADOW."""
+    try:
+        from cores.shadow_lifecycle import feature_mode
+
+        mode = str(feature_mode("fill_chaser") or "").strip().lower()
+        return mode if mode in {"live", "shadow", "off"} else "shadow"
+    except Exception:
+        return "shadow"
+
+
 def _decide_loop_c(env: dict, crontab: str):
     # Canonical FILL_CHASER_* with deprecated LOOP_C_* alias fallback.
     live = (env.get("FILL_CHASER_LIVE") or env.get("LOOP_C_LIVE") or "").lower()
     enabled = (env.get("FILL_CHASER_ENABLED") or env.get("LOOP_C_ENABLED") or "").lower()
     has_cron = (_cron_has_script(crontab, "loop_c_fill_chaser.py") or _cron_has_script(crontab, "fill_chaser.py"))
+    lifecycle = _fill_chaser_lifecycle_mode()
 
     if enabled == "false":
         return "OFF", "FILL_CHASER_ENABLED=false"
-    if live == "true" and has_cron:
-        return "LIVE", "FILL_CHASER_LIVE=true, cron=있음"
-    if live == "true" and not has_cron:
-        return "미스케줄", "FILL_CHASER_LIVE=true but cron=없음"
+    if lifecycle == "off":
+        return "OFF", f"FILL_CHASER_LIVE={live or '(unset)'}, lifecycle=off"
     if not has_cron:
-        return "미스케줄", f"cron=없음, FILL_CHASER_LIVE={live or '(unset)'}"
-    return "SHADOW", f"FILL_CHASER_LIVE={live or '(unset)'}, cron=있음"
+        return (
+            "미스케줄",
+            f"cron=없음, FILL_CHASER_LIVE={live or '(unset)'}, "
+            f"lifecycle={lifecycle}",
+        )
+    if live == "true" and lifecycle == "live":
+        return "LIVE", "FILL_CHASER_LIVE=true, lifecycle=live, cron=있음"
+    return (
+        "SHADOW",
+        f"FILL_CHASER_LIVE={live or '(unset)'}, lifecycle={lifecycle}, cron=있음",
+    )
 
 
 def _decide_micro_split_shadow(env: dict, crontab: str):

--- a/tools/fill_chaser.py
+++ b/tools/fill_chaser.py
@@ -277,15 +277,18 @@ def chase_count_for(
 ) -> int:
     """Count AMENDs for this order, optionally isolated by runtime mode."""
     try:
-        sql = (
-            "SELECT COUNT(*) FROM loop_c_chase_log "
-            "WHERE order_no=? AND market=? AND action='AMEND'"
-        )
-        params: tuple[Any, ...] = (order_no, market)
-        if mode is not None:
-            sql += " AND mode=?"
-            params += (mode,)
-        row = conn.execute(sql, params).fetchone()
+        if mode is None:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM loop_c_chase_log "
+                "WHERE order_no=? AND market=? AND action='AMEND'",
+                (order_no, market),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM loop_c_chase_log "
+                "WHERE order_no=? AND market=? AND action='AMEND' AND mode=?",
+                (order_no, market, mode),
+            ).fetchone()
         return int(row[0]) if row else 0
     except sqlite3.Error:
         return 0

--- a/tools/fill_chaser.py
+++ b/tools/fill_chaser.py
@@ -30,10 +30,9 @@ SAFETY (read before enabling):
     what it WOULD amend/cancel and places NO real TR. The trading context is only
     opened for price/inquiry reads in SHADOW; no amend/cancel TR is ever sent.
   - FILL_CHASER_ENABLED=false disables the loop entirely (kill switch).
-  - ⚠️ The KIS amend/cancel/unfilled-inquiry TR wrappers this loop depends on were
-    mirrored from existing order wrappers + the KIS sample repo but were NOT
-    validated against a live KIS account. DO NOT set FILL_CHASER_LIVE=true until the
-    live-validation checklist in tasks/loop_c_design_notes.md is signed off.
+  - KIS amend/unfilled-inquiry wrappers were live-validated on US orders before
+    promotion.  LIVE still requires BOTH FILL_CHASER_LIVE=true and an explicit
+    fill_chaser lifecycle state of live; either gate can roll the feature back.
   - Separate process → no in-process asyncio locks apply. Concurrency guarded by
     a SQLite owner_lock (BEGIN IMMEDIATE) per ticker, reusing Hardstop's
     loop_a_position_state table so all loops serialise on the SAME lock.
@@ -44,7 +43,7 @@ SAFETY (read before enabling):
 Usage:
     python tools/fill_chaser.py [--market kr|us|both] [--once]
 
-Intended cron (SHADOW until reviewed; NOT installed) — KR and US as SEPARATE
+Intended cron — KR and US as SEPARATE
 processes (cores-shadowing isolation; --market both fans out automatically):
     */2 9-15 * * 1-5      cd /root/prism-insight && python tools/fill_chaser.py --market kr
     */2 22-23,0-5 * * 1-5 cd /root/prism-insight && python tools/fill_chaser.py --market us
@@ -269,14 +268,24 @@ def record_chase(conn: sqlite3.Connection, ticker: str, market: str, side: str,
         logger.warning("chase log failed %s/%s: %s", ticker, market, e)
 
 
-def chase_count_for(conn: sqlite3.Connection, order_no: str, market: str) -> int:
-    """How many AMENDs Fill-chaser has already logged for this order_no."""
+def chase_count_for(
+    conn: sqlite3.Connection,
+    order_no: str,
+    market: str,
+    *,
+    mode: str | None = None,
+) -> int:
+    """Count AMENDs for this order, optionally isolated by runtime mode."""
     try:
-        row = conn.execute(
+        sql = (
             "SELECT COUNT(*) FROM loop_c_chase_log "
-            "WHERE order_no=? AND market=? AND action='AMEND'",
-            (order_no, market),
-        ).fetchone()
+            "WHERE order_no=? AND market=? AND action='AMEND'"
+        )
+        params: tuple[Any, ...] = (order_no, market)
+        if mode is not None:
+            sql += " AND mode=?"
+            params += (mode,)
+        row = conn.execute(sql, params).fetchone()
         return int(row[0]) if row else 0
     except sqlite3.Error:
         return 0
@@ -539,7 +548,7 @@ async def _act_on_order(conn, trader, market: str, order: Dict[str, Any],
         if market_price <= 0:
             return
 
-        already = chase_count_for(conn, order_no, market)
+        already = chase_count_for(conn, order_no, market, mode=mode)
         ceiling_price = order_price * (1.0 + BUY_MAX_PREMIUM_PCT)
 
         # ── BUY ceiling enforcement ──────────────────────────────────────────
@@ -645,13 +654,26 @@ async def _do_amend(conn, trader, market, order, run_id, summary, mode,
                 unfilled_qty, order.get("exchange"),
             )
         ok = bool(result and result.get("success"))
-        summary["amended"] += 1 if ok else 0
-        record_chase(conn, ticker, market, side, order_no, "AMEND", mode,
-                     old_price, new_price, unfilled_qty, already + 1,
-                     (result or {}).get("message", ""), run_id)
-        logger.warning("[LIVE][%s] %s amend success=%s msg=%s",
-                       market, ticker, ok, (result or {}).get("message"))
+        message = (result or {}).get("message", "")
+        if ok:
+            summary["amended"] += 1
+            record_chase(conn, ticker, market, side, order_no, "AMEND", mode,
+                         old_price, new_price, unfilled_qty, already + 1,
+                         message, run_id)
+            logger.warning("[LIVE][%s] %s amend success=True msg=%s",
+                           market, ticker, message)
+        else:
+            summary["skipped"] += 1
+            record_chase(conn, ticker, market, side, order_no, "SKIP", mode,
+                         old_price, old_price, unfilled_qty, already,
+                         f"amend rejected: {message}", run_id)
+            logger.error("[LIVE][%s] %s amend success=False msg=%s",
+                         market, ticker, message)
     except Exception as e:
+        summary["skipped"] += 1
+        record_chase(conn, ticker, market, side, order_no, "SKIP", mode,
+                     old_price, old_price, unfilled_qty, already,
+                     f"amend exception: {type(e).__name__}", run_id)
         logger.error("[%s] %s amend failed: %s", market, ticker, e)
 
 
@@ -673,7 +695,7 @@ async def _do_cancel(conn, trader, market, order, run_id, summary, mode,
         )
         record_chase(conn, ticker, market, side, order_no, "CANCEL", mode,
                      old_price, old_price, unfilled_qty,
-                     chase_count_for(conn, order_no, market),
+                     chase_count_for(conn, order_no, market, mode=mode),
                      f"{reason} payload={payload.get('params')}", run_id)
         return
 
@@ -691,13 +713,29 @@ async def _do_cancel(conn, trader, market, order, run_id, summary, mode,
                 order.get("exchange"),
             )
         ok = bool(result and result.get("success"))
-        summary["cancelled"] += 1 if ok else 0
-        record_chase(conn, ticker, market, side, order_no, "CANCEL", mode,
-                     old_price, old_price, unfilled_qty,
-                     chase_count_for(conn, order_no, market), reason, run_id)
-        logger.warning("[LIVE][%s] %s cancel success=%s msg=%s",
-                       market, ticker, ok, (result or {}).get("message"))
+        message = (result or {}).get("message", "")
+        already = chase_count_for(conn, order_no, market, mode=mode)
+        if ok:
+            summary["cancelled"] += 1
+            record_chase(conn, ticker, market, side, order_no, "CANCEL", mode,
+                         old_price, old_price, unfilled_qty, already, reason, run_id)
+            logger.warning("[LIVE][%s] %s cancel success=True msg=%s",
+                           market, ticker, message)
+        else:
+            summary["skipped"] += 1
+            record_chase(conn, ticker, market, side, order_no, "SKIP", mode,
+                         old_price, old_price, unfilled_qty, already,
+                         f"cancel rejected: {message}", run_id)
+            logger.error("[LIVE][%s] %s cancel success=False msg=%s",
+                         market, ticker, message)
     except Exception as e:
+        summary["skipped"] += 1
+        record_chase(
+            conn, ticker, market, side, order_no, "SKIP", mode,
+            old_price, old_price, unfilled_qty,
+            chase_count_for(conn, order_no, market, mode=mode),
+            f"cancel exception: {type(e).__name__}", run_id,
+        )
         logger.error("[%s] %s cancel failed: %s", market, ticker, e)
 
 


### PR DESCRIPTION
## Summary
- make feature_status report the effective fill-chaser lifecycle gate
- isolate SHADOW and LIVE chase budgets
- record rejected broker amend/cancel responses as SKIP instead of successful actions
- document the 2026-08-19 lifecycle downgrade and promotion evidence

## Incident evidence
- WDAY: 5-share BUY, 0 filled, DFD end-of-day cancellation
- actual fill-chaser runs were SHADOW from 2026-08-19 although feature_status reported LIVE
- affected US buys after downgrade: COP/OXY/LITE/RJF filled naturally; HOOD/WDAY did not fill
- audited US sells all filled
- promotion evidence: 27 distinct US live amend successes, 579 shadow actions, 0 payload/duplicate errors

## Verification
- lifecycle/feature/KR tests: 72 passed
- isolated US fill-chaser tests: 17 passed
- Ruff F/E9, py_compile, diff-check passed