### PR TITLE
fix: decouple strategy pilot entries from broker cash

### DIFF
--- a/cores/buy_gate.py
+++ b/cores/buy_gate.py
@@ -120,8 +120,10 @@ def evaluate_production_buy_gate(
     but must not silently remove the market-risk filter.
 
     ``market_pulse`` and ``pilot_budget_available`` are runtime-authoritative
-    inputs. Never derive them from LLM scenario policy annotations. Pilot budget
-    permission means the caller has a usable half-budget cap for a NEW entry.
+    inputs. Never derive them solely from LLM scenario policy annotations.
+    ``pilot_budget_available`` retains its historical API name, but now means
+    the runtime can record a NEW half-slot strategy entry, not that an account
+    has cash. Broker caps are separately enforced before physical submission.
     """
     data = dict(scenario or {})
     facts = trend_facts or str(data.get("_deterministic_trend_facts") or "")

--- a/prism-us/tests/test_us_buy_runtime_safety.py
+++ b/prism-us/tests/test_us_buy_runtime_safety.py
@@ -20,10 +20,27 @@ mod = base.us_agent_module
 Agent = base.USStockTrackingAgent
 
 
+@pytest.mark.parametrize("budget", [None, 0, 1, 1000])
+@pytest.mark.parametrize("risk_valid", [False, True])
+def test_pilot_strategy_gate_is_cash_independent_not_risk_independent(monkeypatch, budget, risk_valid):
+    monkeypatch.setenv("REGIME_MIN_SCORE_FLOOR", "true")
+    agent = Agent.__new__(Agent)
+    agent.active_account = {"buy_amount_usd": budget}
+    agent._buy_floor_regime = lambda: "sideways"
+    rp = agent._regime_policy_mod()
+    monkeypatch.setattr(rp, "get_market_pulse_state", lambda _market: "UPTREND")
+    scenario = {"decision": "Enter", "buy_score": 6, "min_score": 5,
+                "target_price": 115 if risk_valid else 99, "stop_loss": 95,
+                "risk_reward_ratio": 3,
+                "regime_entry_policy": {"mode": "rebound_pilot", "position_fraction": 0.5,
+                                        "cash_budget": None}}
+    assert agent._evaluate_production_buy_gate(scenario, 100)["allowed"] is risk_valid
+
+
 @pytest.mark.parametrize("score,pulse,cap,allowed", [
     (7, "UPTREND", None, True), (7, None, None, False),
     (7, "CORRECTION", None, False), (6, "UPTREND", 500, True),
-    (6, "UPTREND", None, False), (6, "UPTREND", 1000, False),
+    (6, "UPTREND", None, False), (6, "UPTREND", 1000, True),
 ])
 @pytest.mark.parametrize("decision", ["entry", "진입", "매수"])
 def test_runtime_policy_reaches_us_gate_and_broker_boundary(monkeypatch, score, pulse, cap, allowed, decision):

--- a/prism-us/tests/test_us_order_budget.py
+++ b/prism-us/tests/test_us_order_budget.py
@@ -30,6 +30,18 @@ def broker(price=300):
     return trader
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("budget", [None, 0, -1, False, float("nan"), float("inf"), "bad"])
+async def test_strict_budget_never_uses_default_before_quote(budget):
+    trader = broker()
+    result = await trader._execute_buy_stock("SNDK", budget, "NASD", 300, strict_budget=True)
+    assert not result["success"]
+    assert result["quantity"] == 0
+    trader.get_current_price.assert_not_called()
+    trader._request.assert_not_called()
+    trader._queue_pending_order.assert_not_called()
+
+
 @pytest.mark.parametrize('budget', [0, -1, float('nan'), float('inf'), False, 500])
 @pytest.mark.parametrize('route', ['buy_limit_price', 'buy_reserved_order'])
 def test_invalid_or_unaffordable_budget_never_orders_or_queues(budget, route):

--- a/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
+++ b/prism-us/tests/test_us_stock_tracking_agent_process_reports.py
@@ -898,8 +898,10 @@ async def test_process_reports_analyzes_once_and_dedupes_signals(
         assert micro_split_events == []
 
 
+@pytest.mark.parametrize("configured_budget", [None, 0, 1, 2000.0])
+@pytest.mark.parametrize("broker_success", [False, True])
 @pytest.mark.asyncio
-async def test_sideways_uptrend_score_six_uses_half_size_us_order(monkeypatch, tmp_path):
+async def test_sideways_uptrend_score_six_uses_half_size_us_order(monkeypatch, tmp_path, configured_budget, broker_success):
     regime_policy = _load_module(
         "root_regime_policy_rebound_test", PROJECT_ROOT / "cores" / "regime_policy.py"
     )
@@ -911,7 +913,7 @@ async def test_sideways_uptrend_score_six_uses_half_size_us_order(monkeypatch, t
         "name": "us-primary",
         "account_key": "vps:us-primary:01",
         "product": "01",
-        "buy_amount_usd": 2000.0,
+        "buy_amount_usd": configured_budget,
     }]
     agent.active_account = None
     agent.max_slots = 10
@@ -949,8 +951,19 @@ async def test_sideways_uptrend_score_six_uses_half_size_us_order(monkeypatch, t
     agent._check_sector_diversity = AsyncMock(return_value=True)
     agent._buy_floor_regime = lambda: "sideways"
     agent._regime_policy_mod = lambda: regime_policy
+    agent.conn = sqlite3.connect(":memory:")
+    agent.cursor = agent.conn.cursor()
+    schema = _load_module("root_schema_pilot_test", PROJECT_ROOT / "tracking" / "db_schema.py")
+    agent.cursor.execute(schema.TABLE_STOCK_HOLDINGS.replace("stock_holdings", "us_stock_holdings"))
+    agent.message_queue = []
+    agent._msg_types = []
+    agent._mirror_position_open = MagicMock()
+    agent._get_trigger_win_rate = lambda *_a: None
+    entry_events = []
+    monkeypatch.setitem(USStockTrackingAgent._buy_stock_with_position.__globals__, "emit_trading_context",
+                        lambda kind, **kwargs: entry_events.append((kind, kwargs)))
     agent._buy_stock_with_position = AsyncMock(
-        return_value=LegacyPositionWriteResult(True, 1)
+        wraps=USStockTrackingAgent._buy_stock_with_position.__get__(agent)
     )
     agent._link_position_entry_intent = lambda **_kwargs: True
     agent._save_watchlist_item = AsyncMock(return_value=True)
@@ -961,7 +974,7 @@ async def test_sideways_uptrend_score_six_uses_half_size_us_order(monkeypatch, t
         async def async_buy_stock(self, ticker, limit_price=None, buy_amount=None, quote_validator=None, strict_budget=False):
             assert strict_budget is True
             buy_amounts.append(buy_amount)
-            return await super().async_buy_stock(ticker, limit_price, buy_amount)
+            return {"success": broker_success, "message": "fake accepted" if broker_success else "fake rejected"}
 
     module = types.ModuleType("trading.us_stock_trading")
     module.AsyncUSTradingContext = PilotTradingContext
@@ -976,8 +989,21 @@ async def test_sideways_uptrend_score_six_uses_half_size_us_order(monkeypatch, t
     )
 
     assert (buy_count, sell_count) == (1, 0)
+    policy = agent._buy_stock_with_position.call_args.args[3]["regime_entry_policy"]
+    assert policy["mode"] == "rebound_pilot"
+    assert policy["position_fraction"] == 0.5
+    stored = agent.cursor.execute("SELECT scenario FROM us_stock_holdings").fetchall()
+    assert len(stored) == 1
+    assert json.loads(stored[0][0])["regime_entry_policy"] == policy
+    entries = [payload for kind, payload in entry_events if kind == "entry.executed"]
+    assert len(entries) == 1
+    assert entries[0]["scenario"]["regime_entry_policy"] == policy
+    if configured_budget != 2000.0:
+        assert buy_amounts == []
+        assert policy["cash_budget"] == (None if not configured_budget else configured_budget * 0.5)
+        return
     assert buy_amounts == [1000.0]
-    assert redis_calls[0]["scenario"]["regime_entry_policy"] == {
+    assert policy == {
         "mode": "rebound_pilot",
         "position_fraction": 0.5,
         "cash_budget": 1000.0,

--- a/prism-us/trading/us_stock_trading.py
+++ b/prism-us/trading/us_stock_trading.py
@@ -1425,7 +1425,7 @@ class USStockTrading:
     async def _execute_buy_stock(self, ticker: str, buy_amount: float = None,
                                  exchange: str = None, limit_price: float = None, *, quote_validator=None, strict_budget: bool = False) -> Dict[str, Any]:
         """Execute buy stock logic"""
-        amount = resolve_order_budget(buy_amount, self.buy_amount)
+        amount = resolve_order_budget(buy_amount, 0 if strict_budget else self.buy_amount)
 
         result = {
             'success': False,
@@ -1440,6 +1440,8 @@ class USStockTrading:
 
         if not amount:
             result['message'] = 'Buy budget must be finite and positive'
+            if strict_budget:
+                result['status'] = 'blocked_budget'
             return result
         if strict_budget and not resolve_order_budget(limit_price, 0):
             result['message'] = 'Strict budget requires a positive limit price'

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -2589,6 +2589,23 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                 raise ValueError(f"broker quote gate: {gate.get('reason', 'blocked')}")
         return validate
 
+    @staticmethod
+    def _pilot_broker_budget_block(scenario, amount, price):
+        """Keep account funding failures outside strategy eligibility."""
+        from prism_core.order_budget import whole_share_quantity
+
+        if (scenario.get("regime_entry_policy") or {}).get("mode") != "rebound_pilot":
+            return None
+        if whole_share_quantity(amount, price) > 0:
+            return None
+        return {
+            "success": False,
+            "status": "blocked_budget",
+            "reason_code": "pilot_budget_unavailable_or_below_one_share",
+            "message": "Pilot broker budget unavailable or below one share; strategy entry preserved",
+            "quantity": 0,
+        }
+
     def _evaluate_production_buy_gate(
         self,
         scenario: Dict[str, Any],
@@ -2609,16 +2626,12 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                 if regime_policy is not None and _gate.normalize_regime(computed_regime) == "sideways" else None
             )
             policy = scenario.get("regime_entry_policy") or {}
-            configured_cap = (
-                regime_policy.configured_entry_amount(getattr(self, "active_account", None), "us", 0.5)
-                if regime_policy is not None else None
-            )
+            # Historical gate argument names strategy half-slot permission;
+            # account cash is checked only at the broker boundary below.
             pilot_budget_available = (
                 isinstance(policy, dict)
                 and policy.get("mode") == "rebound_pilot"
                 and policy.get("position_fraction") == 0.5
-                and configured_cap is not None
-                and policy.get("cash_budget") == configured_cap
             )
             result = _gate.evaluate_production_buy_gate(
                 {**scenario, "decision": self._normalize_decision(scenario.get("decision", "no_entry"))},
@@ -4097,34 +4110,25 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                             entry_cash_amount = _rp.configured_entry_amount(
                                 account, "us", 0.5
                             )
-                            if entry_cash_amount is None:
-                                rebound_pilot = False
-                                logger.error(
-                                    "[REGIME_REBOUND_PILOT] %s(%s) blocked: "
-                                    "configured US buy amount unavailable",
-                                    company_name,
-                                    ticker,
-                                )
-                            else:
-                                scenario = dict(scenario)
-                                scenario["regime_entry_policy"] = {
-                                    "mode": "rebound_pilot",
-                                    "position_fraction": 0.5,
-                                    "cash_budget": entry_cash_amount,
-                                    "budget_semantics": "maximum_order_notional",
-                                    "regime": floor_regime,
-                                    "market_pulse": pulse_state,
-                                }
-                                analysis_result["scenario"] = scenario
-                                logger.warning(
-                                    "[REGIME_REBOUND_PILOT] %s(%s) score=%s "
-                                    "min=%s position=50%% cash_amount=%s",
-                                    company_name,
-                                    ticker,
-                                    adjusted_score,
-                                    min_score,
-                                    entry_cash_amount,
-                                )
+                            scenario = dict(scenario)
+                            scenario["regime_entry_policy"] = {
+                                "mode": "rebound_pilot",
+                                "position_fraction": 0.5,
+                                "cash_budget": entry_cash_amount,
+                                "budget_semantics": "maximum_order_notional",
+                                "regime": floor_regime,
+                                "market_pulse": pulse_state,
+                            }
+                            analysis_result["scenario"] = scenario
+                            logger.warning(
+                                "[REGIME_REBOUND_PILOT] %s(%s) score=%s "
+                                "min=%s position=50%% cash_amount=%s",
+                                company_name,
+                                ticker,
+                                adjusted_score,
+                                min_score,
+                                entry_cash_amount,
+                            )
 
                     rationale = scenario.get("rationale", "") or ""
                     logger.info(
@@ -4286,50 +4290,62 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                                     opened_position_id = legacy_position_id(
                                         "US", buy_result.legacy_holding_id
                                     )
-                                    async with ExecutionService.us(
-                                        account_name=account["name"],
-                                        db_path=self.db_path,
-                                    ) as trading:
-                                        quote = await asyncio.to_thread(trading.get_current_price, ticker, strict=True)
-                                        broker_price = self._validated_buy_quote(
-                                            quote.get("current_price") if isinstance(quote, dict) else None
-                                        )
-                                        apply_buy_scenario_contract(
-                                            scenario, market="US", entry_price=broker_price
-                                        )
-                                        broker_gate = self._evaluate_production_buy_gate(
-                                            scenario,
-                                            broker_price,
-                                            score_override=adjusted_score,
-                                            is_add=is_add,
-                                        )
-                                        if not broker_gate.get("allowed", False):
-                                            raise ValueError(
-                                                "Fresh broker BUY gate rejected: "
-                                                + str(broker_gate.get("reason", "blocked"))
-                                            )
-                                        logger.info("[BUY_QUOTE][US] broker ticker=%s price=%s exchange_quote_age=unknown", ticker, broker_price)
+                                    blocked = self._pilot_broker_budget_block(scenario, entry_cash_amount, current_price)
+                                    if blocked is not None:
                                         order_intent = OrderIntent.create(
-                                            market="US",
-                                            account_id=account_key,
-                                            symbol=ticker,
-                                            side="buy",
-                                            order_style="smart",
-                                            source="us_batch",
+                                            market="US", account_id=account_key, symbol=ticker,
+                                            side="buy", order_style="smart", source="us_batch",
                                             source_decision_id=source_decision_id,
                                             source_position_id=opened_position_id,
-                                            cash_amount=entry_cash_amount,
-                                            limit_price=broker_price,
+                                            cash_amount=entry_cash_amount, limit_price=current_price,
                                             reason="AI analysis entry",
                                         )
-                                        trade_result = await trading.execute_buy(
-                                            ticker=ticker,
-                                            buy_amount=entry_cash_amount,
-                                            limit_price=broker_price,
-                                            intent=order_intent,
-                                            quote_validator=self._buy_quote_validator(scenario, score_override=adjusted_score, is_add=is_add, ticker=ticker, account_key=order_intent.account_id),
-                                            **({"strict_budget": True} if (scenario.get("regime_entry_policy") or {}).get("mode") == "rebound_pilot" else {}),
-                                        )
+                                        trade_result = blocked
+                                    else:
+                                        async with ExecutionService.us(
+                                            account_name=account["name"],
+                                            db_path=self.db_path,
+                                        ) as trading:
+                                            quote = await asyncio.to_thread(trading.get_current_price, ticker, strict=True)
+                                            broker_price = self._validated_buy_quote(
+                                                quote.get("current_price") if isinstance(quote, dict) else None
+                                            )
+                                            apply_buy_scenario_contract(
+                                                scenario, market="US", entry_price=broker_price
+                                            )
+                                            broker_gate = self._evaluate_production_buy_gate(
+                                                scenario,
+                                                broker_price,
+                                                score_override=adjusted_score,
+                                                is_add=is_add,
+                                            )
+                                            if not broker_gate.get("allowed", False):
+                                                raise ValueError(
+                                                    "Fresh broker BUY gate rejected: "
+                                                    + str(broker_gate.get("reason", "blocked"))
+                                                )
+                                            logger.info("[BUY_QUOTE][US] broker ticker=%s price=%s exchange_quote_age=unknown", ticker, broker_price)
+                                            order_intent = OrderIntent.create(
+                                                market="US",
+                                                account_id=account_key,
+                                                symbol=ticker,
+                                                side="buy",
+                                                order_style="smart",
+                                                source="us_batch",
+                                                source_decision_id=source_decision_id,
+                                                source_position_id=opened_position_id,
+                                                cash_amount=entry_cash_amount,
+                                                limit_price=broker_price,
+                                                reason="AI analysis entry",
+                                            )
+                                            trade_result = await trading.execute_buy(
+                                                ticker=ticker,
+                                                buy_amount=entry_cash_amount,
+                                                limit_price=broker_price,
+                                                intent=order_intent,
+                                                quote_validator=self._buy_quote_validator(scenario, score_override=adjusted_score, is_add=is_add, ticker=ticker, account_key=order_intent.account_id),
+                                                **({"strict_budget": True} if (scenario.get("regime_entry_policy") or {}).get("mode") == "rebound_pilot" else {}),
+                                            )
 
                                     persisted_intent_id = trade_result.get("intent_id")
                                     if persisted_intent_id:

--- a/prism_core/entry_score_policy.py
+++ b/prism_core/entry_score_policy.py
@@ -1,7 +1,10 @@
 """Shared KR/US entry-score contract; no market-data or broker imports.
 
-Pulse and pilot budget permission must come from runtime callers, never model
-scenario annotations. Distribution caution is resolved by the final buy gate.
+Pulse and pilot half-slot support must come from runtime callers, never model
+scenario annotations. The legacy ``pilot_budget_available`` parameter describes
+strategy allocation support; it is not proof of broker cash or an order cap.
+Distribution caution is resolved by the final buy gate. Execution caps remain
+mandatory at the independent broker boundary.
 """
 from __future__ import annotations
 

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -1912,6 +1912,13 @@ class StockTrackingAgent:
     async def _execute_pending_kr_entry(
         self, prepared: _PreparedKrEntry, *, current_price: float
     ) -> Dict[str, Any]:
+        blocked = self._pilot_broker_budget_block(
+            prepared.scenario,
+            float(prepared.intent.cash_amount) if prepared.intent.cash_amount is not None else None,
+            current_price,
+        )
+        if blocked is not None:
+            return blocked
         async with ExecutionService.domestic(
             account_name=prepared.account_name,
             intent_store=prepared.intent_store,
@@ -2813,7 +2820,7 @@ class StockTrackingAgent:
                     message += f"💼 포트폴리오 관점:\n  {portfolio_context}\n"
 
             self._queue_message(message, "analysis")
-            logger.info(f"{ticker}({company_name}) purchase complete")
+            logger.info(f"{ticker}({company_name}) strategy entry recorded")
 
             return LegacyPositionWriteResult(True, int(legacy_holding_id))
 
@@ -2848,6 +2855,23 @@ class StockTrackingAgent:
             self._buy_floor_regime_cache = _c
         return _c
 
+    @staticmethod
+    def _pilot_broker_budget_block(scenario, amount, price):
+        """Keep account funding failures outside strategy eligibility."""
+        from prism_core.order_budget import whole_share_quantity
+
+        if (scenario.get("regime_entry_policy") or {}).get("mode") != "rebound_pilot":
+            return None
+        if whole_share_quantity(amount, price) > 0:
+            return None
+        return {
+            "success": False,
+            "status": "blocked_budget",
+            "reason_code": "pilot_budget_unavailable_or_below_one_share",
+            "message": "Pilot broker budget unavailable or below one share; strategy entry preserved",
+            "quantity": 0,
+        }
+
     def _evaluate_production_buy_gate(
         self,
         scenario: Dict[str, Any],
@@ -2865,18 +2889,17 @@ class StockTrackingAgent:
         """
         try:
             from cores.buy_gate import evaluate_production_buy_gate, normalize_regime
-            from cores.regime_policy import configured_entry_amount, get_market_pulse_state
+            from cores.regime_policy import get_market_pulse_state
 
             computed_regime = scenario.get("_deterministic_market_regime") or self._buy_floor_regime()
             pulse = get_market_pulse_state("kr") if normalize_regime(computed_regime) == "sideways" else None
             policy = scenario.get("regime_entry_policy") or {}
-            configured_cap = configured_entry_amount(getattr(self, "active_account", None), "kr", 0.5)
+            # Historical gate argument names strategy half-slot permission;
+            # account cash is checked only at the broker boundary below.
             pilot_budget_available = (
                 isinstance(policy, dict)
                 and policy.get("mode") == "rebound_pilot"
                 and policy.get("position_fraction") == 0.5
-                and configured_cap is not None
-                and policy.get("cash_budget") == configured_cap
             )
 
             result = evaluate_production_buy_gate(
@@ -4224,34 +4247,25 @@ class StockTrackingAgent:
                                 entry_cash_amount = configured_entry_amount(
                                     account, "kr", 0.5
                                 )
-                                if entry_cash_amount is None:
-                                    _regime_floor_block = True
-                                    logger.error(
-                                        "[REGIME_REBOUND_PILOT] %s(%s) blocked: "
-                                        "configured KR buy amount unavailable",
-                                        company_name,
-                                        ticker,
-                                    )
-                                else:
-                                    scenario = dict(scenario)
-                                    scenario["regime_entry_policy"] = {
-                                        "mode": "rebound_pilot",
-                                        "position_fraction": 0.5,
-                                        "cash_budget": entry_cash_amount,
-                                        "budget_semantics": "maximum_order_notional",
-                                        "regime": _fr,
-                                        "market_pulse": _pulse,
-                                    }
-                                    analysis_result["scenario"] = scenario
-                                    logger.warning(
-                                        "[REGIME_REBOUND_PILOT] %s(%s) score=%s "
-                                        "min=%s position=50%% cash_amount=%s",
-                                        company_name,
-                                        ticker,
-                                        buy_score,
-                                        min_score,
-                                        entry_cash_amount,
-                                    )
+                                scenario = dict(scenario)
+                                scenario["regime_entry_policy"] = {
+                                    "mode": "rebound_pilot",
+                                    "position_fraction": 0.5,
+                                    "cash_budget": entry_cash_amount,
+                                    "budget_semantics": "maximum_order_notional",
+                                    "regime": _fr,
+                                    "market_pulse": _pulse,
+                                }
+                                analysis_result["scenario"] = scenario
+                                logger.warning(
+                                    "[REGIME_REBOUND_PILOT] %s(%s) score=%s "
+                                    "min=%s position=50%% cash_amount=%s",
+                                    company_name,
+                                    ticker,
+                                    buy_score,
+                                    min_score,
+                                    entry_cash_amount,
+                                )
                             elif buy_score < min_score:
                                 _regime_floor_block = True
                     except Exception as _fe:
@@ -4494,7 +4508,7 @@ class StockTrackingAgent:
                             buy_count += 1
                             state["traded"] = True
                             logger.info(
-                                f"Purchase complete: {company_name}({ticker}) @ "
+                                f"Strategy entry recorded: {company_name}({ticker}) @ "
                                 f"{current_price:,.0f} KRW"
                             )
                             continue
@@ -4527,18 +4541,20 @@ class StockTrackingAgent:
                                 reason="AI analysis entry",
                             )
                             try:
-                                async with ExecutionService.domestic(
-                                    account_name=account["name"],
-                                    db_path=self.db_path,
-                                ) as trading:
-                                    trade_result = await trading.execute_buy(
-                                        stock_code=ticker,
-                                        buy_amount=entry_cash_amount,
-                                        limit_price=current_price,
-                                        intent=order_intent,
-                                        quote_validator=self._buy_quote_validator(scenario, ticker=ticker, account_key=order_intent.account_id),
-                                        **({"strict_budget": True} if (scenario.get("regime_entry_policy") or {}).get("mode") == "rebound_pilot" else {}),
-                                    )
+                                trade_result = self._pilot_broker_budget_block(scenario, entry_cash_amount, current_price)
+                                if trade_result is None:
+                                    async with ExecutionService.domestic(
+                                        account_name=account["name"],
+                                        db_path=self.db_path,
+                                    ) as trading:
+                                        trade_result = await trading.execute_buy(
+                                            stock_code=ticker,
+                                            buy_amount=entry_cash_amount,
+                                            limit_price=current_price,
+                                            intent=order_intent,
+                                            quote_validator=self._buy_quote_validator(scenario, ticker=ticker, account_key=order_intent.account_id),
+                                            **({"strict_budget": True} if (scenario.get("regime_entry_policy") or {}).get("mode") == "rebound_pilot" else {}),
+                                        )
                             except OrderOutcomeUnknown as error:
                                 self._link_position_entry_intent(
                                     legacy_holding_id=buy_result.legacy_holding_id,
@@ -4602,7 +4618,7 @@ class StockTrackingAgent:
                         if buy_success:
                             buy_count += 1
                             state["traded"] = True
-                            logger.info(f"Purchase complete: {company_name}({ticker}) @ {current_price:,.0f} KRW")
+                            logger.info(f"Strategy entry recorded: {company_name}({ticker}) @ {current_price:,.0f} KRW")
                         else:
                             state["should_save_watchlist"] = True
                             state["skip_reason"] = state["skip_reason"] or "Purchase failed"
@@ -4653,7 +4669,7 @@ class StockTrackingAgent:
                     was_traded=False,
                 )
 
-            logger.info(f"Report processing complete - Purchased: {buy_count} stocks, Sold: {sell_count} stocks")
+            logger.info(f"Report processing complete - Strategy entries: {buy_count} stocks, Sold: {sell_count} stocks")
             return buy_count, sell_count
 
         except Exception as e:

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -548,34 +548,25 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                             entry_cash_amount = configured_entry_amount(
                                 getattr(self, "active_account", None), "kr", 0.5
                             )
-                            if entry_cash_amount is None:
-                                rebound_pilot = False
-                                logger.error(
-                                    "[REGIME_REBOUND_PILOT] %s(%s) blocked: "
-                                    "configured KR buy amount unavailable",
-                                    company_name,
-                                    ticker,
-                                )
-                            else:
-                                scenario = dict(scenario)
-                                scenario["regime_entry_policy"] = {
-                                    "mode": "rebound_pilot",
-                                    "position_fraction": 0.5,
-                                    "cash_budget": entry_cash_amount,
-                                    "budget_semantics": "maximum_order_notional",
-                                    "regime": _fr,
-                                    "market_pulse": _pulse,
-                                }
-                                analysis_result["scenario"] = scenario
-                                logger.warning(
-                                    "[REGIME_REBOUND_PILOT] %s(%s) score=%s "
-                                    "min=%s position=50%% cash_amount=%s",
-                                    company_name,
-                                    ticker,
-                                    buy_score,
-                                    min_score,
-                                    entry_cash_amount,
-                                )
+                            scenario = dict(scenario)
+                            scenario["regime_entry_policy"] = {
+                                "mode": "rebound_pilot",
+                                "position_fraction": 0.5,
+                                "cash_budget": entry_cash_amount,
+                                "budget_semantics": "maximum_order_notional",
+                                "regime": _fr,
+                                "market_pulse": _pulse,
+                            }
+                            analysis_result["scenario"] = scenario
+                            logger.warning(
+                                "[REGIME_REBOUND_PILOT] %s(%s) score=%s "
+                                "min=%s position=50%% cash_amount=%s",
+                                company_name,
+                                ticker,
+                                buy_score,
+                                min_score,
+                                entry_cash_amount,
+                            )
                 except Exception as _fe:
                     logger.warning(f"[REGIME_MIN_SCORE_FLOOR] fail-open, LLM min_score 유지: {_fe}")
 
@@ -953,7 +944,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
 
                         buy_count += 1
                         logger.info(
-                            f"Purchase complete: {company_name}({ticker}) @ "
+                            f"Strategy entry recorded: {company_name}({ticker}) @ "
                             f"{current_price:,.0f} KRW"
                         )
                         continue
@@ -989,19 +980,21 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                         )
                         # Call actual account trading function (async)
                         try:
-                            async with ExecutionService.domestic(
-                                account_name=account_name,
-                                db_path=self.db_path,
-                            ) as trading:
-                                # Execute async buy with limit price for reserved orders
-                                trade_result = await trading.execute_buy(
-                                    stock_code=ticker,
-                                    buy_amount=entry_cash_amount,
-                                    limit_price=current_price,
-                                    intent=order_intent,
-                                    quote_validator=self._buy_quote_validator(scenario, is_add=is_add, ticker=ticker, account_key=order_intent.account_id),
-                                    **({"strict_budget": True} if (scenario.get("regime_entry_policy") or {}).get("mode") == "rebound_pilot" else {}),
-                                )
+                            trade_result = self._pilot_broker_budget_block(scenario, entry_cash_amount, current_price)
+                            if trade_result is None:
+                                async with ExecutionService.domestic(
+                                    account_name=account_name,
+                                    db_path=self.db_path,
+                                ) as trading:
+                                    # Execute async buy with limit price for reserved orders
+                                    trade_result = await trading.execute_buy(
+                                        stock_code=ticker,
+                                        buy_amount=entry_cash_amount,
+                                        limit_price=current_price,
+                                        intent=order_intent,
+                                        quote_validator=self._buy_quote_validator(scenario, is_add=is_add, ticker=ticker, account_key=order_intent.account_id),
+                                        **({"strict_budget": True} if (scenario.get("regime_entry_policy") or {}).get("mode") == "rebound_pilot" else {}),
+                                    )
                         except OrderOutcomeUnknown as error:
                             self._link_position_entry_intent(
                                 legacy_holding_id=buy_result.legacy_holding_id,
@@ -1056,7 +1049,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
 
                     if buy_success:
                         buy_count += 1
-                        logger.info(f"Purchase complete: {company_name}({ticker}) @ {current_price:,.0f} KRW")
+                        logger.info(f"Strategy entry recorded: {company_name}({ticker}) @ {current_price:,.0f} KRW")
                     else:
                         logger.warning(f"Purchase failed: {company_name}({ticker})")
 
@@ -1074,7 +1067,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                 except Exception as alert_err:
                     logger.error(f"Buy-analysis failure alert send failed: {alert_err}")
 
-            logger.info(f"Report processing complete - Purchased: {buy_count} items, Sold: {sell_count} items")
+            logger.info(f"Report processing complete - Strategy entries: {buy_count} items, Sold: {sell_count} items")
             return buy_count, sell_count
 
         except Exception as e:

--- a/tests/test_astra_kr_safety.py
+++ b/tests/test_astra_kr_safety.py
@@ -30,10 +30,43 @@ def scenario_agent():
     return agent
 
 
+@pytest.mark.parametrize("budget", [None, 0, 1, 1000])
+@pytest.mark.parametrize("risk_valid", [False, True])
+def test_pilot_strategy_gate_is_cash_independent_not_risk_independent(monkeypatch, budget, risk_valid):
+    import cores.regime_policy as rp
+    monkeypatch.setenv("REGIME_MIN_SCORE_FLOOR", "true")
+    monkeypatch.setattr(rp, "get_market_pulse_state", lambda _market: "UPTREND")
+    agent = scenario_agent()
+    agent.active_account = {"buy_amount_krw": budget}
+    agent._buy_floor_regime = lambda: "sideways"
+    scenario = {"decision": "Enter", "buy_score": 6, "min_score": 5,
+                "target_price": 115 if risk_valid else 99, "stop_loss": 95,
+                "risk_reward_ratio": 3,
+                "regime_entry_policy": {"mode": "rebound_pilot", "position_fraction": 0.5,
+                                        "cash_budget": None}}
+    assert agent._evaluate_production_buy_gate(scenario, 100)["allowed"] is risk_valid
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("budget", [None, 0, 50])
+async def test_pending_pilot_budget_guard_never_opens_broker(monkeypatch, budget):
+    agent = scenario_agent()
+    broker = MagicMock(side_effect=AssertionError("must not open broker"))
+    monkeypatch.setattr(mod.ExecutionService, "domestic", broker)
+    prepared = SimpleNamespace(
+        scenario={"regime_entry_policy": {"mode": "rebound_pilot", "position_fraction": 0.5}},
+        intent=SimpleNamespace(cash_amount=budget),
+    )
+    result = await agent._execute_pending_kr_entry(prepared, current_price=100)
+    assert result["status"] == "blocked_budget"
+    assert result["quantity"] == 0
+    broker.assert_not_called()
+
+
 @pytest.mark.parametrize("score,pulse,cap,allowed", [
     (7, "UPTREND", None, True), (7, None, None, False),
     (7, "CORRECTION", None, False), (6, "UPTREND", 500, True),
-    (6, "UPTREND", None, False), (6, "UPTREND", 1000, False),
+    (6, "UPTREND", None, False), (6, "UPTREND", 1000, True),
 ])
 @pytest.mark.parametrize("decision", ["Enter", "진입", "매수"])
 def test_runtime_policy_reaches_kr_gate_and_broker_boundary(monkeypatch, score, pulse, cap, allowed, decision):

--- a/tests/test_kr_order_budget.py
+++ b/tests/test_kr_order_budget.py
@@ -22,6 +22,26 @@ def broker(price=300_000):
     return trader
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("budget", [None, 0, -1, False, float("nan"), float("inf"), "bad"])
+async def test_strict_budget_never_uses_default_before_quote(budget):
+    trader = broker()
+    result = await trader._execute_buy_stock("006400", budget, 300_000, strict_budget=True)
+    assert not result["success"]
+    assert result["quantity"] == 0
+    trader.get_current_price.assert_not_called()
+    trader._request.assert_not_called()
+
+
+@pytest.mark.parametrize("budget", [None, 0, -1, False, float("nan"), float("inf"), "bad"])
+def test_smart_strict_budget_never_uses_default(budget):
+    trader = broker()
+    result = trader.smart_buy("006400", budget, 300_000, strict_budget=True)
+    assert not result["success"]
+    assert result["status"] == "blocked_budget"
+    trader._request.assert_not_called()
+
+
 @pytest.mark.parametrize('budget', [0, -1, float('nan'), float('inf'), False, 500_000])
 @pytest.mark.parametrize('route', ['buy_market_price', 'buy_limit_price', 'buy_reserved_order', 'buy_closing_price'])
 def test_invalid_or_unaffordable_budget_never_orders(budget, route):

--- a/tests/test_stock_tracking_agent_process_reports.py
+++ b/tests/test_stock_tracking_agent_process_reports.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 import sqlite3
 import sys
@@ -440,19 +441,25 @@ async def test_process_reports_analyzes_once_and_dedupes_signals(monkeypatch, ca
     assert "partial success" in caplog.text.lower()
 
 
+@pytest.mark.parametrize("configured_budget", [None, 0, 1000, 1_000_000])
+@pytest.mark.parametrize("broker_success", [False, True])
+@pytest.mark.parametrize("enhanced", [False, True])
 @pytest.mark.asyncio
-async def test_sideways_uptrend_score_six_uses_half_size_kr_order(monkeypatch, tmp_path):
+async def test_sideways_uptrend_score_six_uses_half_size_kr_order(monkeypatch, tmp_path, configured_budget, broker_success, enhanced, caplog):
     from cores import regime_policy
+    from stock_tracking_enhanced_agent import EnhancedStockTrackingAgent
+    caplog.set_level(logging.INFO)
 
-    agent = StockTrackingAgent.__new__(StockTrackingAgent)
+    agent_class = EnhancedStockTrackingAgent if enhanced else StockTrackingAgent
+    agent = agent_class.__new__(agent_class)
     agent.db_path = str(tmp_path / "kr-rebound-pilot.sqlite")
     _ensure_reentry_schema(agent.db_path)
     agent.account_configs = [{
         "name": "kr-primary",
         "account_key": "vps:kr-primary:01",
-        "buy_amount_krw": 1_000_000,
+        "buy_amount_krw": configured_budget,
     }]
-    agent.active_account = None
+    agent.active_account = agent.account_configs[0] if enhanced else None
     agent.max_slots = 10
     agent._position_pending_kr_ready = False
 
@@ -484,8 +491,19 @@ async def test_sideways_uptrend_score_six_uses_half_size_kr_order(monkeypatch, t
     agent._get_current_slots_count = AsyncMock(return_value=0)
     agent._check_sector_diversity = AsyncMock(return_value=True)
     agent._buy_floor_regime = lambda: "sideways"
+    agent.conn = sqlite3.connect(":memory:")
+    agent.cursor = agent.conn.cursor()
+    from tracking.db_schema import TABLE_STOCK_HOLDINGS
+    agent.cursor.execute(TABLE_STOCK_HOLDINGS)
+    agent.message_queue = []
+    agent._msg_types = []
+    agent._mirror_position_open = MagicMock()
+    agent._get_trigger_win_rate = lambda *_a: None
+    entry_events = []
+    monkeypatch.setattr(sys.modules[StockTrackingAgent.__module__], "emit_trading_context",
+                        lambda kind, **kwargs: entry_events.append((kind, kwargs)))
     agent._buy_stock_with_position = AsyncMock(
-        return_value=LegacyPositionWriteResult(True, 1)
+        wraps=agent_class._buy_stock_with_position.__get__(agent)
     )
     agent._link_position_entry_intent = lambda **_kwargs: True
 
@@ -495,7 +513,7 @@ async def test_sideways_uptrend_score_six_uses_half_size_kr_order(monkeypatch, t
         async def async_buy_stock(self, stock_code, limit_price=None, buy_amount=None, quote_validator=None, strict_budget=False):
             assert strict_budget is True
             buy_amounts.append(buy_amount)
-            return await super().async_buy_stock(stock_code, limit_price, buy_amount)
+            return {"success": broker_success, "message": "fake accepted" if broker_success else "fake rejected"}
 
     redis_calls, gcp_calls = [], []
     _install_signal_modules(monkeypatch, redis_calls, gcp_calls)
@@ -504,11 +522,29 @@ async def test_sideways_uptrend_score_six_uses_half_size_kr_order(monkeypatch, t
     monkeypatch.setenv("REGIME_MIN_SCORE_FLOOR", "true")
     monkeypatch.setenv("POSITION_PENDING_KR_ENABLED", "false")
 
-    buy_count, sell_count = await StockTrackingAgent.process_reports(
+    buy_count, sell_count = await agent_class.process_reports(
         agent, ["report-a.pdf"]
     )
 
     assert (buy_count, sell_count) == (1, 0)
+    policy = agent._buy_stock_with_position.call_args.args[3]["regime_entry_policy"]
+    assert policy["mode"] == "rebound_pilot"
+    assert policy["position_fraction"] == 0.5
+    stored = agent.cursor.execute("SELECT scenario FROM stock_holdings").fetchall()
+    assert len(stored) == 1
+    assert json.loads(stored[0][0])["regime_entry_policy"] == policy
+    entries = [payload for kind, payload in entry_events if kind == "entry.executed"]
+    assert len(entries) == 1
+    assert entries[0]["scenario"]["regime_entry_policy"] == policy
+    assert "Strategy entry recorded:" in caplog.text
+    assert "Strategy entries: 1" in caplog.text
+    assert "purchase complete" not in caplog.text.lower()
+    assert "Purchased:" not in caplog.text
+    if configured_budget != 1_000_000:
+        assert buy_amounts == []
+        assert "Actual purchase failed: Pilot broker budget unavailable" in caplog.text
+        assert policy["cash_budget"] == (None if not configured_budget else configured_budget * 0.5)
+        return
     assert buy_amounts == [500_000]
     assert redis_calls[0]["scenario"]["regime_entry_policy"] == {
         "mode": "rebound_pilot",

--- a/trading/domestic_stock_trading.py
+++ b/trading/domestic_stock_trading.py
@@ -623,6 +623,10 @@ class DomesticStockTrading:
         order_window = _domestic_order_window(now)
 
         if strict_budget:
+            if not resolve_order_budget(buy_amount, 0):
+                return {'success': False, 'order_no': None, 'stock_code': stock_code,
+                        'quantity': 0, 'status': 'blocked_budget',
+                        'message': 'Strict budget requires an explicit positive buy amount'}
             # Pilot allocation is a notional cap, so market-price execution is
             # not acceptable. No fallback may silently remove the limit.
             if not resolve_order_budget(limit_price, 0) or int(limit_price) <= 0:
@@ -1329,8 +1333,8 @@ class DomesticStockTrading:
             }
 
     async def _execute_buy_stock(self, stock_code: str, buy_amount: int = None, limit_price: int = None, *, quote_validator=None, strict_budget: bool = False) -> Dict[str, Any]:
-        # Use class default if buy_amount is None
-        amount = resolve_order_budget(buy_amount, self.buy_amount)
+        # Only normal orders may default an omitted amount to the full budget.
+        amount = resolve_order_budget(buy_amount, 0 if strict_budget else self.buy_amount)
 
         result = {
             'success': False,
@@ -1345,6 +1349,8 @@ class DomesticStockTrading:
 
         if not amount:
             result['message'] = 'Buy budget must be finite and positive'
+            if strict_budget:
+                result['status'] = 'blocked_budget'
             return result
         if strict_budget and not resolve_order_budget(limit_price, 0):
             result['message'] = 'Strict budget requires a positive limit price'


### PR DESCRIPTION
Depends on PR #693; retarget to main after it merges. Preserve the runtime-validated 50% strategy policy and strategy entry records when actual account funds are absent, zero or below one share. Broker strict-budget failure is separate and remains blocked before ExecutionService submission; no silent fallback to full-size budget. Discard model-supplied policy annotations and recompute existing risk/score gates. Preserve pilot ownership exclusion and pending-entry OFF behavior. No new live top-up controller or relaxed risk gates. Validation: KR 239 and US 113 tests independently passed; 44 pure policy tests passed. Independent architect review approved. Documentation clarifies the legacy pilot_budget_available name denotes strategy half-slot support rather than broker cash.