### PR TITLE
fix: sanitize KR failure alerts and harden portfolio delivery

### DIFF
--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -51,6 +51,7 @@ from cores.llm.codex_oauth_fast_backend import generate_codex_fast
 from cores.openai_error_logging import log_openai_error
 from cores.agents.trading_agents import create_trading_scenario_agent
 from cores.utils import parse_llm_json
+from report_model_config import REPORT_AUX_EFFORT, REPORT_AUX_MODEL
 from prism_core.execution_service import (
     ExecutionService,
     OrderOutcomeUnknown,
@@ -197,26 +198,29 @@ async def _generate_trading_scenario_json(
     llm,
     prompt_message: str,
     *,
-    attempts: int = 2,
+    attempts: int = 3,
     retry_delay_seconds: float = 1.0,
 ) -> Optional[Dict[str, Any]]:
     """Generate and parse a trading scenario without silently accepting empties.
 
     The ChatGPT OAuth proxy occasionally returns an empty completion after a
     transient MCP/tool failure. Treating that as a valid ``No Entry`` scenario
-    produces misleading score-0 Telegram messages. A single bounded retry is
-    enough to recover common transient failures while keeping batch latency
-    bounded; callers still receive an explicitly failed fallback if both calls
-    are unusable.
+    produces misleading score-0 Telegram messages. Two primary-model attempts
+    are followed by one bounded auxiliary-model attempt. Callers still receive
+    an explicitly failed fallback if all three responses are unusable.
     """
     last_response = ""
-    for attempt in range(1, max(1, attempts) + 1):
+    bounded_attempts = max(1, attempts)
+    for attempt in range(1, bounded_attempts + 1):
+        final_auxiliary_attempt = attempt == bounded_attempts and bounded_attempts >= 3
+        model = REPORT_AUX_MODEL if final_auxiliary_attempt else "gpt-5.6-sol"
+        effort = REPORT_AUX_EFFORT if final_auxiliary_attempt else "high"
         try:
             last_response = await llm.generate_str(
                 message=prompt_message,
                 request_params=RequestParams(
-                    model="gpt-5.6-sol",
-                    reasoning_effort="high",
+                    model=model,
+                    reasoning_effort=effort,
                     maxTokens=30000,
                 ),
             ) or ""
@@ -224,7 +228,7 @@ async def _generate_trading_scenario_json(
             logger.warning(
                 "Trading scenario LLM call failed (attempt %s/%s): %s",
                 attempt,
-                max(1, attempts),
+                bounded_attempts,
                 type(exc).__name__,
             )
             last_response = ""
@@ -234,17 +238,20 @@ async def _generate_trading_scenario_json(
             return scenario_json
 
         logger.warning(
-            "Trading scenario response empty or invalid (attempt %s/%s, chars=%s)",
+            "Trading scenario response empty or invalid "
+            "(attempt %s/%s, model=%s, effort=%s, chars=%s)",
             attempt,
-            max(1, attempts),
+            bounded_attempts,
+            model,
+            effort,
             len(last_response),
         )
-        if attempt < max(1, attempts):
+        if attempt < bounded_attempts:
             await asyncio.sleep(retry_delay_seconds)
 
     logger.error(
         "Trading scenario parse failed after %s attempt(s); using explicit failure fallback",
-        max(1, attempts),
+        bounded_attempts,
     )
     return None
 
@@ -4601,8 +4608,10 @@ class StockTrackingAgent:
                 msg_type = self._msg_types[idx] if idx < len(self._msg_types) else None
                 effect_id = self._message_effect_id(idx)
                 logger.info(f"Sending Telegram message: {chat_id}")
+                sent_message_id = None
 
                 async def send_primary_message(payload=None):
+                    nonlocal sent_message_id
                     # Telegram message length limit (4096 characters)
                     MAX_MESSAGE_LENGTH = 4096
                     outbound_message = message
@@ -4646,7 +4655,8 @@ class StockTrackingAgent:
                         # Notify with full original message, link to first part
                         firebase_tasks.append(self._schedule_firebase(message, chat_id, first_msg_id, msg_type=msg_type))
 
-                    return str(first_msg_id)
+                    sent_message_id = str(first_msg_id)
+                    return sent_message_id
 
                 try:
                     if effect_id:
@@ -4677,7 +4687,12 @@ class StockTrackingAgent:
                         "delivered",
                         "already_delivered",
                     }:
-                        logger.info(f"Telegram message sent: {chat_id}")
+                        logger.info(
+                            "Telegram message sent: %s type=%s message_id=%s",
+                            chat_id,
+                            msg_type or "unknown",
+                            sent_message_id or "already-delivered",
+                        )
                 except TelegramError as e:
                     logger.error(f"Telegram message send failed: {e}")
                     success = False

--- a/telegram_config.py
+++ b/telegram_config.py
@@ -7,6 +7,7 @@ and minimizes redundant conditional processing.
 """
 import logging
 import os
+import re
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -214,6 +215,49 @@ async def send_openai_quota_alert(telegram_config: "TelegramConfig", market: str
         logger.error(f"[{market}] Failed to send OpenAI quota alert: {e}")
 
 
+def _public_buy_analysis_failure_detail(detail: str) -> str:
+    """Convert internal failure text into a path-free subscriber summary."""
+    labels = []
+    for raw in re.split(r"[;\n]+", str(detail or "")):
+        item = raw.strip()
+        if not item:
+            continue
+        match = re.search(r"(?P<ticker>\d{6})_(?P<company>[^_:/\\]+)", item)
+        if match:
+            company = re.sub(r"[^0-9A-Za-z가-힣& .()-]", "", match.group("company"))
+            label = f"{company}({match.group('ticker')})" if company else match.group("ticker")
+        else:
+            label = "후보 종목"
+
+        lowered = item.lower()
+        if "scenario_llm" in lowered or "trading_scenario" in lowered:
+            reason = "매매 시나리오 생성 실패"
+        elif "ticker" in lowered:
+            reason = "종목 식별 실패"
+        elif "price" in lowered or "가격" in item:
+            reason = "가격 데이터 확인 실패"
+        else:
+            reason = "분석 처리 실패"
+        public = f"{label}: {reason}"
+        if public not in labels:
+            labels.append(public)
+    return " / ".join(labels[:3])
+
+
+def build_buy_analysis_failure_alert(
+    *, failed: int, total: int, market: str = "KR", detail: str = ""
+) -> str:
+    """Build the subscriber alert without paths, filenames, or internal codes."""
+    public_detail = _public_buy_analysis_failure_detail(detail)
+    return (
+        f"⚠️ [{market}] 매수 후보 분석 실패\n\n"
+        f"이번 배치의 매수 후보 {total}종목 중 {failed}종목의 분석이 실패해 "
+        f"해당 종목의 매수 판단이 이루어지지 않았습니다.\n"
+        + (f"\n• 대상: {public_detail}\n" if public_detail else "")
+        + "• 조치: 운영 시스템에서 자동 확인 중입니다."
+    )
+
+
 async def send_buy_analysis_failure_alert(telegram_config: "TelegramConfig", failed: int, total: int,
                                           market: str = "KR", detail: str = ""):
     """Alert the main channel when buy-candidate report analyses failed.
@@ -223,7 +267,7 @@ async def send_buy_analysis_failure_alert(telegram_config: "TelegramConfig", fai
     the operator only notices by absence.
     """
     if not telegram_config or not telegram_config.use_telegram:
-        return
+        return None
 
     try:
         from telegram import Bot
@@ -232,21 +276,28 @@ async def send_buy_analysis_failure_alert(telegram_config: "TelegramConfig", fai
         request = HTTPXRequest(connect_timeout=10.0, read_timeout=10.0)
         bot = Bot(token=telegram_config.bot_token, request=request)
 
-        alert_message = (
-            f"⚠️ [{market}] 매수 후보 분석 실패\n\n"
-            f"이번 배치의 매수 후보 {total}종목 중 {failed}종목의 분석이 실패해 "
-            f"해당 종목의 매수 판단이 이루어지지 않았습니다.\n"
-            + (f"\n• 사유: {detail}\n" if detail else "")
-            + "• 조치: 서버 로그(stock_analysis_*.log)에서 원인 확인"
+        alert_message = build_buy_analysis_failure_alert(
+            failed=failed,
+            total=total,
+            market=market,
+            detail=detail,
         )
 
-        await bot.send_message(
+        result = await bot.send_message(
             chat_id=telegram_config.channel_id,
             text=alert_message
         )
-        logger.info(f"[{market}] Buy-analysis failure alert sent ({failed}/{total})")
+        logger.info(
+            "[%s] Buy-analysis failure alert sent (%s/%s) message_id=%s",
+            market,
+            failed,
+            total,
+            result.message_id,
+        )
+        return result.message_id
     except Exception as e:
         logger.error(f"[{market}] Failed to send buy-analysis failure alert: {e}")
+        return None
 
 
 async def send_market_data_failure_alert(

--- a/tests/test_buy_analysis_failure_alert.py
+++ b/tests/test_buy_analysis_failure_alert.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import telegram
+
+from telegram_config import (
+    build_buy_analysis_failure_alert,
+    send_buy_analysis_failure_alert,
+)
+
+
+def test_public_failure_alert_removes_internal_paths_and_error_codes() -> None:
+    message = build_buy_analysis_failure_alert(
+        failed=1,
+        total=3,
+        market="KR",
+        detail=(
+            "/root/prism-insight/pdf_reports/"
+            "044490_태웅_20260902_afternoon_gpt-5.6-luna.pdf: "
+            "scenario_llm_empty_or_invalid"
+        ),
+    )
+
+    assert "태웅(044490)" in message
+    assert "매매 시나리오 생성 실패" in message
+    assert "운영 시스템에서 자동 확인 중" in message
+    for forbidden in (
+        "/root",
+        "pdf_reports",
+        ".pdf",
+        ".log",
+        "gpt-5.6",
+        "scenario_llm_empty_or_invalid",
+    ):
+        assert forbidden not in message
+
+
+@pytest.mark.asyncio
+async def test_failure_alert_returns_and_logs_telegram_message_id(
+    monkeypatch, caplog
+) -> None:
+    sent = []
+
+    class FakeBot:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def send_message(self, **kwargs):
+            sent.append(kwargs)
+            return SimpleNamespace(message_id=9182)
+
+    monkeypatch.setattr(telegram, "Bot", FakeBot)
+    config = SimpleNamespace(
+        use_telegram=True,
+        bot_token="redacted-test-token",
+        channel_id="channel-1",
+    )
+
+    with caplog.at_level("INFO"):
+        message_id = await send_buy_analysis_failure_alert(
+            config,
+            failed=1,
+            total=3,
+            market="KR",
+            detail="044490_태웅_report.pdf: scenario_llm_empty_or_invalid",
+        )
+
+    assert message_id == 9182
+    assert sent[0]["chat_id"] == "channel-1"
+    assert "message_id=9182" in caplog.text
+    assert ".pdf" not in sent[0]["text"]

--- a/tests/test_exit_effect_telegram_queue.py
+++ b/tests/test_exit_effect_telegram_queue.py
@@ -132,3 +132,29 @@ async def test_telegram_error_reschedules_only_telegram_effect(monkeypatch, tmp_
     assert rows[1]["status"] == "PENDING"
     assert rows[1]["last_error"] == "TelegramError"
     assert all(row["status"] == "PENDING" for row in (rows[0], rows[2], rows[3]))
+
+
+@pytest.mark.asyncio
+async def test_portfolio_delivery_log_contains_type_and_message_id(
+    monkeypatch, tmp_path, caplog
+):
+    agent = _agent(tmp_path / "portfolio-log.sqlite")
+
+    async def send(chat_id, text):
+        assert chat_id == "channel-1"
+        assert text == "portfolio"
+        return SimpleNamespace(message_id=842)
+
+    agent._send_with_retry = send
+    monkeypatch.setattr(
+        "portfolio_broadcast.should_send_portfolio", lambda *_a, **_k: True
+    )
+
+    with caplog.at_level("INFO"):
+        result = await agent.send_telegram_message(
+            "channel-1", portfolio_force=True
+        )
+
+    assert result is True
+    assert "type=portfolio" in caplog.text
+    assert "message_id=842" in caplog.text

--- a/tests/test_trading_scenario_retry.py
+++ b/tests/test_trading_scenario_retry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import pytest
 
+from report_model_config import REPORT_AUX_EFFORT, REPORT_AUX_MODEL
 from stock_tracking_agent import _generate_trading_scenario_json
 from tracking.helpers import default_scenario
 
@@ -11,9 +12,11 @@ class _FlakyScenarioLLM:
     def __init__(self, responses):
         self.responses = list(responses)
         self.calls = 0
+        self.request_params = []
 
     async def generate_str(self, **kwargs):
         self.calls += 1
+        self.request_params.append(kwargs["request_params"])
         return self.responses.pop(0)
 
 
@@ -35,14 +38,40 @@ async def test_empty_first_response_is_retried_and_parsed():
 
 @pytest.mark.asyncio
 async def test_repeated_empty_responses_return_none_without_unbounded_retry():
-    llm = _FlakyScenarioLLM(["", ""])
+    llm = _FlakyScenarioLLM(["", "", ""])
 
     result = await _generate_trading_scenario_json(
         llm, "scenario prompt", retry_delay_seconds=0
     )
 
-    assert llm.calls == 2
+    assert llm.calls == 3
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_final_attempt_uses_bounded_auxiliary_model_fallback():
+    llm = _FlakyScenarioLLM(
+        [
+            "",
+            "",
+            '{"decision":"No Entry","buy_score":0,"sector":"기계"}',
+        ]
+    )
+
+    result = await _generate_trading_scenario_json(
+        llm, "scenario prompt", retry_delay_seconds=0
+    )
+
+    assert result["sector"] == "기계"
+    assert [params.model for params in llm.request_params[:2]] == [
+        "gpt-5.6-sol",
+        "gpt-5.6-sol",
+    ]
+    assert all(
+        params.reasoning_effort == "high" for params in llm.request_params[:2]
+    )
+    assert llm.request_params[2].model == REPORT_AUX_MODEL
+    assert llm.request_params[2].reasoning_effort == REPORT_AUX_EFFORT
 
 
 def test_default_scenario_is_marked_as_incomplete():


### PR DESCRIPTION
## Summary
- remove server paths, filenames, model slugs, and internal error codes from subscriber buy-analysis failure alerts
- return and log Telegram message IDs for future containment
- add a bounded third trading-scenario attempt using the auxiliary model after two empty primary responses
- log Telegram message type and message ID, including portfolio deliveries

## Incident
- 2026-09-02 KR afternoon: Taewoong trading scenario returned empty/invalid after Codex Fast fallback and two primary-model attempts
- failure alert exposed an internal report filename and stock_analysis log identifier
- exposed alert message was identified and deleted
- current portfolio had actually posted at 15:10 KST and was resent on user request

## Verification
- 56 KR tracking/Telegram/portfolio tests passed
- py_compile, Ruff F/E9 excluding two unrelated legacy F841 findings, and diff-check passed