### PR TITLE
feat: Astra SELL 전환 설정 분리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -287,3 +287,10 @@ TELEGRAM_CHANNEL_ID=your_channel_id
 # Parallel BUY analysis only; holdings/slot checks and order application stay serial.
 # TRADING_ANALYSIS_CONCURRENCY=3
 # US_TRADING_ANALYSIS_CONCURRENCY=3
+
+# SELL-only Codex settings; independent of BUY. Unset values retain Sol/default
+# effort and PRISM_CODEX_FAST_TIMEOUT (fallback 90s). Examples are not enabled.
+# PRISM_SELL_CODEX_MODEL=gpt-6-astra
+# PRISM_SELL_CODEX_EFFORT=high
+# PRISM_SELL_CODEX_TIMEOUT=120
+# Timeout must be finite, greater than 0 and at most 600 seconds.

--- a/docs/ASTRA_SELL_ROLLOUT_ko.md
+++ b/docs/ASTRA_SELL_ROLLOUT_ko.md
@@ -1,0 +1,51 @@
+# Astra SELL 전환
+
+## 승인과 범위
+
+2026-09-09 사용자가 기존 BUY 전환에 이어 KR/US SELL도 Astra로 전환하도록 승인했다.
+대상은 정규 orchestrator의 Codex SELL primary이며, 매매 기준·순서·주문 로직은 변경하지 않는다.
+매도 품질이나 수익률에서 Astra가 sol보다 우월하다는 결론으로 해석하지 않는다.
+
+후속 설정은 `PRISM_SELL_CODEX_MODEL=gpt-6-astra`,
+`PRISM_SELL_CODEX_EFFORT=high`, `PRISM_SELL_CODEX_TIMEOUT=120`이다.
+Fast는 기존 공통 backend 설정을 유지한다. 기존 SELL timeout을 늘리지 않는다.
+
+BUY의 Astra/high/240초·최대3개 병렬 설정은 그대로 두며, SELL은 기존 순차 실행을 유지한다.
+기존 sol/high legacy fallback도 유지한다. 기존 `ASTRA_BUY_PREDEPLOYMENT_SAFETY_ko.md`의
+SELL sol 유지 설명은 BUY-only 초기 배포 시점의 상태이며 이 후속 전환에서만 달라진다.
+
+## 구현 계약
+
+- `prism_core.codex_config.resolve_sell_codex_settings()`가 독립적인 SELL 설정을 읽는다.
+- 미설정 모델은 기존 sol, effort는 모델 기본값, timeout은 기존 shared 값 또는90초다.
+- BUY 설정이 SELL로 전파되거나 반대로 전파되지 않는다.
+- 공통 immutable 설정·허용 목록·유한 timeout 검증을 재사용한다.
+- `BuyCodexSettings` 기존 import는 호환 유지한다.
+- KR/US SELL 모두 기존 cancellation-safe `generate_codex_fast_async()`를 사용한다.
+- 설정 오류·CLI 실패·JSON 파싱 실패는 기존 fallback을 유지한다. 취소는 fallback 없이 전파한다.
+- 로그는 requested model/effort/tier/timeout이며 실제 backend snapshot·청구 tier 확정값이 아니다.
+
+## 전환 절차
+
+1. PR head·CI·독립 리뷰와 서버 clean 상태를 확인한다.
+2. 실행 중인 orchestrator가 없을 때 검증 commit을 ff-only 배포한다.
+3. 기존 CLI0.153.4와 CODEX_HOME을 그대로 사용해 주문 없는 SELL 점검을 실시한다.
+4. 서버 내부에 cron을 백업하고 네 정규 배치에 SELL 세 변수만 명시한다.
+5. BUY 변수·CLI 경로·기존 shared timeout·다른 cron 명령과 시간을 바꾸지 않는다.
+6. 환경을 다시 파싱해 BUY/Sell resolver와 연결을 확인한다.
+7. 다음 정상 배치에서 SELL 요청모델·effort·시간·fallback을 확인한다. 배치를 중복 실행하지 않는다.
+
+모델만 바꿨다고 기존 timeout 안에 모든 운영 요청이 완료된다는 보장은 없다.
+timeout은 실제 로그에 따라 별도로 검토하며 자동 확대하지 않는다.
+
+## 롤백
+
+네 배치의 SELL override를 제거하면 기존 sol/implicit effort/shared timeout 경로로 돌아간다.
+BUY 설정과 배포된 안전 보강을 불필요하게 되돌리지 않는다. 원장·주문·체결 기록을 복원하거나
+삭제하지 않는다. 설정 백업에는 비밀값이 포함될 수 있으므로 서버 안에만 보관한다.
+
+## 검증 한계
+
+지금까지의 합성 SELL 사례에서는 sol과 Astra의 최종 판단이 같았다. 애매한 실제 과거 매도
+사례와 장기 운영 성과를 충분히 비교하지 않았으므로 우위 판정은 미확정이다.
+기술적인 전환 가능성·기존 규칙 보존·fallback·취소 검증과 투자 성과 검증을 구분한다.

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -166,7 +166,7 @@ def _import_from_main_cores(module_name: str, relative_path: str):
     return module
 
 
-from prism_core.codex_config import resolve_buy_codex_settings
+from prism_core.codex_config import resolve_buy_codex_settings, resolve_sell_codex_settings
 from prism_core.trading_scenario_contract import apply_buy_scenario_contract
 
 # Pre-load telegram_translator_agent from main project (used in multiple methods)
@@ -2375,13 +2375,18 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     )
                     if not instruction:
                         raise RuntimeError("sell agent instruction unavailable")
-                    timeout = int(os.environ.get("PRISM_CODEX_FAST_TIMEOUT", "90"))
-                    codex_result = await asyncio.to_thread(
-                        generate_codex_fast,
+                    settings = resolve_sell_codex_settings()
+                    logger.info(
+                        "[CODEX_FAST] US sell requested_model=%s requested_effort=%s "
+                        "requested_tier=fast timeout_s=%s ticker=%s",
+                        settings.model, settings.reasoning_effort, settings.timeout, ticker or "?",
+                    )
+                    codex_result = await generate_codex_fast_async(
                         system_prompt=instruction,
                         user_prompt=prompt_message,
-                        model="gpt-5.6-sol",
-                        timeout=timeout,
+                        model=settings.model,
+                        reasoning_effort=settings.reasoning_effort,
+                        timeout=settings.timeout,
                         mcp_profile="us_trading",
                         require_mcp_calls=True,
                     )

--- a/prism_core/codex_config.py
+++ b/prism_core/codex_config.py
@@ -1,4 +1,4 @@
-"""BUY-only Codex settings; SELL callers deliberately do not use these."""
+"""Independent BUY and SELL Codex settings with shared pure validation."""
 from __future__ import annotations
 
 import math
@@ -28,22 +28,35 @@ def validate_timeout(value: object) -> float:
 
 
 @dataclass(frozen=True)
-class BuyCodexSettings:
+class CodexSettings:
     model: str
     reasoning_effort: str | None
     timeout: float
 
 
-def resolve_buy_codex_settings(environ: Mapping[str, str] | None = None) -> BuyCodexSettings:
-    """Resolve explicit BUY overrides; timeouts are finite and at most 600s."""
+# Preserve the public BUY settings import and immutable value semantics.
+BuyCodexSettings = CodexSettings
+
+
+def _resolve_codex_settings(side: str, environ: Mapping[str, str] | None) -> CodexSettings:
     env = os.environ if environ is None else environ
-    model = env.get("PRISM_BUY_CODEX_MODEL", "gpt-5.6-sol")
-    effort = env.get("PRISM_BUY_CODEX_EFFORT")
+    model = env.get(f"PRISM_{side}_CODEX_MODEL", "gpt-5.6-sol")
+    effort = env.get(f"PRISM_{side}_CODEX_EFFORT")
     if model not in SUPPORTED_MODELS:
         raise CodexFastError(f"Unsupported Codex model: {model}")
     if effort is not None and effort not in SUPPORTED_REASONING_EFFORTS:
         raise CodexFastError(f"Unsupported Codex reasoning effort: {effort}")
     timeout = validate_timeout(env.get(
-        "PRISM_BUY_CODEX_TIMEOUT", env.get("PRISM_CODEX_FAST_TIMEOUT", "90"),
+        f"PRISM_{side}_CODEX_TIMEOUT", env.get("PRISM_CODEX_FAST_TIMEOUT", "90"),
     ))
-    return BuyCodexSettings(model, effort, timeout)
+    return CodexSettings(model, effort, timeout)
+
+
+def resolve_buy_codex_settings(environ: Mapping[str, str] | None = None) -> BuyCodexSettings:
+    """Resolve explicit BUY overrides; timeouts are finite and at most 600s."""
+    return _resolve_codex_settings("BUY", environ)
+
+
+def resolve_sell_codex_settings(environ: Mapping[str, str] | None = None) -> CodexSettings:
+    """Resolve SELL overrides independently of BUY, preserving unset defaults."""
+    return _resolve_codex_settings("SELL", environ)

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -18,7 +18,8 @@ import os
 import traceback
 
 from mcp_agent.workflows.llm.augmented_llm import RequestParams
-from cores.llm.codex_oauth_fast_backend import generate_codex_fast
+from cores.llm.codex_oauth_fast_backend import generate_codex_fast_async
+from prism_core.codex_config import resolve_sell_codex_settings
 from cores.llm.openai_responses_llm import OpenAIResponsesLLM as OpenAIAugmentedLLM
 
 # Import core agents
@@ -1513,13 +1514,18 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                     )
                     if not instruction:
                         raise RuntimeError("sell agent instruction unavailable")
-                    timeout = int(os.environ.get("PRISM_CODEX_FAST_TIMEOUT", "90"))
-                    codex_result = await asyncio.to_thread(
-                        generate_codex_fast,
+                    settings = resolve_sell_codex_settings()
+                    logger.info(
+                        "[CODEX_FAST] KR sell requested_model=%s requested_effort=%s "
+                        "requested_tier=fast timeout_s=%s ticker=%s",
+                        settings.model, settings.reasoning_effort, settings.timeout, ticker or "?",
+                    )
+                    codex_result = await generate_codex_fast_async(
                         system_prompt=instruction,
                         user_prompt=prompt_message,
-                        model="gpt-5.6-sol",
-                        timeout=timeout,
+                        model=settings.model,
+                        reasoning_effort=settings.reasoning_effort,
+                        timeout=settings.timeout,
                         mcp_profile="kr_trading",
                         require_mcp_calls=True,
                     )

--- a/tests/test_buy_codex_settings.py
+++ b/tests/test_buy_codex_settings.py
@@ -5,7 +5,7 @@ import sys
 
 import pytest
 
-from prism_core.codex_config import resolve_buy_codex_settings
+from prism_core.codex_config import BuyCodexSettings, resolve_buy_codex_settings, resolve_sell_codex_settings
 from cores.llm.codex_oauth_fast_backend import CodexFastError, _command
 
 
@@ -15,6 +15,39 @@ def test_defaults_are_unchanged_and_frozen():
     with pytest.raises(FrozenInstanceError):
         settings.model = "gpt-6-astra"
     assert not any("model_reasoning_effort" in arg for arg in _command("codex", settings.model, None))
+
+
+def test_sell_defaults_frozen_and_buy_import_compatible():
+    settings = resolve_sell_codex_settings({})
+    assert isinstance(resolve_buy_codex_settings({}), BuyCodexSettings)
+    assert (settings.model, settings.reasoning_effort, settings.timeout) == ("gpt-5.6-sol", None, 90)
+    with pytest.raises(FrozenInstanceError):
+        settings.timeout = 120
+    assert resolve_sell_codex_settings({"PRISM_CODEX_FAST_TIMEOUT": "120"}).timeout == 120
+
+
+def test_buy_sell_overrides_are_independent():
+    env = {"PRISM_BUY_CODEX_MODEL": "gpt-6-astra", "PRISM_BUY_CODEX_EFFORT": "high",
+           "PRISM_BUY_CODEX_TIMEOUT": "240", "PRISM_SELL_CODEX_MODEL": "gpt-5.6-sol",
+           "PRISM_SELL_CODEX_EFFORT": "medium", "PRISM_SELL_CODEX_TIMEOUT": "120",
+           "PRISM_CODEX_FAST_TIMEOUT": "55"}
+    assert resolve_buy_codex_settings(env) == BuyCodexSettings("gpt-6-astra", "high", 240)
+    assert resolve_sell_codex_settings(env) == BuyCodexSettings("gpt-5.6-sol", "medium", 120)
+    assert resolve_sell_codex_settings({k: v for k, v in env.items() if "SELL" not in k}) == BuyCodexSettings("gpt-5.6-sol", None, 55)
+    assert resolve_buy_codex_settings({k: v for k, v in env.items() if "BUY" not in k}) == BuyCodexSettings("gpt-5.6-sol", None, 55)
+
+
+@pytest.mark.parametrize("key,value", [("MODEL", "arbitrary"), ("EFFORT", ""), ("EFFORT", "invalid"), *[("TIMEOUT", value) for value in ["", "nan", "inf", "-1", "0", "601", "abc"]]])
+def test_invalid_sell_settings_fail_closed(key, value):
+    with pytest.raises(CodexFastError):
+        resolve_sell_codex_settings({f"PRISM_SELL_CODEX_{key}": value})
+
+
+def test_sell_environment_resolution(monkeypatch):
+    monkeypatch.setenv("PRISM_SELL_CODEX_MODEL", "gpt-6-astra")
+    monkeypatch.setenv("PRISM_SELL_CODEX_EFFORT", "high")
+    monkeypatch.setenv("PRISM_SELL_CODEX_TIMEOUT", "120")
+    assert resolve_sell_codex_settings() == BuyCodexSettings("gpt-6-astra", "high", 120)
 
 
 def test_explicit_astra_effort_and_timeout_precedence():

--- a/tests/test_codex_oauth_fast_backend.py
+++ b/tests/test_codex_oauth_fast_backend.py
@@ -180,6 +180,88 @@ def test_kr_trading_wires_same_codex_primary_and_legacy_fallback() -> None:
     assert method.index("generate_codex_fast") < method.index("attach_llm(")
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("market,path", [
+    ("KR", "stock_tracking_enhanced_agent.py"),
+    ("US", "prism-us/us_stock_tracking_agent.py"),
+])
+@pytest.mark.parametrize("outcome", ["success", "error", "invalid_config", "invalid_json", "cancel", "disabled"])
+async def test_sell_dispatch_uses_isolated_settings_and_safe_fallback(monkeypatch, caplog, market, path, outcome):
+    """Execute the real dispatch statements, without importing broker/DB modules."""
+    import ast
+    import asyncio
+    import json
+    import logging
+    import os
+    from contextlib import asynccontextmanager
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+    from prism_core.codex_config import resolve_sell_codex_settings
+
+    source = (Path(__file__).resolve().parents[1] / path).read_text("utf-8")
+    method = next(n for n in ast.walk(ast.parse(source)) if isinstance(n, ast.AsyncFunctionDef) and n.name == "_analyze_sell_decision")
+    body = next(n.body for n in method.body if isinstance(n, ast.Try))
+    start = next(i for i, n in enumerate(body) if isinstance(n, ast.Assign) and any(isinstance(t, ast.Name) and t.id == "response" for t in n.targets))
+    end = next(i for i in range(start, len(body)) if isinstance(body[i], ast.If) and ast.unparse(body[i].test) == "response is None")
+    # Keep the original await, fallback context managers, and exception handlers.
+    harness = ast.AsyncFunctionDef(name="dispatch", args=ast.arguments(posonlyargs=[], args=[], kwonlyargs=[], kw_defaults=[], defaults=[]), body=body[start:end + 1] + [ast.Return(value=ast.Name(id="response", ctx=ast.Load()))], decorator_list=[])
+    module = ast.fix_missing_locations(ast.Module(body=[harness], type_ignores=[]))
+    monkeypatch.setenv(f"PRISM_{market}_CODEX_FAST_SELL", "0" if outcome == "disabled" else "1")
+    monkeypatch.setenv("PRISM_SELL_CODEX_MODEL", "gpt-6-astra")
+    monkeypatch.setenv("PRISM_SELL_CODEX_EFFORT", "high")
+    monkeypatch.setenv("PRISM_SELL_CODEX_TIMEOUT", "nan" if outcome == "invalid_config" else "120")
+    monkeypatch.setenv("PRISM_BUY_CODEX_TIMEOUT", "240")
+    monkeypatch.setenv("PRISM_CODEX_FAST_TIMEOUT", "90")
+    response = '{"decision":"hold"}'
+    generate = AsyncMock(return_value=SimpleNamespace(text="invalid" if outcome == "invalid_json" else response, latency_s=1, mcp_calls=[{}]))
+    if outcome in {"error", "cancel"}:
+        generate.side_effect = RuntimeError("offline") if outcome == "error" else asyncio.CancelledError()
+    legacy = AsyncMock(return_value=response)
+    attach = AsyncMock(return_value=SimpleNamespace(generate_str=legacy))
+    host_calls = []
+
+    @asynccontextmanager
+    async def host():
+        host_calls.append("entered")
+        yield
+        host_calls.append("exited")
+
+    def parse(text, **kwargs):
+        try:
+            return json.loads(text)
+        except ValueError:
+            return None
+
+    namespace = dict(os=os, logger=logging.getLogger("sell_dispatch_test"),
+                     self=SimpleNamespace(sell_decision_agent=SimpleNamespace(instruction="read-only test", attach_llm=attach), _get_legacy_fallback_lock=asyncio.Lock),
+                     generate_codex_fast_async=generate, resolve_sell_codex_settings=resolve_sell_codex_settings,
+                     parse_llm_json=parse, ticker="TEST", prompt_message="no orders",
+                     OpenAIAugmentedLLM=object(), RequestParams=SimpleNamespace,
+                     app=SimpleNamespace(run=host))
+    namespace[f"_{market.lower()}_codex_runtime_enabled"] = lambda: True
+    exec(compile(module, path, "exec"), namespace)
+    with caplog.at_level("INFO"):
+        if outcome == "cancel":
+            with pytest.raises(asyncio.CancelledError):
+                await namespace["dispatch"]()
+        else:
+            assert await namespace["dispatch"]() == response
+    if outcome not in {"invalid_config", "disabled"}:
+        assert generate.await_count == 1
+        assert generate.await_args.kwargs == dict(system_prompt="read-only test", user_prompt="no orders", model="gpt-6-astra", reasoning_effort="high", timeout=120, mcp_profile=f"{market.lower()}_trading", require_mcp_calls=True)
+        assert "requested_model=gpt-6-astra requested_effort=high requested_tier=fast timeout_s=120" in caplog.text
+    else:
+        generate.assert_not_awaited()
+    if outcome in {"success", "cancel"}:
+        attach.assert_not_awaited()
+        assert host_calls == []
+    else:
+        attach.assert_awaited_once()
+        params = legacy.await_args.kwargs["request_params"]
+        assert (params.model, params.reasoning_effort, params.maxTokens) == ("gpt-5.6-sol", "high", 30000)
+        assert host_calls == ["entered", "exited"]
+
+
 def test_us_sell_wires_codex_mcp_before_legacy_fallback() -> None:
     source = (
         Path(__file__).resolve().parents[1]
@@ -189,6 +271,8 @@ def test_us_sell_wires_codex_mcp_before_legacy_fallback() -> None:
     method = source[source.index("    async def _analyze_sell_decision("):]
     method = method[:method.index("    async def ", 20_000)]
     assert "PRISM_US_CODEX_FAST_SELL" in method
+    assert "await generate_codex_fast_async(" in method
+    assert "resolve_sell_codex_settings()" in method
     assert 'mcp_profile="us_trading"' in method
     assert "require_mcp_calls=True" in method
     assert "falling back to mcp-agent" in method
@@ -203,6 +287,8 @@ def test_kr_sell_wires_codex_mcp_before_legacy_fallback() -> None:
     method = source[source.index("    async def _analyze_sell_decision("):]
     method = method[:method.index("    async def ", 20_000)]
     assert "PRISM_KR_CODEX_FAST_SELL" in method
+    assert "await generate_codex_fast_async(" in method
+    assert "resolve_sell_codex_settings()" in method
     assert 'mcp_profile="kr_trading"' in method
     assert "require_mcp_calls=True" in method
     assert "falling back to mcp-agent" in method


### PR DESCRIPTION
## 승인/범위
사용자가 KR/US SELL까지 Astra/high/Fast로 전환하도록 승인했습니다. SELLtimeout120초, BUY Astra/high240초·병렬3, 기존매매규칙/주문순서/legacySol-highfallback은 유지합니다.

## 변경
- 독립 SELL model/effort/timeout resolver와 공유검증
- KR/US SELL cancellation-safe async backend 및 requested설정로그
- 미설정기본값은기존sol/모델기본effort/sharedtimeout 보존
- BUY 설정타입import호환 및 교차오염방지
- CI에 이미포함된파일에 설정/성공/실패/파싱/취소/비활성 SELL AST실행회귀 추가

## 검증
공통회귀163passed, Python3.12 backend/config/cleanup62passed, 독립리뷰APPROVE. 거래소주문/운영설정변경은아직없음. CI통과및무주문SELL프롬프트점검후배포합니다.

## 해석
Astra의매도품질·수익률우위는미입증입니다. 기존후속배치점검을새SELL설정에맞춰갱신하고timeout/fallback을관측합니다.