### PR TITLE
fix: honor fill-chaser lifecycle from direct cron entrypoint

### DIFF
--- a/tests/test_fill_chaser_direct_entrypoint.py
+++ b/tests/test_fill_chaser_direct_entrypoint.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_direct_script_resolves_live_lifecycle_without_repo_on_sys_path(
+    tmp_path,
+) -> None:
+    state = tmp_path / "shadow_lifecycle_state.json"
+    state.write_text(
+        json.dumps({"features": {"fill_chaser": {"mode": "live"}}}),
+        encoding="utf-8",
+    )
+    probe = """
+import json
+from pathlib import Path
+import runpy
+import sys
+
+root = Path(sys.argv[1]).resolve()
+tools = root / "tools"
+sys.path = [str(tools)] + [
+    entry for entry in sys.path
+    if Path(entry or ".").resolve() != root
+]
+namespace = runpy.run_path(
+    str(tools / "fill_chaser.py"),
+    run_name="fill_chaser_direct_probe",
+)
+print(json.dumps({
+    "lifecycle": namespace["_FILL_CHASER_LIFECYCLE_MODE"],
+    "live": namespace["FILL_CHASER_LIVE"],
+}))
+"""
+    env = os.environ.copy()
+    env.update(
+        {
+            "FILL_CHASER_LIVE": "true",
+            "SHADOW_LIFECYCLE_STATE": str(state),
+        }
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe, str(ROOT)],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert json.loads(result.stdout) == {"lifecycle": "live", "live": True}

--- a/tools/fill_chaser.py
+++ b/tools/fill_chaser.py
@@ -122,11 +122,27 @@ def _env_flag(suffix: str, default: bool) -> bool:
     return str(raw).strip().lower() in ("1", "true", "yes", "on")
 
 
-try:
-    from cores.shadow_lifecycle import feature_mode as _shadow_feature_mode
-    _FILL_CHASER_LIFECYCLE_MODE = _shadow_feature_mode("fill_chaser")
-except Exception:
-    _FILL_CHASER_LIFECYCLE_MODE = "shadow"
+def _load_fill_chaser_lifecycle_mode() -> str:
+    """Load the root lifecycle module without importing a market `cores` package."""
+    try:
+        import importlib.util
+
+        path = PROJECT_ROOT / "cores" / "shadow_lifecycle.py"
+        spec = importlib.util.spec_from_file_location(
+            "prism_fill_chaser_shadow_lifecycle",
+            path,
+        )
+        if spec is None or spec.loader is None:
+            return "shadow"
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        mode = str(module.feature_mode("fill_chaser") or "").strip().lower()
+        return mode if mode in {"live", "shadow", "off"} else "shadow"
+    except Exception:
+        return "shadow"
+
+
+_FILL_CHASER_LIFECYCLE_MODE = _load_fill_chaser_lifecycle_mode()
 
 FILL_CHASER_ENABLED = _env_flag("ENABLED", True) and _FILL_CHASER_LIFECYCLE_MODE != "off"
 # LIVE requires both the explicit broker flag and a manually promoted lifecycle


### PR DESCRIPTION
## Summary
- load shadow lifecycle by file path before market-specific path bootstrap
- avoid importing/caching the wrong market cores package
- add a subprocess regression that reproduces python tools/fill_chaser.py without the repo root on sys.path

## Production symptom
- feature_status saw lifecycle=live after promotion
- the direct cron entrypoint still fell back to mode=SHADOW because cores.shadow_lifecycle was not importable
- open orders were zero, so no broker action occurred during the failed smoke

## Verification
- direct-entrypoint/lifecycle/feature/KR tests: 73 passed
- isolated US tests: 17 passed
- Ruff F/E9, py_compile, diff-check passed