### PR TITLE
fix: Astra BUY 운영 전 안전 보강

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -276,3 +276,14 @@ TELEGRAM_CHANNEL_ID=your_channel_id
 # EVALUATION_REPORT_MAX_CHARS=40000
 # TELEGRAM_ANALYSIS_MODEL=gpt-5.6-terra
 # TELEGRAM_ANALYSIS_EFFORT=medium
+
+# BUY-only Codex settings. Unset values preserve the existing Sol/default-effort
+# path and PRISM_CODEX_FAST_TIMEOUT (fallback 90s). SELL does NOT use these keys.
+# Explicit rollout candidate after tests + Codex CLI 0.153.4 smoke; not enabled here.
+# PRISM_BUY_CODEX_MODEL=gpt-6-astra
+# PRISM_BUY_CODEX_EFFORT=high
+# PRISM_BUY_CODEX_TIMEOUT=240
+# Timeout must be finite, greater than 0 and at most 600 seconds.
+# Parallel BUY analysis only; holdings/slot checks and order application stay serial.
+# TRADING_ANALYSIS_CONCURRENCY=3
+# US_TRADING_ANALYSIS_CONCURRENCY=3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,29 @@ jobs:
       - name: Check third-party copyleft licenses
         run: python tools/license_compliance.py
 
+      # Reuse the production dependency environment for runtime import parity.
+      # KR/US packages intentionally shadow one another: separate pytest processes.
+      - name: Install existing test runners
+        run: python -m pip install pytest pytest-asyncio
+
+      - name: Offline BUY runtime safety regression
+        env:
+          PRISM_DISABLE_SIGNAL_PUBLISH: "1"
+        run: |
+          python -m pytest tests/test_trading_scenario_contract.py \
+            tests/test_trading_agents_prompt_rules.py \
+            tests/test_codex_oauth_fast_backend.py tests/test_buy_codex_settings.py \
+            tests/test_codex_fast_process_cleanup.py -q
+          # Existing bootstrap creates only a fake example.com KIS config, removes it at exit.
+          python -m pytest tests/test_multi_account_domestic.py \
+            tests/test_astra_kr_safety.py tests/test_kr_buy_quote_validation.py \
+            tests/test_parallel_trading_batch.py tests/test_trading_scenario_retry.py \
+            tests/test_stock_tracking_agent_process_reports.py tests/test_kr_pending_entry.py -q
+          python -m pytest prism-us/tests/test_us_buy_runtime_safety.py \
+            prism-us/tests/test_us_parallel_trading_analysis.py \
+            prism-us/tests/test_us_stock_tracking_agent_process_reports.py \
+            prism-us/tests/test_trading_agents_prompt_rules.py -q
+
   dashboard:
     name: Dashboard production build
     runs-on: ubuntu-latest
@@ -76,6 +99,9 @@ jobs:
       - name: Run tests
         run: |
           python -m pytest cores/llm/tests/ -q
+          python -m pytest --noconftest tests/test_buy_codex_settings.py \
+            tests/test_trading_scenario_contract.py tests/test_codex_oauth_fast_backend.py \
+            tests/test_codex_fast_process_cleanup.py -q
           # Lightweight real-order boundary gates. Keep KR/US fill-chaser in
           # separate processes because their runtime packages intentionally
           # shadow one another.

--- a/cores/agents/trading_agents.py
+++ b/cores/agents/trading_agents.py
@@ -1,4 +1,8 @@
 from mcp_agent.agents.agent import Agent
+from prism_core.trading_scenario_contract import (
+    buy_scenario_prompt_contract,
+    sell_scenario_authority_contract,
+)
 
 # Fallback sector names when dynamic data is not available
 KRX_STANDARD_SECTORS = [
@@ -694,6 +698,7 @@ def create_trading_scenario_agent(language: str = "ko", sector_names: list = Non
         """
 
     instruction = instruction.replace("{sector_constraint}", sector_constraint)
+    instruction += buy_scenario_prompt_contract(language)
 
     return Agent(
         name="trading_scenario_agent",
@@ -1152,7 +1157,7 @@ def create_sell_decision_agent(language: str = "ko"):
 
     return Agent(
         name="sell_decision_agent",
-        instruction=instruction,
+        instruction=instruction + sell_scenario_authority_contract(language),
         # perplexity: 핵심-0 법인 이벤트(상폐/공개매수 등) 뉴스 자율 점검에 필요
         server_names=["kospi_kosdaq", "sqlite", "time", "perplexity"]
     )

--- a/cores/llm/codex_oauth_fast_backend.py
+++ b/cores/llm/codex_oauth_fast_backend.py
@@ -25,7 +25,6 @@ from typing import Literal
 
 from prism_core.codex_config import (
     CodexFastError as CodexFastError,
-    MAX_TIMEOUT_SECONDS as MAX_TIMEOUT_SECONDS,
     SUPPORTED_MODELS as SUPPORTED_MODELS,
     SUPPORTED_REASONING_EFFORTS as SUPPORTED_REASONING_EFFORTS,
     validate_timeout as validate_timeout,
@@ -109,7 +108,10 @@ def _terminate_owned_process(process: subprocess.Popen) -> None:
             if os.name == "posix":
                 os.killpg(process.pid, sig)
             elif process.poll() is None:
-                process.terminate() if sig == signal.SIGTERM else process.kill()
+                if sig == signal.SIGTERM:
+                    process.terminate()
+                else:
+                    process.kill()
         except ProcessLookupError:
             pass
 
@@ -236,7 +238,7 @@ def generate_codex_fast(
                         raise CodexFastError("Codex Fast cancelled")
                     remaining = timeout - (time.monotonic() - started)
                     if remaining <= 0:
-                        raise subprocess.TimeoutExpired(process.args, timeout)
+                        raise CodexFastError(f"Codex Fast timed out after {timeout:g}s")
                     try:
                         stdout, stderr = process.communicate(input=prompt, timeout=min(0.1, remaining))
                         break

--- a/cores/llm/codex_oauth_fast_backend.py
+++ b/cores/llm/codex_oauth_fast_backend.py
@@ -6,10 +6,13 @@ rules.  Trading callers must retain an existing backend as fallback.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import shutil
+import signal
 import stat
+import threading
 
 # Fixed argv, no shell, and a permission-checked executable.
 import subprocess  # nosec B404
@@ -20,8 +23,13 @@ from pathlib import Path
 from typing import Literal
 
 
-class CodexFastError(RuntimeError):
-    pass
+from prism_core.codex_config import (
+    CodexFastError as CodexFastError,
+    MAX_TIMEOUT_SECONDS as MAX_TIMEOUT_SECONDS,
+    SUPPORTED_MODELS as SUPPORTED_MODELS,
+    SUPPORTED_REASONING_EFFORTS as SUPPORTED_REASONING_EFFORTS,
+    validate_timeout as validate_timeout,
+)
 
 
 @dataclass(frozen=True)
@@ -42,7 +50,6 @@ class CodexFastResult:
 
 
 McpProfile = Literal["kr_trading", "us_trading"]
-SUPPORTED_MODELS = frozenset({"gpt-5.6-sol"})
 SUPPORTED_MCP_PROFILES = frozenset({"kr_trading", "us_trading"})
 
 
@@ -67,11 +74,14 @@ def _command(
     codex_bin: str,
     model: str,
     mcp_profile: McpProfile | None,
+    reasoning_effort: str | None = None,
 ) -> list[str]:
     if model not in SUPPORTED_MODELS:
         raise CodexFastError(f"Unsupported Codex model: {model}")
     if mcp_profile is not None and mcp_profile not in SUPPORTED_MCP_PROFILES:
         raise CodexFastError(f"Unsupported Codex MCP profile: {mcp_profile}")
+    if reasoning_effort is not None and reasoning_effort not in SUPPORTED_REASONING_EFFORTS:
+        raise CodexFastError(f"Unsupported Codex reasoning effort: {reasoning_effort}")
     command = [
         codex_bin,
         "exec",
@@ -87,7 +97,37 @@ def _command(
     ]
     if mcp_profile:
         command[2:2] = ["--profile", mcp_profile]
+    if reasoning_effort is not None:
+        command[2:2] = ["-c", f'model_reasoning_effort="{reasoning_effort}"']
     return command
+
+
+def _terminate_owned_process(process: subprocess.Popen) -> None:
+    """Terminate only our new session, including MCP descendants, then reap."""
+    def send(sig: int) -> None:
+        try:
+            if os.name == "posix":
+                os.killpg(process.pid, sig)
+            elif process.poll() is None:
+                process.terminate() if sig == signal.SIGTERM else process.kill()
+        except ProcessLookupError:
+            pass
+
+    send(signal.SIGTERM)
+    # Do not reap the leader until the final group signal: its PID cannot be
+    # reused while it remains our unreaped child. Descendants may ignore TERM.
+    time.sleep(0.2)
+    send(signal.SIGKILL if os.name == "posix" else signal.SIGTERM)
+    if os.name != "posix" and process.poll() is None:
+        process.kill()
+    try:
+        process.communicate(timeout=1)
+    except subprocess.TimeoutExpired:
+        # A detached descendant might retain pipes; never wait on those forever.
+        for pipe in (process.stdin, process.stdout, process.stderr):
+            if pipe is not None:
+                pipe.close()
+        process.wait(timeout=1)
 
 
 def _parse_stream(
@@ -155,12 +195,15 @@ def generate_codex_fast(
     system_prompt: str,
     user_prompt: str,
     model: str = "gpt-5.6-sol",
-    timeout: int = 90,
+    timeout: float = 90,
     codex_bin: str | None = None,
     codex_home: str | None = None,
     mcp_profile: McpProfile | None = None,
     require_mcp_calls: bool = False,
+    reasoning_effort: str | None = None,
+    _cancel_event: threading.Event | None = None,
 ) -> CodexFastResult:
+    timeout = validate_timeout(timeout)
     executable = _resolve_codex_executable(
         codex_bin or os.environ.get("PRISM_CODEX_BIN", "codex")
     )
@@ -174,27 +217,42 @@ def generate_codex_fast(
             # The executable is resolved, permission-checked, and invoked with a
             # fixed argv list. No shell parsing or untrusted option expansion occurs.
             # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args, python.lang.security.audit.dangerous-subprocess-use-audit.dangerous-subprocess-use-audit
-            process = subprocess.run(  # nosec B603
-                _command(executable, model, mcp_profile),  # nosemgrep
-                input=_prompt(system_prompt, user_prompt, mcp_profile),
-                capture_output=True,
+            process = subprocess.Popen(  # nosec B603
+                _command(executable, model, mcp_profile, reasoning_effort),  # nosemgrep
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 text=True,
                 cwd=run_dir,
                 env=environment,
-                timeout=timeout,
-                check=False,
                 # MCP stdio children are managed by Codex. Keep their shutdown
                 # signals out of the long-lived PRISM orchestrator process group.
-                start_new_session=True,
+                start_new_session=os.name == "posix",
             )
+            try:
+                prompt = _prompt(system_prompt, user_prompt, mcp_profile)
+                while True:
+                    if _cancel_event is not None and _cancel_event.is_set():
+                        raise CodexFastError("Codex Fast cancelled")
+                    remaining = timeout - (time.monotonic() - started)
+                    if remaining <= 0:
+                        raise subprocess.TimeoutExpired(process.args, timeout)
+                    try:
+                        stdout, stderr = process.communicate(input=prompt, timeout=min(0.1, remaining))
+                        break
+                    except subprocess.TimeoutExpired:
+                        prompt = None
+            except BaseException:
+                _terminate_owned_process(process)
+                raise
     except (OSError, subprocess.TimeoutExpired) as exc:
         raise CodexFastError(f"Codex Fast unavailable: {exc}") from exc
     latency = time.monotonic() - started
     if process.returncode != 0:
         raise CodexFastError(
-            f"Codex Fast rc={process.returncode}: {process.stderr[-300:]}"
+            f"Codex Fast rc={process.returncode}: {stderr[-300:]}"
         )
-    text, usage, mcp_calls = _parse_stream(process.stdout)
+    text, usage, mcp_calls = _parse_stream(stdout)
     if not text:
         raise CodexFastError("Codex Fast returned no final agent message")
     if require_mcp_calls and not any(
@@ -207,3 +265,25 @@ def generate_codex_fast(
         usage=usage,
         mcp_calls=mcp_calls,
     )
+
+
+async def generate_codex_fast_async(**kwargs) -> CodexFastResult:
+    """Keep the loop responsive and finish child cleanup before cancellation."""
+    cancel_event = threading.Event()
+    worker = asyncio.create_task(asyncio.to_thread(
+        generate_codex_fast, **kwargs, _cancel_event=cancel_event,
+    ))
+    try:
+        return await asyncio.shield(worker)
+    except asyncio.CancelledError:
+        cancel_event.set()
+        while not worker.done():
+            try:
+                await asyncio.shield(worker)
+            except asyncio.CancelledError:
+                continue
+            except Exception:
+                break
+        if worker.done() and not worker.cancelled():
+            worker.exception()
+        raise

--- a/docs/ASTRA_BUY_PREDEPLOYMENT_SAFETY_ko.md
+++ b/docs/ASTRA_BUY_PREDEPLOYMENT_SAFETY_ko.md
@@ -1,0 +1,113 @@
+# Astra BUY 운영 반영 전 안전 계약
+
+## 범위
+
+2026-09-09 사용자 요청에 따른 사전 보강이다. 운영 서버 기준선은 `3b63370d`이다.
+모델·CLI·cron의 운영 전환은 이 변경과 별개다. BTC, 보고서 모델, 매매 점수와
+regime 기준, 계좌별 슬롯·주문 순서는 변경하지 않는다.
+
+검증 후보는 Astra/high/Fast, BUY timeout 240초, 최대 3개 동시 분석이다.
+고정 입력 24회에서 매수 평균 high 44.3초/xhigh 129.1초였고, 별도 MCP 병렬
+시험에서 한국 3건 121.0초, 미국 3건 135.6초를 관측했다. 작은 표본의 기술
+통계이며 수익성·모델 동등성·운영 p95 또는 240초 완료 보장이 아니다.
+
+## 기본값과 설정 분리
+
+`prism_core.codex_config.resolve_buy_codex_settings()`만 BUY 설정을 읽는다.
+
+- `PRISM_BUY_CODEX_MODEL`: 미설정 시 `gpt-5.6-sol`.
+- `PRISM_BUY_CODEX_EFFORT`: 미설정 시 CLI 모델 기본값. 임의 medium으로 표시하지 않는다.
+- `PRISM_BUY_CODEX_TIMEOUT`: 미설정 시 `PRISM_CODEX_FAST_TIMEOUT`, 그것도 없으면 90초.
+- timeout은 유한한 `(0, 600]`초만 허용한다. 모델·effort는 허용 목록으로 검증한다.
+- SELL은 기존 sol, 기존 shared timeout, 기존 implicit effort를 유지한다.
+- Fast는 기존 CLI 명령의 명시 설정을 유지한다. 로그의 모델·effort·tier는 요청값이지
+  실제 backend snapshot이나 청구 tier 확인값이 아니다.
+- 기존 legacy sol fallback과 KR 마지막 보조모델 재시도는 유지한다.
+
+`.env.example`의 새 항목은 주석 상태다. 이 코드를 배포해도 Astra/병렬도3/240초가
+자동으로 활성화되지는 않는다. KR 기본 병렬도4, US 기본2도 보존한다.
+
+## 프로세스 소유권
+
+BUY는 `generate_codex_fast_async()`를 사용한다. 취소 시 thread에 신호를 보내고
+정리가 끝난 후 취소를 전파한다. 동기 함수도 timeout 시 본인이 만든 프로세스 그룹에
+TERM, 짧은 유예, KILL을 적용하고 직접 자식을 회수한다.
+
+- POSIX에서는 `start_new_session`으로 만든 그룹만 종료한다. 다른 PID를 탐색·종료하지 않는다.
+- 반복 취소도 정리를 중단하지 않는다. timeout·취소는 legacy 판단 성공으로 처리하지 않는다.
+- Windows는 직접 자식 정리만 보장한다. 운영 대상 db-server는 Linux다.
+- 모델 호출 timeout은 fallback 재시도까지 포함하는 전체 후보 deadline이 아니다.
+
+KR도 US와 같이 전체 legacy MCP host 수명을 agent-instance lock으로 직렬화한다.
+LLM 대기 동안 DB lock을 유지하지 않는다. 세 Codex 호출이 함께 실패해도 legacy
+host가 동시에 세 개 시작되지 않도록 회귀 테스트한다.
+
+## 매도 우선과 순차 실행
+
+US는 모든 계좌의 `update_holdings()`를 BUY pre-pass 전에 실행한다. 그 후 공유
+분석 계좌를 primary로 복원하고 BUY 분석을 병렬 실행한다. BUY 적용은 기존 보고서
+순서와 계좌별 보유·슬롯·섹터 게이트를 유지한다. 매도 검토가 실패한 계좌의 BUY는
+건너뛰되 다른 계좌의 검토와 기존 위험 관리는 계속한다.
+
+이 변경은 별도 시장/하드스탑 루프를 대체하지 않는다. 다른 루프가 배치 지연의
+위험을 모두 해결한다고 가정하지 않는다.
+
+## 가격 재조회와 원장 독립성
+
+분석 때 확보한 가격을 무조건 최종 BUY 가격으로 재사용하지 않는다.
+
+- KR: 읽기 전용 KIS 시세를 우선하고, 사용할 수 없으면 별도로 조회한 당일 KRX
+  데이터로 simulator-only 경로를 지원한다. 저장된 보유/분석 DB 가격으로 되돌아가지 않는다.
+  KRX 당일 행이 없으면 과거 거래일 값을 임의 허용하지 않는다.
+- US: 계좌별 적용 직전 독립적인 시장 시세를 다시 조회한다. broker intent 생성 전에도
+  엄격한 KIS quote를 읽으며 이전 기준가 `base`로 대체하지 않는다.
+- 유효한 양수·유한수인지 확인하고, 기존 target/stop 관계와 기존 진입 게이트를
+  재검증한다. 새로운 slippage·수익률·나이 임계값은 추가하지 않는다.
+- 목표가·손절가·점수를 시세에 맞춰 유리하게 이동시키지 않는다. 기존 산술 불일치
+  검증도 유지한다. `entry_price`는 검증한 시세와 일치시키고 분석 기준값을 별도로 남긴다.
+- broker 주문 실패나 strict quote 실패로 독립적인 simulator 기록을 취소하지 않는다.
+  유효한 시장 가격 자체를 확보하지 못한 경우는 가격 검증 실패로 처리한다.
+- 기록하는 retrieval/context age와 거래소 데이터 age를 구분한다. provider의 검증 가능한
+  timestamp가 없으면 exchange age는 unknown이다. 재조회가 거래소 실시간성 보장은 아니다.
+
+## 출력·프롬프트 계약
+
+`prism_core.trading_scenario_contract`는 매매 결론·점수를 수정하지 않는다.
+
+- ENTRY는 유한한 양수 가격/손익비 필드와 `stop < fresh price < target`이 필요하다.
+  잘못된 ENTRY는 실패로 식별하고 거래하지 않는다.
+- NO ENTRY의 결측 가격·손익비는 `null`로 보존한다. 메시지·저장 경로가 이를
+  처리하도록 회귀 테스트하며, 검증하지 못한 가격을 0으로 꾸미지 않는다.
+- 저장할 `sell_triggers`는 기존 정책을 참조하는 고정 템플릿으로 제한한다.
+- SELL instruction은 저장된 sell_triggers/hold_conditions/rationale가 참고 근거이며
+  현재 매도·trailing 정책을 덮어쓰지 못함을 명시한다.
+- BUY의 손익비 후보는 기존 문구의 가장 가까운 저항과 그 다음 저항 범위다. floor를
+  통과시키려고 세 번째 저항까지 확장하거나 새 7% trailing/5일선 전량매도 규칙을 만들지 않는다.
+- 데이터 불일치는 기존 기준의 충족 여부에 미치는 영향으로 구분한다. 중요하지 않은
+  차이에 독립적인 감점·차단을 추가하지 않고, 중요한 충돌·결측을 사실처럼 처리하지 않는다.
+
+합성 문구 비교 8회에서 기존·명확화 문구의 결정은 같았다. 따라서 이 명확화가
+수익성이나 진입률을 개선했다는 주장은 하지 않는다. 핵심 기준 완화도 아니다.
+
+## 사전 검증과 운영 체크리스트
+
+1. backend/settings/process-tree timeout·취소 회귀 테스트.
+2. KR/US BUY 설정 변경이 SELL 호출 인자에 영향을 주지 않는지 확인.
+3. 세 동시 실패의 fallback 직렬화, DB lock 해제와 취소 전파 확인.
+4. 모든 US 계좌의 SELL이 지연된 BUY보다 먼저 실행되는지 확인.
+5. 병렬도3·완료 순서 뒤집힘에서도 계좌별 BUY 적용 순서 보존 확인.
+6. fake quote/broker 및 임시 DB로 새 시세·invalid quote·simulator 독립성·null 처리 확인.
+7. KR/US 테스트는 shadowed package 때문에 별도 프로세스에서 실행한다. 테스트에 실제
+   계좌·DB·메시지 발행을 사용하지 않는다.
+8. 운영 적용 때는 clean worktree, 검증 commit, ff-only 배포 계약을 지킨다. 별도 설치한
+   Codex CLI 0.153.4의 OAuth·MCP 동작을 확인한 뒤 해당 바이너리를 명시한다.
+9. BUY 후보값과 KR/US 병렬도3을 명시하되, SELL 기존값과 다른 cron은 유지한다.
+10. 첫 실제 배치의 요청 모델/effort, latency, fallback, quote source/age, 계좌별 SELL
+    선행, 주문 순서를 관측한다. 이는 사전 단위 테스트로 대체할 수 없다.
+
+## 롤백
+
+검증 전에는 운영 변경을 하지 않는다. 향후 전환 후 롤백 시 BUY override 제거 또는
+기존 sol 설정 복원, 기존 Codex 바이너리 및 병렬도 복원으로 모델 경로를 되돌린다.
+이미 생성된 주문·체결·원장은 Git으로 되돌리지 않는다. runtime 설정 백업은 비추적
+안전 경로에 보존하며 보고서/저장소로 비밀값을 복사하지 않는다.

--- a/prism-us/cores/agents/trading_agents.py
+++ b/prism-us/cores/agents/trading_agents.py
@@ -8,6 +8,10 @@ Note: These agents will be integrated in Phase 6 (Trading System).
 """
 
 from mcp_agent.agents.agent import Agent
+from prism_core.trading_scenario_contract import (
+    buy_scenario_prompt_contract,
+    sell_scenario_authority_contract,
+)
 
 # Fallback sector names when dynamic data is not available
 GICS_SECTORS = [
@@ -710,6 +714,7 @@ Prohibited: `"$170"`, `"about $170"`, `"minimum 170"`.
 """
 
     instruction = instruction.replace("{sector_constraint}", sector_constraint)
+    instruction += buy_scenario_prompt_contract(language)
 
     return Agent(
         name="us_trading_scenario_agent",
@@ -1105,7 +1110,7 @@ Trailing Stop %: Bull peak × 0.92 (-8%), Bear/Sideways peak × 0.95 (-5%)
 
     return Agent(
         name="us_sell_decision_agent",
-        instruction=instruction,
+        instruction=instruction + sell_scenario_authority_contract(language),
         # perplexity: 핵심-0 법인 이벤트(상폐/공개매수/파산 등) 뉴스 자율 점검에 필요
         server_names=["yahoo_finance", "sqlite", "time", "perplexity"]
     )

--- a/prism-us/tests/test_us_buy_runtime_safety.py
+++ b/prism-us/tests/test_us_buy_runtime_safety.py
@@ -1,0 +1,441 @@
+from __future__ import annotations
+
+import asyncio
+import builtins
+import io
+import json
+import sqlite3
+import sys
+import types
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import test_us_stock_tracking_agent_process_reports as base
+
+mod = base.us_agent_module
+Agent = base.USStockTrackingAgent
+
+
+@pytest.fixture(autouse=True)
+def offline_transitive_market_data(monkeypatch):
+    import pandas as pd
+    import yfinance as yf
+    ticker = types.SimpleNamespace(info={}, history=lambda *args, **kwargs: pd.DataFrame())
+    monkeypatch.setattr(yf, "Ticker", lambda *args, **kwargs: ticker)
+    monkeypatch.setattr(yf, "download", lambda *args, **kwargs: pd.DataFrame())
+
+
+@pytest.mark.parametrize("value", [None, False, 0, -1, "nan", float("inf"), "bad"])
+def test_invalid_fresh_buy_quote_is_rejected(value):
+    with pytest.raises(ValueError):
+        Agent._validated_buy_quote(value)
+
+
+@pytest.mark.asyncio
+async def test_independent_quote_has_no_previous_close_or_db_fallback(monkeypatch):
+    monkeypatch.setitem(sys.modules, "yfinance", types.SimpleNamespace(
+        Ticker=lambda ticker: types.SimpleNamespace(info={"previousClose": 100})
+    ))
+    agent = Agent.__new__(Agent)
+    with pytest.raises(ValueError):
+        await agent._refresh_buy_quote("AAPL")
+
+
+def make_agent(monkeypatch):
+    agent = Agent.__new__(Agent)
+    agent.account_configs = [
+        {"name": name, "account_key": f"vps:{name}:01", "product": "01", "buy_amount_usd": 1000}
+        for name in ("primary", "secondary")
+    ]
+    agent.active_account = None
+    agent.db_path = ":memory:"
+    agent.conn = sqlite3.connect(":memory:")
+    agent.cursor = agent.conn.cursor()
+    agent.max_slots = 10
+    agent.enable_journal = False
+    agent.update_holdings = AsyncMock(return_value=[])
+    agent._is_ticker_in_holdings = AsyncMock(return_value=False)
+    agent._get_current_slots_count = AsyncMock(return_value=0)
+    agent._check_sector_diversity = AsyncMock(return_value=True)
+    agent._regime_policy_mod = lambda: None
+    agent._buy_floor_regime = lambda: "strong_bull"
+    agent._evaluate_production_buy_gate = MagicMock(return_value={"allowed": True})
+    agent._save_watchlist_item = AsyncMock(return_value=True)
+    agent._link_position_entry_intent = MagicMock()
+    agent._refresh_buy_quote = AsyncMock(return_value=101)
+    base._install_signal_modules(monkeypatch, [], [])
+    monkeypatch.setitem(sys.modules, "reentry_cooldown", types.SimpleNamespace(
+        reentry_block=lambda *args, **kwargs: None,
+        COOLDOWN_LIVE=False, COOLDOWN_RISK_EXIT_LIVE=False,
+    ))
+    for name in ("emit_trading_context", "emit_micro_split_shadow", "emit_fill_reconciliation"):
+        monkeypatch.setattr(mod, name, MagicMock())
+    return agent
+
+
+def core_result(ticker):
+    return {
+        "success": True, "ticker": ticker, "company_name": ticker,
+        "current_price": 100, "decision": "entry", "raw_decision": "entry",
+        "sector": "Technology", "rank_change_msg": "",
+        "scenario": {"decision": "entry", "buy_score": 9, "min_score": 7,
+                     "expected_return_pct": 20, "expected_loss_pct": 10,
+                     "target_price": 120, "stop_loss": 90, "risk_reward_ratio": 2,
+                     "investment_period": "short", "rationale": "test"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_real_failed_holdings_review_excludes_only_failed_account(monkeypatch):
+    agent = make_agent(monkeypatch)
+    agent.update_holdings = Agent.update_holdings.__get__(agent, Agent)
+    agent._get_live_regime_safe = MagicMock(return_value="strong_bull")
+    agent.cursor = MagicMock()
+    agent.cursor.fetchall.return_value = []
+    reviews = []
+
+    def query(sql, params=()):
+        if "FROM us_stock_holdings" in sql:
+            reviews.append(params[0])
+            if params[0] == "vps:primary:01":
+                raise sqlite3.OperationalError("incomplete primary holdings review")
+
+    agent.cursor.execute.side_effect = query
+    agent._analyze_report_core = AsyncMock(return_value=core_result("AAPL"))
+    buys = []
+
+    async def buy(*args, **kwargs):
+        buys.append(agent.active_account["name"])
+        return base.LegacyPositionWriteResult(True, len(buys))
+
+    agent._buy_stock_with_position = buy
+    agent.sell_stock = AsyncMock()
+    monkeypatch.setattr(mod.ExecutionService, "us", MagicMock(side_effect=RuntimeError("no broker")))
+    try:
+        assert await agent.process_reports(["AAPL"]) == (1, 0)
+        assert reviews == ["vps:primary:01", "vps:secondary:01"]
+        assert buys == ["secondary"]
+        agent.sell_stock.assert_not_awaited()
+        # Existing non-batch callers keep the previous empty-list error behavior.
+        agent.active_account = agent.account_configs[0]
+        assert await agent.update_holdings() == []
+    finally:
+        agent.conn.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("broker_quote", [102, None, float("nan"), 125])
+async def test_buy_uses_fresh_quotes_and_preserves_simulator_on_broker_failure(monkeypatch, broker_quote):
+    agent = make_agent(monkeypatch)
+    agent.account_configs = agent.account_configs[:1]
+    agent._analyze_report_core = AsyncMock(return_value=core_result("AAPL"))
+    agent._buy_stock_with_position = AsyncMock(return_value=base.LegacyPositionWriteResult(True, 1))
+
+    broker = MagicMock()
+    broker.get_current_price.return_value = {"current_price": broker_quote}
+    broker.execute_buy = AsyncMock(return_value={"success": True, "message": "fake"})
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=broker)
+    context.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(mod.ExecutionService, "us", MagicMock(return_value=context))
+    try:
+        assert await agent.process_reports(["AAPL"]) == (1, 0)
+        assert agent._buy_stock_with_position.await_args.args[2] == 101
+        assert agent._evaluate_production_buy_gate.call_args_list[0].args[1] == 101
+        if broker_quote == 102:
+            assert broker.execute_buy.await_args.kwargs["limit_price"] == 102
+            assert float(broker.execute_buy.await_args.kwargs["intent"].limit_price) == 102
+        else:
+            broker.execute_buy.assert_not_awaited()
+    finally:
+        agent.conn.close()
+
+
+@pytest.mark.asyncio
+async def test_broker_quote_inside_levels_rechecks_existing_risk_gate(monkeypatch):
+    agent = make_agent(monkeypatch)
+    agent.account_configs = agent.account_configs[:1]
+    analysis = core_result("AAPL")
+    analysis["scenario"].update({
+        "entry_price": 100, "target_price": 110, "stop_loss": 95,
+        "risk_reward_ratio": 2, "expected_return_pct": 10,
+        "expected_loss_pct": 5, "_deterministic_market_regime": "strong_bull",
+    })
+    agent._analyze_report_core = AsyncMock(return_value=analysis)
+    agent._refresh_buy_quote = AsyncMock(return_value=100)
+    agent._buy_stock_with_position = AsyncMock(return_value=base.LegacyPositionWriteResult(True, 1))
+    real_gate = Agent._evaluate_production_buy_gate.__get__(agent, Agent)
+    initial = real_gate(analysis["scenario"], 100, score_override=9, is_add=False)
+    refreshed = real_gate(analysis["scenario"], 106, score_override=9, is_add=False)
+    assert initial["allowed"] is True
+    assert {"rr_below_floor", "stop_exceeds_regime_limit"} <= {
+        finding["code"] for finding in refreshed["findings"]
+    }
+    agent._evaluate_production_buy_gate = MagicMock(wraps=real_gate)
+    broker = MagicMock()
+    broker.get_current_price.return_value = {"current_price": 106}
+    broker.execute_buy = AsyncMock()
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=broker)
+    context.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(mod.ExecutionService, "us", MagicMock(return_value=context))
+    create_intent = MagicMock(side_effect=AssertionError("rejected quote must not create intent"))
+    monkeypatch.setattr(mod.OrderIntent, "create", create_intent)
+    try:
+        assert await agent.process_reports(["AAPL"]) == (1, 0)
+        agent._buy_stock_with_position.assert_awaited_once()
+        assert agent._buy_stock_with_position.await_args.args[2] == 100
+        assert [call.args[1] for call in agent._evaluate_production_buy_gate.call_args_list] == [100, 106]
+        assert agent._evaluate_production_buy_gate.call_args.kwargs == {"score_override": 9, "is_add": False}
+        create_intent.assert_not_called()
+        broker.execute_buy.assert_not_awaited()
+    finally:
+        agent.conn.close()
+
+
+@pytest.mark.asyncio
+async def test_parallel_three_analysis_then_sequential_account_buys_in_input_order(monkeypatch):
+    monkeypatch.setattr(mod, "US_TRADING_ANALYSIS_CONCURRENCY", 3)
+    agent = make_agent(monkeypatch)
+    paths = ["A", "B", "C", "D"]
+    active = peak = 0
+    buys = []
+
+    async def core(path):
+        nonlocal active, peak
+        assert agent.active_account["name"] == "primary"
+        assert agent.update_holdings.await_count == 2
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep({"A": .04, "B": .03, "C": .01, "D": .01}[path])
+        active -= 1
+        return core_result(path)
+
+    async def buy(ticker, *args, **kwargs):
+        assert active == 0
+        buys.append((agent.active_account["name"], ticker))
+        await asyncio.sleep(0)
+        return base.LegacyPositionWriteResult(True, len(buys))
+
+    agent._analyze_report_core = core
+    agent._buy_stock_with_position = buy
+    # Missing broker configuration must not prevent independent simulator buys.
+    monkeypatch.setattr(mod.ExecutionService, "us", MagicMock(side_effect=RuntimeError("no broker")))
+    try:
+        assert await agent.process_reports(paths) == (8, 0)
+        assert peak == 3
+        assert buys == [(account, ticker) for account in ("primary", "secondary") for ticker in paths]
+        assert agent.update_holdings.await_count == 2
+    finally:
+        agent.conn.close()
+
+
+@pytest.mark.asyncio
+async def test_bad_market_quote_blocks_ledger_and_broker(monkeypatch):
+    agent = make_agent(monkeypatch)
+    agent._analyze_report_core = AsyncMock(return_value=core_result("AAPL"))
+    agent._refresh_buy_quote = AsyncMock(side_effect=ValueError("missing quote"))
+    agent._buy_stock_with_position = AsyncMock()
+    broker_factory = MagicMock()
+    monkeypatch.setattr(mod.ExecutionService, "us", broker_factory)
+    try:
+        assert await agent.process_reports(["AAPL"]) == (0, 0)
+        agent._buy_stock_with_position.assert_not_awaited()
+        broker_factory.assert_not_called()
+    finally:
+        agent.conn.close()
+
+
+@pytest.mark.parametrize("last,strict,expected", [("", True, None), ("", False, 100), ("nan", True, None), ("102", True, 102)])
+def test_broker_strict_quote_rejects_base_without_changing_default(monkeypatch, last, strict, expected):
+    original_open = builtins.open
+    def fake_open(path, *args, **kwargs):
+        if str(path).endswith("kis_devlp.yaml"):
+            return io.StringIO("{}")
+        return original_open(path, *args, **kwargs)
+    monkeypatch.setattr(builtins, "open", fake_open)
+    monkeypatch.setitem(sys.modules, "kis_auth", MagicMock())
+    old_path = list(sys.path)
+    try:
+        trading = base._load_module("us_strict_quote_tests", base.PRISM_US_DIR / "trading/us_stock_trading.py")
+    finally:
+        sys.path[:] = old_path
+    trader = trading.USStockTrading.__new__(trading.USStockTrading)
+    response = MagicMock()
+    response.isOK.return_value = True
+    response.getBody.return_value = types.SimpleNamespace(output={"last": last, "base": "100"})
+    trader._request = MagicMock(return_value=response)
+    quote = trader.get_current_price("AAPL", "NASD", strict=strict)
+    assert (quote["current_price"] if quote else None) == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("market_open,reserved_available", [(True, True), (False, True), (False, False)])
+async def test_internal_refetch_cannot_replace_validated_order_limit(monkeypatch, market_open, reserved_available):
+    original_open = builtins.open
+    def fake_open(path, *args, **kwargs):
+        if str(path).endswith("kis_devlp.yaml"):
+            return io.StringIO("{}")
+        return original_open(path, *args, **kwargs)
+    monkeypatch.setattr(builtins, "open", fake_open)
+    monkeypatch.setitem(sys.modules, "kis_auth", MagicMock())
+    old_path = list(sys.path)
+    try:
+        trading = base._load_module("us_validated_limit_tests", base.PRISM_US_DIR / "trading/us_stock_trading.py")
+    finally:
+        sys.path[:] = old_path
+    trader = trading.USStockTrading.__new__(trading.USStockTrading)
+    trader.buy_amount = 1000
+    trader.auto_trading = True
+    trader.mode = "demo"
+    trader.trenv = types.SimpleNamespace(my_acct="fake", my_prod="01")
+    trader._get_stock_lock = AsyncMock(return_value=asyncio.Lock())
+    trader._semaphore = asyncio.Semaphore(1)
+    trader._global_lock = asyncio.Lock()
+    # This later read differs radically from the caller-validated quote.
+    trader.get_current_price = MagicMock(return_value={"current_price": 50})
+    trader.is_market_open = MagicMock(return_value=market_open)
+    trader.is_reserved_order_available = MagicMock(return_value=reserved_available)
+    trader._queue_pending_order = MagicMock(return_value={"success": True, "order_no": "queued"})
+    response = MagicMock()
+    response.isOK.return_value = True
+    response.getBody.return_value = types.SimpleNamespace(output={"ODNO": "fake-order"})
+    trader._request = MagicMock(return_value=response)
+    monkeypatch.setattr(trading.asyncio, "sleep", AsyncMock())
+    result = await trader.async_buy_stock("AAPL", 1000, "NASD", limit_price=100)
+    assert result["success"] is True
+    trader.get_current_price.assert_called_once()
+    if not market_open and not reserved_available:
+        trader._request.assert_not_called()
+        assert trader._queue_pending_order.call_args.kwargs["limit_price"] == 100
+        assert trader._queue_pending_order.call_args.kwargs["buy_amount"] == 1000
+    else:
+        params = trader._request.call_args.args[2]
+        assert params["ORD_QTY" if market_open else "FT_ORD_QTY"] == "10"
+        assert params["OVRS_ORD_UNPR" if market_open else "FT_ORD_UNPR3"] == "100.00"
+
+
+@pytest.mark.asyncio
+async def test_no_entry_null_levels_store_without_quote_or_formatting_failure(monkeypatch):
+    agent = make_agent(monkeypatch)
+    agent.cursor = MagicMock()
+    agent.cursor.lastrowid = 1
+    agent._get_trigger_win_rate = MagicMock(return_value=None)
+    agent._msg_types = []
+    agent.message_queue = []
+    scenario = mod.apply_buy_scenario_contract({
+        "decision": "no_entry", "target_price": None, "stop_loss": None,
+        "risk_reward_ratio": None, "expected_return_pct": None,
+        "expected_loss_pct": None,
+    }, market="US", entry_price=100)
+    try:
+        result = await Agent._save_watchlist_item(
+            agent, "AAPL", "Apple", 100, 5, 7, "no_entry", "not enough evidence", scenario, "Technology"
+        )
+        assert result is True
+        performance_params = agent.cursor.execute.call_args_list[1].args[1]
+        assert performance_params[5] == "NEUTRAL"
+        assert performance_params[6:8] == (None, None)
+        agent._refresh_buy_quote.assert_not_awaited()
+    finally:
+        agent.conn.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("decision,expected_success", [("entry", False), ("no_entry", True)])
+async def test_core_validates_entry_but_preserves_no_entry_nulls(monkeypatch, decision, expected_success):
+    agent = Agent.__new__(Agent)
+    agent._extract_ticker_info = AsyncMock(return_value=("AAPL", "Apple"))
+    agent._get_current_stock_price = AsyncMock(return_value=100)
+    agent._get_trading_value_rank_change = AsyncMock(return_value=(0, ""))
+    scenario = {"decision": decision, "target_price": None, "stop_loss": None,
+                "risk_reward_ratio": None, "expected_return_pct": None,
+                "expected_loss_pct": None}
+    agent._extract_trading_scenario = AsyncMock(return_value=scenario)
+    monkeypatch.setitem(sys.modules, "pdf_converter", types.SimpleNamespace(pdf_to_markdown_text=lambda path: "report"))
+    result = await agent._analyze_report_core("fake.pdf")
+    assert result["success"] is expected_success
+    if expected_success:
+        assert result["scenario"]["target_price"] is None
+        assert result["scenario"]["stop_loss"] is None
+        assert result["analysis_quote_at"] >= result["context_started_at"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancelled", [False, True])
+async def test_us_buy_routes_astra_effort_and_timeout_to_async_backend(monkeypatch, cancelled):
+    agent = make_agent(monkeypatch)
+    agent.active_account = agent.account_configs[0]
+    agent.cursor = MagicMock()
+    agent.cursor.fetchall.return_value = []
+    agent.get_journal_context = MagicMock(return_value="")
+    agent.get_score_adjustment = MagicMock(return_value=(0, []))
+    agent._get_trend_facts = MagicMock(return_value="")
+    agent._stamp_scenario_market_regime = lambda scenario: scenario
+    agent.trading_agent = types.SimpleNamespace(instruction="test instruction")
+    monkeypatch.setenv("PRISM_US_CODEX_FAST_TRADING", "1")
+    monkeypatch.setenv("PRISM_BUY_CODEX_MODEL", "gpt-6-astra")
+    monkeypatch.setenv("PRISM_BUY_CODEX_EFFORT", "high")
+    monkeypatch.setenv("PRISM_BUY_CODEX_TIMEOUT", "180")
+    backend = AsyncMock(return_value=types.SimpleNamespace(
+        text=json.dumps(core_result("AAPL")["scenario"]), latency_s=1, mcp_calls=[{}]
+    ))
+    if cancelled:
+        backend.side_effect = asyncio.CancelledError
+    monkeypatch.setattr(mod, "generate_codex_fast_async", backend)
+    monkeypatch.setattr(mod, "generate_codex_fast", MagicMock(side_effect=AssertionError("BUY must be async")))
+    try:
+        if cancelled:
+            with pytest.raises(asyncio.CancelledError):
+                await agent._extract_trading_scenario("report", ticker="AAPL")
+        else:
+            result = await agent._extract_trading_scenario("report", ticker="AAPL")
+            assert result["decision"] == "entry"
+        assert backend.await_args.kwargs["model"] == "gpt-6-astra"
+        assert backend.await_args.kwargs["reasoning_effort"] == "high"
+        assert backend.await_args.kwargs["timeout"] == 180
+        assert backend.await_args.kwargs["mcp_profile"] == "us_trading"
+    finally:
+        agent.conn.close()
+
+
+@pytest.mark.asyncio
+async def test_failed_codex_preserves_serialized_legacy_fallback(monkeypatch):
+    agent = make_agent(monkeypatch)
+    agent.active_account = agent.account_configs[0]
+    agent.cursor = MagicMock()
+    agent.cursor.fetchall.return_value = []
+    agent.get_journal_context = MagicMock(return_value="")
+    agent.get_score_adjustment = MagicMock(return_value=(0, []))
+    agent._get_trend_facts = MagicMock(return_value="")
+    agent._stamp_scenario_market_regime = lambda scenario: scenario
+    active = peak = 0
+
+    async def legacy(**kwargs):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(.01)
+        active -= 1
+        return json.dumps(core_result("AAPL")["scenario"])
+
+    @asynccontextmanager
+    async def run():
+        yield
+
+    agent.trading_agent = types.SimpleNamespace(
+        instruction="test", attach_llm=AsyncMock(return_value=types.SimpleNamespace(generate_str=legacy))
+    )
+    monkeypatch.setattr(mod, "app", types.SimpleNamespace(run=run))
+    monkeypatch.setenv("PRISM_US_CODEX_FAST_TRADING", "1")
+    monkeypatch.setattr(mod, "generate_codex_fast_async", AsyncMock(side_effect=RuntimeError("unavailable")))
+    try:
+        results = await asyncio.gather(*(agent._extract_trading_scenario("report", ticker=ticker) for ticker in ("A", "B", "C")))
+        assert peak == 1
+        assert all(result["decision"] == "entry" for result in results)
+    finally:
+        agent.conn.close()

--- a/prism-us/tests/test_us_parallel_trading_analysis.py
+++ b/prism-us/tests/test_us_parallel_trading_analysis.py
@@ -50,13 +50,14 @@ def test_us_trading_analysis_concurrency_defaults_to_two() -> None:
 async def test_us_buy_analysis_prepass_is_bounded_and_preserves_input_order(
     monkeypatch,
 ) -> None:
-    monkeypatch.setattr(agent_module, "US_TRADING_ANALYSIS_CONCURRENCY", 2)
+    monkeypatch.setattr(agent_module, "US_TRADING_ANALYSIS_CONCURRENCY", 3)
     agent = _make_agent()
-    paths = ["report-a.pdf", "report-b.pdf", "report-c.pdf"]
+    paths = ["report-a.pdf", "report-b.pdf", "report-c.pdf", "report-d.pdf"]
     delays = {
         "report-a.pdf": 0.04,
         "report-b.pdf": 0.03,
         "report-c.pdf": 0.01,
+        "report-d.pdf": 0.01,
     }
     active = 0
     peak = 0
@@ -87,5 +88,54 @@ async def test_us_buy_analysis_prepass_is_bounded_and_preserves_input_order(
     monkeypatch.setattr(agent_module.logger, "error", capture_error)
 
     assert await agent.process_reports(paths) == (0, 0)
-    assert peak == 2
+    assert peak == 3
     assert failure_order == paths
+
+
+@pytest.mark.asyncio
+async def test_all_account_sells_finish_before_slow_buy_and_primary_context(monkeypatch):
+    agent = _make_agent()
+    agent.account_configs.append({"name": "secondary", "account_key": "vps:secondary:01", "product": "01"})
+    events = []
+    release = asyncio.Event()
+
+    async def sell(**kwargs):
+        events.append(("sell", agent.active_account["name"]))
+        return [{}]
+
+    async def core(path):
+        events.append(("buy_analysis", agent.active_account["name"]))
+        await release.wait()
+        raise ValueError("isolated candidate failure")
+
+    agent.update_holdings = sell
+    agent._analyze_report_core = core
+    task = asyncio.create_task(agent.process_reports(["slow.pdf"]))
+    for _ in range(20):
+        await asyncio.sleep(0)
+        if len(events) == 3:
+            break
+    try:
+        assert events == [("sell", "us-primary"), ("sell", "secondary"), ("buy_analysis", "us-primary")]
+        assert not task.done()
+    finally:
+        release.set()
+    assert await task == (0, 2)
+
+
+@pytest.mark.asyncio
+async def test_failed_sell_review_does_not_skip_other_accounts():
+    agent = _make_agent()
+    agent.account_configs.append({"name": "secondary", "account_key": "vps:secondary:01", "product": "01"})
+    names = []
+
+    async def sell(**kwargs):
+        names.append(agent.active_account["name"])
+        if len(names) == 1:
+            raise RuntimeError("sell review unavailable")
+        return [{}]
+
+    agent.update_holdings = sell
+    agent._analyze_report_core = AsyncMock(return_value={"success": False})
+    assert await agent.process_reports(["report.pdf"]) == (0, 1)
+    assert names == ["us-primary", "secondary"]

--- a/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
+++ b/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
@@ -8,7 +8,8 @@ import threading
 import types
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
+from importlib.machinery import SourceFileLoader
 
 import pytest
 
@@ -115,7 +116,16 @@ def _load_us_agent_module():
         kis_auth_module.get_configured_accounts = lambda **kwargs: []
         sys.modules["trading.kis_auth"] = kis_auth_module
 
-        return _load_module("prism_us_stock_tracking_agent_process_tests", PRISM_US_DIR / "us_stock_tracking_agent.py")
+        original_exec = SourceFileLoader.exec_module
+        def isolated_exec(loader, module):
+            if Path(loader.path).resolve() == (PROJECT_ROOT / "trading/kis_auth.py").resolve():
+                module.getEnv = kis_auth_module.getEnv
+                module.get_configured_accounts = kis_auth_module.get_configured_accounts
+                module.mask_account_number = lambda value: str(value)[:2] + "****" + str(value)[-2:]
+                return
+            original_exec(loader, module)
+        with patch.object(SourceFileLoader, "exec_module", isolated_exec):
+            return _load_module("prism_us_stock_tracking_agent_process_tests", PRISM_US_DIR / "us_stock_tracking_agent.py")
     finally:
         sys.path[:] = original_sys_path
         for key, original in original_modules.items():
@@ -127,6 +137,23 @@ def _load_us_agent_module():
 
 us_agent_module = _load_us_agent_module()
 USStockTrackingAgent = us_agent_module.USStockTrackingAgent
+
+@pytest.fixture(autouse=True)
+def isolated_fresh_quotes(monkeypatch):
+    import pandas as pd
+    import yfinance as yf
+
+    class OfflineTicker:
+        info = {"regularMarketPrice": 180.5}
+
+        def history(self, *args, **kwargs):
+            return pd.DataFrame()
+
+    monkeypatch.setattr(yf, "Ticker", lambda *args, **kwargs: OfflineTicker())
+    monkeypatch.setattr(yf, "download", lambda *args, **kwargs: pd.DataFrame())
+    async def quote(self, ticker):
+        return 180.5 if ticker == "AAPL" else 100.0
+    monkeypatch.setattr(USStockTrackingAgent, "_refresh_buy_quote", quote)
 
 from prism_core.positions import LegacyPositionWriteResult
 
@@ -160,6 +187,9 @@ class _FakeAsyncUSTradingContext:
 
     async def __aexit__(self, exc_type, exc, tb):
         return False
+
+    def get_current_price(self, ticker, **kwargs):
+        return {"current_price": 180.5}
 
     async def async_buy_stock(self, ticker, limit_price=None, buy_amount=None):
         # buy_amount mirrors the real USStockTrading.async_buy_stock signature
@@ -610,6 +640,7 @@ def _install_signal_modules(monkeypatch, redis_calls, gcp_calls):
 
 
 def _install_us_trading_module(monkeypatch):
+    monkeypatch.setattr(USStockTrackingAgent, "_refresh_buy_quote", AsyncMock(return_value=180.5))
     module = types.ModuleType("trading.us_stock_trading")
     module.AsyncUSTradingContext = _FakeAsyncUSTradingContext
     monkeypatch.setitem(sys.modules, "trading.us_stock_trading", module)
@@ -667,6 +698,8 @@ async def test_process_reports_analyzes_once_and_dedupes_signals(
             "company_name": "Apple Inc.",
             "current_price": 180.5,
             "scenario": {
+                "decision": "entry", "expected_return_pct": (198 - 180.5) / 180.5 * 100,
+                "expected_loss_pct": (180.5 - 170) / 180.5 * 100,
                 "buy_score": 8, "min_score": 7, "sector": "Technology",
                 "target_price": 198.0, "stop_loss": 170.0,
                 "risk_reward_ratio": 1.75,
@@ -678,7 +711,7 @@ async def test_process_reports_analyzes_once_and_dedupes_signals(
             "rank_change_percentage": 9.0,
         }
 
-    async def fake_update_holdings():
+    async def fake_update_holdings(**kwargs):
         return []
 
     async def fake_is_ticker_in_holdings(ticker):
@@ -827,6 +860,8 @@ async def test_sideways_uptrend_score_six_uses_half_size_us_order(monkeypatch, t
             "company_name": "Apple Inc.",
             "current_price": 180.5,
             "scenario": {
+                "decision": "entry", "expected_return_pct": (200 - 180.5) / 180.5 * 100,
+                "expected_loss_pct": (180.5 - 170) / 180.5 * 100,
                 "buy_score": 6,
                 "min_score": 5,
                 "sector": "Technology",
@@ -913,6 +948,7 @@ async def test_process_reports_applies_macro_adjustment_to_final_score(
             "company_name": "Lagging Inc.",
             "current_price": 100.0,
             "scenario": {
+                "decision": "entry", "expected_return_pct": 15, "expected_loss_pct": 5,
                 "buy_score": 5,
                 "macro_adjustment": -1,
                 "effective_score": 4,
@@ -992,7 +1028,7 @@ async def test_process_reports_saves_watchlist_once_when_not_traded(monkeypatch)
             "rank_change_percentage": 1.0,
         }
 
-    async def fake_update_holdings():
+    async def fake_update_holdings(**kwargs):
         return []
 
     async def fake_is_ticker_in_holdings(ticker):

--- a/prism-us/trading/us_stock_trading.py
+++ b/prism-us/trading/us_stock_trading.py
@@ -383,13 +383,14 @@ class USStockTrading:
         )
         return "NYSE"
 
-    def get_current_price(self, ticker: str, exchange: str = None) -> Optional[Dict[str, Any]]:
+    def get_current_price(self, ticker: str, exchange: str = None, *, strict: bool = False) -> Optional[Dict[str, Any]]:
         """
         Get current market price for US stock
 
         Args:
             ticker: Stock ticker symbol (e.g., "AAPL", "MSFT")
             exchange: Exchange code (NASD, NYSE, AMEX) - auto-detected if not provided
+            strict: Require a finite positive last quote, without previous-close fallback.
 
         Returns:
             {
@@ -428,6 +429,9 @@ class USStockTrading:
                 current_price = _safe_float(data.get('last'))
 
                 # When market is closed, 'last' is empty; fall back to 'base' (previous day close)
+                if strict and (not math.isfinite(current_price) or current_price <= 0):
+                    logger.warning(f"[{ticker}] Fresh BUY quote unavailable; rejecting base-price fallback")
+                    return None
                 if current_price <= 0:
                     base_price = _safe_float(data.get('base'))
                     if base_price > 0:

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -25,10 +25,12 @@ import asyncio
 from contextlib import asynccontextmanager
 import json
 import logging
+import math
 import os
 import re
 import sqlite3
 import sys
+import time
 import traceback
 import importlib.util as _ilu
 from datetime import datetime
@@ -126,6 +128,7 @@ _codex_mod = _ilu.module_from_spec(_codex_spec)
 sys.modules[_codex_spec.name] = _codex_mod
 _codex_spec.loader.exec_module(_codex_mod)  # type: ignore[union-attr]
 generate_codex_fast = _codex_mod.generate_codex_fast
+generate_codex_fast_async = _codex_mod.generate_codex_fast_async
 del _ilu, _spec, _mod, _codex_spec, _codex_mod
 
 # Import US-specific modules
@@ -162,6 +165,9 @@ def _import_from_main_cores(module_name: str, relative_path: str):
     spec.loader.exec_module(module)
     return module
 
+
+from prism_core.codex_config import resolve_buy_codex_settings
+from prism_core.trading_scenario_contract import apply_buy_scenario_contract
 
 # Pre-load telegram_translator_agent from main project (used in multiple methods)
 _translator_module = _import_from_main_cores(
@@ -1399,13 +1405,13 @@ class USStockTrackingAgent:
                     )
                     if not instruction:
                         raise RuntimeError("trading agent instruction unavailable")
-                    timeout = int(os.environ.get("PRISM_CODEX_FAST_TIMEOUT", "90"))
-                    codex_result = await asyncio.to_thread(
-                        generate_codex_fast,
+                    settings = resolve_buy_codex_settings()
+                    codex_result = await generate_codex_fast_async(
                         system_prompt=instruction,
                         user_prompt=prompt_message,
-                        model="gpt-5.6-sol",
-                        timeout=timeout,
+                        model=settings.model,
+                        reasoning_effort=settings.reasoning_effort,
+                        timeout=settings.timeout,
                         mcp_profile="us_trading",
                         require_mcp_calls=True,
                     )
@@ -1415,11 +1421,15 @@ class USStockTrackingAgent:
                     )
                     logger.info(
                         "[CODEX_FAST] US scenario ticker=%s latency_s=%.2f "
-                        "parse_ok=%s mcp_calls=%s",
+                        "parse_ok=%s mcp_calls=%s requested_model=%s "
+                        "requested_effort=%s fast=true timeout_s=%s",
                         ticker_tag,
                         codex_result.latency_s,
                         scenario_json is not None,
                         len(codex_result.mcp_calls),
+                        settings.model,
+                        settings.reasoning_effort or "model_default",
+                        settings.timeout,
                     )
                     if scenario_json is None:
                         logger.warning(
@@ -1525,6 +1535,7 @@ class USStockTrackingAgent:
         """
         try:
             logger.info(f"Starting report analysis: {pdf_report_path}")
+            context_started_at = time.monotonic()
 
             ticker, company_name = await self._extract_ticker_info(pdf_report_path)
             if not ticker or not company_name:
@@ -1534,6 +1545,7 @@ class USStockTrackingAgent:
             db_lock = self._get_db_lock()
             async with db_lock:
                 current_price = await self._get_current_stock_price(ticker)
+            analysis_quote_at = time.monotonic()
             if current_price <= 0:
                 logger.error(f"{ticker} current price query failed")
                 return {"success": False, "error": "Current price query failed"}
@@ -1568,6 +1580,9 @@ class USStockTrackingAgent:
                 return {"success": False, "error": "analysis_failed",
                         "ticker": ticker, "company_name": company_name}
 
+            scenario = apply_buy_scenario_contract(
+                scenario, market="US", entry_price=current_price
+            )
             raw_decision = scenario.get("decision", "no_entry")
             sector = scenario.get("sector", "Unknown")
 
@@ -1576,6 +1591,8 @@ class USStockTrackingAgent:
                 "ticker": ticker,
                 "company_name": company_name,
                 "current_price": current_price,
+                "context_started_at": context_started_at,
+                "analysis_quote_at": analysis_quote_at,
                 "scenario": scenario,
                 "decision": self._normalize_decision(raw_decision),
                 "raw_decision": raw_decision,
@@ -1588,6 +1605,27 @@ class USStockTrackingAgent:
             logger.error(f"[ANALYSIS_FAILED] Error analyzing report ({pdf_report_path}): {str(e)}")
             logger.error(traceback.format_exc())
             return {"success": False, "error": str(e)}
+
+    async def _refresh_buy_quote(self, ticker: str) -> float:
+        """Fetch independent market data, never a saved/previous-close fallback."""
+        def fetch() -> float:
+            import yfinance as yf
+            value = yf.Ticker(ticker).info.get("regularMarketPrice")
+            return self._validated_buy_quote(value)
+
+        return await asyncio.to_thread(fetch)
+
+    @staticmethod
+    def _validated_buy_quote(value: Any) -> float:
+        if isinstance(value, bool):
+            raise ValueError("Invalid fresh BUY quote")
+        try:
+            price = float(value)
+        except (TypeError, ValueError) as error:
+            raise ValueError("Invalid fresh BUY quote") from error
+        if not math.isfinite(price) or price <= 0:
+            raise ValueError("Invalid fresh BUY quote")
+        return price
 
     async def analyze_report(self, pdf_report_path: str) -> Dict[str, Any]:
         """
@@ -2037,7 +2075,7 @@ class USStockTrackingAgent:
                     company_name,
                     now,
                     current_price,
-                    'UP' if target_price > current_price else 'DOWN' if target_price < current_price else 'NEUTRAL',
+                    'UP' if target_price is not None and target_price > current_price else 'DOWN' if target_price is not None and target_price < current_price else 'NEUTRAL',
                     target_price,
                     stop_loss,
                     buy_score,
@@ -3226,9 +3264,12 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
             logger.error(traceback.format_exc())
             return False
 
-    async def update_holdings(self) -> List[Dict[str, Any]]:
+    async def update_holdings(self, *, raise_on_error: bool = False) -> List[Dict[str, Any]]:
         """
         Update holdings information and make sell decisions.
+
+        Args:
+            raise_on_error: Propagate incomplete reviews to batch BUY admission.
 
         Returns:
             List[Dict]: List of sold stock information
@@ -3561,6 +3602,8 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
         except Exception as e:
             logger.error(f"Error updating holdings: {str(e)}")
             logger.error(traceback.format_exc())
+            if raise_on_error:
+                raise
             return []
 
     async def generate_report_summary(self) -> str:
@@ -3733,6 +3776,23 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
             sell_count = 0
             signaled_tickers: set[str] = set()
             analysis_states: list[dict[str, Any]] = []
+            reviewed_accounts = []
+
+            # Complete every account's risk exits before starting costly BUY LLMs.
+            for account in self.account_configs:
+                self._set_active_account(account)
+                try:
+                    sold_stocks = await self.update_holdings(raise_on_error=True)
+                except Exception:
+                    logger.exception("US sell review failed account=%s; skipping its buys",
+                                     self._safe_account_log_label(account))
+                    continue
+                reviewed_accounts.append(account)
+                sell_count += len(sold_stocks)
+                logger.info("US sell review complete account=%s sold=%s",
+                            self._safe_account_log_label(account), len(sold_stocks))
+            # Shared BUY context always belongs to the primary account.
+            self._set_active_account(self.account_configs[0])
 
             concurrency = max(
                 1,
@@ -3782,19 +3842,10 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     }
                 )
 
-            for account in self.account_configs:
+            for account in reviewed_accounts:
                 self._set_active_account(account)
                 label = self._safe_account_log_label(account)
                 logger.info(f"Processing US reports for account {label}")
-
-                # Update existing holdings and make sell decisions
-                sold_stocks = await self.update_holdings()
-                sell_count += len(sold_stocks)
-
-                if sold_stocks:
-                    logger.info(f"{len(sold_stocks)} stocks sold for {label}")
-                else:
-                    logger.info(f"No stocks sold for {label}")
 
                 for state in analysis_states:
                     analysis_result = state["analysis"]
@@ -3807,6 +3858,28 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     analysis_result["scenario"] = scenario
                     sector = analysis_result.get("sector", "Unknown")
                     rank_change_msg = analysis_result.get("rank_change_msg", "")
+
+                    if analysis_result.get("decision") == "entry":
+                        # Independent of KIS; never use saved analysis prices for
+                        # account-specific gates or the simulator entry ledger.
+                        try:
+                            current_price = await self._refresh_buy_quote(ticker)
+                            scenario = apply_buy_scenario_contract(
+                                scenario, market="US", entry_price=current_price
+                            )
+                            now = time.monotonic()
+                            logger.info(
+                                "[BUY_QUOTE][US] ticker=%s context_age_s=%s "
+                                "analysis_quote_retrieval_age_s=%s fresh_price=%s "
+                                "exchange_quote_age=unknown",
+                                ticker,
+                                now - analysis_result["context_started_at"] if "context_started_at" in analysis_result else None,
+                                now - analysis_result["analysis_quote_at"] if "analysis_quote_at" in analysis_result else None,
+                                current_price,
+                            )
+                        except Exception as quote_error:
+                            logger.warning("[BUY_QUOTE][US] skipping %s: %s", ticker, quote_error)
+                            continue
 
                     # Pyramiding (#288): allow an additional independent entry for a
                     # held ticker only when the strong-bull add-gate passes. Otherwise
@@ -4130,27 +4203,46 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                                     opened_position_id = legacy_position_id(
                                         "US", buy_result.legacy_holding_id
                                     )
-                                    order_intent = OrderIntent.create(
-                                        market="US",
-                                        account_id=account_key,
-                                        symbol=ticker,
-                                        side="buy",
-                                        order_style="smart",
-                                        source="us_batch",
-                                        source_decision_id=source_decision_id,
-                                        source_position_id=opened_position_id,
-                                        cash_amount=entry_cash_amount,
-                                        limit_price=current_price,
-                                        reason="AI analysis entry",
-                                    )
                                     async with ExecutionService.us(
                                         account_name=account["name"],
                                         db_path=self.db_path,
                                     ) as trading:
+                                        quote = await asyncio.to_thread(trading.get_current_price, ticker, strict=True)
+                                        broker_price = self._validated_buy_quote(
+                                            quote.get("current_price") if isinstance(quote, dict) else None
+                                        )
+                                        apply_buy_scenario_contract(
+                                            scenario, market="US", entry_price=broker_price
+                                        )
+                                        broker_gate = self._evaluate_production_buy_gate(
+                                            scenario,
+                                            broker_price,
+                                            score_override=adjusted_score,
+                                            is_add=is_add,
+                                        )
+                                        if not broker_gate.get("allowed", False):
+                                            raise ValueError(
+                                                "Fresh broker BUY gate rejected: "
+                                                + str(broker_gate.get("reason", "blocked"))
+                                            )
+                                        logger.info("[BUY_QUOTE][US] broker ticker=%s price=%s exchange_quote_age=unknown", ticker, broker_price)
+                                        order_intent = OrderIntent.create(
+                                            market="US",
+                                            account_id=account_key,
+                                            symbol=ticker,
+                                            side="buy",
+                                            order_style="smart",
+                                            source="us_batch",
+                                            source_decision_id=source_decision_id,
+                                            source_position_id=opened_position_id,
+                                            cash_amount=entry_cash_amount,
+                                            limit_price=broker_price,
+                                            reason="AI analysis entry",
+                                        )
                                         trade_result = await trading.execute_buy(
                                             ticker=ticker,
                                             buy_amount=entry_cash_amount,
-                                            limit_price=current_price,
+                                            limit_price=broker_price,
                                             intent=order_intent,
                                         )
 

--- a/prism_core/codex_config.py
+++ b/prism_core/codex_config.py
@@ -1,0 +1,49 @@
+"""BUY-only Codex settings; SELL callers deliberately do not use these."""
+from __future__ import annotations
+
+import math
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+
+class CodexFastError(RuntimeError):
+    pass
+
+
+SUPPORTED_MODELS = frozenset({"gpt-5.6-sol", "gpt-6-astra"})
+SUPPORTED_REASONING_EFFORTS = frozenset({"low", "medium", "high", "xhigh", "max", "ultra"})
+MAX_TIMEOUT_SECONDS = 600
+
+
+def validate_timeout(value: object) -> float:
+    """Bound runtime to (0, 600] seconds; reject non-finite configuration."""
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise CodexFastError("Codex timeout must be a finite number in (0, 600]") from exc
+    if isinstance(value, bool) or not math.isfinite(timeout) or not 0 < timeout <= MAX_TIMEOUT_SECONDS:
+        raise CodexFastError("Codex timeout must be a finite number in (0, 600]")
+    return timeout
+
+
+@dataclass(frozen=True)
+class BuyCodexSettings:
+    model: str
+    reasoning_effort: str | None
+    timeout: float
+
+
+def resolve_buy_codex_settings(environ: Mapping[str, str] | None = None) -> BuyCodexSettings:
+    """Resolve explicit BUY overrides; timeouts are finite and at most 600s."""
+    env = os.environ if environ is None else environ
+    model = env.get("PRISM_BUY_CODEX_MODEL", "gpt-5.6-sol")
+    effort = env.get("PRISM_BUY_CODEX_EFFORT")
+    if model not in SUPPORTED_MODELS:
+        raise CodexFastError(f"Unsupported Codex model: {model}")
+    if effort is not None and effort not in SUPPORTED_REASONING_EFFORTS:
+        raise CodexFastError(f"Unsupported Codex reasoning effort: {effort}")
+    timeout = validate_timeout(env.get(
+        "PRISM_BUY_CODEX_TIMEOUT", env.get("PRISM_CODEX_FAST_TIMEOUT", "90"),
+    ))
+    return BuyCodexSettings(model, effort, timeout)

--- a/prism_core/trading_scenario_contract.py
+++ b/prism_core/trading_scenario_contract.py
@@ -1,0 +1,157 @@
+"""BUY output boundary: data validity and existing SELL-policy authority.
+
+This module does not score candidates, change entry thresholds, or execute orders.
+Missing NO ENTRY prices stay missing. ENTRY must carry executable numeric levels.
+"""
+from __future__ import annotations
+
+import copy
+import math
+from typing import Any
+
+_NUMBERS = ('entry_price', 'target_price', 'stop_loss', 'risk_reward_ratio',
+            'expected_return_pct', 'expected_loss_pct')
+_ENTRY = {'진입', '매수', 'enter', 'entry', 'buy', 'yes'}
+_NO_ENTRY = {'미진입', '관망', '보류', '패스', 'skip', 'no entry', 'no_entry',
+             'no-entry', 'no', 'pass', 'watch', 'hold'}
+
+# These are the existing BUY prompt's policy template, not model-generated rules.
+# Detailed trailing parameters remain owned by the live SELL instruction/state.
+_SELL_TRIGGERS_KO = (
+    ('익절 마일스톤: 목표가·주요 저항선 도달은 자동 매도 명령이 아닙니다. '
+    'parabolic/strong_bull/moderate_bull에서는 추세가 유지되면 보유하고 '
+    '현재 매도 에이전트의 trailing stop 규율을 적용합니다. '
+    'sideways/moderate_bear/strong_bear에서는 기존 익절 규율을 적용합니다.'),
+    ('추세 약화: 기존 종가·거래량·섹터/시장 조건에 따른 매도 에이전트의 규율을 적용합니다. '
+    '매수 시나리오의 자유서술로 새로운 단독 매도 조건을 만들지 않습니다.'),
+    '하드 스탑: 종가 기준 stop_loss 이탈로 판단하며 장중 wick만으로 매도하지 않습니다.',
+    ('오닐 절대 손절: 종가 기준 매수가 대비 -7% 손실 기준과 기존 매도 에이전트의 '
+    '명시적인 우선순위·예외 규율을 적용합니다.'),
+    '시간 점검: 보유 일수는 추세 점검 시점이지 독립적인 자동 매도 트리거가 아닙니다.',
+)
+_SELL_TRIGGERS_EN = (
+    ('Target/resistance is a milestone, not an unconditional sell order. In '
+    'parabolic/strong_bull/moderate_bull retain intact trends and use the live '
+    'SELL agent trailing policy; otherwise use its existing profit-taking policy.'),
+    ('Trend weakening follows the existing SELL closing-price, volume and '
+    'sector/market rules. BUY free text cannot create a new standalone exit rule.'),
+    'Hard stop uses completed close below stop_loss, never an intraday wick alone.',
+    ('Apply the existing SELL absolute closing-loss -7% rule and its explicit '
+    'priority/exception contract, without deriving a new trailing percentage.'),
+    'Holding time is a trend-review checkpoint, not an automatic exit trigger.',
+)
+
+
+def _number(value: Any, field: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+        raise ValueError(f'scenario invalid number: {field}')  # noqa: TRY004 — uniform validation boundary
+    try:
+        result = float(value.replace(',', '').strip() if isinstance(value, str) else value)
+    except (ValueError, OverflowError) as exc:
+        raise ValueError(f'scenario invalid number: {field}') from exc
+    if not math.isfinite(result):
+        raise ValueError(f'scenario nonfinite number: {field}')
+    return result
+
+
+def format_optional_number(value: Any, format_spec: str = ',.0f', *, missing: str = '미확인') -> str:
+    """Render missing values honestly rather than formatting None or inventing 0."""
+    try:
+        number = _number(value, 'display')
+    except ValueError:
+        return missing
+    return missing if number is None else format(number, format_spec)
+
+
+def apply_buy_scenario_contract(scenario: dict, *, market: str, entry_price: Any) -> dict:
+    """Copy, normalize and validate a BUY scenario; never weaken an entry gate.
+
+    Call again with a refreshed execution quote before an ENTRY is applied.
+    The decision and scores are untouched. The SELL policy template is installed
+    independently of LLM prose; no new trading rule is inferred from that prose.
+    """
+    if not isinstance(market, str) or market.upper() not in {'KR', 'US'} or not isinstance(scenario, dict):
+        raise ValueError('scenario invalid market or object')
+    decision = scenario.get('decision')
+    if not isinstance(decision, str) or decision.strip().lower() not in _ENTRY | _NO_ENTRY:
+        raise ValueError('scenario invalid decision')
+    entering = decision.strip().lower() in _ENTRY
+    result = copy.deepcopy(scenario)
+    for field in _NUMBERS:
+        result[field] = _number(result.get(field), field)
+    if entering:
+        price = _number(entry_price, 'execution_price')
+        if price is None or price <= 0:
+            raise ValueError('scenario invalid execution price')
+        reference = result['entry_price']
+        if reference is not None and not (
+            result['stop_loss'] is not None and result['target_price'] is not None
+            and result['stop_loss'] < reference < result['target_price']
+        ):
+            raise ValueError('scenario invalid reported entry price')
+        result.setdefault('_analysis_entry_price', reference if reference is not None else price)
+        result['entry_price'] = price
+        if any(result[field] is None or result[field] <= 0 for field in _NUMBERS):
+            raise ValueError('scenario ENTRY requires positive price/risk numbers')
+        if not result['stop_loss'] < price < result['target_price']:
+            raise ValueError('scenario ENTRY price must lie between stop and target')
+    scenarios = result.get('trading_scenarios')
+    if scenarios is None:
+        scenarios = {}
+    if not isinstance(scenarios, dict):
+        raise ValueError('scenario invalid trading_scenarios object')  # noqa: TRY004 — uniform validation boundary
+    korean = any('\uac00' <= ch <= '\ud7a3' for ch in decision)
+    scenarios['sell_triggers'] = list(_SELL_TRIGGERS_KO if korean else _SELL_TRIGGERS_EN)
+    result['trading_scenarios'] = scenarios
+    result['_scenario_contract_version'] = 'buy-scenario-v1'
+    return result
+
+
+def buy_scenario_prompt_contract(language: str = 'ko') -> str:
+    if language == 'en':
+        return '''
+## Output and evidence contract
+- Include entry_price. For ENTRY all price/risk fields must be finite positive numbers.
+  For NO ENTRY, unknown price/risk fields may be null; do not invent zero or a price.
+- A same-basis discrepancy that cannot change an existing gate is not an independent
+  rejection/score penalty. Explain material uncertainty only for the affected data
+  and dependent existing gates; never choose a convenient value or invent missing facts.
+- R/R candidates use the nearest major resistance and the next resistance only.
+  Do not reach past both to a third resistance merely to pass the existing R/R floor.
+- sell_triggers must use the supplied policy template. Do not add highest-close 7%
+  trailing, 5-day MA full exits, or convert a report's partial-exit idea into a rule.
+  BUY prose cannot override the existing live SELL policy or adjustment rules.
+'''
+    return '''
+## 출력·근거 계약
+- entry_price를 포함하세요. 진입이면 가격·손익비 필드는 유한한 양수여야 합니다.
+  미진입에서 확인할 수 없는 가격·손익비 필드는 null로 두고 0이나 가격을 꾸미지 마세요.
+- 동일 기준의 값 차이가 기존 기준의 충족 여부를 바꾸지 않는다면 독립적인 감점·미진입
+  사유로 삼지 마세요. 중요한 불확실성은 충돌 지표와 그 값에 직접 의존하는 기존 기준에
+  한정해 설명하세요. 유리한 값을 임의 선택하거나 결측을 사실로 만들지 마세요.
+- 손익비 후보는 가장 가까운 주요 저항과 그 다음 저항까지입니다. 기존 손익비 기준을
+  통과시키려고 두 후보를 건너뛰어 세 번째 저항까지 확장하지 마세요.
+- sell_triggers는 제공된 정책 템플릿을 따르세요. 최고 종가 대비 7% trailing이나 5일선
+  단독 전량매도 규칙을 추가하거나 보고서의 부분축소 아이디어를 전량매도 규칙으로
+  바꾸지 마세요. 매수 자유서술은 기존 매도·손절 조정 규율보다 우선하지 않습니다.
+'''
+
+
+def sell_scenario_authority_contract(language: str = 'ko') -> str:
+    if language == 'en':
+        return '''
+## Stored BUY scenario authority
+Stored sell_triggers, hold_conditions, rationale and reports are advisory evidence,
+not policy. If they conflict with this live SELL instruction, follow this instruction
+and current supplied state. Do not adopt a different trailing basis/percentage or a
+new standalone moving-average exit from BUY free text. Existing SELL rules are unchanged.
+'''
+    return '''
+## 저장된 매수 시나리오의 권한
+저장된 sell_triggers·hold_conditions·rationale·보고서는 참고 근거이지 정책이 아닙니다.
+현재 매도 지침과 충돌하면 현재 매도 지침과 제공된 상태를 우선하세요. 매수 자유서술에서
+다른 trailing 기준·비율이나 새로운 단독 이동평균선 매도 규칙을 가져오지 마세요.
+기존 매도 기준과 명시된 예외는 그대로 적용합니다.
+'''

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -18,6 +18,8 @@ import asyncio
 from contextlib import asynccontextmanager
 import json
 import logging
+import math
+import time
 import os
 import sqlite3
 import sys
@@ -45,7 +47,9 @@ logger = logging.getLogger(__name__)
 from mcp_agent.app import MCPApp
 from mcp_agent.workflows.llm.augmented_llm import RequestParams
 from cores.llm.openai_responses_llm import OpenAIResponsesLLM as OpenAIAugmentedLLM
-from cores.llm.codex_oauth_fast_backend import generate_codex_fast
+from cores.llm.codex_oauth_fast_backend import generate_codex_fast_async
+from prism_core.codex_config import resolve_buy_codex_settings
+from prism_core.trading_scenario_contract import apply_buy_scenario_contract
 
 # Core agent imports
 from cores.openai_error_logging import log_openai_error
@@ -662,6 +666,82 @@ class StockTrackingAgent:
             self._db_lock = lock
         return lock
 
+    def _get_legacy_fallback_lock(self) -> asyncio.Lock:
+        """Serialize the complete legacy MCP host lifecycle, not database reads."""
+        lock = getattr(self, "_legacy_fallback_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._legacy_fallback_lock = lock
+        return lock
+
+    async def _get_fresh_buy_quote(self, ticker: str) -> Dict[str, Any]:
+        """Read-only quote retrieval; never use a persisted holding/analysis price."""
+        try:
+            from trading.domestic_stock_trading import AsyncTradingContext
+            account = getattr(self, "active_account", None) or {}
+            async with AsyncTradingContext(account_name=account.get("name")) as trading:
+                info = await asyncio.to_thread(trading.get_current_price, ticker)
+            price = float((info or {}).get("current_price") or 0)
+            if math.isfinite(price) and price > 0:
+                return {"price": price, "source": "kis_quote", "provider_date": None,
+                        "retrieved_at_monotonic": time.monotonic()}
+        except Exception as exc:
+            logger.warning("[BUY_QUOTE][KR] %s KIS unavailable: %s", ticker, type(exc).__name__)
+
+        # Independent market data keeps simulator BUYs independent of broker
+        # initialization/order success. Only today's row is accepted, not the
+        # nearest prior session or the database fallback used during analysis.
+        from zoneinfo import ZoneInfo
+        from krx_data_client import get_market_ohlcv_by_date
+        day = datetime.now(ZoneInfo("Asia/Seoul")).strftime("%Y%m%d")
+        frame = await asyncio.to_thread(get_market_ohlcv_by_date, day, day, ticker)
+        if frame.empty or frame.index[-1].strftime("%Y%m%d") != day:
+            raise ValueError("fresh BUY quote provider date is not today")
+        provider_day = frame.index[-1].strftime("%Y%m%d")
+        price = float(frame.iloc[-1]["Close"])
+        if not math.isfinite(price) or price <= 0:
+            raise ValueError("fresh BUY quote invalid")
+        return {"price": price, "source": "krx_same_day_close", "provider_date": provider_day,
+                "retrieved_at_monotonic": time.monotonic()}
+
+    def _buy_quote_validator(self, scenario, *, is_add=False):
+        """Revalidate the broker's final sizing quote without changing ledger state."""
+        def validate(price):
+            normalized = apply_buy_scenario_contract(scenario, market="KR", entry_price=price)
+            gate = self._evaluate_production_buy_gate(
+                normalized, price, score_override=scenario.get("buy_score"), is_add=is_add
+            )
+            if not gate.get("allowed"):
+                raise ValueError(f"broker quote gate: {gate.get('reason', 'blocked')}")
+        return validate
+
+    async def _refresh_buy_boundary(self, ticker, scenario, analysis_result, *, buy_score, is_add=False):
+        """Refresh price and rerun existing checks immediately before entry effects."""
+        quote = await self._get_fresh_buy_quote(ticker)
+        price = float(quote["price"])
+        if not math.isfinite(price) or price <= 0:
+            raise ValueError("fresh BUY quote invalid")
+        now = time.monotonic()
+        captured = analysis_result.get("quote_captured_at_monotonic")
+        logger.info(
+            "[BUY_QUOTE][KR] ticker=%s source=%s provider_date=%s "
+            "analysis_context_age_s=%s retrieval_age_s=%.3f exchange_age_s=unknown",
+            ticker, quote["source"], quote.get("provider_date"),
+            round(now - captured, 3) if captured is not None else "unknown",
+            now - quote["retrieved_at_monotonic"],
+        )
+        # Validate the same scenario levels against the refreshed entry price;
+        # do not move stops/targets or introduce a slippage threshold.
+        normalized = apply_buy_scenario_contract(scenario, market="KR", entry_price=price)
+        gate = self._evaluate_production_buy_gate(
+            normalized, price, score_override=buy_score, is_add=is_add
+        )
+        if not gate.get("allowed"):
+            raise ValueError(f"fresh BUY quote gate: {gate.get('reason', 'blocked')}")
+        scenario.update(normalized)
+        analysis_result["current_price"] = price
+        return price
+
     def _get_trend_facts(self, ticker: str) -> str:
         """Compute deterministic individual-stock trend facts for the buy prompt's trend gate.
 
@@ -1044,13 +1124,13 @@ class StockTrackingAgent:
                     )
                     if not instruction:
                         raise RuntimeError("trading agent instruction unavailable")
-                    timeout = int(os.environ.get("PRISM_CODEX_FAST_TIMEOUT", "90"))
-                    codex_result = await asyncio.to_thread(
-                        generate_codex_fast,
+                    settings = resolve_buy_codex_settings()
+                    codex_result = await generate_codex_fast_async(
                         system_prompt=instruction,
                         user_prompt=prompt_message,
-                        model="gpt-5.6-sol",
-                        timeout=timeout,
+                        model=settings.model,
+                        reasoning_effort=settings.reasoning_effort,
+                        timeout=settings.timeout,
                         mcp_profile="kr_trading",
                         require_mcp_calls=True,
                     )
@@ -1059,9 +1139,13 @@ class StockTrackingAgent:
                         context="KR Codex Fast trading scenario",
                     )
                     logger.info(
-                        "[CODEX_FAST] KR scenario ticker=%s latency_s=%.2f "
+                        "[CODEX_FAST] KR scenario ticker=%s model=%s effort=%s "
+                        "service_tier=fast timeout=%s latency_s=%.2f "
                         "parse_ok=%s mcp_calls=%s",
                         ticker or "?",
+                        settings.model,
+                        settings.reasoning_effort or "model_default",
+                        settings.timeout,
                         codex_result.latency_s,
                         scenario_json is not None,
                         len(codex_result.mcp_calls),
@@ -1083,8 +1167,9 @@ class StockTrackingAgent:
                     )
 
                 if _kr_codex_runtime_enabled():
-                    async with app.run():
-                        scenario_json = await _legacy_scenario()
+                    async with self._get_legacy_fallback_lock():
+                        async with app.run():
+                            scenario_json = await _legacy_scenario()
                 else:
                     scenario_json = await _legacy_scenario()
             if scenario_json is not None:
@@ -1143,7 +1228,8 @@ class StockTrackingAgent:
             # Shared-sqlite read: serialize against concurrent pre-pass tasks.
             async with db_lock:
                 current_price = await self._get_current_stock_price(ticker)
-            if current_price <= 0:
+            quote_captured_at = time.monotonic()
+            if not math.isfinite(current_price) or current_price <= 0:
                 logger.error(f"{ticker} current price query failed")
                 return {"success": False, "error": "Current price query failed"}
 
@@ -1167,6 +1253,9 @@ class StockTrackingAgent:
                 db_lock=db_lock
             )
 
+            scenario = apply_buy_scenario_contract(
+                scenario, market="KR", entry_price=current_price
+            )
             raw_decision = scenario.get("decision", "No entry")
             sector = scenario.get("sector", "Unknown")
 
@@ -1175,6 +1264,7 @@ class StockTrackingAgent:
                 "ticker": ticker,
                 "company_name": company_name,
                 "current_price": current_price,
+                "quote_captured_at_monotonic": quote_captured_at,
                 "scenario": scenario,
                 "decision": self._normalize_decision(raw_decision),
                 "raw_decision": raw_decision,
@@ -1790,6 +1880,7 @@ class StockTrackingAgent:
                 limit_price=current_price,
                 intent=prepared.intent,
                 reservation=prepared.reservation,
+                quote_validator=self._buy_quote_validator(prepared.scenario, is_add=prepared.is_add),
             )
 
     def _queue_message(
@@ -4198,6 +4289,19 @@ class StockTrackingAgent:
                         )
 
                     if entry_eligible:
+                        try:
+                            current_price = await self._refresh_buy_boundary(
+                                ticker, scenario, analysis_result, buy_score=buy_score
+                            )
+                        except Exception as quote_error:
+                            logger.warning("[BUY_QUOTE][KR] %s entry blocked: %s", ticker, quote_error)
+                            scenario["_decision_context"].update(
+                                gate_allowed=False,
+                                gate_reason="fresh_quote_revalidation_failed",
+                            )
+                            state["should_save_watchlist"] = True
+                            state["skip_reason"] = "Fresh quote unavailable or scenario invalid at refreshed price"
+                            continue
                         if self._position_pending_kr_enabled():
                             prepared = None
                             try:
@@ -4364,6 +4468,7 @@ class StockTrackingAgent:
                                         buy_amount=entry_cash_amount,
                                         limit_price=current_price,
                                         intent=order_intent,
+                                        quote_validator=self._buy_quote_validator(scenario),
                                     )
                             except OrderOutcomeUnknown as error:
                                 self._link_position_entry_intent(

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -677,9 +677,8 @@ class StockTrackingAgent:
     async def _get_fresh_buy_quote(self, ticker: str) -> Dict[str, Any]:
         """Read-only quote retrieval; never use a persisted holding/analysis price."""
         try:
-            from trading.domestic_stock_trading import AsyncTradingContext
             account = getattr(self, "active_account", None) or {}
-            async with AsyncTradingContext(account_name=account.get("name")) as trading:
+            async with ExecutionService.domestic(account_name=account.get("name")) as trading:
                 info = await asyncio.to_thread(trading.get_current_price, ticker)
             price = float((info or {}).get("current_price") or 0)
             if math.isfinite(price) and price > 0:

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -506,11 +506,11 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                 # Resolve the legacy dynamic-risk fallback before the final
                 # deterministic gate so missing prices are validated rather
                 # than silently filled only after the buy decision.
-                if scenario.get("target_price", 0) <= 0:
+                if decision == "Enter" and (scenario.get("target_price") or 0) <= 0:
                     scenario["target_price"] = await self._dynamic_target_price(
                         ticker, current_price
                     )
-                if scenario.get("stop_loss", 0) <= 0:
+                if decision == "Enter" and (scenario.get("stop_loss") or 0) <= 0:
                     scenario["stop_loss"] = await self._dynamic_stop_loss(
                         ticker, current_price
                     )
@@ -795,6 +795,25 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
 
                 # Process buy if entry decision
                 if entry_eligible:
+                    try:
+                        current_price = await self._refresh_buy_boundary(
+                            ticker, scenario, analysis_result,
+                            buy_score=buy_score, is_add=is_add,
+                        )
+                    except Exception as quote_error:
+                        logger.warning("[BUY_QUOTE][KR][enhanced] %s entry blocked: %s", ticker, quote_error)
+                        scenario["_decision_context"].update(
+                            gate_allowed=False,
+                            gate_reason="fresh_quote_revalidation_failed",
+                        )
+                        await self._save_watchlist_item(
+                            ticker=ticker, company_name=company_name,
+                            current_price=current_price, buy_score=buy_score,
+                            min_score=min_score, decision="Watch",
+                            skip_reason="Fresh quote unavailable or scenario invalid at refreshed price",
+                            scenario=scenario, sector=sector, was_traded=False,
+                        )
+                        continue
                     if self._position_pending_kr_enabled():
                         prepared = None
                         active_account = getattr(self, "active_account", None)
@@ -962,6 +981,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                                     buy_amount=entry_cash_amount,
                                     limit_price=current_price,
                                     intent=order_intent,
+                                    quote_validator=self._buy_quote_validator(scenario, is_add=is_add),
                                 )
                         except OrderOutcomeUnknown as error:
                             self._link_position_entry_intent(
@@ -1543,8 +1563,9 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                     )
 
                 if _kr_codex_runtime_enabled():
-                    async with app.run():
-                        response = await _legacy_sell_response()
+                    async with self._get_legacy_fallback_lock():
+                        async with app.run():
+                            response = await _legacy_sell_response()
                 else:
                     response = await _legacy_sell_response()
 

--- a/tests/test_astra_kr_safety.py
+++ b/tests/test_astra_kr_safety.py
@@ -31,6 +31,28 @@ def scenario_agent():
 
 
 @pytest.mark.asyncio
+async def test_quote_uses_execution_service_for_read_only_access(monkeypatch):
+    agent = scenario_agent()
+    agent.active_account = {'name': 'fake-account'}
+    service = SimpleNamespace(get_current_price=MagicMock(return_value={'current_price': 72000}),
+                              execute_buy=AsyncMock(), pre_reserved_buy=AsyncMock(), sell=AsyncMock())
+
+    @asynccontextmanager
+    async def read_context():
+        yield service
+
+    factory = MagicMock(side_effect=lambda **kwargs: read_context())
+    monkeypatch.setattr(mod.ExecutionService, 'domestic', factory)
+    quote = await agent._get_fresh_buy_quote('005930')
+    assert quote['price'] == 72000
+    factory.assert_called_once_with(account_name='fake-account')
+    service.get_current_price.assert_called_once_with('005930')
+    service.execute_buy.assert_not_called()
+    service.pre_reserved_buy.assert_not_called()
+    service.sell.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_three_fast_failures_serialize_entire_legacy_host(monkeypatch):
     monkeypatch.setenv("PRISM_KR_CODEX_FAST_TRADING", "1")
     agent = scenario_agent()

--- a/tests/test_astra_kr_safety.py
+++ b/tests/test_astra_kr_safety.py
@@ -1,0 +1,187 @@
+"""KR BUY safety regression tests. No broker orders or persistent databases."""
+import asyncio
+import sys
+import sqlite3
+import time
+import types
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pandas as pd
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import stock_tracking_agent as mod
+
+
+def scenario_agent():
+    agent = mod.StockTrackingAgent.__new__(mod.StockTrackingAgent)
+    agent.cursor = MagicMock()
+    agent.cursor.fetchall.return_value = []
+    agent._account_scope = MagicMock(return_value=("test", None))
+    agent._get_current_slots_count = AsyncMock(return_value=0)
+    agent.max_slots = 10
+    agent.enable_journal = False
+    agent.language = "ko"
+    agent.trading_agent = SimpleNamespace(instruction="test instruction", attach_llm=AsyncMock())
+    agent._stamp_scenario_market_regime = lambda s: s
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_three_fast_failures_serialize_entire_legacy_host(monkeypatch):
+    monkeypatch.setenv("PRISM_KR_CODEX_FAST_TRADING", "1")
+    agent = scenario_agent()
+    state = {"active": 0, "peak": 0, "calls": 0}
+
+    @asynccontextmanager
+    async def host():
+        state["active"] += 1
+        state["peak"] = max(state["peak"], state["active"])
+        await asyncio.sleep(0.01)
+        try:
+            yield
+        finally:
+            await asyncio.sleep(0.01)
+            state["active"] -= 1
+
+    async def legacy(*args):
+        state["calls"] += 1
+        await asyncio.sleep(0.01)
+        return {"decision": "No Entry"}
+
+    monkeypatch.setattr(mod, "app", SimpleNamespace(run=host))
+    monkeypatch.setattr(mod, "generate_codex_fast_async", AsyncMock(side_effect=RuntimeError("offline")))
+    monkeypatch.setattr(mod, "_generate_trading_scenario_json", legacy)
+    results = await asyncio.gather(*(agent._extract_trading_scenario("report", "") for _ in range(3)))
+    assert all(s["decision"] == "No Entry" for s in results)
+    assert state == {"active": 0, "peak": 1, "calls": 3}
+    assert not agent._get_db_lock().locked()
+
+
+@pytest.mark.asyncio
+async def test_buy_uses_buy_only_settings(monkeypatch, caplog):
+    monkeypatch.setenv("PRISM_KR_CODEX_FAST_TRADING", "1")
+    monkeypatch.setenv("PRISM_BUY_CODEX_MODEL", "gpt-6-astra")
+    monkeypatch.setenv("PRISM_BUY_CODEX_EFFORT", "high")
+    monkeypatch.setenv("PRISM_BUY_CODEX_TIMEOUT", "123")
+    agent = scenario_agent()
+    generate = AsyncMock(return_value=SimpleNamespace(text='{"decision":"No Entry"}', latency_s=1, mcp_calls=[{}]))
+    monkeypatch.setattr(mod, "generate_codex_fast_async", generate)
+    with caplog.at_level("INFO"):
+        await agent._extract_trading_scenario("report", "")
+    assert generate.await_args.kwargs["model"] == "gpt-6-astra"
+    assert generate.await_args.kwargs["reasoning_effort"] == "high"
+    assert generate.await_args.kwargs["timeout"] == 123
+    agent.trading_agent.attach_llm.assert_not_awaited()
+    assert "model=gpt-6-astra effort=high service_tier=fast timeout=123" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_simulator_quote_survives_broker_unavailable_without_db(monkeypatch):
+    import trading.domestic_stock_trading as trading
+    agent = scenario_agent()
+    monkeypatch.setattr(trading, "AsyncTradingContext", MagicMock(side_effect=RuntimeError("no credentials")))
+    data = types.ModuleType("krx_data_client")
+    day = datetime.now(ZoneInfo("Asia/Seoul")).strftime("%Y%m%d")
+    frame = pd.DataFrame({"Close": [72000]}, index=pd.to_datetime([day]))
+    data.get_market_ohlcv_by_date = MagicMock(return_value=frame)
+    monkeypatch.setitem(sys.modules, "krx_data_client", data)
+    quote = await agent._get_fresh_buy_quote("005930")
+    assert quote["price"] == 72000
+    assert quote["source"] == "krx_same_day_close"
+    assert data.get_market_ohlcv_by_date.call_args.args == (day, day, "005930")
+    agent.cursor.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("price", [0, -1, float("nan"), float("inf")])
+async def test_no_stale_db_price_when_fresh_sources_invalid(monkeypatch, price):
+    import trading.domestic_stock_trading as trading
+    agent = scenario_agent()
+    agent.cursor.fetchone.return_value = (70000,)
+    monkeypatch.setattr(trading, "AsyncTradingContext", MagicMock(side_effect=RuntimeError("offline")))
+    data = types.ModuleType("krx_data_client")
+    data.get_market_ohlcv_by_date = lambda day, end, ticker: pd.DataFrame({"Close": [price]}, index=pd.to_datetime([day]))
+    monkeypatch.setitem(sys.modules, "krx_data_client", data)
+    with pytest.raises(ValueError):
+        await agent._get_fresh_buy_quote("005930")
+    agent.cursor.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_krx_rewound_prior_session_quote_is_rejected(monkeypatch):
+    import trading.domestic_stock_trading as trading
+    agent = scenario_agent()
+    monkeypatch.setattr(trading, "AsyncTradingContext", MagicMock(side_effect=RuntimeError("offline")))
+    prior = datetime.now(ZoneInfo("Asia/Seoul")) - timedelta(days=1)
+    data = types.ModuleType("krx_data_client")
+    data.get_market_ohlcv_by_date = lambda *a: pd.DataFrame({"Close": [72000]}, index=pd.to_datetime([prior.strftime("%Y%m%d")]))
+    monkeypatch.setitem(sys.modules, "krx_data_client", data)
+    with pytest.raises(ValueError, match="provider date"):
+        await agent._get_fresh_buy_quote("005930")
+    agent.cursor.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_boundary_refreshes_then_revalidates_existing_gate(monkeypatch, caplog):
+    agent = scenario_agent()
+    agent._get_fresh_buy_quote = AsyncMock(return_value={"price": 72000, "source": "fake", "provider_date": None, "retrieved_at_monotonic": time.monotonic()})
+    agent._evaluate_production_buy_gate = MagicMock(return_value={"allowed": True})
+    contract = MagicMock(side_effect=lambda scenario, **kwargs: dict(scenario))
+    monkeypatch.setattr(mod, "apply_buy_scenario_contract", contract)
+    scenario = {"decision": "Enter", "target_price": 90000, "stop_loss": 65000}
+    analysis = {"current_price": 70000, "quote_captured_at_monotonic": time.monotonic() - 300}
+    with caplog.at_level("INFO"):
+        price = await agent._refresh_buy_boundary("005930", scenario, analysis, buy_score=9)
+    assert price == analysis["current_price"] == 72000
+    assert contract.call_args.kwargs == {"market": "KR", "entry_price": 72000}
+    assert agent._evaluate_production_buy_gate.call_args.args[1] == 72000
+    assert "analysis_context_age_s=" in caplog.text
+    assert "exchange_age_s=unknown" in caplog.text
+    agent._evaluate_production_buy_gate.return_value = {"allowed": False, "reason": "existing rule"}
+    with pytest.raises(ValueError, match="existing rule"):
+        await agent._refresh_buy_boundary("005930", scenario, analysis, buy_score=9)
+
+
+@pytest.mark.asyncio
+async def test_no_entry_null_prices_survive_watchlist_storage(monkeypatch):
+    from tracking.db_schema import TABLE_WATCHLIST_HISTORY, TABLE_ANALYSIS_PERFORMANCE_TRACKER
+    agent = scenario_agent()
+    agent.conn = sqlite3.connect(":memory:")
+    agent.cursor = agent.conn.cursor()
+    agent.cursor.execute(TABLE_WATCHLIST_HISTORY)
+    agent.cursor.execute(TABLE_ANALYSIS_PERFORMANCE_TRACKER)
+    monkeypatch.setattr(mod, "emit_trading_context", MagicMock())
+    scenario = {"decision": "NO ENTRY", "target_price": None, "stop_loss": None, "risk_reward_ratio": None}
+    try:
+        assert await agent._save_watchlist_item(
+            ticker="005930", company_name="test", current_price=70000,
+            buy_score=0, min_score=5, decision="Skip", skip_reason="No entry",
+            scenario=scenario, sector="Tech",
+        )
+        assert agent.cursor.execute("SELECT target_price, stop_loss, risk_reward_ratio FROM watchlist_history").fetchone() == (None, None, None)
+        assert agent.cursor.execute("SELECT target_price, stop_loss, risk_reward_ratio FROM analysis_performance_tracker").fetchone() == (None, None, None)
+    finally:
+        agent.conn.close()
+
+
+@pytest.mark.asyncio
+async def test_core_applies_contract_to_captured_price(monkeypatch):
+    agent = scenario_agent()
+    agent._extract_ticker_info = AsyncMock(return_value=("005930", "test"))
+    agent._get_current_stock_price = AsyncMock(return_value=70000)
+    agent._get_trading_value_rank_change = AsyncMock(return_value=(0, ""))
+    agent._extract_trading_scenario = AsyncMock(return_value={"decision": "NO ENTRY", "target_price": None, "stop_loss": None})
+    pdf = types.ModuleType("pdf_converter")
+    pdf.pdf_to_markdown_text = lambda path: "report"
+    monkeypatch.setitem(sys.modules, "pdf_converter", pdf)
+    contract = MagicMock(side_effect=lambda scenario, **kw: dict(scenario))
+    monkeypatch.setattr(mod, "apply_buy_scenario_contract", contract)
+    result = await agent._analyze_report_core("fake.pdf")
+    assert result["success"] is True
+    assert result["scenario"]["target_price"] is None
+    contract.assert_called_once_with(agent._extract_trading_scenario.return_value, market="KR", entry_price=70000)
+    assert result["quote_captured_at_monotonic"] <= time.monotonic()

--- a/tests/test_buy_codex_settings.py
+++ b/tests/test_buy_codex_settings.py
@@ -1,0 +1,71 @@
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from prism_core.codex_config import resolve_buy_codex_settings
+from cores.llm.codex_oauth_fast_backend import CodexFastError, _command
+
+
+def test_defaults_are_unchanged_and_frozen():
+    settings = resolve_buy_codex_settings({})
+    assert (settings.model, settings.reasoning_effort, settings.timeout) == ("gpt-5.6-sol", None, 90)
+    with pytest.raises(FrozenInstanceError):
+        settings.model = "gpt-6-astra"
+    assert not any("model_reasoning_effort" in arg for arg in _command("codex", settings.model, None))
+
+
+def test_explicit_astra_effort_and_timeout_precedence():
+    settings = resolve_buy_codex_settings({"PRISM_BUY_CODEX_MODEL": "gpt-6-astra", "PRISM_BUY_CODEX_EFFORT": "high", "PRISM_BUY_CODEX_TIMEOUT": "120", "PRISM_CODEX_FAST_TIMEOUT": "60"})
+    assert (settings.model, settings.reasoning_effort, settings.timeout) == ("gpt-6-astra", "high", 120)
+    command = _command("codex", settings.model, "kr_trading", settings.reasoning_effort)
+    assert 'model_reasoning_effort="high"' in command
+    assert 'service_tier="fast"' in command
+    assert "--ephemeral" in command and "read-only" in command
+    assert resolve_buy_codex_settings({"PRISM_CODEX_FAST_TIMEOUT": "55"}).timeout == 55
+
+
+@pytest.mark.parametrize("key,value", [("PRISM_BUY_CODEX_MODEL", "arbitrary"), ("PRISM_BUY_CODEX_EFFORT", "invalid"), ("PRISM_BUY_CODEX_EFFORT", ""), *[("PRISM_BUY_CODEX_TIMEOUT", value) for value in ["", "nan", "inf", "-1", "0", "601", "abc"]]])
+def test_invalid_settings_fail_closed(key, value):
+    with pytest.raises(CodexFastError):
+        resolve_buy_codex_settings({key: value})
+
+
+@pytest.mark.parametrize("effort", ["low", "medium", "high", "xhigh", "max", "ultra"])
+def test_effort_allowlist(effort):
+    assert f'model_reasoning_effort="{effort}"' in _command("codex", "gpt-6-astra", None, effort)
+    with pytest.raises(CodexFastError):
+        _command("codex", "gpt-6-astra", None, effort + '";evil')
+
+
+def test_environment_resolution_and_timeout_boundary(monkeypatch):
+    monkeypatch.setenv("PRISM_BUY_CODEX_MODEL", "gpt-6-astra")
+    monkeypatch.setenv("PRISM_BUY_CODEX_EFFORT", "ultra")
+    monkeypatch.setenv("PRISM_BUY_CODEX_TIMEOUT", "600")
+    settings = resolve_buy_codex_settings()
+    assert (settings.model, settings.reasoning_effort, settings.timeout) == ("gpt-6-astra", "ultra", 600)
+    assert resolve_buy_codex_settings({"PRISM_BUY_CODEX_TIMEOUT": "0.01"}).timeout == 0.01
+
+
+def test_settings_and_file_loaded_backend_with_us_cores_namespace():
+    root = Path(__file__).resolve().parents[1]
+    script = '''
+import importlib.util
+import pathlib
+import sys
+root = pathlib.Path.cwd()
+sys.path.insert(0, str(root / "prism-us"))
+import cores
+assert "prism-us" in cores.__file__
+from prism_core.codex_config import CodexFastError, resolve_buy_codex_settings
+spec = importlib.util.spec_from_file_location("codex_oauth_fast_backend", root / "cores/llm/codex_oauth_fast_backend.py")
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+assert module.CodexFastError is CodexFastError
+assert resolve_buy_codex_settings({}).model == "gpt-5.6-sol"
+'''
+    result = subprocess.run([sys.executable, "-c", script], cwd=root, capture_output=True, text=True, timeout=10)
+    assert result.returncode == 0, result.stderr

--- a/tests/test_codex_fast_process_cleanup.py
+++ b/tests/test_codex_fast_process_cleanup.py
@@ -1,0 +1,80 @@
+"""Harmless real process tests: no Codex/auth/network or production data."""
+import asyncio
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+from cores.llm import codex_oauth_fast_backend as backend
+
+
+@pytest.fixture
+def child_tree(monkeypatch, tmp_path):
+    if os.name != "posix":
+        pytest.skip("POSIX owned process group regression")
+    pid_path = tmp_path / "pids"
+    child_script = "import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)"
+    parent_script = (
+        "import os,signal,subprocess,sys,time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        f"child=subprocess.Popen([sys.executable,'-c',{child_script!r}]); "
+        f"open({str(pid_path)!r},'w').write(str(os.getpid())+' '+str(child.pid)); "
+        "time.sleep(60)"
+    )
+    monkeypatch.setattr(backend, "_resolve_codex_executable", lambda _: sys.executable)
+    monkeypatch.setattr(backend, "_command", lambda *args: [sys.executable, "-c", parent_script])
+    return pid_path
+
+
+def assert_tree_stopped(pid_path):
+    pids = [int(pid) for pid in pid_path.read_text().split()]
+    for pid in pids:
+        deadline = time.monotonic() + 3
+        while True:
+            result = subprocess.run(["ps", "-o", "stat=", "-p", str(pid)], capture_output=True, text=True)
+            # Orphaned grandchildren may briefly await system reaping as zombies.
+            if not result.stdout.strip() or result.stdout.strip().startswith("Z"):
+                break
+            assert time.monotonic() < deadline, f"child {pid} remains running"
+            time.sleep(0.02)
+    with pytest.raises(ChildProcessError):
+        os.waitpid(pids[0], os.WNOHANG)
+
+
+def test_timeout_terminates_child_and_grandchild(child_tree, monkeypatch):
+    signaled_groups = []
+    real_killpg = os.killpg
+
+    def record_killpg(group, sig):
+        signaled_groups.append(group)
+        assert group != os.getpgrp()
+        real_killpg(group, sig)
+
+    monkeypatch.setattr(os, "killpg", record_killpg)
+    started = time.monotonic()
+    with pytest.raises(backend.CodexFastError, match="timed out"):
+        backend.generate_codex_fast(system_prompt="s", user_prompt="u", timeout=0.5)
+    assert time.monotonic() - started < 3
+    assert_tree_stopped(child_tree)
+    leader = int(child_tree.read_text().split()[0])
+    assert signaled_groups == [leader, leader]
+
+
+def test_async_cancellation_waits_for_process_tree_cleanup(child_tree):
+    async def run():
+        task = asyncio.create_task(backend.generate_codex_fast_async(system_prompt="s", user_prompt="u", timeout=30))
+        deadline = time.monotonic() + 3
+        while not child_tree.exists():
+            assert time.monotonic() < deadline
+            await asyncio.sleep(0.01)
+        started = time.monotonic()
+        task.cancel()
+        await asyncio.sleep(0.02)
+        task.cancel()  # repeated cancellation must not abandon the cleanup worker
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert time.monotonic() - started < 3
+        assert_tree_stopped(child_tree)
+    asyncio.run(run())

--- a/tests/test_codex_oauth_fast_backend.py
+++ b/tests/test_codex_oauth_fast_backend.py
@@ -221,7 +221,10 @@ def test_trading_mcp_profiles_allow_only_read_only_sqlite_tools(
     profile_name: str,
     market_server: str,
 ) -> None:
-    import tomllib
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # Python 3.10: pytest already depends on this backport.
+        import tomli as tomllib
 
     profile_path = Path(__file__).resolve().parents[1] / "deploy" / profile_name
     config = tomllib.loads(profile_path.read_text("utf-8"))

--- a/tests/test_codex_oauth_fast_backend.py
+++ b/tests/test_codex_oauth_fast_backend.py
@@ -9,6 +9,10 @@ import pytest
 import cores.llm.codex_oauth_fast_backend as backend
 
 
+def fake_process(returncode=0, stdout="", stderr=""):
+    return SimpleNamespace(returncode=returncode, communicate=lambda **kwargs: (stdout, stderr))
+
+
 @pytest.fixture
 def _trusted_codex(monkeypatch) -> None:
     monkeypatch.setattr(
@@ -70,9 +74,12 @@ def test_codex_fast_backend_uses_isolated_ephemeral_command(
             }),
             json.dumps({"type": "turn.completed", "usage": {"output_tokens": 10}}),
         ])
-        return SimpleNamespace(returncode=0, stdout=stream, stderr="")
+        def communicate(**communication):
+            seen["kwargs"].update(communication)
+            return stream, ""
+        return SimpleNamespace(returncode=0, communicate=communicate)
 
-    monkeypatch.setattr(backend.subprocess, "run", fake_run)
+    monkeypatch.setattr(backend.subprocess, "Popen", fake_run)
     result = backend.generate_codex_fast(
         system_prompt="system",
         user_prompt="user",
@@ -110,8 +117,8 @@ def test_codex_fast_backend_requires_mcp_call_when_requested(
     ])
     monkeypatch.setattr(
         backend.subprocess,
-        "run",
-        lambda *_args, **_kwargs: SimpleNamespace(
+        "Popen",
+        lambda *_args, **_kwargs: fake_process(
             returncode=0, stdout=stream, stderr=""
         ),
     )
@@ -131,8 +138,8 @@ def test_codex_fast_backend_raises_on_cli_failure(
 ) -> None:
     monkeypatch.setattr(
         backend.subprocess,
-        "run",
-        lambda *_args, **_kwargs: SimpleNamespace(
+        "Popen",
+        lambda *_args, **_kwargs: fake_process(
             returncode=1, stdout="", stderr="auth failed"
         ),
     )
@@ -148,7 +155,7 @@ def test_us_trading_wires_codex_primary_before_legacy_fallback() -> None:
     method = source[source.index("    async def _extract_trading_scenario("):]
     method = method[:method.index("    async def ", 20_000)]
     assert "PRISM_US_CODEX_FAST_TRADING" in method
-    assert "await asyncio.to_thread(" in method
+    assert "await generate_codex_fast_async(" in method
     assert "generate_codex_fast" in method
     assert 'mcp_profile="us_trading"' in method
     assert "require_mcp_calls=True" in method
@@ -164,7 +171,7 @@ def test_kr_trading_wires_same_codex_primary_and_legacy_fallback() -> None:
     method = source[source.index("    async def _extract_trading_scenario("):]
     method = method[:method.index("    def _default_scenario")]
     assert "PRISM_KR_CODEX_FAST_TRADING" in method
-    assert "await asyncio.to_thread(" in method
+    assert "await generate_codex_fast_async(" in method
     assert "generate_codex_fast" in method
     assert 'mcp_profile="kr_trading"' in method
     assert "require_mcp_calls=True" in method

--- a/tests/test_kr_buy_quote_validation.py
+++ b/tests/test_kr_buy_quote_validation.py
@@ -1,0 +1,71 @@
+"""Final broker quote validation, with fake broker transport only."""
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import trading.domestic_stock_trading as mod
+from stock_tracking_agent import StockTrackingAgent
+
+
+def broker():
+    trader = mod.DomesticStockTrading.__new__(mod.DomesticStockTrading)
+    trader.buy_amount = 100000
+    trader._get_stock_lock = AsyncMock(return_value=asyncio.Lock())
+    trader._semaphore = asyncio.Semaphore(1)
+    trader._global_lock = asyncio.Lock()
+    trader.get_current_price = MagicMock(return_value={"current_price": 72000})
+    trader.smart_buy = MagicMock(return_value={"success": True, "order_no": "fake"})
+    return trader
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reason", ["existing RR gate", "connection timeout exception"])
+async def test_internal_quote_rejection_is_known_no_submit(reason):
+    from prism_core.execution_service import ExecutionService
+    trader = broker()
+    validator = MagicMock(side_effect=ValueError(reason))
+    result = await trader._execute_buy_stock("005930", quote_validator=validator)
+    assert result["success"] is False
+    assert not result.get("outcome_unknown", False)
+    assert result["message"] == "BUY quote validation rejected before submission"
+    assert ExecutionService._classify_result(result)[0] == "FAILED"
+    trader.smart_buy.assert_not_called()
+    validator.assert_called_once_with(72000)
+
+
+@pytest.mark.asyncio
+async def test_accepted_quote_passed_to_actual_sizing_without_refetch():
+    trader = broker()
+    validator = MagicMock()
+    result = await trader._execute_buy_stock("005930", limit_price=70000, quote_validator=validator)
+    assert result["success"] is True
+    assert [call.args[0] for call in validator.call_args_list] == [72000, 70000]
+    trader.smart_buy.assert_called_once_with("005930", 100000, 70000, quote_price=72000)
+    trader.get_current_price.assert_called_once()
+
+
+def test_final_market_quantity_consumes_validated_quote(monkeypatch):
+    trader = broker()
+    trader.auto_trading = True
+    trader.mode = "demo"
+    trader.trenv = SimpleNamespace(my_acct="fake", my_prod="01")
+    trader._request = MagicMock(return_value=SimpleNamespace(isOK=lambda: True, getBody=lambda: SimpleNamespace(output={"ODNO": "fake"})))
+    trader.get_current_price.side_effect = AssertionError("hidden quote refetch")
+    result = mod.DomesticStockTrading.buy_market_price(trader, "005930", 150000, quote_price=72000)
+    assert result["success"] is True
+    assert result["quantity"] == 2
+    trader.get_current_price.assert_not_called()
+
+
+def test_broker_callback_runs_full_gate_even_inside_stop_target():
+    agent = StockTrackingAgent.__new__(StockTrackingAgent)
+    scenario = {"decision": "Enter", "buy_score": 9, "entry_price": 70000,
+                "target_price": 90000, "stop_loss": 65000,
+                "risk_reward_ratio": 4, "expected_return_pct": 28, "expected_loss_pct": 7}
+    agent._evaluate_production_buy_gate = MagicMock(return_value={"allowed": False, "reason": "existing RR gate"})
+    with pytest.raises(ValueError, match="existing RR gate"):
+        agent._buy_quote_validator(scenario)(85000)
+    assert agent._evaluate_production_buy_gate.call_args.args[1] == 85000
+    assert scenario["entry_price"] == 70000  # independent ledger unchanged

--- a/tests/test_kr_pending_entry.py
+++ b/tests/test_kr_pending_entry.py
@@ -67,6 +67,10 @@ def _pending_entry_agent(db_path: Path):
     connection = sqlite3.connect(db_path)
     connection.row_factory = sqlite3.Row
     connection.execute(TABLE_STOCK_HOLDINGS)
+    connection.execute(
+        "CREATE TABLE IF NOT EXISTS trading_history "
+        "(ticker TEXT, account_key TEXT, sell_date TEXT, profit_rate REAL, exit_kind TEXT)"
+    )
     PositionStore(connection).ensure_schema()
     connection.commit()
     IntentStore(db_path)
@@ -97,6 +101,11 @@ def _pending_entry_agent(db_path: Path):
             "company_name": "Samsung Electronics",
             "current_price": 70000,
             "scenario": {
+                "decision": "Enter",
+                "entry_price": 70000,
+                "risk_reward_ratio": 2,
+                "expected_return_pct": 14,
+                "expected_loss_pct": 7,
                 "buy_score": 8,
                 "min_score": 7,
                 "sector": "Technology",
@@ -109,6 +118,9 @@ def _pending_entry_agent(db_path: Path):
         }
 
     agent._analyze_report_core = analyze_report
+    # This fixture isolates pending-order lifecycle; quote/contract revalidation
+    # is exercised separately in test_astra_kr_safety with fake market data.
+    agent._refresh_buy_boundary = AsyncMock(return_value=70000)
     agent.update_holdings = AsyncMock(return_value=[])
     agent._is_ticker_in_holdings = AsyncMock(return_value=False)
     agent._get_current_slots_count = AsyncMock(return_value=0)
@@ -126,11 +138,15 @@ def _install_pending_entry_runtime(
     broker_error: BaseException | None = None,
     broker_started: asyncio.Event | None = None,
     broker_release: asyncio.Event | None = None,
+    broker_quote: float | None = None,
 ):
     broker_calls = []
     publish_states = []
     redis_calls = []
     gcp_calls = []
+    # Use a deterministic market snapshot without invoking external providers;
+    # leave the real cooldown and regime-floor checks enabled.
+    monkeypatch.setattr("cores.regime_policy.get_market_pulse_state", lambda *_a, **_kw: "UPTREND")
 
     class BrokerContext:
         def __init__(self, account_name=None, **_kwargs):
@@ -143,8 +159,13 @@ def _install_pending_entry_runtime(
             return False
 
         async def async_buy_stock(
-            self, stock_code, limit_price=None, buy_amount=None
+            self, stock_code, limit_price=None, buy_amount=None, quote_validator=None
         ):
+            if broker_quote is not None:
+                try:
+                    quote_validator(broker_quote)
+                except ValueError as exc:
+                    return {"success": False, "message": str(exc)}
             broker_calls.append(
                 {
                     "stock_code": stock_code,
@@ -187,6 +208,22 @@ def _install_pending_entry_runtime(
     monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "true")
     monkeypatch.setenv("POSITION_LEDGER_SHADOW_ENABLED", "true")
     return broker_calls, publish_states, redis_calls, gcp_calls
+
+
+@pytest.mark.asyncio
+async def test_pending_final_broker_quote_rejection_is_failed_not_unknown(monkeypatch, tmp_path):
+    path = tmp_path / "quote-rejected.sqlite"
+    agent, connection = _pending_entry_agent(path)
+    broker_calls, publish, redis, gcp = _install_pending_entry_runtime(
+        monkeypatch, agent=agent, db_path=path, broker_quote=85000,
+    )
+    try:
+        assert await agent.process_reports(["quote-rejected.pdf"]) == (0, 0)
+        assert connection.execute("SELECT status FROM order_intents").fetchone()[0] == "FAILED"
+        assert connection.execute("SELECT COUNT(*) FROM stock_holdings").fetchone()[0] == 0
+        assert not broker_calls and not publish and not redis and not gcp
+    finally:
+        connection.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_parallel_trading_batch.py
+++ b/tests/test_parallel_trading_batch.py
@@ -39,6 +39,11 @@ from prism_core.positions import LegacyPositionWriteResult
 from stock_tracking_enhanced_agent import EnhancedStockTrackingAgent
 
 
+@pytest.fixture(autouse=True)
+def _offline_market_pulse(monkeypatch):
+    monkeypatch.setattr("cores.regime_policy.get_market_pulse_state", lambda *_a, **_kw: "UPTREND")
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -57,7 +62,57 @@ def _make_agent() -> EnhancedStockTrackingAgent:
     agent._dynamic_target_price = AsyncMock(return_value=81000)
     agent._dynamic_stop_loss = AsyncMock(return_value=65000)
     agent._buy_floor_regime = MagicMock(return_value="strong_bull")
+    agent._refresh_buy_boundary = AsyncMock(return_value=70000)
     return agent
+
+
+@pytest.mark.asyncio
+async def test_env_cap_three_preserves_default_four(monkeypatch):
+    monkeypatch.delenv("TRADING_ANALYSIS_CONCURRENCY", raising=False)
+    assert enh_mod._resolve_trading_analysis_concurrency() == 4
+    monkeypatch.setenv("TRADING_ANALYSIS_CONCURRENCY", "3")
+    monkeypatch.setattr(enh_mod, "TRADING_ANALYSIS_CONCURRENCY", enh_mod._resolve_trading_analysis_concurrency())
+    agent = _make_agent()
+    state = {"active": 0, "peak": 0}
+
+    async def core(path):
+        state["active"] += 1
+        state["peak"] = max(state["peak"], state["active"])
+        await asyncio.sleep(0.01)
+        state["active"] -= 1
+        return _core_ok(path, path)
+
+    agent._analyze_report_core = core
+    agent.analyze_report = AsyncMock(side_effect=lambda path, **kw: kw["precomputed_core"])
+    await agent.process_reports([f"{n}.pdf" for n in range(7)])
+    assert state == {"active": 0, "peak": 3}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pending", ["true", "false"])
+async def test_invalid_final_quote_prevents_both_entry_routes(monkeypatch, pending):
+    monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", pending)
+    agent = _make_agent()
+    agent.db_path = ":memory:"
+    result = _core_ok("005930", "test", decision="Enter")
+    agent._analyze_report_core = AsyncMock(return_value=result)
+    agent.analyze_report = AsyncMock(return_value=result)
+    agent._refresh_buy_boundary = AsyncMock(side_effect=ValueError("quote unavailable"))
+    agent._buy_stock_with_position = AsyncMock()
+    agent._prepare_pending_kr_entry = MagicMock()
+    agent._execute_pending_kr_entry = AsyncMock()
+    cooldown = types.ModuleType("reentry_cooldown")
+    cooldown.reentry_block = lambda *a, **kw: None
+    cooldown.COOLDOWN_LIVE = False
+    cooldown.COOLDOWN_RISK_EXIT_LIVE = False
+    monkeypatch.setitem(sys.modules, "reentry_cooldown", cooldown)
+    assert await agent.process_reports(["005930_test.pdf"]) == (0, 0)
+    agent._refresh_buy_boundary.assert_awaited_once()
+    agent._buy_stock_with_position.assert_not_awaited()
+    agent._prepare_pending_kr_entry.assert_not_called()
+    agent._execute_pending_kr_entry.assert_not_awaited()
+    saved = agent._save_watchlist_item.await_args.kwargs
+    assert saved["scenario"]["_decision_context"]["gate_allowed"] is False
 
 
 def _ensure_reentry_schema(path):
@@ -221,7 +276,7 @@ async def test_gates_run_sequentially_after_parallel_phase(monkeypatch, tmp_path
         async def __aexit__(self, *a):
             return False
 
-        async def async_buy_stock(self, stock_code, limit_price=None, buy_amount=None):
+        async def async_buy_stock(self, stock_code, limit_price=None, buy_amount=None, quote_validator=None):
             return {"success": True, "message": "ok"}
 
     monkeypatch.setattr(domestic_trading, "AsyncTradingContext", _FakeTradingCtx)
@@ -348,7 +403,7 @@ async def test_enhanced_pending_gate_false_preserves_legacy_message_broker_publi
         async def __aexit__(self, *_args):
             return False
 
-        async def async_buy_stock(self, stock_code, limit_price=None, buy_amount=None):
+        async def async_buy_stock(self, stock_code, limit_price=None, buy_amount=None, quote_validator=None):
             events.append("broker")
             return {"success": True, "message": "ok"}
 

--- a/tests/test_stock_tracking_agent_process_reports.py
+++ b/tests/test_stock_tracking_agent_process_reports.py
@@ -19,6 +19,11 @@ from prism_core.positions import LegacyPositionWriteResult
 from tracking.db_schema import TABLE_STOCK_HOLDINGS, TABLE_TRADING_HISTORY
 
 
+@pytest.fixture(autouse=True)
+def _offline_market_pulse(monkeypatch):
+    monkeypatch.setattr("cores.regime_policy.get_market_pulse_state", lambda *_a, **_kw: "UPTREND")
+
+
 def _ensure_reentry_schema(path):
     with sqlite3.connect(path) as connection:
         connection.execute(
@@ -37,7 +42,7 @@ class _FakeAsyncTradingContext:
     async def __aexit__(self, exc_type, exc, tb):
         return False
 
-    async def async_buy_stock(self, stock_code, limit_price=None, buy_amount=None):
+    async def async_buy_stock(self, stock_code, limit_price=None, buy_amount=None, quote_validator=None):
         # buy_amount mirrors the real DomesticStockTrading.async_buy_stock signature
         # (None = full size; set only under PULSE_PILOT_REEXPOSURE pilot sizing).
         return {
@@ -398,6 +403,7 @@ async def test_process_reports_analyzes_once_and_dedupes_signals(monkeypatch, ca
         return True
 
     agent._analyze_report_core = fake_core
+    agent._refresh_buy_boundary = AsyncMock(return_value=70000)
     agent.update_holdings = fake_update_holdings
     agent._is_ticker_in_holdings = fake_is_ticker_in_holdings
     agent._get_current_slots_count = fake_get_current_slots_count
@@ -471,6 +477,7 @@ async def test_sideways_uptrend_score_six_uses_half_size_kr_order(monkeypatch, t
         }
 
     agent._analyze_report_core = fake_core
+    agent._refresh_buy_boundary = AsyncMock(return_value=70000)
     agent.update_holdings = AsyncMock(return_value=[])
     agent._is_ticker_in_holdings = AsyncMock(return_value=False)
     agent._get_current_slots_count = AsyncMock(return_value=0)
@@ -484,7 +491,7 @@ async def test_sideways_uptrend_score_six_uses_half_size_kr_order(monkeypatch, t
     buy_amounts = []
 
     class PilotTradingContext(_FakeAsyncTradingContext):
-        async def async_buy_stock(self, stock_code, limit_price=None, buy_amount=None):
+        async def async_buy_stock(self, stock_code, limit_price=None, buy_amount=None, quote_validator=None):
             buy_amounts.append(buy_amount)
             return await super().async_buy_stock(stock_code, limit_price, buy_amount)
 
@@ -555,7 +562,7 @@ async def test_kr_pending_gate_false_preserves_legacy_message_broker_publish_ord
         return LegacyPositionWriteResult(True, 1)
 
     class OrderedTradingContext(_FakeAsyncTradingContext):
-        async def async_buy_stock(self, stock_code, limit_price=None, buy_amount=None):
+        async def async_buy_stock(self, stock_code, limit_price=None, buy_amount=None, quote_validator=None):
             events.append("broker")
             return await super().async_buy_stock(
                 stock_code, limit_price=limit_price, buy_amount=buy_amount
@@ -571,6 +578,7 @@ async def test_kr_pending_gate_false_preserves_legacy_message_broker_publish_ord
             super().append(value)
 
     agent._analyze_report_core = fake_core
+    agent._refresh_buy_boundary = AsyncMock(return_value=70000)
     agent.update_holdings = AsyncMock(return_value=[])
     agent._is_ticker_in_holdings = AsyncMock(return_value=False)
     agent._get_current_slots_count = AsyncMock(return_value=0)
@@ -674,6 +682,7 @@ async def test_process_reports_saves_watchlist_once_when_not_traded(monkeypatch)
         return True
 
     agent._analyze_report_core = fake_core
+    agent._refresh_buy_boundary = AsyncMock(return_value=70000)
     agent.update_holdings = fake_update_holdings
     agent._is_ticker_in_holdings = fake_is_ticker_in_holdings
     agent._get_current_slots_count = fake_get_current_slots_count

--- a/tests/test_trading_scenario_contract.py
+++ b/tests/test_trading_scenario_contract.py
@@ -1,0 +1,110 @@
+from copy import deepcopy
+
+import pytest
+
+from prism_core.trading_scenario_contract import (
+    apply_buy_scenario_contract,
+    buy_scenario_prompt_contract,
+    format_optional_number,
+    sell_scenario_authority_contract,
+)
+
+
+def entry():
+    return {
+        'decision': '진입', 'target_price': 120, 'stop_loss': 93,
+        'risk_reward_ratio': 2.9, 'expected_return_pct': 20,
+        'expected_loss_pct': 7, 'buy_score': 7,
+        'trading_scenarios': {'key_levels': {'primary_support': 93},
+                              'sell_triggers': ['highest close minus 7%', '5-day MA full exit']},
+    }
+
+
+@pytest.mark.parametrize('market', ['KR', 'US'])
+def test_valid_entry_preserves_economic_inputs_and_replaces_untrusted_exit_rules(market):
+    value = entry()
+    before = deepcopy(value)
+    result = apply_buy_scenario_contract(value, market=market, entry_price=100)
+    assert value == before
+    assert result['entry_price'] == 100
+    assert result['target_price'] == 120 and result['stop_loss'] == 93
+    assert result['buy_score'] == 7
+    assert result['trading_scenarios']['key_levels'] == before['trading_scenarios']['key_levels']
+    assert '5-day MA' not in str(result['trading_scenarios']['sell_triggers'])
+    assert 'highest close' not in str(result['trading_scenarios']['sell_triggers'])
+    assert result['_scenario_contract_version'] == 'buy-scenario-v1'
+
+
+@pytest.mark.parametrize('field', ['target_price', 'stop_loss', 'risk_reward_ratio', 'expected_return_pct', 'expected_loss_pct'])
+@pytest.mark.parametrize('bad', [None, float('nan'), float('inf'), True, 'unknown', -1])
+def test_entry_rejects_missing_nonfinite_and_invalid_risk_values(field, bad):
+    value = entry()
+    value[field] = bad
+    with pytest.raises(ValueError, match='scenario'):
+        apply_buy_scenario_contract(value, market='KR', entry_price=100)
+
+
+@pytest.mark.parametrize('price', [90, 93, 120, 121, None, True, float('nan')])
+def test_fresh_price_must_still_fit_existing_price_levels(price):
+    with pytest.raises(ValueError, match='scenario'):
+        apply_buy_scenario_contract(entry(), market='US', entry_price=price)
+
+
+@pytest.mark.parametrize('decision', ['미진입', 'no_entry', 'No Entry', 'Skip', '관망'])
+def test_no_entry_unknowns_remain_unknown_and_display_without_fabrication(decision):
+    value = {'decision': decision, 'target_price': None, 'stop_loss': None,
+             'risk_reward_ratio': None, 'rationale': 'Conflicting closing prices'}
+    result = apply_buy_scenario_contract(value, market='KR', entry_price=100)
+    assert result['target_price'] is None and result['stop_loss'] is None
+    assert result['entry_price'] is None
+    assert result['risk_reward_ratio'] is None
+    assert result['rationale'] == value['rationale']
+    assert format_optional_number(result['target_price']) == '미확인'
+    assert format_optional_number(None, missing='Unknown') == 'Unknown'
+
+
+def test_string_numbers_are_accepted_without_accepting_currency_prose():
+    value = entry()
+    value['target_price'] = '1,200'
+    assert apply_buy_scenario_contract(value, market='KR', entry_price=100)['target_price'] == 1200
+    value['stop_loss'] = '93원'
+    with pytest.raises(ValueError):
+        apply_buy_scenario_contract(value, market='KR', entry_price=100)
+
+
+def test_optional_format_does_not_display_nonfinite_prices():
+    assert format_optional_number(float('inf')) == '미확인'
+    assert format_optional_number(1234.5, '.2f') == '1234.50'
+
+
+def test_stored_entry_tracks_refreshed_quote_without_losing_original_reference():
+    scenario = entry()
+    scenario['entry_price'] = 100
+    once = apply_buy_scenario_contract(scenario, market='KR', entry_price=101)
+    twice = apply_buy_scenario_contract(once, market='KR', entry_price=102)
+    assert twice['entry_price'] == 102
+    assert twice['_analysis_entry_price'] == 100
+    assert twice['expected_return_pct'] == 20  # reported math is not silently repaired
+    assert scenario['entry_price'] == 100
+
+
+def test_impossible_model_reference_is_not_silently_hidden_by_fresh_quote():
+    scenario = entry()
+    scenario['entry_price'] = 99999
+    with pytest.raises(ValueError, match='scenario invalid reported entry'):
+        apply_buy_scenario_contract(scenario, market='US', entry_price=100)
+
+
+@pytest.mark.parametrize('value', [None, [], {}, {'decision': 'maybe later'}, {'decision': True}])
+def test_malformed_decision_is_not_silently_treated_as_no_entry(value):
+    with pytest.raises(ValueError, match='scenario'):
+        apply_buy_scenario_contract(value, market='KR', entry_price=100)
+
+
+@pytest.mark.parametrize('language', ['ko', 'en'])
+def test_prompt_contract_pins_existing_rules_without_relaxing_thresholds(language):
+    buy = buy_scenario_prompt_contract(language)
+    sell = sell_scenario_authority_contract(language)
+    assert 'entry_price' in buy and 'null' in buy
+    assert 'sell_triggers' in buy and 'sell_triggers' in sell
+    assert '5' in buy and '7%' in buy

--- a/trading/domestic_stock_trading.py
+++ b/trading/domestic_stock_trading.py
@@ -308,7 +308,7 @@ class DomesticStockTrading:
             logger.error(f"Error getting current price: {str(e)}")
             return None
 
-    def calculate_buy_quantity(self, stock_code: str, buy_amount: int = None) -> int:
+    def calculate_buy_quantity(self, stock_code: str, buy_amount: int = None, *, quote_price: float = None) -> int:
         """
         Calculate buyable quantity
 
@@ -322,7 +322,8 @@ class DomesticStockTrading:
         amount = buy_amount if buy_amount else self.buy_amount
 
         # Get current price
-        current_price_info = self.get_current_price(stock_code)
+        current_price_info = ({"current_price": quote_price} if quote_price is not None
+                              else self.get_current_price(stock_code))
         if not current_price_info:
             return 0
 
@@ -347,7 +348,7 @@ class DomesticStockTrading:
 
         return current_quantity
 
-    def buy_market_price(self, stock_code: str, buy_amount: int = None) -> Dict[str, Any]:
+    def buy_market_price(self, stock_code: str, buy_amount: int = None, *, quote_price: float = None) -> Dict[str, Any]:
         """
         Buy at market price
 
@@ -376,7 +377,8 @@ class DomesticStockTrading:
 
 
         # Calculate buyable quantity
-        buy_quantity = self.calculate_buy_quantity(stock_code, buy_amount)
+        buy_quantity = (self.calculate_buy_quantity(stock_code, buy_amount, quote_price=quote_price)
+                        if quote_price is not None else self.calculate_buy_quantity(stock_code, buy_amount))
 
         if buy_quantity == 0:
             return {
@@ -588,7 +590,7 @@ class DomesticStockTrading:
                 'message': f'Error during buy order: {str(e)}'
             }
 
-    def smart_buy(self, stock_code: str, buy_amount: int = None, limit_price: int = None) -> Dict[str, Any]:
+    def smart_buy(self, stock_code: str, buy_amount: int = None, limit_price: int = None, *, quote_price: float = None) -> Dict[str, Any]:
         """
         Automatically buy using the optimal method based on time (excluding after-hours single price trading due to high unfilled probability)
 
@@ -620,18 +622,18 @@ class DomesticStockTrading:
         # Branch by Korean market time (KST), regardless of server/local timezone.
         if order_window == "regular":
             logger.info(f"[{stock_code}] Regular trading hours (KST) - executing market buy")
-            return self.buy_market_price(stock_code, buy_amount)
+            return self.buy_market_price(stock_code, buy_amount, **({"quote_price": quote_price} if quote_price is not None else {}))
 
         if order_window == "closing":
             logger.info(f"[{stock_code}] After-hours closing price time (KST) - executing closing price buy")
-            return self.buy_closing_price(stock_code, buy_amount)
+            return self.buy_closing_price(stock_code, buy_amount, **({"quote_price": quote_price} if quote_price is not None else {}))
 
         if order_window == "reserved":
             if limit_price:
                 logger.info(f"[{stock_code}] Reserved order window (KST) - executing reserved order (limit: {limit_price:,} KRW)")
             else:
                 logger.info(f"[{stock_code}] Reserved order window (KST) - executing reserved order (market)")
-            return self.buy_reserved_order(stock_code, buy_amount, limit_price=limit_price)
+            return self.buy_reserved_order(stock_code, buy_amount, limit_price=limit_price, **({"quote_price": quote_price} if quote_price is not None else {}))
 
         message = "Order window unavailable in KST (reserved orders are accepted 16:00~23:40 and 00:10~07:30)"
         logger.warning(f"[{stock_code}] {message}")
@@ -643,7 +645,7 @@ class DomesticStockTrading:
             'message': message
         }
 
-    def buy_closing_price(self, stock_code: str, buy_amount: int = None) -> Dict[str, Any]:
+    def buy_closing_price(self, stock_code: str, buy_amount: int = None, *, quote_price: float = None) -> Dict[str, Any]:
         """
         Buy at after-hours closing price (15:40~16:00)
         Buy at closing price of the day
@@ -666,7 +668,8 @@ class DomesticStockTrading:
             }
 
         # Calculate buyable quantity
-        buy_quantity = self.calculate_buy_quantity(stock_code, buy_amount)
+        buy_quantity = (self.calculate_buy_quantity(stock_code, buy_amount, quote_price=quote_price)
+                        if quote_price is not None else self.calculate_buy_quantity(stock_code, buy_amount))
 
         if buy_quantity == 0:
             return {
@@ -737,7 +740,7 @@ class DomesticStockTrading:
                 'message': f'Error during buy order: {str(e)}'
             }
 
-    def buy_reserved_order(self, stock_code: str, buy_amount: int = None, end_date: str = None, limit_price: int = None) -> Dict[str, Any]:
+    def buy_reserved_order(self, stock_code: str, buy_amount: int = None, end_date: str = None, limit_price: int = None, *, quote_price: float = None) -> Dict[str, Any]:
         """
         Buy with reserved order (auto-execute on next trading day)
         Reserved order available: 15:40~next business day 07:30 (excluding 23:40~00:10)
@@ -774,7 +777,8 @@ class DomesticStockTrading:
             ord_dvsn_cd = "01"  # Market price
             ord_unpr = "0"
             # For market price, calculate quantity based on current price
-            buy_quantity = self.calculate_buy_quantity(stock_code, amount)
+            buy_quantity = (self.calculate_buy_quantity(stock_code, amount, quote_price=quote_price)
+                            if quote_price is not None else self.calculate_buy_quantity(stock_code, amount))
 
         if buy_quantity == 0:
             return {
@@ -1260,7 +1264,7 @@ class DomesticStockTrading:
             self._stock_locks[stock_code] = asyncio.Lock()
         return self._stock_locks[stock_code]
 
-    async def async_buy_stock(self, stock_code: str, buy_amount: Optional[int] = None, timeout: float = 30.0, limit_price: Optional[int] = None) -> Dict[str, Any]:
+    async def async_buy_stock(self, stock_code: str, buy_amount: Optional[int] = None, timeout: float = 30.0, limit_price: Optional[int] = None, *, quote_validator=None) -> Dict[str, Any]:
         """
         Async buy API (with timeout)
         Get current price → Calculate buyable quantity → Market buy
@@ -1285,7 +1289,10 @@ class DomesticStockTrading:
         """
         try:
             return await asyncio.wait_for(
-                self._execute_buy_stock(stock_code, buy_amount, limit_price),
+                self._execute_buy_stock(
+                    stock_code, buy_amount, limit_price,
+                    **({"quote_validator": quote_validator} if quote_validator is not None else {}),
+                ),
                 timeout=timeout
             )
         except asyncio.TimeoutError:
@@ -1301,7 +1308,7 @@ class DomesticStockTrading:
                 'timestamp': _now_kst().isoformat()
             }
 
-    async def _execute_buy_stock(self, stock_code: str, buy_amount: int = None, limit_price: int = None) -> Dict[str, Any]:
+    async def _execute_buy_stock(self, stock_code: str, buy_amount: int = None, limit_price: int = None, *, quote_validator=None) -> Dict[str, Any]:
         # Use class default if buy_amount is None
         amount = buy_amount if buy_amount else self.buy_amount
 
@@ -1337,6 +1344,21 @@ class DomesticStockTrading:
                             logger.error(f"[Async Buy API] {stock_code} failed to get current price")
                             return result
 
+                        if quote_validator is not None:
+                            try:
+                                price = float(current_price_info['current_price'])
+                                if not math.isfinite(price) or price <= 0:
+                                    raise ValueError("invalid broker quote")
+                                quote_validator(price)
+                                if limit_price and limit_price > 0:
+                                    quote_validator(float(int(limit_price)))
+                            except Exception as exc:
+                                # No order has been submitted: this is a known
+                                # rejection, not an UNKNOWN broker outcome.
+                                logger.warning("[%s] BUY quote validation rejected: %s", stock_code, exc)
+                                result['message'] = 'BUY quote validation rejected before submission'
+                                return result
+
                         result['current_price'] = current_price_info['current_price']
 
                         # Step 2: Calculate buyable quantity (use amount)
@@ -1363,7 +1385,8 @@ class DomesticStockTrading:
                         else:
                             logger.info(f"[Async Buy API] {stock_code} executing with effective limit price: {buy_quantity} shares x {effective_limit_price:,} KRW")
                         buy_result = await asyncio.to_thread(
-                            self.smart_buy, stock_code, amount, effective_limit_price
+                            self.smart_buy, stock_code, amount, effective_limit_price,
+                            **({"quote_price": current_price} if quote_validator is not None else {})
                         )
 
                         if buy_result['success']:
@@ -2115,7 +2138,7 @@ class MultiAccountDomesticStockTrading:
             raise RuntimeError("No primary domestic account configured")
         return self._get_trader(self.primary_account)
 
-    async def async_buy_stock(self, stock_code: str, buy_amount: Optional[int] = None, timeout: float = 30.0, limit_price: Optional[int] = None) -> Dict[str, Any]:
+    async def async_buy_stock(self, stock_code: str, buy_amount: Optional[int] = None, timeout: float = 30.0, limit_price: Optional[int] = None, *, quote_validator=None) -> Dict[str, Any]:
         if not self.account_configs:
             return self._aggregate_results(stock_code, [], action="buy")
         results = []
@@ -2126,6 +2149,7 @@ class MultiAccountDomesticStockTrading:
                 buy_amount=buy_amount,
                 timeout=timeout,
                 limit_price=limit_price,
+                **({"quote_validator": quote_validator} if quote_validator is not None else {}),
             )
             result["account_name"] = account["name"]
             result["account_key"] = account["account_key"]


### PR DESCRIPTION
## 범위
운영 전 안전 보강 완료. 초안 PR이며 병합·배포·운영 모델/cron 전환은 하지 않습니다.

- BUY 전용 설정, 기존 SELL 기본값 유지
- timeout/cancellation 프로세스 그룹 정리, KR legacy fallback 직렬화
- US 모든 계좌 SELL 검토 선행 및 실패 계좌 BUY 제외
- 최종 broker 시세와 기존 진입 gate 재검증, 검증 quote sizing 재사용
- 날짜가 검증된 KRX fallback, US strict quote, simulator/broker 독립성
- NO ENTRY null 보존, canonical sell-policy 권한, 프롬프트 명확화
- CI 및 rollout/rollback 문서

## 최종 검증 (3977a663)
- GitHub 검사7/7 통과: Python3.10/3.11/3.12, 추가 안전 회귀/라이선스, 빌드, Codacy, CLA
- CI 안전 회귀344 passed (공통138/KR105/US101)
- 추가 로컬 KR+실행경계119 passed, Python3.12 경량92 passed
- 독립 코드 리뷰 APPROVE, 남은 지적0
- 신규 backend 메모리 점검 Astra/high/Fast + time MCP19.2초 정상; 운영 소스 미배포
- Python 전용 정적 타입체커 부재는 명시; 컴파일·AST·정적분석·런타임테스트로 검증

## 운영 보존
운영HEAD3b63370, CLI0.144.1, sol, timeout120초와 기존cron 유지. 후보 BUY Astra/high/Fast240초·병렬3은 주석 예시만 제공. 원장·실계좌·주문 데이터를 변경하지 않았습니다.