### PR TITLE
fix(trading): restore analysis notice on KR fresh quote rejection

### DIFF
--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -807,6 +807,18 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                             gate_allowed=False,
                             gate_reason="fresh_quote_revalidation_failed",
                         )
+                        # A completed analysis is still reportable when the final
+                        # safety gate blocks entry. Never classify this as a buy.
+                        skip_message = (
+                            f"⚠️ 매수 보류: {company_name}({ticker})\n\n"
+                            f"매수 Score: {buy_score}점 (최소 기준: {min_score}점)\n"
+                            "최종 결과: 매수 보류 — 주문하지 않았습니다.\n\n"
+                            "분석 후 최신 가격을 확인하는 과정에서 가격 조회 또는 "
+                            "매수 조건 재검증을 통과하지 못했습니다. "
+                            "분석 의견과 별개로 안전 검증에 따라 진입을 차단했습니다."
+                        )
+                        self._msg_types.append("analysis")
+                        self.message_queue.append(skip_message)
                         await self._save_watchlist_item(
                             ticker=ticker, company_name=company_name,
                             current_price=current_price, buy_score=buy_score,

--- a/tests/test_parallel_trading_batch.py
+++ b/tests/test_parallel_trading_batch.py
@@ -113,6 +113,13 @@ async def test_invalid_final_quote_prevents_both_entry_routes(monkeypatch, pendi
     agent._execute_pending_kr_entry.assert_not_awaited()
     saved = agent._save_watchlist_item.await_args.kwargs
     assert saved["scenario"]["_decision_context"]["gate_allowed"] is False
+    assert saved["decision"] == "Watch"
+    assert saved["was_traded"] is False
+    assert agent._msg_types == ["analysis"]
+    assert len(agent.message_queue) == 1
+    assert "매수 보류: test(005930)" in agent.message_queue[0]
+    assert "주문하지 않았습니다" in agent.message_queue[0]
+    assert "quote unavailable" not in agent.message_queue[0]
 
 
 def _ensure_reentry_schema(path):


### PR DESCRIPTION
## Summary
- Queue one analysis-only deferral notice when the enhanced KR fresh quote gate rejects entry.
- Preserve no-order behavior, watchlist persistence, and existing risk thresholds.
- Do not include raw provider errors or stale prices in user notifications.

## Verification
- Reproduced missing notice with failing regression in both pending-entry modes.
- 105 targeted KR regression tests passed on Python 3.12.
- py_compile and git diff --check passed.

## Scope
No app-server change, batch replay, model configuration change, or order submission.