### PR TITLE
feat: guarded test-chat strategy notice transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           python -m pytest tests/test_trend_quality_research.py \
             tests/test_trend_research_capture.py tests/test_strategy_ledger.py tests/test_strategy_ledger_slots.py \
             tests/test_pilot_lifecycle.py tests/test_strategy_ledger_outbox.py \
+            tests/test_strategy_ledger_test_delivery.py \
             tests/test_strategy_ledger_projection.py tests/test_strategy_ledger_messages.py \
             tests/test_trading_context.py tests/test_entry_quality_evidence_packet.py -q
           python -m pytest tests/test_historical_closed_record_evidence.py \

--- a/prism_core/strategy_ledger_messages.py
+++ b/prism_core/strategy_ledger_messages.py
@@ -36,7 +36,7 @@ def format_campaign(snapshot, campaign_id, *, unresolved_execution_overlays=()):
     invested_return = _number(campaign.get("invested_price_return_pct"))
     lines = [
         "📒 슬롯·비중 전략 원장 · 검증용",
-        f"**{_label(campaign['symbol'])} · {status}**",
+        f"{_label(campaign['symbol'])} · {status}",
         "",
         f"점유 슬롯: {1 if units else 0}개",
         f"잔여 배분: {percent(campaign['remaining_allocation'])}",

--- a/prism_core/strategy_ledger_test_delivery.py
+++ b/prism_core/strategy_ledger_test_delivery.py
@@ -1,0 +1,148 @@
+"""Explicit test-chat-only outbox transport, with at most one automatic attempt.
+
+No import-time sending, environment/config routing, retry, broadcast, or orders.
+The caller injects a bot token for this call only; it is never persisted/logged.
+HTTP failures and ambiguous receipts leave the durable claim UNKNOWN. A valid
+receipt with failed ACK persistence is returned for manual reconciliation only.
+Crashes may lose a claimed notice; this is not exactly-once Telegram delivery.
+"""
+import asyncio
+from datetime import datetime, timezone
+import json
+import math
+import re
+import uuid
+
+import aiohttp
+
+from prism_core.strategy_ledger import _time
+
+AUTHORIZED_TEST_CHAT_ID = 7726642089
+MAX_RESPONSE_BYTES = 65536
+
+
+def _now():
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _result(status, reason, attempted=False, **evidence):
+    # Never include exception text, response bodies, URLs, or secret arguments.
+    return {"status": status, "reason": reason, "send_attempted": attempted, **evidence}
+
+
+def _frozen_notice_valid(notice, notice_id, token):
+    text = notice.get("text")
+    return (
+        notice.get("kind") == "strategy_notice"
+        and notice.get("notice_id") == notice_id
+        and notice.get("delivery_scope") == "TEST_CHAT_ONLY"
+        and isinstance(text, str) and bool(text.strip())
+        and len(text.encode("utf-16-le")) // 2 <= 4096
+        and token not in text
+    )
+
+
+def _receipt(payload):
+    if not isinstance(payload, dict) or payload.get("ok") is not True:
+        return None
+    message = payload.get("result")
+    if not isinstance(message, dict):
+        return None
+    chat, message_id = message.get("chat"), message.get("message_id")
+    if (not isinstance(chat, dict) or type(chat.get("id")) is not int
+            or chat["id"] != AUTHORIZED_TEST_CHAT_ID
+            or type(message_id) is not int or message_id <= 0):
+        return None
+    return f"telegram:test-chat:{AUTHORIZED_TEST_CHAT_ID}:message:{message_id}"
+
+
+async def _post_once(token, text, timeout_seconds):
+    timeout = aiohttp.ClientTimeout(total=timeout_seconds)
+    async with aiohttp.ClientSession(
+        timeout=timeout, trust_env=False, cookie_jar=aiohttp.DummyCookieJar(),
+        trace_configs=[], raise_for_status=False,
+    ) as session:
+        async with session.post(
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            json={"chat_id": AUTHORIZED_TEST_CHAT_ID, "text": text,
+                  "link_preview_options": {"is_disabled": True}},
+            allow_redirects=False,
+        ) as response:
+            if response.status != 200:
+                return None
+            chunks, size = [], 0
+            while True:
+                chunk = await response.content.read(min(8192, MAX_RESPONSE_BYTES + 1 - size))
+                if not chunk:
+                    break
+                size += len(chunk)
+                if size > MAX_RESPONSE_BYTES:
+                    return None
+                chunks.append(chunk)
+            return _receipt(json.loads(b"".join(chunks)))
+
+
+async def deliver_test_notice(outbox, notice_id, *, bot_token, chat_id,
+                              timeout_seconds=10.0, clock=_now):
+    """Consume one frozen notice; UNKNOWN is inspectable, never auto-retried.
+
+    The destination must be explicitly supplied and match the single authorized
+    integer ID. Cancellation propagates with a sanitized message after the
+    already-durable UNKNOWN claim; this function never resets that claim.
+    """
+    if type(chat_id) is not int or chat_id != AUTHORIZED_TEST_CHAT_ID:
+        return _result("BLOCKED", "UNAUTHORIZED_TEST_CHAT")
+    if (not isinstance(bot_token, str) or len(bot_token) > 256
+            or not re.fullmatch(r"[0-9]+:[A-Za-z0-9_-]+", bot_token)):
+        return _result("BLOCKED", "INVALID_INJECTED_TOKEN")
+    if (isinstance(timeout_seconds, bool) or not isinstance(timeout_seconds, (int, float))
+            or not math.isfinite(timeout_seconds) or not 0 < timeout_seconds <= 30):
+        return _result("BLOCKED", "INVALID_TIMEOUT")
+    if not isinstance(notice_id, str) or not re.fullmatch(r"ledger-notice:[0-9a-f]{64}", notice_id):
+        return _result("BLOCKED", "INVALID_NOTICE_REFERENCE")
+    try:
+        notice = outbox.status(notice_id)
+        if notice["status"] in {"UNKNOWN", "SENT"}:
+            return _result(notice["status"], "CLAIM_ALREADY_CONSUMED")
+        if not _frozen_notice_valid(notice, notice_id, bot_token):
+            return _result("BLOCKED", "INVALID_FROZEN_TEST_NOTICE")
+    except Exception:
+        return _result("BLOCKED", "NOTICE_READ_FAILED")
+
+    claim_id = "test-chat-send:" + uuid.uuid4().hex
+    try:
+        claimed = outbox.claim(notice_id, claim_id, clock())
+    except Exception:
+        return _result("UNKNOWN", "CLAIM_PERSISTENCE_UNCERTAIN")
+    if not isinstance(claimed, dict):
+        return _result("UNKNOWN", "INVALID_CLAIMED_TEST_NOTICE")
+    if claimed.get("send_authorized") is not True:
+        return _result("SENT" if claimed.get("status") == "SENT" else "UNKNOWN", "CLAIM_ALREADY_CONSUMED")
+    try:
+        if claimed.get("status") != "UNKNOWN" or not _frozen_notice_valid(claimed, notice_id, bot_token):
+            return _result("UNKNOWN", "INVALID_CLAIMED_TEST_NOTICE")
+        receipt = await asyncio.wait_for(
+            _post_once(bot_token, claimed["text"], timeout_seconds), timeout=timeout_seconds,
+        )
+    except asyncio.CancelledError:
+        raise asyncio.CancelledError("test_chat_delivery_cancelled_unknown") from None
+    except asyncio.TimeoutError:
+        return _result("UNKNOWN", "TRANSPORT_TIMEOUT", True)
+    except Exception:
+        return _result("UNKNOWN", "TRANSPORT_ERROR", True)
+    if receipt is None:
+        return _result("UNKNOWN", "UNVERIFIED_TELEGRAM_RECEIPT", True)
+    acknowledged_at = None
+    try:
+        acknowledged_at = _time(clock())
+        ack = outbox.ack(notice_id, claim_id, receipt, acknowledged_at)
+        if not isinstance(ack, dict) or ack.get("status") != "SENT" or ack.get("receipt_ref") != receipt:
+            raise ValueError("ACK result not confirmed")
+    except asyncio.CancelledError:
+        raise asyncio.CancelledError("test_chat_delivery_cancelled_unknown") from None
+    except Exception:
+        # The safe receipt/claim are sufficient for an operator to reconcile;
+        # the adapter will never make another POST for this notice.
+        return _result("UNKNOWN", "ACK_PERSISTENCE_UNCERTAIN", True,
+                       receipt_ref=receipt, claim_id=claim_id, acknowledged_at=acknowledged_at)
+    return _result("SENT", "VALIDATED_TELEGRAM_RECEIPT_ACKED", True, receipt_ref=receipt)

--- a/tests/test_strategy_ledger_messages.py
+++ b/tests/test_strategy_ledger_messages.py
@@ -23,6 +23,7 @@ def test_half_position_is_readable_and_not_a_trade_signal(tmp_path):
     assert not any(word in text for word in ("가상 수량", "가상 현금", "평가자산", "미투입 예산"))
     assert "실제 주문 신호가 아닙니다" in text
     assert "0주로 단정하지 않음" in text
+    assert "TEST · 보유" in text and "**" not in text
     assert len(text) < 3500
 
 

--- a/tests/test_strategy_ledger_test_delivery.py
+++ b/tests/test_strategy_ledger_test_delivery.py
@@ -1,0 +1,345 @@
+"""No Telegram calls: every HTTP session is a test double."""
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from prism_core.strategy_ledger import StrategyLedger
+from prism_core.strategy_ledger_outbox import StrategyLedgerOutbox
+from prism_core import strategy_ledger_test_delivery as delivery
+
+TOKEN = "123456:CANARY_NOT_A_REAL_TELEGRAM_TOKEN_12345"
+CHAT = delivery.AUTHORIZED_TEST_CHAT_ID
+T0 = "2026-09-10T00:00:00Z"
+T1 = "2026-09-10T01:00:00Z"
+T2 = "2026-09-10T02:00:00Z"
+
+
+@pytest.fixture(autouse=True)
+def deny_real_http(monkeypatch):
+    factory = MagicMock(side_effect=AssertionError("real HTTP is forbidden"))
+    monkeypatch.setattr(delivery.aiohttp, "ClientSession", factory)
+    return factory
+
+
+@pytest.fixture
+def box(tmp_path):
+    ledger = StrategyLedger(tmp_path / "test-delivery.sqlite")
+    ledger.create_book("book", "US", mode="SHADOW")
+    ledger.apply_target("buy", "book", "campaign", "SYNTHETIC-DEMO 합성 예시 실제 보유 아님", 50, 100, T0)
+    outbox = StrategyLedgerOutbox(ledger)
+    notice, = outbox.pending()
+    return outbox, notice
+
+
+def ack_payload(message_id=123, chat_id=CHAT):
+    return {"ok": True, "result": {"message_id": message_id, "chat": {"id": chat_id}}}
+
+
+class Stream:
+    def __init__(self, value):
+        self.remaining = value
+        self.reads = 0
+
+    async def read(self, amount):
+        self.reads += 1
+        # Deliberately split JSON over many chunks, unlike a one-read fixture.
+        chunk, self.remaining = self.remaining[:min(amount, 11)], self.remaining[min(amount, 11):]
+        return chunk
+
+
+class Response:
+    def __init__(self, body, status=200, enter_error=None, delay=0):
+        self.status = status
+        self.content = Stream(body)
+        self.enter_error, self.delay = enter_error, delay
+
+    async def __aenter__(self):
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        if self.enter_error:
+            raise self.enter_error
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+def fake_http(monkeypatch, outbox, notice, *, payload=None, body=None, status=200,
+              enter_error=None, delay=0):
+    calls = []
+    response = Response(body if body is not None else json.dumps(
+        ack_payload() if payload is None else payload).encode(), status, enter_error, delay)
+
+    class Session:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        def post(self, url, **kwargs):
+            # A separate connection observes committed UNKNOWN BEFORE HTTP.
+            reopened = StrategyLedgerOutbox(StrategyLedger(outbox.ledger.path))
+            assert reopened.status(notice["notice_id"])["status"] == "UNKNOWN"
+            calls.append((url, kwargs))
+            return response
+
+    factory = MagicMock(return_value=Session())
+    monkeypatch.setattr(delivery.aiohttp, "ClientSession", factory)
+    return calls, response, factory
+
+
+async def send(outbox, notice, **kwargs):
+    options = {"bot_token": TOKEN, "chat_id": CHAT, "clock": lambda: T1}
+    options.update(kwargs)
+    return await delivery.deliver_test_notice(outbox, notice["notice_id"], **options)
+
+
+@pytest.mark.asyncio
+async def test_frozen_slots_text_and_exact_destination_ack_once_then_restart(box, monkeypatch):
+    outbox, notice = box
+    calls, response, factory = fake_http(monkeypatch, outbox, notice)
+    outbox.ledger.mark("later-mark", "campaign", 200, T2)
+    result = await send(outbox, notice)
+    assert result == {"status": "SENT", "reason": "VALIDATED_TELEGRAM_RECEIPT_ACKED",
+                      "send_attempted": True, "receipt_ref": f"telegram:test-chat:{CHAT}:message:123"}
+    assert len(calls) == 1 and response.content.reads > 1
+    url, request = calls[0]
+    assert url == f"https://api.telegram.org/bot{TOKEN}/sendMessage"
+    assert request == {"json": {"chat_id": CHAT, "text": notice["text"],
+                               "link_preview_options": {"is_disabled": True}}, "allow_redirects": False}
+    assert "50%" in notice["text"] and "슬롯" in notice["text"]
+    assert "합성 예시 실제 보유 아님" in notice["text"]
+    assert "**" not in notice["text"]
+    assert "가상 현금" not in notice["text"]
+    assert factory.call_args.kwargs["trust_env"] is False
+    assert factory.call_args.kwargs["trace_configs"] == []
+    assert factory.call_args.kwargs["raise_for_status"] is False
+    assert outbox.status(notice["notice_id"])["status"] == "SENT"
+    reopened = StrategyLedgerOutbox(StrategyLedger(outbox.ledger.path))
+    duplicate = await send(reopened, notice)
+    assert duplicate["status"] == "SENT" and duplicate["send_attempted"] is False
+    assert len(calls) == 1
+    assert TOKEN.encode() not in Path(outbox.ledger.path).read_bytes()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("chat", [None, str(CHAT), True, 0, -CHAT, CHAT + 1, "@broadcast"])
+async def test_wrong_chat_blocks_before_claim_or_transport(box, deny_real_http, chat):
+    outbox, notice = box
+    assert (await send(outbox, notice, chat_id=chat))["reason"] == "UNAUTHORIZED_TEST_CHAT"
+    assert outbox.status(notice["notice_id"])["status"] == "READY"
+    deny_real_http.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("token", [None, "", "CANARY", "12:abc/other", "12:abc\n", "12:a?b"])
+async def test_missing_or_unsafe_token_never_reads_environment_or_sends(box, deny_real_http, monkeypatch, token):
+    outbox, notice = box
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", TOKEN)
+    result = await send(outbox, notice, bot_token=token)
+    assert result["reason"] == "INVALID_INJECTED_TOKEN"
+    assert TOKEN not in str(result)
+    assert outbox.status(notice["notice_id"])["status"] == "READY"
+    deny_real_http.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("payload", [
+    {"ok": False, "description": TOKEN},
+    {"ok": 1, "result": {"message_id": 123, "chat": {"id": CHAT}}},
+    ack_payload(chat_id=CHAT + 1), ack_payload(chat_id=str(CHAT)),
+    ack_payload(message_id=True), ack_payload(message_id=0), ack_payload(message_id=-1),
+    ack_payload(message_id="123"), {"ok": True}, [], None,
+])
+async def test_unverified_receipt_stays_unknown_never_retries(box, monkeypatch, payload):
+    outbox, notice = box
+    body = json.dumps(payload).encode()
+    calls, _, _ = fake_http(monkeypatch, outbox, notice, body=body)
+    result = await send(outbox, notice)
+    assert result["status"] == "UNKNOWN"
+    assert "receipt_ref" not in result and TOKEN not in str(result)
+    assert outbox.status(notice["notice_id"])["status"] == "UNKNOWN"
+    reopened = StrategyLedgerOutbox(StrategyLedger(outbox.ledger.path))
+    assert (await send(reopened, notice))["send_attempted"] is False
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [301, 302, 400, 401, 429, 500])
+async def test_http_errors_or_redirects_never_ack_or_retry(box, monkeypatch, status):
+    outbox, notice = box
+    calls, response, _ = fake_http(monkeypatch, outbox, notice, status=status, body=TOKEN.encode())
+    result = await send(outbox, notice)
+    assert result["status"] == "UNKNOWN" and TOKEN not in str(result)
+    assert response.content.reads == 0
+    assert len(calls) == 1
+    assert outbox.status(notice["notice_id"])["status"] == "UNKNOWN"
+
+
+@pytest.mark.asyncio
+async def test_bounded_timeout_keeps_unknown_and_token_secret(box, monkeypatch, caplog):
+    outbox, notice = box
+    calls, _, _ = fake_http(monkeypatch, outbox, notice, delay=1)
+    result = await send(outbox, notice, timeout_seconds=0.01)
+    assert result["reason"] == "TRANSPORT_TIMEOUT"
+    assert outbox.status(notice["notice_id"])["status"] == "UNKNOWN"
+    assert (await send(outbox, notice))["send_attempted"] is False
+    assert len(calls) == 1
+    assert TOKEN not in caplog.text + json.dumps(result)
+    assert TOKEN.encode() not in Path(outbox.ledger.path).read_bytes()
+
+
+@pytest.mark.asyncio
+async def test_transport_exception_and_ack_exception_cannot_leak_token(box, monkeypatch, caplog):
+    outbox, notice = box
+    calls, _, _ = fake_http(monkeypatch, outbox, notice, enter_error=RuntimeError(
+        f"https://api.telegram.org/bot{TOKEN}/sendMessage"))
+    result = await send(outbox, notice)
+    assert result["reason"] == "TRANSPORT_ERROR" and len(calls) == 1
+    assert TOKEN not in str(result) + caplog.text
+    assert TOKEN.encode() not in Path(outbox.ledger.path).read_bytes()
+
+
+@pytest.mark.asyncio
+async def test_valid_receipt_but_ack_failure_requires_manual_reconciliation(box, monkeypatch, caplog):
+    outbox, notice = box
+    calls, _, _ = fake_http(monkeypatch, outbox, notice)
+    monkeypatch.setattr(outbox, "ack", MagicMock(side_effect=RuntimeError(TOKEN)))
+    result = await send(outbox, notice)
+    assert result["status"] == "UNKNOWN" and result["reason"] == "ACK_PERSISTENCE_UNCERTAIN"
+    assert result["receipt_ref"] == f"telegram:test-chat:{CHAT}:message:123"
+    assert result["acknowledged_at"] == "2026-09-10T01:00:00+00:00"
+    assert outbox.status(notice["notice_id"])["status"] == "UNKNOWN"
+    reopened = StrategyLedgerOutbox(StrategyLedger(outbox.ledger.path))
+    assert (await send(reopened, notice))["send_attempted"] is False
+    assert len(calls) == 1
+    assert TOKEN not in str(result) + caplog.text
+    assert TOKEN.encode() not in Path(outbox.ledger.path).read_bytes()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_consumers_authorize_only_one_post(box, monkeypatch):
+    outbox, notice = box
+    calls, _, _ = fake_http(monkeypatch, outbox, notice, delay=0.02)
+    second = StrategyLedgerOutbox(StrategyLedger(outbox.ledger.path))
+    results = await asyncio.gather(send(outbox, notice), send(second, notice))
+    assert len(calls) == 1
+    assert sum(r["send_attempted"] for r in results) == 1
+    assert outbox.status(notice["notice_id"])["status"] == "SENT"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("body", [b"invalid-json", b"x" * (delivery.MAX_RESPONSE_BYTES + 1)])
+async def test_invalid_or_oversized_response_never_ack(box, monkeypatch, body):
+    outbox, notice = box
+    calls, _, _ = fake_http(monkeypatch, outbox, notice, body=body)
+    assert (await send(outbox, notice))["status"] == "UNKNOWN"
+    assert len(calls) == 1
+    assert outbox.status(notice["notice_id"])["status"] == "UNKNOWN"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("change", [{"delivery_scope": "BROADCAST"}, {"kind": "other"},
+                                   {"text": " "}, {"text": "😀" * 2049}, {"text": TOKEN}])
+async def test_invalid_frozen_notice_not_reformatted_or_sent(box, monkeypatch, deny_real_http, change):
+    outbox, notice = box
+    monkeypatch.setattr(outbox, "status", lambda _ref: {**notice, **change})
+    claim = MagicMock()
+    monkeypatch.setattr(outbox, "claim", claim)
+    result = await send(outbox, notice)
+    assert result["reason"] == "INVALID_FROZEN_TEST_NOTICE"
+    assert TOKEN not in str(result)
+    claim.assert_not_called()
+    deny_real_http.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_propagates_sanitized_and_claim_remains_consumed(box, monkeypatch):
+    outbox, notice = box
+    calls, _, _ = fake_http(monkeypatch, outbox, notice, enter_error=asyncio.CancelledError(TOKEN))
+    with pytest.raises(asyncio.CancelledError) as caught:
+        await send(outbox, notice)
+    assert TOKEN not in str(caught.value)
+    assert outbox.status(notice["notice_id"])["status"] == "UNKNOWN"
+    assert (await send(outbox, notice))["send_attempted"] is False
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_transport_creation_crash_after_claim_never_reopens_attempt(box, monkeypatch, caplog):
+    outbox, notice = box
+    factory = MagicMock(side_effect=RuntimeError(TOKEN))
+    monkeypatch.setattr(delivery.aiohttp, "ClientSession", factory)
+    result = await send(outbox, notice)
+    assert result["status"] == "UNKNOWN"
+    assert outbox.status(notice["notice_id"])["status"] == "UNKNOWN"
+    reopened = StrategyLedgerOutbox(StrategyLedger(outbox.ledger.path))
+    assert (await send(reopened, notice))["send_attempted"] is False
+    factory.assert_called_once()
+    assert TOKEN not in str(result) + caplog.text
+
+
+@pytest.mark.asyncio
+async def test_ack_failure_safe_evidence_can_be_manually_reconciled_without_post(box, monkeypatch):
+    outbox, notice = box
+    calls, _, _ = fake_http(monkeypatch, outbox, notice)
+    monkeypatch.setattr(outbox, "ack", MagicMock(side_effect=RuntimeError(TOKEN)))
+    result = await send(outbox, notice)
+    reopened = StrategyLedgerOutbox(StrategyLedger(outbox.ledger.path))
+    ack = reopened.ack(notice["notice_id"], result["claim_id"], result["receipt_ref"], result["acknowledged_at"])
+    assert ack["status"] == "SENT"
+    assert (await send(reopened, notice))["send_attempted"] is False
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_invalid_ack_clock_is_not_echoed_or_persisted(box, monkeypatch):
+    outbox, notice = box
+    calls, _, _ = fake_http(monkeypatch, outbox, notice)
+    times = iter([T1, TOKEN])
+    result = await send(outbox, notice, clock=lambda: next(times))
+    assert result["status"] == "UNKNOWN"
+    assert result["acknowledged_at"] is None
+    assert TOKEN not in str(result)
+    assert outbox.status(notice["notice_id"])["status"] == "UNKNOWN"
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("timeout", [None, True, 0, -1, 31, float("inf"), float("nan")])
+async def test_invalid_timeout_never_claims_or_sends(box, deny_real_http, timeout):
+    outbox, notice = box
+    assert (await send(outbox, notice, timeout_seconds=timeout))["reason"] == "INVALID_TIMEOUT"
+    assert outbox.status(notice["notice_id"])["status"] == "READY"
+    deny_real_http.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_claim_error_after_commit_is_unknown_and_secret_safe(box, monkeypatch, deny_real_http):
+    outbox, notice = box
+    original = outbox.claim
+    def claim_then_error(*args):
+        original(*args)
+        raise RuntimeError(TOKEN)
+    monkeypatch.setattr(outbox, "claim", claim_then_error)
+    result = await send(outbox, notice)
+    assert result["reason"] == "CLAIM_PERSISTENCE_UNCERTAIN"
+    assert result["send_attempted"] is False
+    assert TOKEN not in str(result)
+    assert outbox.status(notice["notice_id"])["status"] == "UNKNOWN"
+    deny_real_http.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unconfirmed_ack_return_never_claims_sent(box, monkeypatch):
+    outbox, notice = box
+    calls, _, _ = fake_http(monkeypatch, outbox, notice)
+    monkeypatch.setattr(outbox, "ack", lambda *_args: None)
+    result = await send(outbox, notice)
+    assert result["status"] == "UNKNOWN" and result["reason"] == "ACK_PERSISTENCE_UNCERTAIN"
+    assert outbox.status(notice["notice_id"])["status"] == "UNKNOWN"
+    assert len(calls) == 1


### PR DESCRIPTION
Stacked after PR #696. Explicit single authorized test-chat delivery; no broadcast/env routing, broker order or import-time send. Frozen plain text, injected token never logged/persisted, durable UNKNOWN before one POST, strict positive message receipt and exact chat validation before ACK. No redirects/retries/environment proxy use. Timeout, cancellation and uncertain ACK never authorize duplicate send. Remove decorative Markdown stars because transport intentionally sends plain text. Root fresh 102 adapter/outbox/message tests passed; independent architect approved. Actual synthetic 50/100 delivery run is separate verification, not real holdings/model trades/full SHADOW. No automatic sender schedule enabled.