### PR TITLE
feat: durable test-only strategy ledger outbox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
             tests/test_order_budget.py tests/test_pyramid_pilot_exclusion.py -q
           python -m pytest tests/test_trend_quality_research.py \
             tests/test_trend_research_capture.py tests/test_strategy_ledger.py tests/test_strategy_ledger_slots.py \
-            tests/test_pilot_lifecycle.py \
+            tests/test_pilot_lifecycle.py tests/test_strategy_ledger_outbox.py \
             tests/test_strategy_ledger_projection.py tests/test_strategy_ledger_messages.py \
             tests/test_trading_context.py tests/test_entry_quality_evidence_packet.py -q
           # Existing bootstrap creates only a fake example.com KIS config, removes it at exit.

--- a/prism_core/strategy_ledger.py
+++ b/prism_core/strategy_ledger.py
@@ -230,7 +230,7 @@ class StrategyLedger:
         with self._transaction() as db:
             return self._apply_target_in_transaction(db, event_id, payload)
 
-    def _apply_target_in_transaction(self, db, event_id, payload, *, owner=None):
+    def _apply_target_in_transaction(self, db, event_id, payload, *, owner=None, notify=True):
         book_id, campaign_id, symbol = (payload[k] for k in ("book_id", "campaign_id", "symbol"))
         target, price = Decimal(payload["target_pct"]), Decimal(payload["price"])
         timestamp = payload["occurred_at"]
@@ -342,6 +342,8 @@ class StrategyLedger:
         )
         self._save(db, "campaigns", campaign_id, campaign)
         self._save(db, "books", book_id, book)
+        if notify:
+            self._notice(db, event_id, campaign_id, "BUY")
         return {**self._snapshot(db, book_id), "event_applied": True}
 
     def open_pilot(
@@ -370,10 +372,11 @@ class StrategyLedger:
                       "occurred_at": timestamp, "policy_version": owner,
                       "reason": "INITIAL_ELIGIBLE_50", "regime": "shadow_pilot",
                       "source_hash": None, "fee_rate": "0", "slippage_rate": "0"}
-            self._apply_target_in_transaction(db, event_id + ":target", target, owner=owner)
+            self._apply_target_in_transaction(db, event_id + ":target", target, owner=owner, notify=False)
             campaign = self._get(db, "campaigns", campaign_id)
             campaign["pilot"] = pilot
             self._save(db, "campaigns", campaign_id, campaign)
+            self._notice(db, event_id, campaign_id, "BUY")
             return {**self._snapshot(db, book_id), "event_applied": True}
 
     def advance_pilot(self, event_id, campaign_id, *, expected_revision, evidence, occurred_at):
@@ -416,7 +419,7 @@ class StrategyLedger:
                           "occurred_at": timestamp, "policy_version": OWNER,
                           "reason": decision["reason"], "regime": "shadow_pilot",
                           "source_hash": None, "fee_rate": "0", "slippage_rate": "0"}
-                self._apply_target_in_transaction(db, event_id + ":target", target, owner=OWNER)
+                self._apply_target_in_transaction(db, event_id + ":target", target, owner=OWNER, notify=False)
                 campaign = self._get(db, "campaigns", campaign_id)
             campaign["pilot"] = {**pilot, "state": decision["state"], "reason": decision["reason"],
                                  "revision": expected_revision + 1, "last_evaluated_at": timestamp}
@@ -424,6 +427,8 @@ class StrategyLedger:
                 campaign["add_permission"] = decision["state"]
             campaign["last_event_at"] = timestamp
             self._save(db, "campaigns", campaign_id, campaign)
+            if decision["state"] != pilot["state"]:
+                self._notice(db, event_id, campaign_id, "PILOT_STATE")
             return {**self._snapshot(db, book["book_id"]), "event_applied": True}
 
     def sell(
@@ -509,6 +514,7 @@ class StrategyLedger:
                                      "revision": pilot["revision"] + 1, "last_evaluated_at": timestamp}
             self._save(db, "campaigns", campaign_id, campaign)
             self._save(db, "books", book_id, book)
+            self._notice(db, event_id, campaign_id, "SELL")
             return {**self._snapshot(db, book_id), "event_applied": True}
 
     def mark(self, event_id, campaign_id, price, occurred_at, source_hash=None):
@@ -597,11 +603,19 @@ class StrategyLedger:
             campaign = self._get(db, "campaigns", campaign_id)
             applied = self._event(db, event_id, payload)
             if applied:
+                from prism_core.strategy_ledger_outbox import execution_change, previous_execution
+                previous = previous_execution(db, campaign_id, execution_profile_ref, intent_ref)
                 db.execute(
                     "INSERT INTO executions VALUES (?,?,?)",
                     (event_id, campaign_id, _dump({"event_id": event_id, **payload})),
                 )
+                if execution_change(previous, payload):
+                    self._notice(db, event_id, campaign_id, "EXECUTION")
             return {**self._snapshot(db, campaign["book_id"]), "event_applied": applied}
+
+    def _notice(self, db, source_event_id, campaign_id, category):
+        from prism_core.strategy_ledger_outbox import freeze_notice
+        freeze_notice(self, db, source_event_id, campaign_id, category)
 
     def snapshot(self, book_id):
         with self._transaction() as db:

--- a/prism_core/strategy_ledger_outbox.py
+++ b/prism_core/strategy_ledger_outbox.py
@@ -1,0 +1,328 @@
+"""Append-only ledger outbox and pure account evidence; no sender/order imports.
+
+Claiming grants permission once and immediately persists UNKNOWN. A crash before
+or after sending cannot be distinguished; UNKNOWN is never automatically retried.
+This is at-most-one automatic send attempt, NOT exactly-once Telegram delivery.
+Only a separately guarded test-chat sender may consume these frozen notices.
+"""
+import hashlib
+import json
+from decimal import Decimal
+
+from prism_core.strategy_ledger import LedgerError, _dump, _number, _text, _time
+from prism_core.strategy_ledger_execution import project_account_target
+from prism_core.strategy_ledger_messages import format_campaign
+
+EXECUTION_STATUSES = frozenset({"UNKNOWN", "SUBMITTED", "ACCEPTED", "REJECTED", "PARTIAL", "FILLED", "CANCELLED"})
+
+
+def _known_ref(value):
+    return isinstance(value, str) and bool(value.strip()) and value.strip().upper() not in {"UNKNOWN", "MISSING", "[REDACTED]"}
+
+
+def _active_buy_unresolved(record):
+    """No inference that an active order with zero reservation is completed."""
+    if record.get("side") != "BUY" or record.get("status") not in {"SUBMITTED", "ACCEPTED", "PARTIAL"}:
+        return False
+    target, reserved = record.get("submitted_target_pct"), record.get("reserved_buy_notional")
+    return target is None or reserved is None or _number(target) <= 0 or _number(reserved) <= 0
+
+
+def _id(kind, *parts):
+    return "ledger-" + kind + ":" + hashlib.sha256(_dump(parts).encode()).hexdigest()
+
+
+def freeze_notice(ledger, db, source_event_id, campaign_id, category):
+    """Called only inside the source strategy/execution transaction."""
+    headings = {"BUY": "전략 배분 기록", "SELL": "전략 축소·청산 기록",
+                "PILOT_STATE": "파일럿 상태 변경", "EXECUTION": "계좌 집행 증거 변경"}
+    if category not in headings:
+        raise LedgerError("unsupported notice category")
+    campaign = ledger._get(db, "campaigns", campaign_id)
+    snapshot = ledger._snapshot(db, campaign["book_id"])
+    if snapshot["mode"] not in {"SHADOW", "VALIDATION", "VALIDATION_ONLY"}:
+        raise LedgerError("notice delivery is validation/test-chat only")
+    source = db.execute("SELECT payload FROM events WHERE id=?", (source_event_id,)).fetchone()
+    if not source:
+        raise LedgerError("notice source event missing")
+    payload = json.loads(source[0])
+    occurred_at = payload.get("occurred_at") or payload.get("observed_at") or payload.get("pilot", {}).get("entry_at")
+    source_observed_at = _time(occurred_at)
+    snapshot_evidence_at = max(
+        [source_observed_at, _time(campaign["last_event_at"]),
+         _time(snapshot.get("last_accounting_at") or campaign["last_event_at"])]
+        + [_time(record["observed_at"]) for record in snapshot["executions"]]
+    )
+    notice_id = _id("notice", source_event_id, campaign_id, category)
+    state = campaign.get("pilot", {}).get("state")
+    heading = headings[category] + (f" · {state}" if state in {"PILOT_50", "WAIT", "FULL_100", "ADD_CANCELLED", "ADD_EXPIRED", "EXITED"} else "")
+    cumulative_note = ""
+    if category == "EXECUTION" and payload.get("cumulative_fill_quantity") is not None:
+        cumulative_note = f"\n해당 주문의 누적 확인 체결: {_number(payload['cumulative_fill_quantity']):g}주"
+        if payload.get("status") == "CANCELLED":
+            cumulative_note += " · 취소 전에 확인된 체결은 유지됩니다."
+    frozen = {"kind": "strategy_notice", "notice_id": notice_id,
+              "source_event_id": source_event_id, "campaign_id": campaign_id,
+              "book_id": campaign["book_id"], "category": category,
+              "created_at": snapshot_evidence_at, "source_observed_at": source_observed_at,
+              "snapshot_evidence_at": snapshot_evidence_at, "clock_basis": "EVIDENCE_CLOCK_NOT_WALL_CLOCK",
+              "delivery_scope": "TEST_CHAT_ONLY",
+              "text": heading + "\n원천 관측 시각: " + source_observed_at
+                      + "\n고정 원장 증거 기준 시각: " + snapshot_evidence_at
+                      + cumulative_note + "\n" + format_campaign(snapshot, campaign_id)}
+    ledger._event(db, notice_id, frozen)
+
+
+class StrategyLedgerOutbox:
+    def __init__(self, ledger):
+        self.ledger = ledger
+
+    @staticmethod
+    def _read(db, event_id):
+        row = db.execute("SELECT payload FROM events WHERE id=?", (event_id,)).fetchone()
+        return json.loads(row[0]) if row else None
+
+    def _view(self, db, notice_id):
+        notice = self._read(db, notice_id)
+        if not notice or notice.get("kind") != "strategy_notice":
+            raise LedgerError("unknown notice")
+        claim = self._read(db, _id("claim", notice_id))
+        ack = self._read(db, _id("ack", notice_id))
+        return {**notice, "status": "SENT" if ack else "UNKNOWN" if claim else "READY",
+                "claim_id": claim["claim_id"] if claim else None,
+                "receipt_ref": ack["receipt_ref"] if ack else None}
+
+    def pending(self):
+        return self.list_notices(status="READY")
+
+    def list_notices(self, *, status=None):
+        """UNKNOWN remains inspectable for manual reconciliation, never resend."""
+        if status not in {None, "READY", "UNKNOWN", "SENT"}:
+            raise LedgerError("unsupported notice status")
+        with self.ledger._transaction() as db:
+            notices = []
+            for event_id, payload in db.execute("SELECT id, payload FROM events ORDER BY rowid"):
+                if json.loads(payload).get("kind") == "strategy_notice":
+                    notice = self._view(db, event_id)
+                    if status is None or notice["status"] == status:
+                        notices.append(notice)
+            return notices
+
+    def status(self, notice_id):
+        with self.ledger._transaction() as db:
+            return self._view(db, notice_id)
+
+    def claim(self, notice_id, claim_id, claimed_at):
+        claimed_at, claim_id = _time(claimed_at), _text(claim_id)
+        with self.ledger._transaction() as db:
+            notice = self._view(db, notice_id)
+            if notice["status"] != "READY":
+                return {**notice, "send_authorized": False}
+            if claimed_at < notice["created_at"]:
+                raise LedgerError("claim predates notice")
+            self.ledger._event(db, _id("claim", notice_id), {
+                "kind": "notice_claim", "notice_id": notice_id, "claim_id": claim_id,
+                "claimed_at": claimed_at, "status": "UNKNOWN",
+            })
+            return {**self._view(db, notice_id), "send_authorized": True}
+
+    def ack(self, notice_id, claim_id, receipt_ref, acknowledged_at):
+        """Retries must reuse the original receipt AND acknowledgment timestamp."""
+        acknowledged_at = _time(acknowledged_at)
+        if not _known_ref(receipt_ref):
+            raise LedgerError("known receipt evidence required")
+        with self.ledger._transaction() as db:
+            notice = self._view(db, notice_id)
+            claim = self._read(db, _id("claim", notice_id))
+            if not claim or claim["claim_id"] != claim_id:
+                raise LedgerError("ack requires the original send claim")
+            if acknowledged_at < claim["claimed_at"]:
+                raise LedgerError("ack predates claim")
+            self.ledger._event(db, _id("ack", notice_id), {
+                "kind": "notice_ack", "notice_id": notice_id, "claim_id": claim_id,
+                "receipt_ref": _text(receipt_ref), "acknowledged_at": acknowledged_at,
+            })
+            return {**notice, "status": "SENT", "receipt_ref": receipt_ref}
+
+
+def execution_change(previous, current):
+    """Ignore repeat polls/source clocks; changes in evidence remain meaningful."""
+    if previous is not None and _time(current["observed_at"]) <= _time(previous["observed_at"]):
+        return False  # Preserve late/equal-clock evidence without a stale status notice.
+    fields = ("status", "confirmed_quantity", "confirmed_price", "side",
+              "cumulative_fill_quantity", "cumulative_fill_notional", "reserved_buy_notional")
+    return previous is None or any(previous.get(key) != current.get(key) for key in fields)
+
+
+def previous_execution(db, campaign_id, execution_profile_ref, intent_ref):
+    latest = None
+    for data, in db.execute("SELECT data FROM executions ORDER BY rowid DESC"):
+        record = json.loads(data)
+        if (record.get("campaign_id") == campaign_id and record.get("execution_profile_ref") == execution_profile_ref
+                and record.get("intent_ref") == intent_ref):
+            if latest is None or _time(record["observed_at"]) > _time(latest["observed_at"]):
+                latest = record
+    return latest
+
+
+def record_account_evidence(ledger, event_id, campaign_id, *, execution_profile_ref,
+                            intent_ref, side, status, observed_at, evidence_source,
+                            cumulative_fill_quantity=None, cumulative_fill_notional=None,
+                            reserved_buy_notional=None, submitted_target_pct=None):
+    """Persist broker-supplied cumulative PER-INTENT evidence, never infer fills.
+
+    Cancellation does not erase prior fills. A poller must provide final cumulative
+    values and reservation release explicitly; missing values remain unknown.
+    confirmed_* display fields are populated only for PARTIAL/FILLED evidence.
+    """
+    if side not in {"BUY", "SELL"} or status not in EXECUTION_STATUSES:
+        raise LedgerError("invalid account side/status")
+    if not all(_known_ref(value) for value in (execution_profile_ref, intent_ref, evidence_source)):
+        raise LedgerError("explicit account, intent and evidence references required")
+    values = [None if value is None else str(_number(value)) for value in
+              (cumulative_fill_quantity, cumulative_fill_notional, reserved_buy_notional, submitted_target_pct)]
+    quantity, notional, reserved, target = values
+    if target is not None and Decimal(target) > 100:
+        raise LedgerError("submitted target exceeds 100")
+    if (quantity is None) != (notional is None):
+        raise LedgerError("cumulative quantity/notional must be supplied together")
+    if quantity is not None and ((Decimal(quantity) == 0) != (Decimal(notional) == 0)):
+        raise LedgerError("inconsistent cumulative fill quantity/notional")
+    if side == "SELL" and reserved is not None and Decimal(reserved) != 0:
+        raise LedgerError("sell intent cannot carry a buy reservation")
+    source_status = status
+    if status in {"PARTIAL", "FILLED"} and (quantity is None or Decimal(quantity) == 0):
+        status = "UNKNOWN"
+    if _active_buy_unresolved({"side": side, "status": status, "submitted_target_pct": target,
+                               "reserved_buy_notional": reserved}):
+        status = "UNKNOWN"
+    payload = {
+        "kind": "account_execution", "campaign_id": _text(campaign_id),
+        "execution_profile_ref": _text(execution_profile_ref), "intent_ref": _text(intent_ref),
+        "side": side, "status": status, "source_status": source_status, "observed_at": _time(observed_at),
+        "evidence_source": _text(evidence_source), "quantity_semantics": "CUMULATIVE_PER_INTENT",
+        "cumulative_fill_quantity": quantity, "cumulative_fill_notional": notional,
+        "reserved_buy_notional": reserved, "submitted_target_pct": target,
+        "confirmed_quantity": quantity if status in {"PARTIAL", "FILLED"} and quantity is not None and Decimal(quantity) > 0 else None,
+        "confirmed_price": str(Decimal(notional) / Decimal(quantity)) if status in {"PARTIAL", "FILLED"} and quantity is not None and Decimal(quantity) > 0 else None,
+    }
+    with ledger._transaction() as db:
+        campaign = ledger._get(db, "campaigns", campaign_id)
+        applied = ledger._event(db, event_id, payload)
+        if applied:
+            previous = previous_execution(db, campaign_id, execution_profile_ref, intent_ref)
+            db.execute("INSERT INTO executions VALUES (?,?,?)", (event_id, campaign_id, _dump({"event_id": event_id, **payload})))
+            if execution_change(previous, payload):
+                ledger._notice(db, event_id, campaign_id, "EXECUTION")
+        return {**ledger._snapshot(db, campaign["book_id"]), "event_applied": applied}
+
+
+def reconcile_account_evidence(records, *, campaign_id, execution_profile_ref, coverage_complete):
+    """Latest cumulative record per intent, NOT sum of successive poll snapshots.
+
+    Coverage is a caller attestation. Missing final fill/reservation evidence,
+    decreasing counters or conflicting equal-clock records block projection.
+    Empty history is UNKNOWN, not proof of zero account holdings/orders.
+    """
+    grouped, unknown = {}, coverage_complete is not True or not _known_ref(execution_profile_ref)
+    for record in records:
+        if not isinstance(record, dict):
+            unknown = True
+            continue
+        if record.get("campaign_id") != campaign_id or record.get("execution_profile_ref") != execution_profile_ref:
+            continue
+        intent = record.get("intent_ref")
+        if (not _known_ref(intent) or record.get("quantity_semantics") != "CUMULATIVE_PER_INTENT"
+                or record.get("status") not in EXECUTION_STATUSES):
+            unknown = True
+            continue
+        try:
+            _time(record.get("observed_at"))
+            for key in ("cumulative_fill_quantity", "cumulative_fill_notional", "reserved_buy_notional", "submitted_target_pct"):
+                if record.get(key) is not None:
+                    _number(record[key])
+            if record.get("submitted_target_pct") is not None and _number(record["submitted_target_pct"]) > 100:
+                raise LedgerError("invalid submitted target")
+            q, n = record.get("cumulative_fill_quantity"), record.get("cumulative_fill_notional")
+            if (q is None) != (n is None) or (q is not None and ((_number(q) == 0) != (_number(n) == 0))):
+                raise LedgerError("inconsistent cumulative evidence")
+            if record.get("side") == "SELL" and record.get("reserved_buy_notional") is not None and _number(record["reserved_buy_notional"]) != 0:
+                raise LedgerError("invalid sell reservation")
+        except (ValueError, TypeError):
+            unknown = True
+            continue
+        grouped.setdefault(intent, []).append(record)
+    buy_quantity = sell_quantity = confirmed = reserved = target = Decimal(0)
+    for history in grouped.values():
+        history = sorted(history, key=lambda r: (_time(r["observed_at"]), r.get("event_id", "")))
+        previous_quantity = previous_notional = previous_target = Decimal(0)
+        side, last_clock, last_signature = None, None, None
+        for record in history:
+            if record.get("side") not in {"BUY", "SELL"} or (side is not None and side != record["side"]):
+                unknown = True
+            side = record.get("side")
+            clock = _time(record["observed_at"])
+            signature = tuple(record.get(k) for k in ("side", "status", "cumulative_fill_quantity", "cumulative_fill_notional", "reserved_buy_notional", "submitted_target_pct"))
+            if clock == last_clock and signature != last_signature:
+                unknown = True
+            last_clock, last_signature = clock, signature
+            if record.get("submitted_target_pct") is not None:
+                submitted = _number(record["submitted_target_pct"])
+                if submitted < previous_target:
+                    unknown = True
+                previous_target = max(previous_target, submitted)
+            if record.get("cumulative_fill_quantity") is not None and record.get("cumulative_fill_notional") is not None:
+                quantity, notional = _number(record["cumulative_fill_quantity"]), _number(record["cumulative_fill_notional"])
+                if quantity < previous_quantity or notional < previous_notional:
+                    unknown = True
+                previous_quantity, previous_notional = max(previous_quantity, quantity), max(previous_notional, notional)
+        latest = history[-1]
+        if (latest.get("status") == "UNKNOWN" or _active_buy_unresolved(latest) or not _known_ref(latest.get("evidence_source"))
+                or latest.get("cumulative_fill_quantity") is None or latest.get("cumulative_fill_notional") is None
+                or latest.get("reserved_buy_notional") is None or latest.get("submitted_target_pct") is None
+                or (latest.get("status") in {"PARTIAL", "FILLED"} and previous_quantity == 0)):
+            unknown = True
+        if side == "BUY":
+            buy_quantity += previous_quantity
+            confirmed += previous_notional
+            reserved += _number(latest["reserved_buy_notional"]) if latest.get("reserved_buy_notional") is not None else 0
+            target = max(target, previous_target)
+        elif side == "SELL":
+            sell_quantity += previous_quantity
+    unknown = unknown or not grouped or sell_quantity > buy_quantity
+    return {"execution_profile_ref": execution_profile_ref, "campaign_id": campaign_id,
+            "coverage_complete": coverage_complete is True, "unknown_execution": unknown,
+            "confirmed_buy_notional": None if unknown else str(confirmed),
+            "reserved_buy_notional": None if unknown else str(reserved),
+            "previously_submitted_target_pct": None if unknown else str(target),
+            "residual_quantity": None if unknown else str(buy_quantity - sell_quantity),
+            "known_buy_quantity": str(buy_quantity), "known_sell_quantity": str(sell_quantity),
+            "quantity_semantics": "LATEST_CUMULATIVE_PER_INTENT"}
+
+
+def project_account_from_evidence(snapshot, campaign_id, *, account_evidence,
+                                  account_unit_budget, limit_price):
+    """Pure overlay adapter; no account amount changes strategy allocation."""
+    if snapshot.get("mode") not in {"SHADOW", "VALIDATION", "VALIDATION_ONLY"}:
+        return {"status": "BLOCKED", "quantity": 0, "no_order": True, "reason": "NON_VALIDATION_BOOK"}
+    campaign = next((c for c in snapshot["campaigns"] if c["campaign_id"] == campaign_id), None)
+    if campaign is None:
+        raise LedgerError("unknown campaign")
+    if campaign["status"] == "CLOSED" or campaign["add_permission"] != "AVAILABLE":
+        return {"status": "BLOCKED", "quantity": 0, "no_order": True, "reason": "STRATEGY_NOT_ADDABLE"}
+    required = {"confirmed_buy_notional", "reserved_buy_notional", "previously_submitted_target_pct", "unknown_execution", "execution_profile_ref"}
+    if (not isinstance(account_evidence, dict) or not required <= account_evidence.keys()
+            or account_evidence.get("campaign_id") != campaign_id or account_evidence.get("coverage_complete") is not True
+            or type(account_evidence.get("unknown_execution")) is not bool
+            or not _known_ref(account_evidence.get("execution_profile_ref"))):
+        return {"status": "BLOCKED", "quantity": 0, "no_order": True, "reason": "INCOMPLETE_ACCOUNT_EVIDENCE"}
+    if account_unit_budget is None:
+        return {"status": "BLOCKED", "quantity": 0, "no_order": True, "reason": "MISSING_ACCOUNT_BUDGET"}
+    return project_account_target(
+        execution_profile_ref=account_evidence["execution_profile_ref"], account_unit_budget=account_unit_budget,
+        target_pct=campaign["target_pct"], limit_price=limit_price,
+        confirmed_buy_notional=account_evidence["confirmed_buy_notional"],
+        reserved_buy_notional=account_evidence["reserved_buy_notional"],
+        previously_submitted_target_pct=account_evidence["previously_submitted_target_pct"],
+        unknown_execution=account_evidence["unknown_execution"],
+    )

--- a/tests/test_strategy_ledger_outbox.py
+++ b/tests/test_strategy_ledger_outbox.py
@@ -1,0 +1,360 @@
+from concurrent.futures import ThreadPoolExecutor
+import json
+import sqlite3
+
+import pytest
+
+from prism_core.strategy_ledger import LedgerError, StrategyLedger
+from prism_core.strategy_ledger_outbox import (
+    StrategyLedgerOutbox, project_account_from_evidence,
+    reconcile_account_evidence, record_account_evidence,
+)
+
+T0 = "2026-09-10T00:00:00Z"
+T1 = "2026-09-10T01:00:00Z"
+T2 = "2026-09-10T02:00:00Z"
+T3 = "2026-09-10T03:00:00Z"
+
+
+def ledger_at(tmp_path):
+    ledger = StrategyLedger(tmp_path / "outbox.sqlite")
+    ledger.create_book("book", "US", mode="SHADOW")
+    return ledger
+
+
+def buy(ledger):
+    return ledger.apply_target("buy", "book", "c", "TEST", 50, 100, T0)
+
+
+def test_notice_is_atomic_frozen_and_not_emitted_for_marks(tmp_path):
+    ledger = ledger_at(tmp_path)
+    buy(ledger)
+    outbox = StrategyLedgerOutbox(ledger)
+    notice, = outbox.pending()
+    assert "100.00 USD" in notice["text"]
+    assert "원천 관측 시각: 2026-09-10T00:00:00+00:00" in notice["text"]
+    assert notice["delivery_scope"] == "TEST_CHAT_ONLY"
+    ledger.mark("mark", "c", 200, T1)
+    assert outbox.pending() == [notice]
+    assert not buy(ledger)["event_applied"]
+    assert outbox.pending() == [notice]
+
+
+def test_notice_failure_rolls_back_strategy_leg(tmp_path, monkeypatch):
+    ledger = ledger_at(tmp_path)
+    before = ledger.snapshot("book")
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("notice persistence failure")
+
+    monkeypatch.setattr(ledger, "_notice", fail)
+    with pytest.raises(RuntimeError):
+        buy(ledger)
+    assert ledger.snapshot("book") == before
+    assert StrategyLedgerOutbox(ledger).pending() == []
+
+
+def test_claim_crash_is_unknown_and_never_automatically_reauthorized(tmp_path):
+    ledger = ledger_at(tmp_path)
+    buy(ledger)
+    outbox = StrategyLedgerOutbox(ledger)
+    notice, = outbox.pending()
+    claimed = outbox.claim(notice["notice_id"], "worker-1", T1)
+    assert claimed["send_authorized"] is True
+    assert claimed["status"] == "UNKNOWN"
+    reopened = StrategyLedgerOutbox(StrategyLedger(ledger.path))
+    assert reopened.pending() == []
+    assert len(reopened.list_notices(status="UNKNOWN")) == 1
+    assert reopened.claim(notice["notice_id"], "worker-1", T1)["send_authorized"] is False
+    assert reopened.claim(notice["notice_id"], "worker-2", T1)["send_authorized"] is False
+
+
+def test_parallel_claim_and_idempotent_ack(tmp_path):
+    ledger = ledger_at(tmp_path)
+    buy(ledger)
+    notice, = StrategyLedgerOutbox(ledger).pending()
+
+    def claim(worker):
+        return StrategyLedgerOutbox(StrategyLedger(ledger.path)).claim(notice["notice_id"], worker, T1)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(claim, ["one", "two"]))
+    assert sum(result["send_authorized"] for result in results) == 1
+    winner = next(result for result in results if result["send_authorized"])
+    outbox = StrategyLedgerOutbox(ledger)
+    first = outbox.ack(notice["notice_id"], winner["claim_id"], "telegram-receipt", T1)
+    assert first["status"] == "SENT"
+    assert outbox.ack(notice["notice_id"], winner["claim_id"], "telegram-receipt", T1) == first
+
+
+def record(ledger, event, *, profile="account-A", intent="buy-intent", side="BUY", status="PARTIAL", at=T1,
+           quantity=2, notional=200, reserved=300, target=50):
+    return record_account_evidence(ledger, event, "c", execution_profile_ref=profile,
+                                  intent_ref=intent, side=side, status=status, observed_at=at,
+                                  evidence_source="broker-cumulative-snapshot",
+                                  cumulative_fill_quantity=quantity, cumulative_fill_notional=notional,
+                                  reserved_buy_notional=reserved, submitted_target_pct=target)
+
+
+def reconcile(ledger, profile="account-A", coverage=True):
+    return reconcile_account_evidence(ledger.snapshot("book")["executions"], campaign_id="c",
+                                      execution_profile_ref=profile, coverage_complete=coverage)
+
+
+def strategy(snapshot):
+    return {key: value for key, value in snapshot.items() if key not in {"executions", "event_applied"}}
+
+
+def test_cumulative_fill_partial_cancel_late_fill_after_strategy_exit(tmp_path):
+    ledger = ledger_at(tmp_path)
+    before = strategy(buy(ledger))
+    record(ledger, "partial")
+    record(ledger, "repeat-poll", at="2026-09-10T01:30:00Z")
+    assert strategy(ledger.snapshot("book")) == before
+    assert len(StrategyLedgerOutbox(ledger).pending()) == 2  # BUY + changed execution only
+    record(ledger, "cancel", status="CANCELLED", at=T2, reserved=0)
+    evidence = reconcile(ledger)
+    assert evidence["residual_quantity"] == "2"
+    assert evidence["confirmed_buy_notional"] == "200"  # not 200 + 200 + 200
+    assert evidence["reserved_buy_notional"] == "0"
+    notice = StrategyLedgerOutbox(ledger).pending()[-1]
+    assert "누적 확인 체결: 2주" in notice["text"] and "취소 전에 확인된 체결은 유지" in notice["text"]
+    closed = strategy(ledger.sell("strategy-exit", "c", 110, T2))
+    record(ledger, "late-fill", status="FILLED", at=T3, quantity=3, notional=300, reserved=0)
+    assert strategy(ledger.snapshot("book")) == closed
+    assert reconcile(ledger)["residual_quantity"] == "3"
+    record(ledger, "account-reduction", intent="sell-intent", side="SELL", status="FILLED", at=T3,
+           quantity=1, notional=110, reserved=0, target=0)
+    evidence = reconcile(ledger)
+    assert evidence["residual_quantity"] == "2"
+    assert strategy(ledger.snapshot("book")) == closed
+    plan = project_account_from_evidence(ledger.snapshot("book"), "c", account_evidence=evidence,
+                                         account_unit_budget=1000, limit_price=110)
+    assert plan["reason"] == "STRATEGY_NOT_ADDABLE"
+
+
+def test_multiple_accounts_and_account_budget_do_not_change_strategy(tmp_path):
+    ledger = ledger_at(tmp_path)
+    before = strategy(buy(ledger))
+    record(ledger, "account-a-fill", reserved=0, status="FILLED")
+    record(ledger, "account-b-reject", profile="account-B", status="REJECTED", quantity=0, notional=0, reserved=0)
+    assert reconcile(ledger)["residual_quantity"] == "2"
+    assert reconcile(ledger, "account-B")["residual_quantity"] == "0"
+    assert strategy(ledger.snapshot("book")) == before
+    # Explicit caller-provided zero-order coverage, never derived from position.
+    empty_evidence = {"campaign_id": "c", "execution_profile_ref": "account-C", "coverage_complete": True,
+                      "unknown_execution": False, "confirmed_buy_notional": 0,
+                      "reserved_buy_notional": 0, "previously_submitted_target_pct": 0}
+    for budget in (0, 1000):
+        result = project_account_from_evidence(ledger.snapshot("book"), "c", account_evidence=empty_evidence,
+                                               account_unit_budget=budget, limit_price=100)
+        assert result["quantity"] == (0 if budget == 0 else 5)
+        assert result["no_order"] is True
+        assert strategy(ledger.snapshot("book")) == before
+    assert project_account_from_evidence(ledger.snapshot("book"), "c", account_evidence=empty_evidence,
+                                          account_unit_budget=None, limit_price=100)["reason"] == "MISSING_ACCOUNT_BUDGET"
+    assert strategy(ledger.snapshot("book")) == before
+
+
+@pytest.mark.parametrize("missing", ["confirmed_buy_notional", "reserved_buy_notional", "previously_submitted_target_pct", "unknown_execution"])
+def test_account_projection_requires_every_evidence_field(tmp_path, missing):
+    ledger = ledger_at(tmp_path)
+    buy(ledger)
+    record(ledger, "fill", reserved=0)
+    evidence = reconcile(ledger)
+    evidence.pop(missing)
+    result = project_account_from_evidence(ledger.snapshot("book"), "c", account_evidence=evidence,
+                                           account_unit_budget=1000, limit_price=100)
+    assert result["quantity"] == 0 and result["reason"] == "INCOMPLETE_ACCOUNT_EVIDENCE"
+
+
+def test_unknown_reservation_and_missing_cancel_fill_block_not_erase_strategy(tmp_path):
+    ledger = ledger_at(tmp_path)
+    before = strategy(buy(ledger))
+    assert reconcile(ledger)["unknown_execution"] is True
+    record(ledger, "partial")
+    record(ledger, "cancel-missing", status="CANCELLED", at=T2, quantity=None, notional=None, reserved=None)
+    evidence = reconcile(ledger)
+    assert evidence["known_buy_quantity"] == "2"
+    assert evidence["residual_quantity"] is None and evidence["unknown_execution"] is True
+    result = project_account_from_evidence(ledger.snapshot("book"), "c", account_evidence=evidence,
+                                           account_unit_budget=1000, limit_price=100)
+    assert result["reason"] == "UNKNOWN_EXECUTION_RESERVATION"
+    assert strategy(ledger.snapshot("book")) == before
+
+
+def test_legacy_fill_without_cumulative_contract_cannot_size_account(tmp_path):
+    ledger = ledger_at(tmp_path)
+    buy(ledger)
+    ledger.observe_execution("legacy", "c", "account-A", "FILLED", T1, intent_ref="i",
+                             confirmed_quantity=2, confirmed_price=100, evidence_source="broker")
+    assert reconcile(ledger)["unknown_execution"] is True
+
+
+def test_incomplete_fill_status_is_unknown_not_confirmed(tmp_path):
+    ledger = ledger_at(tmp_path)
+    buy(ledger)
+    record(ledger, "incomplete", status="FILLED", quantity=None, notional=None, reserved=None)
+    evidence = ledger.snapshot("book")["executions"][0]
+    assert evidence["status"] == "UNKNOWN" and evidence["source_status"] == "FILLED"
+    assert evidence["confirmed_quantity"] is None
+    assert reconcile(ledger)["unknown_execution"] is True
+
+
+@pytest.mark.parametrize("kind", ["counter_decrease", "same_clock_conflict", "missing_coverage", "submitted_target_decrease"])
+def test_ambiguous_cumulative_history_blocks_projection(tmp_path, kind):
+    ledger = ledger_at(tmp_path)
+    buy(ledger)
+    record(ledger, "first")
+    record(ledger, "second", at=T1 if kind == "same_clock_conflict" else T2,
+           quantity=1 if kind == "counter_decrease" else 3, notional=100 if kind == "counter_decrease" else 300,
+           target=10 if kind == "submitted_target_decrease" else 50)
+    assert reconcile(ledger, coverage=kind != "missing_coverage")["unknown_execution"] is True
+
+
+def test_execution_event_id_conflict_and_notice_failure_are_atomic(tmp_path, monkeypatch):
+    ledger = ledger_at(tmp_path)
+    buy(ledger)
+    record(ledger, "same")
+    assert record(ledger, "same")["event_applied"] is False
+    with pytest.raises(LedgerError, match="conflict"):
+        record(ledger, "same", quantity=3, notional=300)
+    before = ledger.snapshot("book")
+    monkeypatch.setattr(ledger, "_notice", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("crash")))
+    with pytest.raises(RuntimeError):
+        record(ledger, "new", status="CANCELLED", reserved=0, at=T2)
+    assert ledger.snapshot("book") == before
+
+
+def test_ack_requires_claim_and_rejects_conflicting_receipt(tmp_path):
+    ledger = ledger_at(tmp_path)
+    buy(ledger)
+    outbox = StrategyLedgerOutbox(ledger)
+    notice, = outbox.pending()
+    with pytest.raises(LedgerError, match="claim"):
+        outbox.ack(notice["notice_id"], "worker", "receipt", T1)
+    outbox.claim(notice["notice_id"], "worker", T1)
+    with pytest.raises(LedgerError, match="claim"):
+        outbox.ack(notice["notice_id"], "other", "receipt", T1)
+    outbox.ack(notice["notice_id"], "worker", "receipt", T1)
+    with pytest.raises(LedgerError, match="conflict"):
+        outbox.ack(notice["notice_id"], "worker", "different-receipt", T1)
+    with sqlite3.connect(ledger.path) as db, pytest.raises(sqlite3.IntegrityError):
+        db.execute("DELETE FROM events WHERE id=?", (notice["notice_id"],))
+
+
+def test_notice_snapshots_do_not_leak_account_references(tmp_path):
+    ledger = ledger_at(tmp_path)
+    buy(ledger)
+    record(ledger, "execution", profile="SECRET_ACCOUNT", intent="SECRET_INTENT")
+    text = StrategyLedgerOutbox(ledger).pending()[-1]["text"]
+    assert "SECRET" not in text
+    assert len(text) < 3500
+    json.dumps(StrategyLedgerOutbox(ledger).pending())
+
+
+def test_pilot_notices_follow_final_state_once_and_not_every_wait_tick(tmp_path):
+    ledger = StrategyLedger(tmp_path / "pilot.sqlite")
+    ledger.create_book("pilot", "US", cohort="split-pilot-v1", mode="SHADOW")
+    dates = ["2026-09-04", "2026-09-08", "2026-09-09", "2026-09-10"]
+    calendar = {"market": "US", "timezone": "America/New_York", "source_kind": "test_fixture",
+                "source_ref": "outbox-fixture", "verification_status": "VERIFIED",
+                "sessions": [{"date": d, "open_at": d + "T09:30:00-04:00", "close_at": d + "T16:00:00-04:00"} for d in dates]}
+    ledger.open_pilot("open", "pilot", "c", "TEST", 100, "2026-09-04T10:00:00-04:00",
+                      owner="split-pilot-v1", signal_bar=None, calendar=calendar, entry_eligible=True)
+    outbox = StrategyLedgerOutbox(ledger)
+    notice, = outbox.pending()
+    assert "PILOT_50" in notice["text"]
+    ledger.advance_pilot("wait", "c", expected_revision=0, evidence={}, occurred_at="2026-09-08T10:00:00-04:00")
+    ledger.advance_pilot("wait-again", "c", expected_revision=1, evidence={}, occurred_at="2026-09-08T10:01:00-04:00")
+    assert len(outbox.pending()) == 2
+    ledger.advance_pilot("expire", "c", expected_revision=2, evidence={}, occurred_at="2026-09-10T16:00:00-04:00")
+    assert len(outbox.pending()) == 3
+    assert "ADD_EXPIRED" in outbox.pending()[-1]["text"]
+    assert "PILOT_50" in outbox.pending()[0]["text"]  # frozen, not today's state
+
+
+def test_strategy_sell_notice_and_legacy_execution_dedup(tmp_path):
+    ledger = ledger_at(tmp_path)
+    buy(ledger)
+    ledger.observe_execution("reject", "c", "account", "REJECTED", T1, intent_ref="intent")
+    ledger.observe_execution("same-status-poll", "c", "account", "REJECTED", T2, intent_ref="intent")
+    assert len(StrategyLedgerOutbox(ledger).pending()) == 2
+    ledger.sell("sell", "c", 110, T2)
+    notice = StrategyLedgerOutbox(ledger).pending()[-1]
+    assert notice["category"] == "SELL"
+    assert "청산 완료" in notice["text"]
+
+
+def test_no_new_tables_no_broker_or_transport_dependency(tmp_path):
+    import ast
+    from pathlib import Path
+
+    ledger = ledger_at(tmp_path)
+    buy(ledger)
+    with sqlite3.connect(ledger.path) as db:
+        assert {row[0] for row in db.execute("SELECT name FROM sqlite_master WHERE type='table'")} == {
+            "strategy_ledger_metadata", "books", "campaigns", "events", "legs", "executions"}
+    source = Path(__file__).resolve().parents[1] / "prism_core" / "strategy_ledger_outbox.py"
+    imports = [node.module for node in ast.walk(ast.parse(source.read_text())) if isinstance(node, ast.ImportFrom)]
+    assert not any(module and any(name in module for name in ("trading.", "messaging", "telegram", "execution_service")) for module in imports)
+
+
+@pytest.mark.parametrize("status", ["SUBMITTED", "ACCEPTED", "PARTIAL"])
+@pytest.mark.parametrize("target,reserved", [(0, 0), (50, 0), (0, 300), (50, None)])
+def test_active_buy_requires_coherent_submitted_target_and_reservation(tmp_path, status, target, reserved):
+    ledger = ledger_at(tmp_path)
+    buy(ledger)
+    record(ledger, "active", status=status, target=target, reserved=reserved,
+           quantity=1 if status == "PARTIAL" else 0, notional=100 if status == "PARTIAL" else 0)
+    stored = ledger.snapshot("book")["executions"][0]
+    assert stored["status"] == "UNKNOWN" and stored["source_status"] == status
+    assert reconcile(ledger)["unknown_execution"] is True
+    # The pure reconciler must also reject contradictory raw poll evidence,
+    # independent of the writer's defensive normalization.
+    raw = {**stored, "status": status}
+    account = reconcile_account_evidence([raw], campaign_id="c", execution_profile_ref="account-A", coverage_complete=True)
+    assert account["unknown_execution"] is True
+    result = project_account_from_evidence(ledger.snapshot("book"), "c", account_evidence=account,
+                                           account_unit_budget=1000, limit_price=100)
+    assert result["quantity"] == 0 and result["reason"] == "UNKNOWN_EXECUTION_RESERVATION"
+
+
+def test_late_older_execution_is_preserved_without_stale_or_repeated_notice(tmp_path):
+    ledger = ledger_at(tmp_path)
+    buy(ledger)
+    record(ledger, "final", status="FILLED", at=T2, quantity=2, notional=200, reserved=0)
+    outbox = StrategyLedgerOutbox(ledger)
+    original = outbox.pending()
+    record(ledger, "late-old", status="PARTIAL", at=T1, quantity=1, notional=100, reserved=400)
+    assert outbox.pending() == original
+    record(ledger, "new-repeat-final", status="FILLED", at=T3, quantity=2, notional=200, reserved=0)
+    assert outbox.pending() == original
+    assert len(ledger.snapshot("book")["executions"]) == 3
+    assert reconcile(ledger)["residual_quantity"] == "2"
+
+
+def test_late_first_notice_separates_source_clock_from_frozen_snapshot_clock(tmp_path):
+    ledger = ledger_at(tmp_path)
+    buy(ledger)
+    ledger.sell("exit", "c", 110, T2)
+    record(ledger, "old-first-fill", status="FILLED", at=T1, reserved=0)
+    notice = StrategyLedgerOutbox(ledger).pending()[-1]
+    assert notice["source_observed_at"] == "2026-09-10T01:00:00+00:00"
+    assert notice["snapshot_evidence_at"] == "2026-09-10T02:00:00+00:00"
+    assert notice["clock_basis"] == "EVIDENCE_CLOCK_NOT_WALL_CLOCK"
+    assert "원천 관측 시각: 2026-09-10T01:00:00+00:00" in notice["text"]
+    assert "고정 원장 증거 기준 시각: 2026-09-10T02:00:00+00:00" in notice["text"]
+    assert "청산 완료" in notice["text"]
+
+
+@pytest.mark.parametrize("receipt", ["UNKNOWN", "MISSING", "[REDACTED]", " unknown "])
+def test_placeholder_receipt_cannot_mark_sent(tmp_path, receipt):
+    ledger = ledger_at(tmp_path)
+    buy(ledger)
+    outbox = StrategyLedgerOutbox(ledger)
+    notice, = outbox.pending()
+    outbox.claim(notice["notice_id"], "worker", T1)
+    with pytest.raises(LedgerError, match="known receipt"):
+        outbox.ack(notice["notice_id"], "worker", receipt, T1)
+    assert outbox.status(notice["notice_id"])["status"] == "UNKNOWN"


### PR DESCRIPTION
Stacked after PR #694; retarget main after dependency merge. Atomically freeze slot-weight notices with strategy legs and meaningful state/account evidence changes. Durable claim changes READY to UNKNOWN before authorizing one automatic send attempt; no automatic retry after ambiguous delivery. ACK binds original claim and receipt. Preserve cumulative partial-fill evidence through cancel/late fill, separate source/snapshot clocks and unknown account reservations; no strategy state mutation from broker outcomes. No actual sender, order adapter, cron or LIVE promotion in this PR. Independent architect review approved. Root fresh ledger/lifecycle/projection/message/outbox regression: 182 passed. CI includes new outbox tests.