### PR TITLE
fix(ops): restore ChatGPT quota health probe

### DIFF
--- a/tests/test_oauth_healthcheck.py
+++ b/tests/test_oauth_healthcheck.py
@@ -5,7 +5,12 @@ Run: .venv/bin/python -m pytest tests/test_oauth_healthcheck.py -q
 from __future__ import annotations
 
 import importlib.util
+import asyncio
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
 
 
 _SOURCE = Path(__file__).resolve().parents[1] / "tools" / "oauth_healthcheck.py"
@@ -13,6 +18,71 @@ _SPEC = importlib.util.spec_from_file_location("oauth_healthcheck", _SOURCE)
 assert _SPEC and _SPEC.loader
 oauth_healthcheck = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(oauth_healthcheck)
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 500])
+def test_failed_probe_never_exposes_raw_backend_message(status):
+    detail = oauth_healthcheck._quota_http_failure(
+        status, b'{"detail":"model not supported secret-token account-id"}',
+    )
+    assert str(status) in detail
+    assert "secret-token" not in detail
+    assert "account-id" not in detail
+    if status == 400:
+        assert "모델 미지원" in detail
+        assert "잔량은 확인되지 않았습니다" in detail
+
+
+def test_valid_and_rate_limited_responses_keep_quota_parsing():
+    assert oauth_healthcheck._quota_http_failure(200, b"") is None
+    assert oauth_healthcheck._quota_http_failure(429, b"") is None
+    assert "요청 거절" in oauth_healthcheck._quota_http_failure(400, b"invalid input")
+
+
+@pytest.mark.parametrize("status", [200, 400, 429])
+def test_probe_supported_model_and_http_status_handling(monkeypatch, status):
+    from cores.chatgpt_proxy import token_manager
+    import aiohttp
+
+    monkeypatch.delenv("OAUTH_QUOTA_PROBE_MODEL", raising=False)
+    module = importlib.util.module_from_spec(_SPEC)
+    monkeypatch.setattr("dotenv.load_dotenv", lambda *a, **kw: None)
+    _SPEC.loader.exec_module(module)
+    monkeypatch.setattr(token_manager, "TokenManager", lambda: SimpleNamespace(
+        get_token=AsyncMock(return_value="fake-token"),
+        get_account_id=AsyncMock(return_value="fake-account"),
+    ))
+    sent = {}
+
+    class Response:
+        headers = {"x-codex-primary-window-minutes": "10080"}
+        async def __aenter__(self):
+            self.status = status
+            return self
+        async def __aexit__(self, *args):
+            pass
+        async def read(self):
+            return b'{"detail":"model not supported secret-token"}'
+
+    class Session:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *args):
+            pass
+        def post(self, url, **kwargs):
+            sent.update(kwargs)
+            return Response()
+
+    monkeypatch.setattr(aiohttp, "ClientSession", Session)
+    quota, detail = asyncio.run(module._probe_quota())
+    assert sent["json"]["model"] == "gpt-5.6-sol"
+    assert "secret-token" not in detail
+    if status == 400:
+        assert quota is None  # reject even if incidental quota headers exist
+        assert "모델 미지원" in detail
+    else:
+        assert quota["status"] == status
+        assert quota["primary_window_min"] == 10080
 
 
 def _quota(**overrides: int | str) -> dict:

--- a/tools/oauth_healthcheck.py
+++ b/tools/oauth_healthcheck.py
@@ -71,9 +71,9 @@ ALERT_CHAT_ID = os.getenv("OAUTH_ALERT_CHAT_ID") or os.getenv("TELEGRAM_CHANNEL_
 BOT_TOKEN = os.getenv("OAUTH_ALERT_BOT_TOKEN") or os.getenv("TELEGRAM_BOT_TOKEN")
 
 # --- Quota config ----------------------------------------------------------
-# Probe uses the lightest Codex-compatible model (api_translator._MODEL_MAP
-# target) so it burns almost nothing of the quota it is measuring.
-QUOTA_PROBE_MODEL = os.getenv("OAUTH_QUOTA_PROBE_MODEL", "gpt-5.4-mini")
+# Use a verified ChatGPT OAuth-compatible model with a tiny input/output.
+# Generic API model availability does not imply ChatGPT backend support.
+QUOTA_PROBE_MODEL = os.getenv("OAUTH_QUOTA_PROBE_MODEL", "gpt-5.6-sol")
 # "Remaining < this %" on EITHER window triggers the ⚠️ warning highlight.
 QUOTA_WARN_REMAINING_PCT = int(os.getenv("OAUTH_QUOTA_WARN_REMAINING_PCT", "20"))
 
@@ -247,6 +247,20 @@ def _available_quota_windows(q: dict) -> list[dict]:
     return windows
 
 
+def _quota_http_failure(status: int, body: bytes) -> str | None:
+    """Classify rejected probes without exposing the backend response body."""
+    if 200 <= status < 300 or status == 429:
+        return None
+    if status == 400:
+        text = body[:8192].decode("utf-8", errors="replace").lower()
+        if "model" in text and ("not supported" in text or "unsupported" in text):
+            return "조회 모델 미지원 (status=400). 쿼터 잔량은 확인되지 않았습니다."
+        return "쿼터 조회 요청 거절 (status=400). 쿼터 잔량은 확인되지 않았습니다."
+    if status in (401, 403):
+        return f"쿼터 조회 인증/권한 오류 (status={status})."
+    return f"쿼터 조회 백엔드 오류 (status={status}). 쿼터 잔량은 확인되지 않았습니다."
+
+
 async def _probe_quota() -> tuple[dict | None, str]:
     """Fire ONE cheap Codex call and read x-codex-* rate-limit headers.
 
@@ -301,12 +315,17 @@ async def _probe_quota() -> tuple[dict | None, str]:
                 h = resp.headers
                 status = resp.status
                 # Drain the stream so the connection closes cleanly (cheap call).
+                response_body = b""
                 try:
-                    await resp.read()
+                    response_body = await resp.read()
                 except Exception:  # noqa: BLE001
                     pass
     except Exception as e:  # noqa: BLE001
         return None, f"프록시/백엔드 호출 실패: {e!r}"
+
+    failure = _quota_http_failure(status, response_body)
+    if failure:
+        return None, failure
 
     if not any(k.lower().startswith("x-codex-") for k in h):
         return None, f"쿼터 헤더 없음 (status={status}). 백엔드 응답에 x-codex-* 미포함."


### PR DESCRIPTION
## Verified cause
The production gpt-5.4-mini quota probe returns HTTP400 with model-not-supported response and no quota headers. A notification-free gpt-5.6-sol probe returns HTTP200 with a weekly quota window.

## Changes
- Default quota probe to verified OAuth-compatible gpt-5.6-sol.
- Classify HTTP failures before parsing quota headers; never expose response bodies.
- Preserve successful and 429 quota header parsing.

## Validation
12 regression tests pass; focused Ruff and diff checks pass. No trading model/configuration changes. Existing cron and alert destination remain unchanged.