### PR TITLE
fix: bootstrap micro-split evidence CLI

### DIFF
--- a/tests/test_micro_split_evidence_packet.py
+++ b/tests/test_micro_split_evidence_packet.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
+from pathlib import Path
 
 from tools.build_micro_split_evidence_packet import (
     build_micro_split_evidence_packet,
     load_replay_profiles,
 )
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def _event(
@@ -184,3 +189,32 @@ def test_candidate_duplicate_is_reported_separately_from_micro_duplicates() -> N
     assert "DUPLICATE_EVENT_IDS_PRESENT" not in {
         reason["code"] for reason in packet["readiness"]["reasons"]
     }
+
+
+def test_cli_runs_directly_without_repo_root_on_python_path(tmp_path) -> None:
+    source = tmp_path / "events.jsonl"
+    source.write_text("", encoding="utf-8")
+    config = tmp_path / "kis_devlp.yaml"
+    config.write_text("default_unit_amount_usd: 1000\n", encoding="utf-8")
+    output = tmp_path / "packet.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "tools" / "build_micro_split_evidence_packet.py"),
+            "--input",
+            str(source),
+            "--replay-config",
+            str(config),
+            "--output",
+            str(output),
+        ],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(output.read_text(encoding="utf-8"))["packet_id"]

--- a/tools/build_micro_split_evidence_packet.py
+++ b/tools/build_micro_split_evidence_packet.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import sys
 from collections import Counter
 from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
@@ -18,7 +19,14 @@ from typing import Any
 
 import yaml
 
-from prism_core.micro_split import DEFAULT_POLICY, project_execution_on_advance
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from prism_core.micro_split import (
+    DEFAULT_POLICY,
+    project_execution_on_advance,
+)
 
 PACKET_SCHEMA_VERSION = 1
 ANALYSIS_CONTRACT_VERSION = "micro-split-evidence-v1"


### PR DESCRIPTION
## Summary
- make python tools/build_micro_split_evidence_packet.py work from the production cron-style entrypoint
- bootstrap the repository root before importing prism_core
- add a subprocess regression with cwd outside the repository

## Production verification context
The first post-deploy Packet run failed before reading data with ModuleNotFoundError: prism_core. No event, config, DB, order, holding, or message was changed.

## Verification
- root micro-split/observability tests: 79 passed
- isolated US process_reports integration: 16 passed
- Ruff, Bandit, py_compile, diff-check passed