### PR TITLE
fix(kr): enforce weak-regime selection hard cap

### DIFF
--- a/docs/micro-split/FAILURE_LOG_ko.md
+++ b/docs/micro-split/FAILURE_LOG_ko.md
@@ -59,3 +59,23 @@
 - 조치: 비정상 ticker 제거와 trigger별 fail-open 경계를 추가했습니다(PR #634).
 - 교훈: 초분할 stage 계산도 종목 단위 오류를 격리하고 전체 배치를 계속해야 합니다.
 
+## F-010 — KR 약세 레짐 슬롯 제한의 고정 3종목 refill
+
+- 사건: `REGIME_WEAK_NO_TOPDOWN=true`가 `moderate_bear|sideways`의 슬롯 계획을
+  `(top-down=0, bottom-up=2)`로 낮췄지만, KR 최종 선택기는 별도의
+  `max_selections=3`을 사용해 세 번째 bottom-up 후보를 다시 채웠습니다.
+- 영향: 보존된 2026-08-26~09-03 KR 결과에서 초과 세 번째 후보 13건이 발생했습니다.
+  그중 실제 매수로 이어져 청산된 2건은 와이씨 -6.84%, 삼화콘덴서 -5.22%였습니다.
+  성과 표본은 작지만 정책 상한 위반 자체는 결정론적 배선 오류입니다.
+- 삼화콘덴서 경로: 2026-09-02 `moderate_bear` 오후 배치에서 세 번째 후보로
+  추가됐습니다. BUY_QUALITY SHADOW는 `faulty`, 28/100, `would_buy=false`였으나
+  관측 전용이었고, 매매 에이전트가 ATR20 8.8%보다 좁은 약 4.7% stop을 반환해
+  최종 산술 gate를 통과했습니다. 다음 날 -5.22% risk exit로 종료됐습니다.
+- 조치: US와 같은 `_get_regime_selection_plan()`을 KR에 적용해
+  `topdown_slots + bottomup_slots`를 최종 hard cap으로 사용합니다. macro context가
+  없을 때의 기존 3종목 pure-bottom-up fallback은 그대로 유지합니다.
+- 교훈: 레짐별 슬롯을 계산하는 것만으로는 정책이 적용된 것이 아닙니다. 최종 refill과
+  side effect 직전까지 같은 상한을 사용하고, KR/US 대칭 통합 테스트를 둬야 합니다.
+- 비조치: 이 사례만으로 ATR 기반 global veto나 손절 확대를 LIVE로 승격하지 않습니다.
+  과거 replay에서 고변동 종목의 승자 반례가 많았고, 손절 확대는 포지션 점유와 MDD를
+  악화시킬 수 있으므로 별도 risk-normalized SHADOW에서 검증합니다.

--- a/tests/test_regime_weak_no_topdown.py
+++ b/tests/test_regime_weak_no_topdown.py
@@ -40,3 +40,68 @@ def test_on_does_not_touch_bull_or_strong_bear():
     assert _slots("moderate_bull", "true") == (1, 2)
     assert _slots("strong_bull", "true") == (2, 1)
     assert _slots("strong_bear", "true") == (0, 3)  # 이미 top-down 0
+
+
+def test_selection_plan_uses_slot_sum_as_hard_total(monkeypatch):
+    monkeypatch.setattr(
+        trigger_batch, "_get_regime_slots", lambda _regime: (1, 0)
+    )
+
+    assert trigger_batch._get_regime_selection_plan("moderate_bull") == (
+        1,
+        0,
+        1,
+    )
+
+
+def test_final_selection_does_not_refill_past_regime_total(monkeypatch):
+    monkeypatch.setattr(
+        trigger_batch, "_get_regime_slots", lambda _regime: (0, 2)
+    )
+    triggers = {
+        "Trigger A": trigger_batch.pd.DataFrame(
+            {"CompositeScore": [3.0], "종목명": ["A"]}, index=["AAA"]
+        ),
+        "Trigger B": trigger_batch.pd.DataFrame(
+            {"CompositeScore": [2.0], "종목명": ["B"]}, index=["BBB"]
+        ),
+        # Samwha Capacitor occupied this third per-trigger slot even though the
+        # weak-regime plan allowed only two bottom-up selections.
+        "Trigger C": trigger_batch.pd.DataFrame(
+            {"CompositeScore": [1.0], "종목명": ["C"]}, index=["001820"]
+        ),
+    }
+
+    result = trigger_batch.select_final_tickers(
+        triggers,
+        use_hybrid=False,
+        macro_context={"market_regime": "moderate_bear", "leading_sectors": []},
+    )
+
+    selected = [ticker for frame in result.values() for ticker in frame.index]
+    assert selected == ["AAA", "BBB"]
+    assert "001820" not in selected
+
+
+def test_no_macro_context_preserves_legacy_three_candidate_limit(monkeypatch):
+    monkeypatch.setattr(
+        trigger_batch, "_get_regime_slots", lambda _regime: (0, 1)
+    )
+    triggers = {
+        name: trigger_batch.pd.DataFrame(
+            {"CompositeScore": [score], "종목명": [name]}, index=[ticker]
+        )
+        for name, ticker, score in (
+            ("Trigger A", "AAA", 3.0),
+            ("Trigger B", "BBB", 2.0),
+            ("Trigger C", "CCC", 1.0),
+        )
+    }
+
+    result = trigger_batch.select_final_tickers(
+        triggers,
+        use_hybrid=False,
+        macro_context=None,
+    )
+
+    assert sum(len(frame) for frame in result.values()) == 3

--- a/trigger_batch.py
+++ b/trigger_batch.py
@@ -1725,13 +1725,13 @@ def select_final_tickers(triggers: dict, trade_date: str = None, use_hybrid: boo
     # old fixed-three refill silently defeated weak-regime exposure reduction.
     market_regime = macro_context.get("market_regime", "sideways") if macro_context else "sideways"
     if macro_context:
-        topdown_slots, _bottomup_slots, max_selections = (
-            _get_regime_selection_plan(market_regime)
-        )
+        selection_plan = _get_regime_selection_plan(market_regime)
+        topdown_slots = selection_plan[0]
+        max_selections = selection_plan[2]
     else:
         # Preserve the legacy pure bottom-up fallback when macro intelligence
         # is unavailable rather than reducing opportunity on a data outage.
-        topdown_slots, _bottomup_slots, max_selections = (0, 3, 3)
+        topdown_slots, max_selections = (0, 3)
 
     # Build top-down pool
     topdown_pool = _build_topdown_pool(trigger_candidates, macro_context, score_column)

--- a/trigger_batch.py
+++ b/trigger_batch.py
@@ -1531,6 +1531,16 @@ def _get_regime_slots(market_regime: str) -> tuple:
     return (td, bu)
 
 
+def _get_regime_selection_plan(market_regime: str) -> tuple[int, int, int]:
+    """Return top-down, bottom-up, and their hard total selection limit."""
+    topdown_slots, bottomup_slots = _get_regime_slots(market_regime)
+    return (
+        topdown_slots,
+        bottomup_slots,
+        max(0, int(topdown_slots) + int(bottomup_slots)),
+    )
+
+
 def _build_topdown_pool(trigger_candidates: dict, macro_context: dict, score_column: str) -> list:
     """Build top-down candidate pool from leading sectors.
 
@@ -1710,11 +1720,18 @@ def select_final_tickers(triggers: dict, trade_date: str = None, use_hybrid: boo
     # 3. Final stock selection (hybrid top-down + bottom-up)
     selected_tickers = set()
     score_column = "final_score" if use_hybrid and trade_date else "composite_score"
-    max_selections = 3
-
-    # Determine regime and slot allocation
+    # Determine regime and slot allocation.  When macro context is available,
+    # the configured top-down + bottom-up plan is also the final hard cap.  The
+    # old fixed-three refill silently defeated weak-regime exposure reduction.
     market_regime = macro_context.get("market_regime", "sideways") if macro_context else "sideways"
-    topdown_slots, bottomup_slots = _get_regime_slots(market_regime)
+    if macro_context:
+        topdown_slots, bottomup_slots, max_selections = (
+            _get_regime_selection_plan(market_regime)
+        )
+    else:
+        # Preserve the legacy pure bottom-up fallback when macro intelligence
+        # is unavailable rather than reducing opportunity on a data outage.
+        topdown_slots, bottomup_slots, max_selections = (0, 3, 3)
 
     # Build top-down pool
     topdown_pool = _build_topdown_pool(trigger_candidates, macro_context, score_column)

--- a/trigger_batch.py
+++ b/trigger_batch.py
@@ -1725,13 +1725,13 @@ def select_final_tickers(triggers: dict, trade_date: str = None, use_hybrid: boo
     # old fixed-three refill silently defeated weak-regime exposure reduction.
     market_regime = macro_context.get("market_regime", "sideways") if macro_context else "sideways"
     if macro_context:
-        topdown_slots, bottomup_slots, max_selections = (
+        topdown_slots, _bottomup_slots, max_selections = (
             _get_regime_selection_plan(market_regime)
         )
     else:
         # Preserve the legacy pure bottom-up fallback when macro intelligence
         # is unavailable rather than reducing opportunity on a data outage.
-        topdown_slots, bottomup_slots, max_selections = (0, 3, 3)
+        topdown_slots, _bottomup_slots, max_selections = (0, 3, 3)
 
     # Build top-down pool
     topdown_pool = _build_topdown_pool(trigger_candidates, macro_context, score_column)


### PR DESCRIPTION
## Summary
- enforce the KR top-down + bottom-up slot sum as the final selection hard cap
- keep the legacy three-candidate fallback when macro context is unavailable
- add KR parity regression tests matching the already-fixed US path
- document the Samwha Capacitor incident and affected production scope

## Production evidence
- weak-regime plan advertised `(0, 2)` but KR selected 3 candidates
- 13 excess third-slot candidates observed from 2026-08-26 through 2026-09-03
- two became closed trades: YC -6.84%, Samwha Capacitor -5.22%
- Samwha Capacitor was exactly the third bottom-up selection on 2026-09-02 afternoon

## Verification
- `pytest -q tests/test_regime_weak_no_topdown.py tests/test_buy_gate.py tests/test_buy_gate_shadow.py` (20 passed)
- `pytest -q prism-us/tests/test_regime_weak_no_topdown_us.py` (7 passed)
- `python tests/test_issue_289_screening.py` (59 passed)
- `python -m py_compile trigger_batch.py`
- targeted Ruff undefined-name/syntax checks and diff check passed

## Safety
- does not change stop widths, scores, order sizing, or execution code
- does not promote ATR/ADR or BUY_QUALITY shadow findings to LIVE
- only makes the existing weak-regime slot policy reach final selection
