### PR TITLE
fix: eliminate large-prompt Codex stdin deadlock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
           python -m pytest tests/test_trading_scenario_contract.py \
             tests/test_trading_agents_prompt_rules.py \
             tests/test_codex_oauth_fast_backend.py tests/test_buy_codex_settings.py \
-            tests/test_codex_fast_process_cleanup.py tests/test_entry_score_policy_contract.py \
+            tests/test_codex_fast_process_cleanup.py tests/test_codex_fast_large_stdin.py \
+            tests/test_codex_fast_stage_telemetry.py tests/test_entry_score_policy_contract.py \
             tests/test_regime_min_score_floor.py tests/test_buy_gate.py \
             tests/test_order_budget.py tests/test_pyramid_pilot_exclusion.py -q
           python -m pytest tests/test_trend_quality_research.py \

--- a/cores/llm/codex_oauth_fast_backend.py
+++ b/cores/llm/codex_oauth_fast_backend.py
@@ -61,6 +61,7 @@ logger = logging.getLogger(__name__)
 _MAX_OUTPUT_BYTES = 32 * 1024 * 1024
 _MAX_TELEMETRY_LINE = 64 * 1024
 _MAX_STAGE_EVENTS = 256
+_STDIN_WRITE_BUDGET = 64 * 1024
 _SAFE_SERVERS = frozenset({"time", "sqlite", "perplexity", "kospi_kosdaq", "yahoo_finance"})
 _SAFE_TOOLS = frozenset({
     "get_current_time", "list_tables", "describe_table", "read_query", "perplexity_ask",
@@ -72,6 +73,42 @@ _SAFE_TOOLS = frozenset({
 })
 
 
+class _StdinPump:
+    """Own a detached POSIX stdin pipe; never retry/resend accepted bytes.
+
+    communicate(input=None) drains stdout/stderr only. Retrying communicate with
+    None cannot reliably finish partially written input on CPython POSIX, so the
+    public stdin stream is detached before the first communicate call.
+    """
+
+    def __init__(self, stream, payload):
+        self.stream = stream
+        self.data = memoryview(payload)
+        self.total = len(payload)
+        self.sent = 0
+        self.closed = False
+        os.set_blocking(stream.fileno(), False)
+
+    def advance(self):
+        budget = _STDIN_WRITE_BUDGET
+        while not self.closed and self.sent < self.total and budget:
+            try:
+                count = os.write(self.stream.fileno(), self.data[self.sent:self.sent + budget])
+            except (BlockingIOError, InterruptedError):
+                return
+            if count <= 0:
+                raise OSError("stdin write made no progress")
+            self.sent += count
+            budget -= count
+        if self.sent == self.total:
+            self.close()  # The child receives EOF only after the entire payload.
+
+    def close(self):
+        if not self.closed:
+            self.stream.close()
+            self.closed = True
+
+
 class _StreamTelemetry:
     """Incremental cursor over communicate's cumulative snapshots; bounded state."""
 
@@ -81,6 +118,7 @@ class _StreamTelemetry:
         self.pending = b""
         self.dropping = False
         self.first_seen = False
+        self.agent_message_seen = self.model_final_seen = False
         self.last_stage = "start"
         self.mcp_started = self.mcp_completed = self.mcp_errors = 0
         self.active = {}
@@ -156,8 +194,12 @@ class _StreamTelemetry:
                 self._stage("mcp_error" if failed else "mcp_completed",
                             tool_s=-1 if began is None else time.monotonic() - began, **metadata)
         elif kind == "item.completed" and isinstance(item, dict) and item.get("type") == "agent_message":
-            self._stage("model_final")
+            self.agent_message_seen = True
+            self._stage("agent_message")
         elif kind == "turn.completed":
+            if self.agent_message_seen and not self.model_final_seen:
+                self.model_final_seen = True
+                self._stage("model_final")
             self._stage("turn_completed")
         elif kind in ("turn.failed", "error"):
             self._stage("turn_error")
@@ -335,17 +377,18 @@ def generate_codex_fast(
         raise CodexFastError("Codex timeout must be a finite number in (0, 600]") from None
     telemetry_started = time.monotonic()
     request_id = uuid.uuid4().hex
+    pump = None
 
     def log_event(category: str, returncode: int | None = None, *,
                   server="none", tool="none", tool_s=-1) -> None:
         # Only allowlisted configuration and numeric process metadata. Never
         # include exception text, prompts, streams, paths, or MCP payloads.
         logger.log(
-            logging.WARNING if category in {"timeout", "cancelled", "launch_error", "process_io_error", "nonzero_exit", "missing_final", "missing_successful_mcp", "output_limit", "cleanup_unconfirmed"} else logging.INFO,
+            logging.WARNING if category in {"timeout", "cancelled", "launch_error", "process_io_error", "nonzero_exit", "missing_final", "missing_successful_mcp", "output_limit", "cleanup_unconfirmed", "unsupported_platform", "incomplete_stdin"} else logging.INFO,
             "[CODEX_FAST] category=%s model=%s effort=%s profile=%s "
             "timeout_s=%g elapsed_s=%.3f rc=%s request_id=%s last_stage=%s "
             "mcp_started=%d mcp_completed=%d mcp_errors=%d mcp_pending=%d "
-            "server=%s tool=%s tool_s=%.3f",
+            "server=%s tool=%s tool_s=%.3f stdin_total_bytes=%d stdin_sent_bytes=%d stdin_closed=%d",
             category,
             model if model in SUPPORTED_MODELS else "invalid",
             reasoning_effort if reasoning_effort in SUPPORTED_REASONING_EFFORTS else (
@@ -358,6 +401,9 @@ def generate_codex_fast(
             request_id, telemetry.last_stage, telemetry.mcp_started,
             telemetry.mcp_completed, telemetry.mcp_errors, len(telemetry.active),
             server, tool, tool_s,
+            pump.total if pump is not None else 0,
+            pump.sent if pump is not None else 0,
+            int(pump.closed) if pump is not None else 0,
         )
 
     telemetry = _StreamTelemetry(log_event)
@@ -371,6 +417,9 @@ def generate_codex_fast(
             raise CodexFastError("Codex Fast output limit exceeded")
 
     log_event("start")
+    if os.name != "posix":
+        log_event("unsupported_platform")
+        raise CodexFastError("Codex Fast requires POSIX nonblocking pipes; use fallback")
     try:
         executable = _resolve_codex_executable(
             codex_bin or os.environ.get("PRISM_CODEX_BIN", "codex")
@@ -401,8 +450,11 @@ def generate_codex_fast(
                 # signals out of the long-lived PRISM orchestrator process group.
                 start_new_session=os.name == "posix",
             )
+            stdin_stream = process.stdin
+            process.stdin = None  # Public pipe ownership transfers to our pump.
             try:
                 prompt = _prompt(system_prompt, user_prompt, mcp_profile).encode("utf-8")
+                pump = _StdinPump(stdin_stream, prompt)
                 while True:
                     if _cancel_event is not None and _cancel_event.is_set():
                         log_event("cancelled")
@@ -411,17 +463,34 @@ def generate_codex_fast(
                     if remaining <= 0:
                         log_event("timeout")
                         raise CodexFastError(f"Codex Fast timed out after {timeout:g}s")
+                    pump.advance()
+                    remaining = timeout - (time.monotonic() - started)
+                    if remaining <= 0:
+                        continue
                     try:
-                        stdout, stderr = process.communicate(input=prompt, timeout=min(0.1, remaining))
+                        # A short drain poll while input remains prevents pipe-size
+                        # dependent throttling; completed input retains 100ms polls.
+                        poll = .01 if not pump.closed else .1
+                        stdout, stderr = process.communicate(input=None, timeout=min(poll, remaining))
                         break
                     except subprocess.TimeoutExpired as exc:
-                        prompt = None
                         check_output(exc.output, exc.stderr)
                         telemetry.consume(exc.output)
             except BaseException:
-                group_confirmed = _terminate_owned_process(process)
-                log_event("cleanup_unconfirmed" if group_confirmed is False else "cleanup_completed")
+                try:
+                    if pump is not None:
+                        pump.close()
+                    elif stdin_stream is not None:
+                        stdin_stream.close()
+                finally:
+                    group_confirmed = _terminate_owned_process(process)
+                    log_event("cleanup_unconfirmed" if group_confirmed is False else "cleanup_completed")
                 raise
+            finally:
+                if pump is not None:
+                    pump.close()
+                elif stdin_stream is not None:
+                    stdin_stream.close()
             # communicate has reaped the leader. Do not signal its now-reusable
             # PID/group if completed-output validation fails.
             check_output(stdout, stderr)
@@ -435,6 +504,9 @@ def generate_codex_fast(
         raise CodexFastError(
             f"Codex Fast rc={process.returncode}"
         )
+    if pump.sent != pump.total:
+        log_event("incomplete_stdin", process.returncode)
+        raise CodexFastError("Codex Fast exited before full prompt transmission")
     try:
         stream = stdout.decode("utf-8") if isinstance(stdout, bytes) else stdout
     except UnicodeError:

--- a/tests/test_codex_fast_large_stdin.py
+++ b/tests/test_codex_fast_large_stdin.py
@@ -1,0 +1,149 @@
+"""Real harmless child processes; no Codex, auth, network or broker calls."""
+import hashlib
+import json
+import asyncio
+import logging
+import os
+import re
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+
+from cores.llm import codex_oauth_fast_backend as backend
+
+
+READER = """
+import hashlib,json,sys,time
+time.sleep(.3)
+data=sys.stdin.buffer.read()
+answer=json.dumps({'bytes':len(data),'sha256':hashlib.sha256(data).hexdigest()})
+print(json.dumps({'type':'item.completed','item':{'type':'agent_message','text':answer}}),flush=True)
+print(json.dumps({'type':'turn.completed'}),flush=True)
+"""
+
+
+def child(monkeypatch, script=READER):
+    monkeypatch.setattr(backend, "_resolve_codex_executable", lambda _: sys.executable)
+    monkeypatch.setattr(backend, "_command", lambda *args: [sys.executable, "-u", "-c", script])
+
+
+def verify(prompt, *, timeout=1.5):
+    result = backend.generate_codex_fast(system_prompt="system", user_prompt=prompt, timeout=timeout)
+    expected = backend._prompt("system", prompt, None).encode("utf-8")
+    assert json.loads(result.text) == {"bytes": len(expected), "sha256": hashlib.sha256(expected).hexdigest()}
+
+
+def test_delayed_reader_receives_large_prompt_exactly_once_and_eof(monkeypatch):
+    child(monkeypatch)
+    verify("x" * 200000)
+
+
+def test_three_parallel_multibyte_prompts_and_stderr_backpressure(monkeypatch):
+    child(monkeypatch, READER.replace("data=sys.stdin.buffer.read()", "sys.stderr.buffer.write(b'x'*1000000);sys.stderr.flush()\ndata=sys.stdin.buffer.read()"))
+    with ThreadPoolExecutor(max_workers=3) as pool:
+        list(pool.map(lambda i: verify(("한국어📈" + str(i)) * 20000, timeout=3), range(3)))
+
+
+def track_children(monkeypatch):
+    processes = []
+    real = backend.subprocess.Popen
+
+    def spawn(*args, **kwargs):
+        process = real(*args, **kwargs)
+        processes.append(process)
+        return process
+
+    monkeypatch.setattr(backend.subprocess, "Popen", spawn)
+    return processes
+
+
+def assert_reaped(process):
+    assert process.returncode is not None
+    with pytest.raises(ChildProcessError):
+        os.waitpid(process.pid, os.WNOHANG)
+
+
+def test_timeout_while_large_stdin_blocked_is_bounded_and_safe(monkeypatch, caplog):
+    child(monkeypatch, "import sys,time;sys.stderr.buffer.write(b'x'*1000000);sys.stderr.flush();time.sleep(30)")
+    processes = track_children(monkeypatch)
+    caplog.set_level(logging.INFO)
+    started = time.monotonic()
+    with pytest.raises(backend.CodexFastError, match="timed out"):
+        backend.generate_codex_fast(system_prompt="PRIVATE", user_prompt="PRIVATE" * 200000, timeout=.25)
+    assert time.monotonic() - started < 3
+    assert_reaped(processes[0])
+    record = next(r.getMessage() for r in caplog.records if "category=timeout " in r.getMessage())
+    total, sent, closed = map(int, re.search(r"stdin_total_bytes=(\d+) stdin_sent_bytes=(\d+) stdin_closed=(\d+)", record).groups())
+    assert 0 < sent < total and closed == 0
+    assert "PRIVATE" not in caplog.text
+
+
+def test_repeated_async_cancellation_reaps_blocked_input_child(monkeypatch):
+    child(monkeypatch, "import time;time.sleep(30)")
+    processes = track_children(monkeypatch)
+
+    async def run():
+        task = asyncio.create_task(backend.generate_codex_fast_async(system_prompt="s", user_prompt="x" * 2000000, timeout=30))
+        deadline = time.monotonic() + 3
+        while not processes:
+            assert time.monotonic() < deadline
+            await asyncio.sleep(.01)
+        await asyncio.sleep(.05)
+        started = time.monotonic()
+        task.cancel()
+        await asyncio.sleep(.02)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert time.monotonic() - started < 3
+        assert_reaped(processes[0])
+
+    asyncio.run(run())
+
+
+def test_success_reports_full_transmission_without_logging_prompt(monkeypatch, caplog):
+    child(monkeypatch)
+    caplog.set_level(logging.INFO)
+    verify("PRIVATE_한국어" * 20000)
+    record = next(r.getMessage() for r in caplog.records if "category=success " in r.getMessage())
+    total, sent, closed = map(int, re.search(r"stdin_total_bytes=(\d+) stdin_sent_bytes=(\d+) stdin_closed=(\d+)", record).groups())
+    assert sent == total and total > 200000 and closed == 1
+    assert "PRIVATE" not in caplog.text
+
+
+def test_reaped_early_success_with_incomplete_stdin_is_rejected_without_group_signal(monkeypatch):
+    monkeypatch.setattr(backend, "_resolve_codex_executable", lambda _: sys.executable)
+    monkeypatch.setattr(backend, "_STDIN_WRITE_BUDGET", 32)
+    stream = json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "{}"}})
+    monkeypatch.setattr(backend.subprocess, "Popen", lambda *a, **kw: SimpleNamespace(
+        stdin=open(os.devnull, "wb"), returncode=0, communicate=lambda **kw: (stream, "")))
+    monkeypatch.setattr(backend, "_terminate_owned_process", lambda *a: pytest.fail("leader already reaped; never signal reusable group ID"))
+    with pytest.raises(backend.CodexFastError, match="full prompt transmission"):
+        backend.generate_codex_fast(system_prompt="s", user_prompt="x" * 200000)
+
+
+def test_unsupported_platform_fails_before_launch_for_caller_fallback(monkeypatch):
+    monkeypatch.setattr(backend, "os", SimpleNamespace(name="nt"))
+    monkeypatch.setattr(backend.subprocess, "Popen", lambda *a, **kw: pytest.fail("unsupported platform must not launch"))
+    with pytest.raises(backend.CodexFastError, match="POSIX.*fallback"):
+        backend.generate_codex_fast(system_prompt="s", user_prompt="u")
+
+
+def test_pump_setup_failure_still_closes_stdin_and_reaps(monkeypatch):
+    child(monkeypatch, "import time;time.sleep(30)")
+    processes = track_children(monkeypatch)
+    streams = []
+
+    def fail(stream, payload):
+        streams.append(stream)
+        raise OSError("PRIVATE_SETUP_ERROR")
+
+    monkeypatch.setattr(backend, "_StdinPump", fail)
+    with pytest.raises(backend.CodexFastError) as error:
+        backend.generate_codex_fast(system_prompt="s", user_prompt="u")
+    assert "PRIVATE_SETUP_ERROR" not in str(error.value)
+    assert streams[0].closed
+    assert_reaped(processes[0])

--- a/tests/test_codex_fast_process_cleanup.py
+++ b/tests/test_codex_fast_process_cleanup.py
@@ -55,7 +55,7 @@ def test_timeout_terminates_child_and_grandchild(child_tree, monkeypatch, caplog
     monkeypatch.setattr(os, "killpg", record_killpg)
     started = time.monotonic()
     with pytest.raises(backend.CodexFastError, match="timed out"):
-        backend.generate_codex_fast(system_prompt="PRIVATE_PROMPT", user_prompt="PRIVATE_PROMPT", timeout=0.5)
+        backend.generate_codex_fast(system_prompt="PRIVATE_PROMPT", user_prompt="PRIVATE_PROMPT" * 200000, timeout=0.5)
     assert time.monotonic() - started < 3
     assert_tree_stopped(child_tree)
     leader = int(child_tree.read_text().split()[0])
@@ -67,7 +67,7 @@ def test_timeout_terminates_child_and_grandchild(child_tree, monkeypatch, caplog
 
 def test_async_cancellation_waits_for_process_tree_cleanup(child_tree):
     async def run():
-        task = asyncio.create_task(backend.generate_codex_fast_async(system_prompt="s", user_prompt="u", timeout=30))
+        task = asyncio.create_task(backend.generate_codex_fast_async(system_prompt="s", user_prompt="u" * 2000000, timeout=30))
         deadline = time.monotonic() + 3
         while not child_tree.exists():
             assert time.monotonic() < deadline

--- a/tests/test_codex_fast_stage_telemetry.py
+++ b/tests/test_codex_fast_stage_telemetry.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import re
 import subprocess
 import sys
@@ -111,7 +112,7 @@ def test_parallel_calls_have_distinct_safe_correlation_ids(monkeypatch, caplog):
     monkeypatch.setattr(backend, "_resolve_codex_executable", lambda _: sys.executable)
     output = json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "PRIVATE"}})
     monkeypatch.setattr(backend.subprocess, "Popen", lambda *a, **k: SimpleNamespace(
-        returncode=0, communicate=lambda **kw: (output, "PRIVATE")))
+        stdin=open(os.devnull, "wb"), returncode=0, communicate=lambda **kw: (output, "PRIVATE")))
     caplog.set_level(logging.INFO)
     with ThreadPoolExecutor(max_workers=2) as pool:
         results = list(pool.map(lambda _: backend.generate_codex_fast(system_prompt="PRIVATE", user_prompt="PRIVATE"), range(2)))
@@ -134,7 +135,7 @@ def test_output_budget_fails_closed_and_only_cleans_active_child(monkeypatch, ca
         raise subprocess.TimeoutExpired("PRIVATE", .1, output=b"PRIVATE" * 10)
 
     monkeypatch.setattr(backend.subprocess, "Popen", lambda *a, **k: SimpleNamespace(
-        returncode=0 if completed else None, communicate=communicate))
+        stdin=open(os.devnull, "wb"), returncode=0 if completed else None, communicate=communicate))
     with pytest.raises(backend.CodexFastError, match="output limit"):
         backend.generate_codex_fast(system_prompt="s", user_prompt="u")
     assert len(cleaned) == (0 if completed else 1)
@@ -158,7 +159,18 @@ def test_binary_partial_and_final_newlines_preserve_stages(monkeypatch, caplog, 
     caplog.set_level(logging.INFO)
     result = backend.generate_codex_fast(system_prompt="한국어", user_prompt="한국어", timeout=3)
     assert result.text == "완료"
-    for category in ("first_event", "mcp_started", "mcp_completed", "model_final", "turn_completed"):
+    for category in ("first_event", "mcp_started", "mcp_completed", "agent_message", "model_final", "turn_completed"):
         assert caplog.text.count(f"category={category} ") == 1
     assert "mcp_started=1 mcp_completed=1 mcp_errors=0 mcp_pending=0" in caplog.text
     assert "한국어" not in caplog.text
+
+
+def test_commentary_agent_message_is_not_model_final_before_turn_completion():
+    categories = []
+    telemetry = backend._StreamTelemetry(lambda category, **kw: categories.append(category))
+    telemetry._line(json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "PRIVATE_COMMENTARY"}}))
+    telemetry._line(json.dumps({"type": "item.started", "item": {"type": "mcp_tool_call", "id": "PRIVATE"}}))
+    assert categories == ["first_event", "agent_message", "mcp_started"]
+    telemetry._line(json.dumps({"type": "turn.completed"}))
+    assert categories[-2:] == ["model_final", "turn_completed"]
+    assert "PRIVATE" not in repr(categories)

--- a/tests/test_codex_oauth_fast_backend.py
+++ b/tests/test_codex_oauth_fast_backend.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -11,7 +12,8 @@ import cores.llm.codex_oauth_fast_backend as backend
 
 
 def fake_process(returncode=0, stdout="", stderr=""):
-    return SimpleNamespace(returncode=returncode, communicate=lambda **kwargs: (stdout, stderr))
+    return SimpleNamespace(stdin=open(os.devnull, "wb"), returncode=returncode,
+                           communicate=lambda **kwargs: (stdout, stderr))
 
 
 @pytest.fixture
@@ -49,6 +51,7 @@ def test_command_rejects_unapproved_model_and_profile() -> None:
 def test_codex_fast_backend_uses_isolated_ephemeral_command(
     monkeypatch,
     _trusted_codex,
+    tmp_path,
 ) -> None:
     seen = {}
 
@@ -77,8 +80,9 @@ def test_codex_fast_backend_uses_isolated_ephemeral_command(
         ])
         def communicate(**communication):
             seen["kwargs"].update(communication)
+            seen["prompt"] = (tmp_path / "stdin.bin").read_bytes()
             return stream, ""
-        return SimpleNamespace(returncode=0, communicate=communicate)
+        return SimpleNamespace(stdin=(tmp_path / "stdin.bin").open("wb"), returncode=0, communicate=communicate)
 
     monkeypatch.setattr(backend.subprocess, "Popen", fake_run)
     result = backend.generate_codex_fast(
@@ -98,7 +102,8 @@ def test_codex_fast_backend_uses_isolated_ephemeral_command(
     assert seen["kwargs"]["env"]["CODEX_HOME"] == "/secure/codex-home"
     assert seen["kwargs"]["start_new_session"] is True
     assert seen["kwargs"]["text"] is False
-    assert "도구를 사용하지 마세요" not in seen["kwargs"]["input"].decode("utf-8")
+    assert seen["kwargs"]["input"] is None
+    assert "도구를 사용하지 마세요" not in seen["prompt"].decode("utf-8")
     assert result.text == '{"decision":"미진입"}'
     assert result.usage == {"output_tokens": 10}
     assert [(call.server, call.tool) for call in result.mcp_calls] == [


### PR DESCRIPTION
Reproduced a CPython communicate retry defect: after the first short timeout, input=None stopped transmitting pending prompt bytes and left EOF open. Use a bounded detached POSIX nonblocking stdin pump while communicate drains both output pipes. Preserve cancellation and owned-process cleanup, reject incomplete input, and add sanitized byte counts. Intermediate agent messages no longer claim model completion. No model, effort, deadline, trading policy or cron changes. Regression: 88 related tests passed locally; 8 real harmless-child tests passed on db-server Python 3.11; independent architect exact-hash parallel/backpressure review approved. CI now includes the new regressions. Natural batch recovery remains forward verification.