### PR TITLE
fix(llm): add safe Codex failure diagnostics

### DIFF
--- a/cores/llm/codex_oauth_fast_backend.py
+++ b/cores/llm/codex_oauth_fast_backend.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import shutil
 import signal
@@ -50,6 +51,7 @@ class CodexFastResult:
 
 McpProfile = Literal["kr_trading", "us_trading"]
 SUPPORTED_MCP_PROFILES = frozenset({"kr_trading", "us_trading"})
+logger = logging.getLogger(__name__)
 
 
 def _resolve_codex_executable(candidate: str) -> str:
@@ -206,14 +208,40 @@ def generate_codex_fast(
     _cancel_event: threading.Event | None = None,
 ) -> CodexFastResult:
     timeout = validate_timeout(timeout)
-    executable = _resolve_codex_executable(
-        codex_bin or os.environ.get("PRISM_CODEX_BIN", "codex")
-    )
+    telemetry_started = time.monotonic()
+
+    def log_event(category: str, returncode: int | None = None) -> None:
+        # Only allowlisted configuration and numeric process metadata. Never
+        # include exception text, prompts, streams, paths, or MCP payloads.
+        logger.log(
+            logging.INFO if category == "start" else logging.WARNING,
+            "[CODEX_FAST] category=%s model=%s effort=%s profile=%s "
+            "timeout_s=%g elapsed_s=%.3f rc=%s",
+            category,
+            model if model in SUPPORTED_MODELS else "invalid",
+            reasoning_effort if reasoning_effort in SUPPORTED_REASONING_EFFORTS else (
+                "default" if reasoning_effort is None else "invalid"
+            ),
+            mcp_profile if mcp_profile in SUPPORTED_MCP_PROFILES else (
+                "none" if mcp_profile is None else "invalid"
+            ),
+            timeout, time.monotonic() - telemetry_started, returncode,
+        )
+
+    log_event("start")
+    try:
+        executable = _resolve_codex_executable(
+            codex_bin or os.environ.get("PRISM_CODEX_BIN", "codex")
+        )
+    except CodexFastError:
+        log_event("launch_error")
+        raise
     home = codex_home or os.environ.get("PRISM_CODEX_HOME")
     environment = os.environ.copy()
     if home:
         environment["CODEX_HOME"] = home
     started = time.monotonic()
+    process = None
     try:
         with tempfile.TemporaryDirectory(prefix="prism-codex-fast-") as run_dir:
             # The executable is resolved, permission-checked, and invoked with a
@@ -235,9 +263,11 @@ def generate_codex_fast(
                 prompt = _prompt(system_prompt, user_prompt, mcp_profile)
                 while True:
                     if _cancel_event is not None and _cancel_event.is_set():
+                        log_event("cancelled")
                         raise CodexFastError("Codex Fast cancelled")
                     remaining = timeout - (time.monotonic() - started)
                     if remaining <= 0:
+                        log_event("timeout")
                         raise CodexFastError(f"Codex Fast timed out after {timeout:g}s")
                     try:
                         stdout, stderr = process.communicate(input=prompt, timeout=min(0.1, remaining))
@@ -248,18 +278,22 @@ def generate_codex_fast(
                 _terminate_owned_process(process)
                 raise
     except (OSError, subprocess.TimeoutExpired) as exc:
+        log_event("launch_error" if process is None else "process_io_error")
         raise CodexFastError(f"Codex Fast unavailable: {exc}") from exc
     latency = time.monotonic() - started
     if process.returncode != 0:
+        log_event("nonzero_exit", process.returncode)
         raise CodexFastError(
             f"Codex Fast rc={process.returncode}: {stderr[-300:]}"
         )
     text, usage, mcp_calls = _parse_stream(stdout)
     if not text:
+        log_event("missing_final", process.returncode)
         raise CodexFastError("Codex Fast returned no final agent message")
     if require_mcp_calls and not any(
         call.status == "completed" and not call.error for call in mcp_calls
     ):
+        log_event("missing_successful_mcp", process.returncode)
         raise CodexFastError("Codex Fast returned no MCP tool calls")
     return CodexFastResult(
         text=text,

--- a/tests/test_codex_fast_process_cleanup.py
+++ b/tests/test_codex_fast_process_cleanup.py
@@ -43,7 +43,7 @@ def assert_tree_stopped(pid_path):
         os.waitpid(pids[0], os.WNOHANG)
 
 
-def test_timeout_terminates_child_and_grandchild(child_tree, monkeypatch):
+def test_timeout_terminates_child_and_grandchild(child_tree, monkeypatch, caplog):
     signaled_groups = []
     real_killpg = os.killpg
 
@@ -55,11 +55,14 @@ def test_timeout_terminates_child_and_grandchild(child_tree, monkeypatch):
     monkeypatch.setattr(os, "killpg", record_killpg)
     started = time.monotonic()
     with pytest.raises(backend.CodexFastError, match="timed out"):
-        backend.generate_codex_fast(system_prompt="s", user_prompt="u", timeout=0.5)
+        backend.generate_codex_fast(system_prompt="PRIVATE_PROMPT", user_prompt="PRIVATE_PROMPT", timeout=0.5)
     assert time.monotonic() - started < 3
     assert_tree_stopped(child_tree)
     leader = int(child_tree.read_text().split()[0])
     assert signaled_groups == [leader, leader]
+    assert "category=timeout" in caplog.text
+    assert "timeout_s=0.5" in caplog.text
+    assert "PRIVATE_PROMPT" not in caplog.text
 
 
 def test_async_cancellation_waits_for_process_tree_cleanup(child_tree):

--- a/tests/test_codex_oauth_fast_backend.py
+++ b/tests/test_codex_oauth_fast_backend.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -145,6 +146,75 @@ def test_codex_fast_backend_raises_on_cli_failure(
     )
     with pytest.raises(backend.CodexFastError, match="auth failed"):
         backend.generate_codex_fast(system_prompt="s", user_prompt="u")
+
+
+@pytest.mark.parametrize(
+    ("returncode", "has_final", "mcp_status", "category"),
+    [
+        (7, True, "completed", "nonzero_exit"),
+        (0, False, "completed", "missing_final"),
+        (0, True, "failed", "missing_successful_mcp"),
+    ],
+)
+def test_failure_telemetry_has_safe_metadata_only(
+    monkeypatch, _trusted_codex, caplog, returncode, has_final, mcp_status, category,
+):
+    secret = "DO_NOT_LOG_TOKEN_OR_ACCOUNT_DATA"
+    events = [{
+        "type": "item.completed",
+        "item": {
+            "type": "mcp_tool_call", "server": secret, "tool": secret,
+            "arguments": {"token": secret}, "status": mcp_status,
+            "error": None if mcp_status == "completed" else secret,
+        },
+    }]
+    if has_final:
+        events.append({
+            "type": "item.completed", "item": {"type": "agent_message", "text": secret},
+        })
+    monkeypatch.setattr(
+        backend.subprocess, "Popen",
+        lambda *_args, **_kwargs: fake_process(
+            returncode=returncode, stdout="\n".join(map(json.dumps, events)), stderr=secret,
+        ),
+    )
+    caplog.set_level(logging.INFO, logger=backend.__name__)
+    with pytest.raises(backend.CodexFastError):
+        backend.generate_codex_fast(
+            system_prompt=secret, user_prompt=secret, codex_home=secret,
+            model="gpt-6-astra", reasoning_effort="high", timeout=240,
+            mcp_profile="kr_trading", require_mcp_calls=True,
+        )
+    messages = [record.getMessage() for record in caplog.records]
+    assert len(messages) == 2
+    assert "category=start" in messages[0]
+    assert f"category={category}" in messages[1]
+    assert "model=gpt-6-astra effort=high profile=kr_trading timeout_s=240" in messages[1]
+    assert f"rc={returncode}" in messages[1]
+    assert "elapsed_s=" in messages[1]
+    assert secret not in caplog.text
+
+
+@pytest.mark.parametrize("failure_stage", ["resolve", "popen"])
+def test_launch_error_telemetry_does_not_log_exception(
+    monkeypatch, _trusted_codex, caplog, failure_stage,
+):
+    secret = "PRIVATE_EXECUTABLE_OR_ENV_TOKEN"
+
+    def fail(*args, **kwargs):
+        if failure_stage == "resolve":
+            raise backend.CodexFastError(secret)
+        raise OSError(secret)
+
+    if failure_stage == "resolve":
+        monkeypatch.setattr(backend, "_resolve_codex_executable", fail)
+    else:
+        monkeypatch.setattr(backend.subprocess, "Popen", fail)
+    caplog.set_level(logging.INFO, logger=backend.__name__)
+    with pytest.raises(backend.CodexFastError, match=secret):
+        backend.generate_codex_fast(system_prompt=secret, user_prompt=secret)
+    assert "category=launch_error" in caplog.text
+    assert secret not in caplog.text
 
 
 def test_us_trading_wires_codex_primary_before_legacy_fallback() -> None:


### PR DESCRIPTION
## Summary
- Emit safe start and categorized failure diagnostics with elapsed time and bounded runtime settings.
- Preserve exception compatibility, fallback, process cleanup, environment and model settings.
- Never log prompts, credentials, raw stderr/stdout or MCP data.

## Incident evidence
Today three BUY fallbacks were timing-consistent with 240s timeouts, but historical cause is not recoverable. Isolated same-day three-report replay completed in 102/111/120 seconds with successful MCP calls; this is not full production-load reproduction.

## Validation
Backend, process cleanup and settings regression tests; explicit sensitive-value nondisclosure checks. No order/batch replay or strategy changes.