### PR TITLE
feat(btc): capture causal OHLCV factor evidence

### DIFF
--- a/docs/BTC_QUANTMIND_ADOPTION_2026-09-04_ko.md
+++ b/docs/BTC_QUANTMIND_ADOPTION_2026-09-04_ko.md
@@ -1,0 +1,63 @@
+# BTC QuantMind 선별 도입 기록
+
+> 도입일: 2026-09-04
+> 범위: PRISM-BTC 연구·관측 계층
+> 주문 영향: 없음
+
+## 결론
+
+QuantMind 전체 플랫폼이나 자동 팩터 생성기는 도입하지 않는다. PRISM-BTC에 실제로
+부족했던 아래 두 가지 개념만 독립 구현했다.
+
+1. 작은 고정 OHLCV 팩터 묶음을 모든 4시간 진입 판단과 함께 저장한다.
+2. 팩터 검증은 시간순 train/validation/test와 label horizon·execution lag만큼의
+   embargo를 강제한다.
+
+QuantMind는 AGPL-3.0 프로젝트이므로 소스 코드는 복사하지 않았다. 공개 문서에서 확인한
+연구 개념만 PRISM의 기존 pandas·SQLite 구조에 맞춰 clean-room 방식으로 구현했다.
+
+- 원 프로젝트: https://github.com/qusong0627/QuantMind
+- 라이선스: https://github.com/qusong0627/QuantMind/blob/main/LICENSE
+
+## 도입한 관측값
+
+각 1h·4h·1d 확정봉에서 10·21개 창을 사용한다.
+
+- 로그가격 선형추세의 `R²`
+- 로그수익률 변동성
+- 최근 범위 안 종가 위치(RSV)
+- 가격·거래량 상관계수
+
+`research.market_factors.build_factor_snapshot()`은 기존
+`backtest.engine._get_tf_slice()`를 재사용하므로 평가 시점에 아직 닫히지 않은 상위
+시간대 봉은 포함하지 않는다. 결과는 `btc_decision_log.market_snapshot`의
+`ohlcv_factors`에 schema v2로 저장한다.
+
+## 검증 계약
+
+`research.causal_validation.purged_chronological_splits()`은 다음 순서를 고정한다.
+
+1. train
+2. `label_horizon + execution_lag`만큼 embargo
+3. validation
+4. 같은 embargo
+5. test
+
+`analysis.factor_evidence`는 저장된 판단과 이후 4시간봉 수익률을 연결해 각 구간의
+상관 방향을 출력한다. 표본이 한 세트를 채우지 못하면 `insufficient`이며,
+`promotion_allowed`는 항상 `false`다.
+
+```bash
+cd /root/prism-insight/prism-btc
+python3 -m analysis.factor_evidence
+```
+
+## 의도적으로 제외한 것
+
+- Qlib·RD-Agent 및 LLM 기반 자동 팩터 생성
+- 현재 상위 코인만 과거에도 존재했다고 가정하는 universe 백테스트
+- 이 팩터를 이용한 즉시 진입 차단·가중치·사이징 변경
+- Binance 전용 구현과 PRISM의 Bybit 집행 경로 결합
+
+실제 전략 변경은 충분한 전진 표본에서 validation과 test의 방향이 반복되고, 비용 포함
+성과와 MDD까지 별도 백테스트한 뒤 작은 SHADOW 실험으로만 제안한다.

--- a/prism-btc/analysis/factor_evidence.py
+++ b/prism-btc/analysis/factor_evidence.py
@@ -1,0 +1,248 @@
+"""Offline evidence packet for observational BTC OHLCV factors.
+
+This module never changes strategy configuration.  It labels captured decision
+snapshots with later 4h returns, then reports purged chronological correlations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from research.causal_validation import PurgedSplit, purged_chronological_splits
+
+EVIDENCE_SCHEMA_VERSION = 1
+DEFAULT_TIMEFRAME = "4h"
+
+
+def _finite(value: float) -> float | None:
+    return round(float(value), 8) if math.isfinite(float(value)) else None
+
+
+def _correlation(rows: list[dict[str, Any]], factor: str) -> dict[str, Any]:
+    paired = [
+        (float(row["factors"][factor]), float(row["future_return"]))
+        for row in rows
+        if row["factors"].get(factor) is not None
+    ]
+    entries = [
+        (
+            float(row["factors"][factor]),
+            float(row["future_return"])
+            * (1.0 if row["signal_side"] == "long" else -1.0),
+        )
+        for row in rows
+        if row["signal_side"] in {"long", "short"}
+        and row["factors"].get(factor) is not None
+    ]
+
+    def calculate(values: list[tuple[float, float]]) -> float | None:
+        if len(values) < 3:
+            return None
+        left = np.asarray([value[0] for value in values], dtype=float)
+        right = np.asarray([value[1] for value in values], dtype=float)
+        if float(np.std(left)) == 0.0 or float(np.std(right)) == 0.0:
+            return None
+        return _finite(float(np.corrcoef(left, right)[0, 1]))
+
+    return {
+        "n": len(paired),
+        "correlation": calculate(paired),
+        "directional_entry_n": len(entries),
+        "directional_entry_correlation": calculate(entries),
+    }
+
+
+def _parse_decisions(
+    decisions: list[dict[str, Any]], timeframe: str
+) -> list[dict[str, Any]]:
+    parsed = []
+    for row in decisions:
+        try:
+            market = row["market_snapshot"]
+            if isinstance(market, str):
+                market = json.loads(market)
+            factor_block = market["ohlcv_factors"]["timeframes"][timeframe]
+            if factor_block.get("status") != "ok":
+                continue
+            as_of = pd.Timestamp(factor_block["as_of_open_time"])
+            factors = {
+                str(name): float(value) if value is not None else None
+                for name, value in factor_block.get("values", {}).items()
+            }
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            continue
+        parsed.append({
+            "decision_id": str(row["decision_id"]),
+            "ts": str(row["ts"]),
+            "signal_side": str(row.get("signal_side") or "none"),
+            "as_of_open_time": as_of,
+            "factors": factors,
+        })
+    return sorted(parsed, key=lambda item: item["as_of_open_time"])
+
+
+def _label_forward_returns(
+    rows: list[dict[str, Any]],
+    closes: pd.Series,
+    *,
+    horizon_bars: int,
+    execution_lag: int,
+) -> list[dict[str, Any]]:
+    series = closes.dropna().sort_index().astype(float)
+    labeled = []
+    for row in rows:
+        at = row["as_of_open_time"]
+        location = int(series.index.searchsorted(at, side="left"))
+        if location >= len(series.index) or series.index[location] != at:
+            continue
+        start = location + execution_lag
+        end = start + horizon_bars
+        if start >= len(series) or end >= len(series):
+            continue
+        start_price = float(series.iloc[start])
+        end_price = float(series.iloc[end])
+        if start_price <= 0:
+            continue
+        labeled.append({
+            **row,
+            "future_return": end_price / start_price - 1.0,
+        })
+    return labeled
+
+
+def _split_evidence(
+    rows: list[dict[str, Any]], split: PurgedSplit, split_number: int
+) -> dict[str, Any]:
+    ranges = {
+        "train": split.train,
+        "validation": split.validation,
+        "test": split.test,
+    }
+    factors = sorted({name for row in rows for name in row["factors"]})
+    factor_results = {}
+    for factor in factors:
+        factor_results[factor] = {
+            name: _correlation(rows[start:end], factor)
+            for name, (start, end) in ranges.items()
+        }
+    return {
+        "split_number": split_number,
+        "ranges": {name: list(bounds) for name, bounds in ranges.items()},
+        "factors": factor_results,
+    }
+
+
+def build_evidence_packet(
+    decisions: list[dict[str, Any]],
+    closes: pd.Series,
+    *,
+    timeframe: str = DEFAULT_TIMEFRAME,
+    horizon_bars: int = 6,
+    execution_lag: int = 1,
+    train_size: int = 180,
+    validation_size: int = 60,
+    test_size: int = 60,
+    step_size: int = 60,
+) -> dict[str, Any]:
+    """Build a non-promoting evidence packet from captured decisions."""
+    parsed = _parse_decisions(decisions, timeframe)
+    labeled = _label_forward_returns(
+        parsed,
+        closes,
+        horizon_bars=horizon_bars,
+        execution_lag=execution_lag,
+    )
+    splits = purged_chronological_splits(
+        len(labeled),
+        train_size=train_size,
+        validation_size=validation_size,
+        test_size=test_size,
+        label_horizon=horizon_bars,
+        execution_lag=execution_lag,
+        step_size=step_size,
+    )
+    return {
+        "schema_version": EVIDENCE_SCHEMA_VERSION,
+        "status": "ready" if splits else "insufficient",
+        "timeframe": timeframe,
+        "horizon_bars": horizon_bars,
+        "execution_lag": execution_lag,
+        "embargo_size": horizon_bars + execution_lag,
+        "captured_decisions": len(parsed),
+        "labeled_decisions": len(labeled),
+        "promotion_allowed": False,
+        "note": "관측 전용. 상관관계만으로 전략·게이트를 변경하지 않음.",
+        "splits": [
+            _split_evidence(labeled, split, number)
+            for number, split in enumerate(splits, start=1)
+        ],
+    }
+
+
+def _load_decisions(connection: sqlite3.Connection) -> list[dict[str, Any]]:
+    connection.row_factory = sqlite3.Row
+    return [
+        dict(row) for row in connection.execute(
+            "SELECT decision_id, ts, signal_side, market_snapshot "
+            "FROM btc_decision_log WHERE schema_version>=2 ORDER BY ts"
+        )
+    ]
+
+
+def _load_closes(connection: sqlite3.Connection, timeframe: str) -> pd.Series:
+    rows = connection.execute(
+        "SELECT open_time, close FROM klines "
+        "WHERE timeframe=? AND confirmed=1 ORDER BY open_time",
+        (timeframe,),
+    ).fetchall()
+    index = pd.to_datetime([row[0] for row in rows], unit="ms", utc=True)
+    return pd.Series([float(row[1]) for row in rows], index=index, dtype=float)
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[2]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tracking-db", default=str(root / "stock_tracking_db.sqlite"))
+    parser.add_argument(
+        "--market-db", default=str(root / "prism-btc" / "state" / "btc_market.db")
+    )
+    parser.add_argument("--timeframe", default=DEFAULT_TIMEFRAME)
+    parser.add_argument("--horizon-bars", type=int, default=6)
+    parser.add_argument("--execution-lag", type=int, default=1)
+    parser.add_argument("--train-size", type=int, default=180)
+    parser.add_argument("--validation-size", type=int, default=60)
+    parser.add_argument("--test-size", type=int, default=60)
+    parser.add_argument("--step-size", type=int, default=60)
+    args = parser.parse_args()
+
+    tracking = sqlite3.connect(f"file:{args.tracking_db}?mode=ro", uri=True)
+    market = sqlite3.connect(f"file:{args.market_db}?mode=ro", uri=True)
+    try:
+        packet = build_evidence_packet(
+            _load_decisions(tracking),
+            _load_closes(market, args.timeframe),
+            timeframe=args.timeframe,
+            horizon_bars=args.horizon_bars,
+            execution_lag=args.execution_lag,
+            train_size=args.train_size,
+            validation_size=args.validation_size,
+            test_size=args.test_size,
+            step_size=args.step_size,
+        )
+    finally:
+        tracking.close()
+        market.close()
+    print(json.dumps(packet, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prism-btc/live/decision_capture.py
+++ b/prism-btc/live/decision_capture.py
@@ -14,7 +14,7 @@ from engine.regime import RegimeSnapshot
 from engine.signal import Signal, trend_strength
 from live import tracking
 
-DECISION_SCHEMA_VERSION = 1
+DECISION_SCHEMA_VERSION = 2
 DEFAULT_STRATEGY_ID = "main_trend_v1"
 _EFFECTIVE_QTY_EPS = 1e-8
 
@@ -84,7 +84,11 @@ def _entry_reason_code(reason: str | None) -> str | None:
     return "ENTRY_REJECTED_OTHER"
 
 
-def _market_snapshot(snapshot: RegimeSnapshot, bar_close: float) -> dict[str, Any]:
+def _market_snapshot(
+    snapshot: RegimeSnapshot,
+    bar_close: float,
+    factor_snapshot: dict[str, Any] | None,
+) -> dict[str, Any]:
     states = {}
     for timeframe, state in sorted(snapshot.tf_states.items()):
         states[timeframe] = {
@@ -101,6 +105,11 @@ def _market_snapshot(snapshot: RegimeSnapshot, bar_close: float) -> dict[str, An
         "bar_close": float(bar_close),
         "alignment_score": round(float(snapshot.alignment_score), 4),
         "tf_states": states,
+        "ohlcv_factors": factor_snapshot or {
+            "schema_version": 1,
+            "status": "unavailable",
+            "timeframes": {},
+        },
     }
 
 
@@ -148,10 +157,11 @@ def capture_signal_decision(
     peak_equity: float | None,
     pending: bool,
     code_version: str | None,
+    factor_snapshot: dict[str, Any] | None = None,
 ) -> str:
     """Upsert the signal stage and return its stable decision ID."""
     config_snapshot = _config_snapshot()
-    market = _market_snapshot(snapshot, bar_close)
+    market = _market_snapshot(snapshot, bar_close, factor_snapshot)
     position = _position_context(
         positions, equity=equity, peak_equity=peak_equity, pending=pending
     )

--- a/prism-btc/live/demo.py
+++ b/prism-btc/live/demo.py
@@ -68,6 +68,7 @@ import engine.sizing as _sizing
 from core.risk import compute_operating_risk
 from core.leadership import leadership_multipliers
 from core.failure_guard import should_observe_pyramid_block
+from research.market_factors import build_factor_snapshot
 
 # 거래소 상수.
 _CATEGORY = "linear"
@@ -901,6 +902,9 @@ class DemoAdapter:
                             peak_equity=tracking.peak_equity(conn, mode),
                             pending=False,
                             code_version=tracking.get_meta(conn, "code_version", mode),
+                            factor_snapshot=build_factor_snapshot(
+                                self.tf_data, bar_time
+                            ),
                         )
                     except Exception:  # noqa: BLE001 — 로깅이 매매를 못 막는다
                         pass

--- a/prism-btc/live/shadow.py
+++ b/prism-btc/live/shadow.py
@@ -63,6 +63,7 @@ from core.actions import (
 )
 from core.risk import compute_operating_risk
 from core.leadership import leadership_multipliers
+from research.market_factors import build_factor_snapshot  # noqa: E402
 
 from live import decision_capture, tracking
 from live.tracking import PositionRow, TradeRow
@@ -480,6 +481,9 @@ class ShadowAdapter:
                             peak_equity=tracking.peak_equity(conn, mode),
                             pending=False,
                             code_version=tracking.get_meta(conn, "code_version", mode),
+                            factor_snapshot=build_factor_snapshot(
+                                self.tf_data, bar_time
+                            ),
                         )
                     except Exception as exc:  # noqa: BLE001 - telemetry fails open
                         log.warning("shadow signal telemetry failed: %s", exc)

--- a/prism-btc/research/causal_validation.py
+++ b/prism-btc/research/causal_validation.py
@@ -1,0 +1,78 @@
+"""Chronological train/validation/test splits with a conservative embargo."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PurgedSplit:
+    """Half-open integer ranges suitable for ``iloc`` slicing."""
+
+    train: tuple[int, int]
+    validation: tuple[int, int]
+    test: tuple[int, int]
+    embargo_size: int
+
+
+def purged_chronological_splits(
+    n_samples: int,
+    *,
+    train_size: int,
+    validation_size: int,
+    test_size: int,
+    label_horizon: int,
+    execution_lag: int = 1,
+    step_size: int | None = None,
+    expanding: bool = True,
+) -> list[PurgedSplit]:
+    """Return causal windows separated by ``label_horizon + execution_lag``.
+
+    The embargo prevents a label or delayed execution originating in an earlier
+    window from reaching observations in the next window.  No shuffling is
+    allowed.  An empty list means the sample cannot support one complete split.
+    """
+    sizes = {
+        "n_samples": n_samples,
+        "train_size": train_size,
+        "validation_size": validation_size,
+        "test_size": test_size,
+        "label_horizon": label_horizon,
+        "execution_lag": execution_lag,
+    }
+    if any(int(value) < 0 for value in sizes.values()):
+        raise ValueError("split sizes must be non-negative")
+    if min(train_size, validation_size, test_size) <= 0:
+        raise ValueError("train, validation, and test sizes must be positive")
+    if label_horizon <= 0:
+        raise ValueError("label_horizon must be positive")
+    step = test_size if step_size is None else int(step_size)
+    if step <= 0:
+        raise ValueError("step_size must be positive")
+
+    embargo = int(label_horizon) + int(execution_lag)
+    splits: list[PurgedSplit] = []
+    train_start = 0
+    train_end = int(train_size)
+    while True:
+        validation_start = train_end + embargo
+        validation_end = validation_start + int(validation_size)
+        test_start = validation_end + embargo
+        test_end = test_start + int(test_size)
+        if test_end > int(n_samples):
+            break
+        splits.append(
+            PurgedSplit(
+                train=(train_start, train_end),
+                validation=(validation_start, validation_end),
+                test=(test_start, test_end),
+                embargo_size=embargo,
+            )
+        )
+        if not expanding:
+            train_start += step
+        train_end += step
+    return splits
+
+
+__all__ = ["PurgedSplit", "purged_chronological_splits"]

--- a/prism-btc/research/market_factors.py
+++ b/prism-btc/research/market_factors.py
@@ -1,0 +1,148 @@
+"""Small, causal OHLCV factor snapshot for BTC decision observability.
+
+The values are research inputs only.  They never gate, resize, or place an order.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from backtest.engine import _get_tf_slice
+
+FACTOR_SCHEMA_VERSION = 1
+DEFAULT_WINDOWS = (10, 21)
+DEFAULT_TIMEFRAMES = ("1h", "4h", "1d")
+_REQUIRED_COLUMNS = ("high", "low", "close", "volume")
+
+
+def _finite_or_none(value: float) -> float | None:
+    return round(float(value), 8) if math.isfinite(float(value)) else None
+
+
+def _trend_r2(close: np.ndarray) -> float | None:
+    if len(close) < 2 or np.any(close <= 0):
+        return None
+    y = np.log(close)
+    if float(np.std(y)) == 0.0:
+        return 0.0
+    x = np.arange(len(y), dtype=float)
+    correlation = float(np.corrcoef(x, y)[0, 1])
+    return _finite_or_none(correlation * correlation)
+
+
+def _correlation(left: np.ndarray, right: np.ndarray) -> float | None:
+    if len(left) < 2 or float(np.std(left)) == 0.0 or float(np.std(right)) == 0.0:
+        return None
+    return _finite_or_none(float(np.corrcoef(left, right)[0, 1]))
+
+
+def compute_ohlcv_factors(
+    frame: pd.DataFrame,
+    windows: Sequence[int] = DEFAULT_WINDOWS,
+) -> dict[str, Any]:
+    """Return a fixed factor set from the supplied, already-confirmed bars."""
+    clean_windows = tuple(sorted({int(window) for window in windows if int(window) > 1}))
+    required_rows = max(clean_windows, default=0)
+    if frame is None or frame.empty:
+        return {
+            "schema_version": FACTOR_SCHEMA_VERSION,
+            "status": "missing",
+            "bars": 0,
+            "values": {},
+        }
+    missing = [column for column in _REQUIRED_COLUMNS if column not in frame.columns]
+    if missing:
+        return {
+            "schema_version": FACTOR_SCHEMA_VERSION,
+            "status": "missing_columns",
+            "bars": len(frame),
+            "missing_columns": missing,
+            "values": {},
+        }
+    if len(frame) < required_rows:
+        return {
+            "schema_version": FACTOR_SCHEMA_VERSION,
+            "status": "insufficient",
+            "bars": len(frame),
+            "required_bars": required_rows,
+            "values": {},
+        }
+
+    numeric = frame.loc[:, _REQUIRED_COLUMNS].apply(pd.to_numeric, errors="coerce")
+    values: dict[str, float | None] = {}
+    for window in clean_windows:
+        sample = numeric.tail(window)
+        close = sample["close"].to_numpy(dtype=float)
+        high = sample["high"].to_numpy(dtype=float)
+        low = sample["low"].to_numpy(dtype=float)
+        volume = sample["volume"].to_numpy(dtype=float)
+        if not all(np.isfinite(array).all() for array in (close, high, low, volume)):
+            for name in (
+                "trend_r2", "log_return_vol", "rsv", "price_volume_corr"
+            ):
+                values[f"{name}_{window}"] = None
+            continue
+        values[f"trend_r2_{window}"] = _trend_r2(close)
+        log_returns = np.diff(np.log(close)) if np.all(close > 0) else np.array([])
+        values[f"log_return_vol_{window}"] = (
+            _finite_or_none(float(np.std(log_returns)))
+            if len(log_returns) else None
+        )
+        range_low = float(np.min(low))
+        range_width = float(np.max(high)) - range_low
+        values[f"rsv_{window}"] = (
+            _finite_or_none((float(close[-1]) - range_low) / range_width)
+            if range_width > 0 else None
+        )
+        values[f"price_volume_corr_{window}"] = _correlation(close, volume)
+    return {
+        "schema_version": FACTOR_SCHEMA_VERSION,
+        "status": "ok",
+        "bars": len(frame),
+        "values": values,
+    }
+
+
+def build_factor_snapshot(
+    tf_data: Mapping[str, pd.DataFrame],
+    evaluated_at: pd.Timestamp,
+    timeframes: Sequence[str] = DEFAULT_TIMEFRAMES,
+) -> dict[str, Any]:
+    """Build factors only from candles confirmed at ``evaluated_at``."""
+    evaluated = pd.Timestamp(evaluated_at)
+    result: dict[str, Any] = {
+        "schema_version": FACTOR_SCHEMA_VERSION,
+        "status": "observational_only",
+        "evaluated_at": str(evaluated),
+        "timeframes": {},
+    }
+    for timeframe in timeframes:
+        frame = tf_data.get(timeframe)
+        if frame is None or frame.empty:
+            result["timeframes"][timeframe] = {
+                "schema_version": FACTOR_SCHEMA_VERSION,
+                "status": "missing",
+                "bars": 0,
+                "values": {},
+            }
+            continue
+        confirmed = _get_tf_slice(dict(tf_data), evaluated, timeframe)
+        factors = compute_ohlcv_factors(confirmed)
+        if not confirmed.empty:
+            factors["as_of_open_time"] = str(confirmed.index[-1])
+        result["timeframes"][timeframe] = factors
+    return result
+
+
+__all__ = [
+    "DEFAULT_TIMEFRAMES",
+    "DEFAULT_WINDOWS",
+    "FACTOR_SCHEMA_VERSION",
+    "build_factor_snapshot",
+    "compute_ohlcv_factors",
+]

--- a/prism-btc/tests/test_causal_validation.py
+++ b/prism-btc/tests/test_causal_validation.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from research.causal_validation import purged_chronological_splits
+
+
+def test_purged_split_keeps_label_horizon_out_of_later_windows() -> None:
+    splits = purged_chronological_splits(
+        140,
+        train_size=60,
+        validation_size=20,
+        test_size=20,
+        label_horizon=6,
+        execution_lag=1,
+        step_size=20,
+    )
+
+    assert len(splits) == 2
+    first = splits[0]
+    assert first.embargo_size == 7
+    assert first.train == (0, 60)
+    assert first.validation == (67, 87)
+    assert first.test == (94, 114)
+    assert first.train[1] + first.embargo_size <= first.validation[0]
+    assert first.validation[1] + first.embargo_size <= first.test[0]
+    assert splits[1].train == (0, 80)
+
+
+def test_purged_split_returns_empty_when_sample_cannot_fit_all_windows() -> None:
+    assert purged_chronological_splits(
+        50,
+        train_size=30,
+        validation_size=10,
+        test_size=10,
+        label_horizon=5,
+        execution_lag=1,
+    ) == []
+
+
+def test_rolling_train_window_does_not_expand() -> None:
+    splits = purged_chronological_splits(
+        100,
+        train_size=30,
+        validation_size=10,
+        test_size=10,
+        label_horizon=2,
+        execution_lag=1,
+        step_size=10,
+        expanding=False,
+    )
+
+    assert splits[0].train == (0, 30)
+    assert splits[1].train == (10, 40)

--- a/prism-btc/tests/test_decision_capture.py
+++ b/prism-btc/tests/test_decision_capture.py
@@ -75,13 +75,14 @@ def test_signal_capture_is_stable_versioned_and_secret_minimized() -> None:
     )
     market = json.loads(row["market_snapshot"])
     position = json.loads(row["position_context"])
-    assert row["schema_version"] == 1
+    assert row["schema_version"] == 2
     assert row["strategy_id"] == "main_trend_v1"
     assert row["signal_reason_code"] == "SIGNAL_ACCEPTED"
     assert row["entry_status"] == "PENDING_EVALUATION"
     assert len(row["config_hash"]) == 24
     assert len(row["input_hash"]) == 24
     assert market["tf_states"]["4h"]["trend_strength"] == 2.0
+    assert market["ohlcv_factors"]["status"] == "unavailable"
     assert position["n_open"] == 0
     assert position["effective_n_open"] == 0
     serialized = json.dumps(row, ensure_ascii=False)
@@ -178,4 +179,44 @@ def test_signal_none_is_final_without_entry_evaluation() -> None:
         (decision_id,),
     ).fetchone()
     assert tuple(row) == ("SIGNAL_REJECTED", "SCORE_BELOW_MIN")
+    connection.close()
+
+
+def test_signal_capture_persists_observational_factors_without_changing_signal() -> None:
+    connection = _conn()
+    factor_snapshot = {
+        "schema_version": 1,
+        "status": "observational_only",
+        "timeframes": {
+            "4h": {
+                "status": "ok",
+                "as_of_open_time": "2026-08-30 20:00:00+00:00",
+                "values": {"trend_r2_21": 0.75, "rsv_21": 0.8},
+            }
+        },
+    }
+    decision_id = decision_capture.capture_signal_decision(
+        connection,
+        ts="2026-08-31T00:00:00Z",
+        mode="shadow",
+        strategy_id="main_trend_v1",
+        snapshot=_snapshot(),
+        signal=Signal(side="long", strength=82.5, reason="롱신호 score=82.5"),
+        bar_close=110.0,
+        positions=[],
+        equity=10_000.0,
+        peak_equity=10_000.0,
+        pending=False,
+        code_version="abc123",
+        factor_snapshot=factor_snapshot,
+    )
+
+    row = connection.execute(
+        "SELECT signal_side, entry_status, market_snapshot "
+        "FROM btc_decision_log WHERE decision_id=?",
+        (decision_id,),
+    ).fetchone()
+    market = json.loads(row["market_snapshot"])
+    assert tuple(row[:2]) == ("long", "PENDING_EVALUATION")
+    assert market["ohlcv_factors"] == factor_snapshot
     connection.close()

--- a/prism-btc/tests/test_factor_evidence.py
+++ b/prism-btc/tests/test_factor_evidence.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pandas as pd
+
+from analysis.factor_evidence import build_evidence_packet
+
+
+def _decisions(count: int) -> list[dict]:
+    times = pd.date_range("2025-01-01", periods=count, freq="4h", tz="UTC")
+    return [
+        {
+            "decision_id": f"d-{i}",
+            "ts": str(ts + pd.Timedelta(hours=4)),
+            "signal_side": "long" if i % 3 == 0 else "none",
+            "market_snapshot": json.dumps({
+                "ohlcv_factors": {
+                    "timeframes": {
+                        "4h": {
+                            "status": "ok",
+                            "as_of_open_time": str(ts),
+                            "values": {"trend_r2_21": i / count},
+                        }
+                    }
+                }
+            }),
+        }
+        for i, ts in enumerate(times)
+    ]
+
+
+def test_factor_evidence_uses_purged_chronological_windows() -> None:
+    times = pd.date_range("2025-01-01", periods=150, freq="4h", tz="UTC")
+    closes = pd.Series(
+        np.exp(np.arange(150, dtype=float) ** 2 * 0.00005) * 100.0,
+        index=times,
+    )
+
+    packet = build_evidence_packet(
+        _decisions(130),
+        closes,
+        horizon_bars=3,
+        execution_lag=1,
+        train_size=50,
+        validation_size=20,
+        test_size=20,
+        step_size=20,
+    )
+
+    assert packet["schema_version"] == 1
+    assert packet["status"] == "ready"
+    assert packet["embargo_size"] == 4
+    assert packet["labeled_decisions"] == 130
+    assert packet["splits"]
+    first = packet["splits"][0]
+    assert first["ranges"]["train"] == [0, 50]
+    assert first["ranges"]["validation"] == [54, 74]
+    assert first["ranges"]["test"] == [78, 98]
+    assert first["factors"]["trend_r2_21"]["validation"]["correlation"] > 0
+    assert first["factors"]["trend_r2_21"]["test"]["correlation"] > 0
+
+
+def test_factor_evidence_refuses_to_claim_on_insufficient_sample() -> None:
+    times = pd.date_range("2025-01-01", periods=20, freq="4h", tz="UTC")
+    closes = pd.Series(np.arange(20, dtype=float) + 100.0, index=times)
+
+    packet = build_evidence_packet(
+        _decisions(10),
+        closes,
+        horizon_bars=3,
+        execution_lag=1,
+        train_size=10,
+        validation_size=5,
+        test_size=5,
+    )
+
+    assert packet["status"] == "insufficient"
+    assert packet["splits"] == []
+    assert packet["promotion_allowed"] is False

--- a/prism-btc/tests/test_market_factors.py
+++ b/prism-btc/tests/test_market_factors.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+
+from research.market_factors import build_factor_snapshot, compute_ohlcv_factors
+
+
+def _frame(rows: int = 30) -> pd.DataFrame:
+    index = pd.date_range("2026-01-01", periods=rows, freq="4h", tz="UTC")
+    close = np.exp(np.arange(rows, dtype=float) * 0.01) * 100.0
+    return pd.DataFrame(
+        {
+            "open": close * 0.995,
+            "high": close * 1.01,
+            "low": close * 0.99,
+            "close": close,
+            "volume": np.arange(1, rows + 1, dtype=float) * 10.0,
+        },
+        index=index,
+    )
+
+
+def test_fixed_ohlcv_factor_set_is_finite_and_versioned() -> None:
+    result = compute_ohlcv_factors(_frame())
+
+    assert result["schema_version"] == 1
+    assert result["status"] == "ok"
+    assert result["bars"] == 30
+    assert set(result["values"]) == {
+        "trend_r2_10", "trend_r2_21",
+        "log_return_vol_10", "log_return_vol_21",
+        "rsv_10", "rsv_21",
+        "price_volume_corr_10", "price_volume_corr_21",
+    }
+    assert result["values"]["trend_r2_21"] == 1.0
+    assert all(
+        value is None or math.isfinite(value)
+        for value in result["values"].values()
+    )
+
+
+def test_factor_snapshot_excludes_unclosed_higher_timeframe_candle() -> None:
+    frame = _frame()
+    evaluated_at = frame.index[-1] + pd.Timedelta(hours=4)
+    baseline = build_factor_snapshot({"4h": frame}, evaluated_at, ("4h",))
+
+    future = frame.iloc[[-1]].copy()
+    future.index = pd.DatetimeIndex([evaluated_at])
+    future.loc[:, ["open", "high", "low", "close", "volume"]] = [
+        1.0, 1_000_000.0, 0.1, 999_999.0, 999_999_999.0,
+    ]
+    with_unclosed = build_factor_snapshot(
+        {"4h": pd.concat([frame, future])}, evaluated_at, ("4h",)
+    )
+
+    assert with_unclosed == baseline
+    assert baseline["timeframes"]["4h"]["as_of_open_time"] == str(frame.index[-1])
+
+
+def test_factor_snapshot_marks_insufficient_history_without_raising() -> None:
+    result = build_factor_snapshot(
+        {"4h": _frame(5)}, pd.Timestamp("2026-01-02", tz="UTC"), ("4h", "1d")
+    )
+
+    assert result["timeframes"]["4h"]["status"] == "insufficient"
+    assert result["timeframes"]["1d"]["status"] == "missing"


### PR DESCRIPTION
## 목적
QuantMind 전체/AGPL 코드를 가져오지 않고, PRISM-BTC에 유효한 연구 개념만 clean-room 구현합니다.

## 도입
- 4시간 신호 판단마다 1h/4h/1d 확정봉의 고정 OHLCV 팩터 8종 저장
- 미완결 상위 TF 봉 제외 회귀 테스트
- train/validation/test 사이 label horizon + execution lag embargo 분할
- 저장된 결정과 미래 4h 수익률을 연결하는 read-only evidence packet CLI
- 표본 부족 시 insufficient, promotion_allowed는 항상 false

## 제외
- QuantMind/Qlib/RD-Agent 코드 및 자동 팩터 생성
- 즉시 진입 게이트·사이징·주문 변경
- 자동 LIVE 승격

## 검증
- 전체 prism-btc: 396 passed
- ruff 통과
- 로컬 기존 데이터: captured=0, status=insufficient로 안전 거부

실거래 결정에는 영향 없는 관측 전용 변경입니다.