### PR TITLE
fix(btc): isolate factor evidence by mode

### DIFF
--- a/docs/BTC_QUANTMIND_ADOPTION_2026-09-04_ko.md
+++ b/docs/BTC_QUANTMIND_ADOPTION_2026-09-04_ko.md
@@ -49,7 +49,7 @@ QuantMind는 AGPL-3.0 프로젝트이므로 소스 코드는 복사하지 않았
 
 ```bash
 cd /root/prism-insight/prism-btc
-python3 -m analysis.factor_evidence
+python3 -m analysis.factor_evidence --mode demo
 ```
 
 ## 의도적으로 제외한 것

--- a/prism-btc/analysis/factor_evidence.py
+++ b/prism-btc/analysis/factor_evidence.py
@@ -144,6 +144,7 @@ def build_evidence_packet(
     decisions: list[dict[str, Any]],
     closes: pd.Series,
     *,
+    mode: str = "unspecified",
     timeframe: str = DEFAULT_TIMEFRAME,
     horizon_bars: int = 6,
     execution_lag: int = 1,
@@ -172,6 +173,7 @@ def build_evidence_packet(
     return {
         "schema_version": EVIDENCE_SCHEMA_VERSION,
         "status": "ready" if splits else "insufficient",
+        "mode": mode,
         "timeframe": timeframe,
         "horizon_bars": horizon_bars,
         "execution_lag": execution_lag,
@@ -187,12 +189,15 @@ def build_evidence_packet(
     }
 
 
-def _load_decisions(connection: sqlite3.Connection) -> list[dict[str, Any]]:
+def _load_decisions(
+    connection: sqlite3.Connection, mode: str
+) -> list[dict[str, Any]]:
     connection.row_factory = sqlite3.Row
     return [
         dict(row) for row in connection.execute(
             "SELECT decision_id, ts, signal_side, market_snapshot "
-            "FROM btc_decision_log WHERE schema_version>=2 ORDER BY ts"
+            "FROM btc_decision_log WHERE schema_version>=2 AND mode=? ORDER BY ts",
+            (mode,),
         )
     ]
 
@@ -215,6 +220,7 @@ def main() -> int:
         "--market-db", default=str(root / "prism-btc" / "state" / "btc_market.db")
     )
     parser.add_argument("--timeframe", default=DEFAULT_TIMEFRAME)
+    parser.add_argument("--mode", choices=("shadow", "demo"), default="demo")
     parser.add_argument("--horizon-bars", type=int, default=6)
     parser.add_argument("--execution-lag", type=int, default=1)
     parser.add_argument("--train-size", type=int, default=180)
@@ -227,8 +233,9 @@ def main() -> int:
     market = sqlite3.connect(f"file:{args.market_db}?mode=ro", uri=True)
     try:
         packet = build_evidence_packet(
-            _load_decisions(tracking),
+            _load_decisions(tracking, args.mode),
             _load_closes(market, args.timeframe),
+            mode=args.mode,
             timeframe=args.timeframe,
             horizon_bars=args.horizon_bars,
             execution_lag=args.execution_lag,

--- a/prism-btc/tests/test_factor_evidence.py
+++ b/prism-btc/tests/test_factor_evidence.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 
 import numpy as np
 import pandas as pd
 
-from analysis.factor_evidence import build_evidence_packet
+from analysis.factor_evidence import _load_decisions, build_evidence_packet
 
 
 def _decisions(count: int) -> list[dict]:
@@ -79,3 +80,21 @@ def test_factor_evidence_refuses_to_claim_on_insufficient_sample() -> None:
     assert packet["status"] == "insufficient"
     assert packet["splits"] == []
     assert packet["promotion_allowed"] is False
+
+
+def test_decision_loader_never_mixes_shadow_and_demo_duplicates() -> None:
+    connection = sqlite3.connect(":memory:")
+    connection.execute(
+        "CREATE TABLE btc_decision_log "
+        "(decision_id TEXT, ts TEXT, mode TEXT, schema_version INTEGER, "
+        "signal_side TEXT, market_snapshot TEXT)"
+    )
+    for mode in ("shadow", "demo"):
+        connection.execute(
+            "INSERT INTO btc_decision_log VALUES (?,?,?,?,?,?)",
+            (f"{mode}-id", "2026-01-01", mode, 2, "none", "{}"),
+        )
+
+    rows = _load_decisions(connection, "demo")
+
+    assert [row["decision_id"] for row in rows] == ["demo-id"]


### PR DESCRIPTION
## 수정
- factor evidence 기본 모드를 demo로 고정
- SQL 단계에서 mode를 필터링해 동일 시점 shadow/demo 중복 집계 방지
- 중복 방지 회귀 테스트 추가

## 검증
- factor evidence 테스트 3 passed
- ruff 통과

연구 표본 정확도 보정이며 주문 영향은 없습니다.