### PR TITLE
feat: add micro-split phase 2a evidence replay packet

### DIFF
--- a/docs/micro-split/EVIDENCE_CONTRACT_ko.md
+++ b/docs/micro-split/EVIDENCE_CONTRACT_ko.md
@@ -21,6 +21,24 @@ Baseline과 Micro Split을 서로 다른 종목·기간·레짐에서 비교하�
 - execution provenance: `NOT_REQUESTED|QUEUED|SUBMITTED|CONFIRMED|CANCELLED|REJECTED|UNKNOWN`
 - forward return, MFE, MAE, 손절·trend-exit·target 결과
 
+## 결정론적 Packet
+
+```bash
+python tools/build_micro_split_evidence_packet.py \
+  --input logs/prism_events.jsonl \
+  --replay-config trading/config/kis_devlp.yaml \
+  --market US \
+  --output /tmp/micro-split-evidence.json
+```
+
+- 원시 JSONL과 KIS 설정은 서버 밖으로 복사하지 않습니다.
+- config에서는 USD 단위금액만 읽고 Packet에는 원값·계좌·API 정보를 출력하지 않습니다.
+- 같은 입력의 순서가 달라도 `packet_id`가 같아야 합니다.
+- 같은 `event_id`는 최신 한 건만 남기고 중복 수를 별도 보고합니다.
+- `observed_shadow`와 `candidate_replay`를 절대 합산하지 않습니다.
+- replay는 정수주 실행 가능성 projection이며 실제 진입·체결·성과가 아닙니다.
+- schema v1과 v2를 섞어 coverage 100%로 간주하지 않습니다.
+
 ## 주요 지표
 
 Primary:
@@ -67,4 +85,3 @@ Secondary:
 - `LIMITED_DEMO_REVIEW`
 - `LIMITED_LIVE_REVIEW`
 - `RETIRE`
-

--- a/docs/micro-split/FAILURE_LOG_ko.md
+++ b/docs/micro-split/FAILURE_LOG_ko.md
@@ -79,3 +79,15 @@
 - 비조치: 이 사례만으로 ATR 기반 global veto나 손절 확대를 LIVE로 승격하지 않습니다.
   과거 replay에서 고변동 종목의 승자 반례가 많았고, 손절 확대는 포지션 점유와 MDD를
   악화시킬 수 있으므로 별도 risk-normalized SHADOW에서 검증합니다.
+
+## F-011 — D1~D3 정상만으로 campaign SHADOW를 앞당길 위험
+
+- 사건: 3거래일 동안 기대 이벤트와 실제 이벤트가 일치하고 거래 영향도 0이었습니다.
+- 부족한 증거: 적격 진입은 SPGI·NVDA 2건뿐이고 모두 `SUBMITTED_ONLY`였습니다.
+  confirmed fill과 matured outcome은 0건이며, schema v1은 10% projection만 보존했습니다.
+- 잘못된 접근: hard anomaly가 없다는 이유만으로 10→30→60→100 campaign ledger로 승격.
+- 조치: 판정을 HOLD로 유지하고 schema v2에 전 단계 정수주 projection·최초 실행 가능
+  단계·unit snapshot reference를 추가했습니다. 실제 SHADOW와 candidate replay를 분리하는
+  결정론적 Packet 도구도 추가했습니다.
+- 교훈: 운영 안전성 통과는 데이터 충분성을 뜻하지 않습니다. 기존 SHADOW는 유지할 수
+  있지만 다음 상태 모델은 표본·coverage·성과 계약을 충족한 뒤 별도 승격해야 합니다.

--- a/docs/micro-split/README_ko.md
+++ b/docs/micro-split/README_ko.md
@@ -31,9 +31,25 @@
 
 순수 코어는 DB, 네트워크, 환경 변수, KIS, 에이전트, 주문 모듈을 import하지 않습니다.
 Phase 2a에서는 US 최종 `entry_eligible` 경계가 `observability.micro_split`을 fail-open으로
-호출해 신규 캠페인의 0→10% 목표와 계정별 정수주식 예상 수량만 JSONL에 기록합니다.
+호출해 신규 캠페인의 0→10% 목표와 계정별 정수주식 예상 수량을 JSONL에 기록합니다.
+schema v2는 원 단위금액을 노출하지 않고 10·30·60·100%별 예상 수량, 최초 1주 가능
+단계, 단위금액 snapshot reference를 함께 기록합니다.
 반환값은 사용하지 않으며 `ExecutionService`, holdings, 피라미딩, 매도 루프에는 연결하지
 않습니다. `.env MICRO_SPLIT_SHADOW_ENABLED=false`가 기본 OFF입니다.
+
+`tools/build_micro_split_evidence_packet.py`는 sanitized JSONL의 실제 SHADOW 이벤트와
+과거 candidate의 정수주 counterfactual projection을 분리한 결정론적 Packet을 만듭니다.
+네트워크·DB·브로커·주문 접근은 없습니다.
+
+## D1~D3 판정
+
+- 실제 관측: 3 US 거래일, 후보 19건, 적격 진입·초분할 이벤트 2건
+- 이벤트 계약: 기대 대비 100%, 중복·민감정보 노출·거래 영향 0
+- 실행·성과: `SUBMITTED_ONLY` 2건, confirmed fill 0건, matured outcome 0건
+- 판정: **HOLD / CONTINUE_CAPTURE**
+
+schema v1은 삭제하거나 덮어쓰지 않습니다. v2 coverage와 replay 표본을 별도로 축적하며
+Phase 3 campaign ledger SHADOW로 아직 승격하지 않습니다.
 
 ## 기본 초안 단계
 

--- a/docs/micro-split/ROLLOUT_ko.md
+++ b/docs/micro-split/ROLLOUT_ko.md
@@ -45,6 +45,12 @@
 - `target_pct`, transition reason, projected qty만 secret-minimized event로 기록
 - 같은 `decision_id`와 `policy_version`으로 exact join
 - 계정별 unit amount 원값 대신 필요 시 비율·hash·구간만 내보냄
+- schema v2에서 10·30·60·100% 정수주 projection과 최초 실행 가능 단계를 함께 기록
+- `build_micro_split_evidence_packet.py`로 실제 SHADOW와 candidate replay를 분리
+
+2026-09-04 D1~D3 점검 결과는 3거래일·적격 2건이라 **HOLD**입니다. 두 이벤트의 계약과
+무영향은 정상이지만 schema v1에는 전 단계 projection이 없고 confirmed fill·성과 표본도
+없습니다. v2 배포 뒤 기존 SHADOW를 유지하며 표본을 더 모읍니다.
 
 완료 기준:
 

--- a/observability/micro_split.py
+++ b/observability/micro_split.py
@@ -13,7 +13,7 @@ from prism_core.micro_split import (
     project_execution_on_advance,
 )
 
-SHADOW_SCHEMA_VERSION = 1
+SHADOW_SCHEMA_VERSION = 2
 
 
 def shadow_enabled(value: str | None = None) -> bool:
@@ -26,6 +26,33 @@ def shadow_enabled(value: str | None = None) -> bool:
 def _stable_ref(*parts: Any, length: int) -> str:
     raw = "|".join(str(part or "") for part in parts)
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:length]
+
+
+def _base_stage_projections(
+    *, unit_amount: Any, current_price: Any
+) -> tuple[dict[str, int], int | None]:
+    quantities: dict[str, int] = {}
+    try:
+        for target_pct in DEFAULT_POLICY.base_steps_pct:
+            projection = project_execution_on_advance(
+                unit_amount=unit_amount,
+                previous_target_pct=0,
+                target_pct=target_pct,
+                execution_price=current_price,
+                confirmed_strategy_quantity=0,
+            )
+            quantities[str(target_pct)] = projection.desired_quantity
+    except (TypeError, ValueError):
+        return {}, None
+    first_executable = next(
+        (
+            target_pct
+            for target_pct in DEFAULT_POLICY.base_steps_pct
+            if quantities[str(target_pct)] > 0
+        ),
+        None,
+    )
+    return quantities, first_executable
 
 
 def build_initial_shadow_context(
@@ -42,17 +69,14 @@ def build_initial_shadow_context(
     projection_status = "PROJECTED"
     projected_quantity = None
     projected_delta = None
-    try:
-        projection = project_execution_on_advance(
-            unit_amount=unit_amount,
-            previous_target_pct=0,
-            target_pct=10,
-            execution_price=current_price,
-            confirmed_strategy_quantity=0,
-        )
-        projected_quantity = projection.desired_quantity
-        projected_delta = projection.buy_delta_quantity
-    except (TypeError, ValueError):
+    stage_quantities, first_executable = _base_stage_projections(
+        unit_amount=unit_amount,
+        current_price=current_price,
+    )
+    if stage_quantities:
+        projected_quantity = stage_quantities["10"]
+        projected_delta = projected_quantity
+    else:
         projection_status = "INPUT_UNAVAILABLE"
 
     return {
@@ -70,11 +94,24 @@ def build_initial_shadow_context(
         "execution_profile_ref": _stable_ref(
             "micro-split-execution-profile", account_id, length=16
         ),
+        "unit_amount_snapshot_ref": (
+            _stable_ref(
+                "micro-split-unit-snapshot",
+                account_id,
+                unit_amount,
+                DEFAULT_POLICY.policy_version,
+                length=16,
+            )
+            if stage_quantities
+            else None
+        ),
         "unit_amount_available": unit_amount not in (None, "", 0, 0.0),
         "execution_price_available": current_price not in (None, "", 0, 0.0),
         "projection_status": projection_status,
         "projected_whole_share_quantity": projected_quantity,
         "projected_buy_delta_quantity": projected_delta,
+        "base_stage_projection_quantities": stage_quantities,
+        "first_executable_target_pct": first_executable,
         "internal_target_independent_of_execution": True,
         "decision_ref": _stable_ref("micro-split-decision", decision_id, length=16),
     }

--- a/tests/test_micro_split_evidence_packet.py
+++ b/tests/test_micro_split_evidence_packet.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+
+from tools.build_micro_split_evidence_packet import (
+    build_micro_split_evidence_packet,
+    load_replay_profiles,
+)
+
+
+def _event(
+    event_id: str,
+    event_type: str,
+    timestamp: str,
+    *,
+    ticker: str,
+    decision_id: str,
+    attributes: dict,
+) -> dict:
+    return {
+        "event_id": event_id,
+        "event_type": event_type,
+        "timestamp": timestamp,
+        "market": "US",
+        "ticker": ticker,
+        "decision_id": decision_id,
+        "attributes": attributes,
+    }
+
+
+def test_packet_is_deterministic_secret_minimized_and_separates_replay() -> None:
+    micro_v1 = _event(
+        "micro-1",
+        "micro_split.shadow_evaluated",
+        "2026-09-01T00:00:00Z",
+        ticker="SECRET1",
+        decision_id="raw-decision-1",
+        attributes={
+            "shadow_schema_version": 1,
+            "mode": "SHADOW",
+            "policy_version": "micro-split-v1-draft",
+            "execution_profile_ref": "a" * 16,
+            "projection_status": "PROJECTED",
+            "target_pct": 10,
+            "projected_whole_share_quantity": 0,
+        },
+    )
+    micro_v2 = _event(
+        "micro-2",
+        "micro_split.shadow_evaluated",
+        "2026-09-03T00:00:00Z",
+        ticker="SECRET2",
+        decision_id="raw-decision-2",
+        attributes={
+            "shadow_schema_version": 2,
+            "mode": "SHADOW",
+            "policy_version": "micro-split-v1-draft",
+            "execution_profile_ref": "b" * 16,
+            "unit_amount_snapshot_ref": "c" * 16,
+            "projection_status": "PROJECTED",
+            "target_pct": 10,
+            "projected_whole_share_quantity": 0,
+            "base_stage_projection_quantities": {
+                "10": 0,
+                "30": 1,
+                "60": 2,
+                "100": 4,
+            },
+            "first_executable_target_pct": 30,
+            "internal_target_independent_of_execution": True,
+        },
+    )
+    candidate = _event(
+        "candidate-1",
+        "candidate.evaluated",
+        "2026-09-02T00:00:00Z",
+        ticker="SECRET3",
+        decision_id="raw-decision-3",
+        attributes={
+            "decision_context": {
+                "price": 250,
+                "is_add": False,
+                "selected_for_entry": False,
+            }
+        },
+    )
+    profiles = [{"profile_ref": "profile-safe", "unit_amount": 1000.0}]
+    raw = [micro_v2, candidate, micro_v1, dict(micro_v1)]
+
+    first = build_micro_split_evidence_packet(raw, replay_profiles=profiles)
+    second = build_micro_split_evidence_packet(
+        list(reversed(raw)), replay_profiles=profiles
+    )
+
+    assert first["packet_id"] == second["packet_id"]
+    assert first["observed_shadow"]["raw_event_count"] == 3
+    assert first["observed_shadow"]["distinct_event_count"] == 2
+    assert first["observed_shadow"]["duplicate_event_id_count"] == 1
+    assert first["observed_shadow"]["schema_v2_coverage_rate"] == 0.5
+    assert first["candidate_replay"]["candidate_count"] == 1
+    assert first["candidate_replay"]["projected_row_count"] == 1
+    replay = first["candidate_replay"]["rows"][0]
+    assert replay["base_stage_projection_quantities"] == {
+        "10": 0,
+        "30": 1,
+        "60": 2,
+        "100": 4,
+    }
+    assert replay["first_executable_target_pct"] == 30
+    encoded = json.dumps(first, ensure_ascii=False)
+    for secret in (
+        "SECRET1",
+        "SECRET2",
+        "SECRET3",
+        "raw-decision",
+        "unit_amount",
+    ):
+        assert secret not in encoded
+
+
+def test_replay_profile_loader_reads_only_usd_amounts(tmp_path) -> None:
+    config = tmp_path / "kis_devlp.yaml"
+    config.write_text(
+        """
+default_unit_amount_usd: 1000
+my_app: very-secret-app-key
+my_sec: very-secret-app-secret
+accounts:
+  - name: first-secret-account
+    account: 12345678
+    buy_amount_usd: 750
+  - name: second-secret-account
+    account: 87654321
+    market: us
+""".strip(),
+        encoding="utf-8",
+    )
+
+    profiles = load_replay_profiles(config)
+
+    assert len(profiles) == 2
+    assert sorted(profile["unit_amount"] for profile in profiles) == [750.0, 1000.0]
+    encoded = json.dumps(profiles)
+    for secret in (
+        "very-secret",
+        "first-secret-account",
+        "second-secret-account",
+        "12345678",
+        "87654321",
+    ):
+        assert secret not in encoded
+
+
+def test_packet_reports_hold_until_v2_coverage_and_sample_thresholds() -> None:
+    packet = build_micro_split_evidence_packet([], replay_profiles=[])
+
+    assert packet["readiness"]["data_sufficient"] is False
+    assert packet["readiness"]["verdict"] == "CONTINUE_CAPTURE"
+    assert {item["code"] for item in packet["readiness"]["reasons"]} >= {
+        "OBSERVED_DECISIONS_LT_30",
+        "OBSERVED_DATES_LT_20",
+        "SCHEMA_V2_COVERAGE_LT_100_PCT",
+        "CANDIDATE_REPLAY_UNAVAILABLE",
+    }
+
+
+def test_candidate_duplicate_is_reported_separately_from_micro_duplicates() -> None:
+    candidate = _event(
+        "candidate-duplicate",
+        "candidate.evaluated",
+        "2026-09-02T00:00:00Z",
+        ticker="SAFE",
+        decision_id="decision-safe",
+        attributes={"decision_context": {"price": 100, "is_add": False}},
+    )
+
+    packet = build_micro_split_evidence_packet(
+        [candidate, dict(candidate)],
+        replay_profiles=[{"profile_ref": "profile-safe", "unit_amount": 1000}],
+    )
+
+    assert packet["observed_shadow"]["duplicate_event_id_count"] == 0
+    assert packet["candidate_replay"]["duplicate_event_id_count"] == 1
+    assert "DUPLICATE_EVENT_IDS_PRESENT" not in {
+        reason["code"] for reason in packet["readiness"]["reasons"]
+    }

--- a/tests/test_micro_split_observability.py
+++ b/tests/test_micro_split_observability.py
@@ -9,6 +9,14 @@ from observability.micro_split import (
 )
 
 
+def _contains_exact_value(value, forbidden) -> bool:
+    if isinstance(value, dict):
+        return any(_contains_exact_value(item, forbidden) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(_contains_exact_value(item, forbidden) for item in value)
+    return value in forbidden
+
+
 def test_shadow_flag_defaults_off_and_parses_explicit_values(monkeypatch) -> None:
     monkeypatch.delenv("MICRO_SPLIT_SHADOW_ENABLED", raising=False)
     assert shadow_enabled() is False
@@ -33,9 +41,18 @@ def test_initial_shadow_context_keeps_unit_amount_secret() -> None:
     assert context["target_pct"] == 10
     assert context["target_slot_units"] == 0.1
     assert context["reason_code"] == "ENTRY_ELIGIBLE_SCOUT"
+    assert context["shadow_schema_version"] == 2
     assert context["projection_status"] == "PROJECTED"
     assert context["projected_whole_share_quantity"] == 0
     assert context["projected_buy_delta_quantity"] == 0
+    assert context["base_stage_projection_quantities"] == {
+        "10": 0,
+        "30": 0,
+        "60": 1,
+        "100": 1,
+    }
+    assert context["first_executable_target_pct"] == 60
+    assert len(context["unit_amount_snapshot_ref"]) == 16
     assert len(context["execution_profile_ref"]) == 16
     assert "secret-account" not in encoded
     assert "1000000" not in encoded
@@ -69,6 +86,9 @@ def test_missing_unit_amount_still_records_internal_shadow_target() -> None:
     assert context["target_pct"] == 10
     assert context["projection_status"] == "INPUT_UNAVAILABLE"
     assert context["projected_whole_share_quantity"] is None
+    assert context["base_stage_projection_quantities"] == {}
+    assert context["first_executable_target_pct"] is None
+    assert context["unit_amount_snapshot_ref"] is None
 
 
 def test_emit_shadow_is_flagged_deterministic_and_secret_minimized(
@@ -95,8 +115,15 @@ def test_emit_shadow_is_flagged_deterministic_and_secret_minimized(
     assert first["event_id"] == second["event_id"]
     assert first["event_type"] == "micro_split.shadow_evaluated"
     assert first["attributes"]["target_pct"] == 10
+    assert first["attributes"]["base_stage_projection_quantities"] == {
+        "10": 0,
+        "30": 1,
+        "60": 3,
+        "100": 5,
+    }
+    assert first["attributes"]["first_executable_target_pct"] == 30
     assert "secret-account" not in json.dumps(first)
-    assert "1100" not in json.dumps(first)
+    assert not _contains_exact_value(first, {1100, "1100", "1100.0"})
 
 
 def test_emit_shadow_off_has_no_file_side_effect(monkeypatch, tmp_path) -> None:

--- a/tests/test_observability_insights_export.py
+++ b/tests/test_observability_insights_export.py
@@ -266,6 +266,7 @@ def test_snapshot_reports_micro_split_shadow_capture() -> None:
                 "2026-09-01T00:00:00Z",
                 market="US",
                 attributes={
+                    "shadow_schema_version": 2,
                     "mode": "SHADOW",
                     "policy_version": "micro-split-v1-draft",
                     "reason_code": "ENTRY_ELIGIBLE_SCOUT",
@@ -273,6 +274,13 @@ def test_snapshot_reports_micro_split_shadow_capture() -> None:
                     "target_pct": 10,
                     "projection_status": "PROJECTED",
                     "projected_whole_share_quantity": 0,
+                    "base_stage_projection_quantities": {
+                        "10": 0,
+                        "30": 0,
+                        "60": 1,
+                        "100": 1,
+                    },
+                    "first_executable_target_pct": 60,
                 },
             ),
             "decision_id": "decision-1",
@@ -305,6 +313,15 @@ def test_snapshot_reports_micro_split_shadow_capture() -> None:
     assert capture["policy_version_distribution"] == {"micro-split-v1-draft": 2}
     assert capture["target_pct_distribution"] == {"10": 2}
     assert capture["projection_status_distribution"] == {"PROJECTED": 2}
+    assert capture["schema_version_distribution"] == {"1": 1, "2": 1}
+    assert capture["schema_v2_coverage_rate"] == 0.5
+    assert capture["first_executable_target_pct_distribution"] == {"60": 1}
+    assert capture["zero_whole_share_projection_by_stage"] == {
+        "10": 1,
+        "30": 1,
+        "60": 0,
+        "100": 0,
+    }
     assert capture["zero_whole_share_projection_count"] == 1
     assert capture["latest_at"] == "2026-09-01T00:01:00Z"
 

--- a/tools/build_micro_split_evidence_packet.py
+++ b/tools/build_micro_split_evidence_packet.py
@@ -1,0 +1,487 @@
+"""Build a deterministic, secret-minimized 초분할 evidence packet.
+
+The tool reads local sanitized observability JSONL and an optional local KIS
+configuration.  It performs no network, database, broker, or trading calls.
+Actual SHADOW observations and candidate replay projections remain separate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import Counter
+from collections.abc import Iterable, Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from prism_core.micro_split import DEFAULT_POLICY, project_execution_on_advance
+
+PACKET_SCHEMA_VERSION = 1
+ANALYSIS_CONTRACT_VERSION = "micro-split-evidence-v1"
+MIN_OBSERVED_DATES = 20
+MIN_OBSERVED_DECISIONS = 30
+BASE_STAGES = DEFAULT_POLICY.base_steps_pct
+_EVENT_TYPES = {"candidate.evaluated", "micro_split.shadow_evaluated"}
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _text(value: Any) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _number(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _parse_time(value: Any) -> datetime | None:
+    normalized = _text(value)
+    if normalized is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _canonical(value: Mapping[str, Any]) -> str:
+    return json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+
+
+def _ref(*parts: Any) -> str:
+    raw = "|".join(str(part or "") for part in parts)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def _stage_quantities(unit_amount: Any, price: Any) -> tuple[dict[str, int], int | None]:
+    quantities: dict[str, int] = {}
+    try:
+        for target_pct in BASE_STAGES:
+            projection = project_execution_on_advance(
+                unit_amount=unit_amount,
+                previous_target_pct=0,
+                target_pct=target_pct,
+                execution_price=price,
+                confirmed_strategy_quantity=0,
+            )
+            quantities[str(target_pct)] = projection.desired_quantity
+    except (TypeError, ValueError):
+        return {}, None
+    first_executable = next(
+        (
+            target_pct
+            for target_pct in BASE_STAGES
+            if quantities[str(target_pct)] > 0
+        ),
+        None,
+    )
+    return quantities, first_executable
+
+
+def load_replay_profiles(config_path: str | Path) -> list[dict[str, Any]]:
+    """Load unique USD sizing profiles while returning no account or secret fields."""
+    path = Path(config_path)
+    raw = path.read_bytes()
+    config = yaml.safe_load(raw) or {}
+    if not isinstance(config, Mapping):
+        return []
+    default = _number(config.get("default_unit_amount_usd"))
+    amounts = set()
+    accounts = config.get("accounts")
+    if isinstance(accounts, list):
+        for account in accounts:
+            if not isinstance(account, Mapping) or account.get("enabled", True) is False:
+                continue
+            account_market = str(account.get("market") or "all").strip().lower()
+            if account_market not in {"us", "all", "both"}:
+                continue
+            amount = _number(account.get("buy_amount_usd")) or default
+            if amount is not None:
+                amounts.add(amount)
+    elif default is not None:
+        amounts.add(default)
+    sizing_fingerprint = hashlib.sha256(
+        json.dumps(sorted(amounts), separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return [
+        {
+            "profile_ref": _ref(
+                "micro-split-replay-profile",
+                sizing_fingerprint,
+                amount,
+            ),
+            "unit_amount": amount,
+        }
+        for amount in sorted(amounts)
+    ]
+
+
+def _deduplicate(
+    raw_events: Iterable[Mapping[str, Any]],
+) -> tuple[list[dict[str, Any]], int, int]:
+    by_id: dict[str, dict[str, Any]] = {}
+    duplicate_count = 0
+    raw_supported = 0
+    for raw in raw_events:
+        event = dict(raw)
+        if event.get("event_type") not in _EVENT_TYPES:
+            continue
+        raw_supported += 1
+        event_id = _text(event.get("event_id"))
+        if event_id is None:
+            continue
+        existing = by_id.get(event_id)
+        if existing is not None:
+            duplicate_count += 1
+            if (str(event.get("timestamp") or ""), _canonical(event)) <= (
+                str(existing.get("timestamp") or ""),
+                _canonical(existing),
+            ):
+                continue
+        by_id[event_id] = event
+    events = sorted(
+        by_id.values(),
+        key=lambda event: (
+            str(event.get("timestamp") or ""),
+            str(event.get("event_id") or ""),
+        ),
+    )
+    return events, raw_supported, duplicate_count
+
+
+def _observed_row(event: Mapping[str, Any]) -> dict[str, Any]:
+    attributes = _mapping(event.get("attributes"))
+    quantities = _mapping(attributes.get("base_stage_projection_quantities"))
+    safe_quantities = {}
+    for stage in BASE_STAGES:
+        key = str(stage)
+        if key not in quantities:
+            continue
+        value = quantities[key]
+        if value == 0 or _number(value) is not None:
+            safe_quantities[key] = int(value)
+    return {
+        "event_ref": _ref("event", event.get("event_id")),
+        "decision_ref": _text(attributes.get("decision_ref"))
+        or _ref("decision", event.get("decision_id")),
+        "symbol_ref": _ref("symbol", event.get("market"), event.get("ticker")),
+        "timestamp": _text(event.get("timestamp")),
+        "schema_version": int(attributes.get("shadow_schema_version") or 1),
+        "mode": _text(attributes.get("mode")),
+        "policy_version": _text(attributes.get("policy_version")),
+        "regime": _text(attributes.get("regime")),
+        "execution_profile_ref": _text(attributes.get("execution_profile_ref")),
+        "unit_snapshot_ref": _text(attributes.get("unit_amount_snapshot_ref")),
+        "projection_status": _text(attributes.get("projection_status")),
+        "target_pct": attributes.get("target_pct"),
+        "projected_whole_share_quantity": attributes.get(
+            "projected_whole_share_quantity"
+        ),
+        "base_stage_projection_quantities": safe_quantities,
+        "first_executable_target_pct": attributes.get(
+            "first_executable_target_pct"
+        ),
+        "internal_target_independent_of_execution": bool(
+            attributes.get("internal_target_independent_of_execution")
+        ),
+    }
+
+
+def build_micro_split_evidence_packet(
+    raw_events: Iterable[Mapping[str, Any]],
+    *,
+    market: str = "US",
+    replay_profiles: Iterable[Mapping[str, Any]] = (),
+) -> dict[str, Any]:
+    """Return a deterministic packet with observed and replay cohorts separated."""
+    normalized_market = str(market or "US").upper()
+    raw_list = list(raw_events)
+    events, _, _ = _deduplicate(raw_list)
+    market_events = [
+        event
+        for event in events
+        if str(event.get("market") or "").upper() == normalized_market
+    ]
+    raw_micro_count = sum(
+        event.get("event_type") == "micro_split.shadow_evaluated"
+        and str(event.get("market") or "").upper() == normalized_market
+        for event in raw_list
+    )
+    observed_events = [
+        event
+        for event in market_events
+        if event.get("event_type") == "micro_split.shadow_evaluated"
+    ]
+    micro_duplicate_count = raw_micro_count - len(observed_events)
+    raw_candidate_count = sum(
+        event.get("event_type") == "candidate.evaluated"
+        and str(event.get("market") or "").upper() == normalized_market
+        for event in raw_list
+    )
+    distinct_candidate_event_count = sum(
+        event.get("event_type") == "candidate.evaluated" for event in market_events
+    )
+    candidate_duplicate_count = raw_candidate_count - distinct_candidate_event_count
+    observed_rows = [_observed_row(event) for event in observed_events]
+    observed_dates = {
+        timestamp.date().isoformat()
+        for row in observed_rows
+        if (timestamp := _parse_time(row.get("timestamp"))) is not None
+    }
+    v2_rows = [
+        row
+        for row in observed_rows
+        if row["schema_version"] >= 2
+        and set(row["base_stage_projection_quantities"])
+        == {str(stage) for stage in BASE_STAGES}
+    ]
+    first_stage_distribution = Counter(
+        str(row.get("first_executable_target_pct") or "NONE")
+        for row in v2_rows
+    )
+
+    candidates_by_decision: dict[str, dict[str, Any]] = {}
+    for event in market_events:
+        if event.get("event_type") != "candidate.evaluated":
+            continue
+        attributes = _mapping(event.get("attributes"))
+        decision_context = _mapping(attributes.get("decision_context"))
+        if bool(decision_context.get("is_add")):
+            continue
+        identity = _text(event.get("decision_id")) or str(event.get("event_id"))
+        existing = candidates_by_decision.get(identity)
+        if existing is None or (
+            str(event.get("timestamp") or ""), _canonical(event)
+        ) > (str(existing.get("timestamp") or ""), _canonical(existing)):
+            candidates_by_decision[identity] = event
+    dated_candidates = [
+        event
+        for event in candidates_by_decision.values()
+        if _parse_time(event.get("timestamp")) is not None
+    ]
+    replay_dates = sorted(
+        {_parse_time(event.get("timestamp")).date().isoformat() for event in dated_candidates}
+    )[-60:]
+    replay_date_set = set(replay_dates)
+    replay_candidates = [
+        event
+        for event in dated_candidates
+        if _parse_time(event.get("timestamp")).date().isoformat() in replay_date_set
+    ]
+    profiles = [
+        {
+            "profile_ref": _text(profile.get("profile_ref")),
+            "unit_amount": _number(profile.get("unit_amount")),
+        }
+        for profile in replay_profiles
+        if _text(profile.get("profile_ref"))
+        and _number(profile.get("unit_amount")) is not None
+    ]
+    replay_rows = []
+    candidates_with_price = 0
+    for event in sorted(
+        replay_candidates,
+        key=lambda item: (str(item.get("timestamp") or ""), str(item.get("event_id") or "")),
+    ):
+        attributes = _mapping(event.get("attributes"))
+        decision_context = _mapping(attributes.get("decision_context"))
+        price = _number(decision_context.get("price"))
+        if price is None:
+            continue
+        candidates_with_price += 1
+        for profile in profiles:
+            quantities, first_executable = _stage_quantities(
+                profile["unit_amount"], price
+            )
+            if not quantities:
+                continue
+            replay_rows.append(
+                {
+                    "decision_ref": _ref("decision", event.get("decision_id")),
+                    "symbol_ref": _ref(
+                        "symbol", event.get("market"), event.get("ticker")
+                    ),
+                    "timestamp": _text(event.get("timestamp")),
+                    "profile_ref": profile["profile_ref"],
+                    "selected_for_entry": bool(
+                        decision_context.get("selected_for_entry")
+                    ),
+                    "base_stage_projection_quantities": quantities,
+                    "first_executable_target_pct": first_executable,
+                    "ingestion_mode": _text(attributes.get("ingestion_mode"))
+                    or "live",
+                }
+            )
+
+    observed_decisions = len(
+        {row["decision_ref"] for row in observed_rows if row.get("decision_ref")}
+    )
+    v2_coverage = len(v2_rows) / len(observed_rows) if observed_rows else 0.0
+    reasons = []
+    for code, failed, observed, minimum in (
+        (
+            "OBSERVED_DATES_LT_20",
+            len(observed_dates) < MIN_OBSERVED_DATES,
+            len(observed_dates),
+            MIN_OBSERVED_DATES,
+        ),
+        (
+            "OBSERVED_DECISIONS_LT_30",
+            observed_decisions < MIN_OBSERVED_DECISIONS,
+            observed_decisions,
+            MIN_OBSERVED_DECISIONS,
+        ),
+        (
+            "SCHEMA_V2_COVERAGE_LT_100_PCT",
+            v2_coverage < 1.0,
+            round(v2_coverage, 4),
+            1.0,
+        ),
+        (
+            "CANDIDATE_REPLAY_UNAVAILABLE",
+            not replay_rows,
+            len(replay_rows),
+            1,
+        ),
+    ):
+        if failed:
+            reasons.append({"code": code, "observed": observed, "minimum": minimum})
+    if micro_duplicate_count:
+        reasons.append(
+            {
+                "code": "DUPLICATE_EVENT_IDS_PRESENT",
+                "observed": micro_duplicate_count,
+                "maximum": 0,
+            }
+        )
+
+    payload = {
+        "packet_schema_version": PACKET_SCHEMA_VERSION,
+        "analysis_contract_version": ANALYSIS_CONTRACT_VERSION,
+        "market": normalized_market,
+        "as_of": max(
+            (str(event.get("timestamp") or "") for event in market_events),
+            default=None,
+        ),
+        "policy": {
+            "policy_version": DEFAULT_POLICY.policy_version,
+            "base_steps_pct": list(BASE_STAGES),
+            "trading_impact": "none",
+        },
+        "observed_shadow": {
+            "raw_event_count": raw_micro_count,
+            "distinct_event_count": len(observed_rows),
+            "duplicate_event_id_count": micro_duplicate_count,
+            "decision_count": observed_decisions,
+            "decision_date_count": len(observed_dates),
+            "schema_v2_count": len(v2_rows),
+            "schema_v2_coverage_rate": round(v2_coverage, 4),
+            "first_executable_target_pct_distribution": dict(
+                sorted(first_stage_distribution.items())
+            ),
+            "rows": observed_rows,
+        },
+        "candidate_replay": {
+            "kind": "counterfactual_projection_only",
+            "actual_observation": False,
+            "decision_date_count": len(replay_dates),
+            "duplicate_event_id_count": candidate_duplicate_count,
+            "candidate_count": len(replay_candidates),
+            "candidate_price_coverage_rate": round(
+                candidates_with_price / len(replay_candidates), 4
+            )
+            if replay_candidates
+            else 0.0,
+            "profile_count": len(profiles),
+            "projected_row_count": len(replay_rows),
+            "rows": replay_rows,
+        },
+        "security": {
+            "packet_sanitized": True,
+            "raw_identifiers_exported": False,
+            "raw_sizing_values_exported": False,
+        },
+        "readiness": {
+            "data_sufficient": not reasons,
+            "verdict": "PREREGISTER_REPLAY" if not reasons else "CONTINUE_CAPTURE",
+            "reasons": reasons,
+            "automatic_shadow_forbidden": True,
+            "automatic_live_forbidden": True,
+        },
+    }
+    packet_id = hashlib.sha256(_canonical(payload).encode("utf-8")).hexdigest()[:24]
+    return {"packet_id": packet_id, **payload}
+
+
+def _load_jsonl(paths: Iterable[str | Path]) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    events = []
+    diagnostics = Counter()
+    for raw_path in paths:
+        diagnostics["input_file_count"] += 1
+        path = Path(raw_path)
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                diagnostics["input_line_count"] += 1
+                try:
+                    value = json.loads(line)
+                except json.JSONDecodeError:
+                    diagnostics["invalid_json_line_count"] += 1
+                    continue
+                if not isinstance(value, Mapping):
+                    diagnostics["non_object_line_count"] += 1
+                    continue
+                events.append(dict(value))
+    return events, dict(diagnostics)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", action="append", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--market", default="US")
+    parser.add_argument("--replay-config")
+    args = parser.parse_args()
+
+    events, input_diagnostics = _load_jsonl(args.input)
+    profiles = load_replay_profiles(args.replay_config) if args.replay_config else []
+    packet = build_micro_split_evidence_packet(
+        events,
+        market=args.market,
+        replay_profiles=profiles,
+    )
+    packet["input_diagnostics"] = input_diagnostics
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(packet, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(
+        "micro-split evidence packet "
+        f"{packet['packet_id']} observed={packet['observed_shadow']['distinct_event_count']} "
+        f"replay={packet['candidate_replay']['projected_row_count']} "
+        f"verdict={packet['readiness']['verdict']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/export_observability_insights.py
+++ b/tools/export_observability_insights.py
@@ -419,6 +419,36 @@ def _market_snapshot(
         str(event.get("attributes", {}).get("projection_status") or "unknown")
         for event in micro_split_events
     )
+    micro_schema_versions = Counter(
+        str(event.get("attributes", {}).get("shadow_schema_version") or 1)
+        for event in micro_split_events
+    )
+    micro_v2_events = [
+        event
+        for event in micro_split_events
+        if int(event.get("attributes", {}).get("shadow_schema_version") or 1) >= 2
+        and isinstance(
+            event.get("attributes", {}).get("base_stage_projection_quantities"),
+            Mapping,
+        )
+    ]
+    micro_first_executable = Counter(
+        str(
+            event.get("attributes", {}).get("first_executable_target_pct")
+            or "NONE"
+        )
+        for event in micro_v2_events
+    )
+    micro_zero_by_stage = {
+        str(stage): sum(
+            event.get("attributes", {})
+            .get("base_stage_projection_quantities", {})
+            .get(str(stage))
+            == 0
+            for event in micro_v2_events
+        )
+        for stage in (10, 30, 60, 100)
+    }
 
     return {
         "actual": _trade_metrics(actual),
@@ -504,6 +534,16 @@ def _market_snapshot(
             "policy_version_distribution": dict(micro_policy_versions),
             "target_pct_distribution": dict(micro_targets),
             "projection_status_distribution": dict(micro_projection_statuses),
+            "schema_version_distribution": dict(micro_schema_versions),
+            "schema_v2_coverage_rate": _rounded(
+                len(micro_v2_events) / len(micro_split_events)
+                if micro_split_events
+                else None
+            ),
+            "first_executable_target_pct_distribution": dict(
+                micro_first_executable
+            ),
+            "zero_whole_share_projection_by_stage": micro_zero_by_stage,
             "zero_whole_share_projection_count": sum(
                 event.get("attributes", {}).get("projected_whole_share_quantity")
                 == 0


### PR DESCRIPTION
## Decision
D1-D3 verdict is HOLD / CONTINUE_CAPTURE, not GO. Operational invariants passed, but only 3 sessions and 2 eligible entries exist; confirmed fills and matured outcomes are zero.

## Changes
- bump micro-split observation schema to v2
- capture secret-minimized 10/30/60/100 whole-share projections, first executable stage, and sizing snapshot ref
- add deterministic build_micro_split_evidence_packet.py
- keep observed SHADOW and candidate replay cohorts separate
- expose v2 coverage and executable-stage distributions in the existing dashboard exporter
- document D1-D3 HOLD evidence and failure lesson

## Safety
- no order, holdings, score, message, or caller changes
- existing Phase 2a SHADOW remains the only enabled behavior
- no campaign ledger or LIVE execution

## Verification
- root micro-split/observability tests: 78 passed
- isolated US process_reports integration: 16 passed
- Ruff, Bandit, py_compile, diff-check passed