### PR TITLE
feat: explicit isolated agent initialization and fallback contexts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
           PRISM_DISABLE_SIGNAL_PUBLISH: "1"
         run: |
           python -m pytest tests/test_agent_lazy_broker_imports.py -q
+          python -m pytest tests/test_agent_virtual_initialization.py \
+            tests/test_agent_instance_mcp_fallback.py tests/test_isolated_agent_runtime.py -q
           python -m pytest tests/test_trading_scenario_contract.py \
             tests/test_trading_agents_prompt_rules.py \
             tests/test_codex_oauth_fast_backend.py tests/test_buy_codex_settings.py \

--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -169,6 +169,10 @@ def _import_from_main_cores(module_name: str, relative_path: str):
 
 
 from prism_core.codex_config import resolve_buy_codex_settings, resolve_sell_codex_settings
+from prism_core.isolated_agent_runtime import (
+    prepare_isolated_runtime, configured_mcp_app, attach_isolated_llm,
+    virtual_account_label, require_execution_runtime,
+)
 from prism_core.trading_scenario_contract import apply_buy_scenario_contract
 
 # Pre-load telegram_translator_agent from main project (used in multiple methods)
@@ -256,14 +260,32 @@ def _get_kis_auth():
 class _LazyMCPApp:
     """Construct mcp-agent only when legacy mode or fallback actually needs it."""
 
-    def __init__(self, name: str):
+    def __init__(self, name: str, settings_factory=None):
         self.name = name
+        self.settings_factory = settings_factory
+        self.context = None
+        self._run_reserved = False
 
     @asynccontextmanager
     async def run(self):
-        instance = MCPApp(name=self.name)
-        async with instance.run():
-            yield
+        if self.settings_factory is None:
+            instance = MCPApp(name=self.name)
+            async with instance.run():
+                yield
+            return
+        if self._run_reserved or self.context is not None:
+            raise RuntimeError("Isolated MCP context is already active")
+        self._run_reserved = True  # Reserve before the first startup await.
+        try:
+            instance = configured_mcp_app(MCPApp, self.name, self.settings_factory)
+            async with instance.run():
+                if instance.context is None:
+                    raise RuntimeError("Isolated MCP context unavailable")
+                self.context = instance.context
+                yield
+        finally:
+            self.context = None
+            self._run_reserved = False
 
 
 app = _LazyMCPApp(name="us_stock_tracking")
@@ -669,7 +691,8 @@ class USStockTrackingAgent:
         self,
         db_path: str = "stock_tracking_db.sqlite",
         telegram_token: str = None,
-        enable_journal: bool = None
+        enable_journal: bool = None,
+        *, virtual_accounts=None, isolated_db_root=None, mcp_settings_factory=None,
     ):
         """
         Initialize US Stock Tracking Agent.
@@ -680,7 +703,19 @@ class USStockTrackingAgent:
             enable_journal: Enable trading journal feature.
                 Priority: parameter > ENABLE_TRADING_JOURNAL env > default(False).
                 (KR 에이전트와 동일 토글 — 기존엔 US가 env 무시하고 False 하드코딩이라 일지 미동작)
+            virtual_accounts: Explicit SHADOW identities; requires a private marked DB root.
+            isolated_db_root: Opt-in private root, never an existing unmarked DB.
+            mcp_settings_factory: Lazy explicit openai+mcp mapping; profile capabilities require separate audit.
         """
+        self._isolated_runtime = prepare_isolated_runtime(
+            db_path, virtual_accounts, isolated_db_root, mcp_settings_factory, "US",
+        )
+        if self._isolated_runtime is not None and telegram_token is not None:
+            raise ValueError("Virtual runtime forbids direct Telegram credentials")
+        self._instance_mcp_app = (
+            _LazyMCPApp("us_stock_tracking_isolated", mcp_settings_factory)
+            if mcp_settings_factory is not None else None
+        )
         self.max_slots = self.MAX_SLOTS
         self.message_queue = []
         self._msg_types = []  # msg_type for each message in queue
@@ -688,7 +723,7 @@ class USStockTrackingAgent:
         self._broadcast_task = None  # Track broadcast translation task
         self.trading_agent = None
         self.sell_decision_agent = None
-        self.db_path = db_path
+        self.db_path = self._isolated_runtime.db_path if self._isolated_runtime is not None else db_path
         self.conn = None
         self.cursor = None
         self.language = "en"  # Default to English for US
@@ -718,7 +753,7 @@ class USStockTrackingAgent:
         self.compression_manager = None
 
         # Set Telegram bot token
-        self.telegram_token = telegram_token or os.environ.get("TELEGRAM_BOT_TOKEN")
+        self.telegram_token = None if self._isolated_runtime is not None else (telegram_token or os.environ.get("TELEGRAM_BOT_TOKEN"))
         self.telegram_bot = None
         if self.telegram_token:
             self.telegram_bot = Bot(token=self.telegram_token)
@@ -742,7 +777,8 @@ class USStockTrackingAgent:
         self.language = language
 
         # Initialize SQLite connection
-        self.conn = sqlite3.connect(self.db_path)
+        isolated = getattr(self, "_isolated_runtime", None)
+        self.conn = isolated.connect() if isolated is not None else sqlite3.connect(self.db_path)
         self.conn.row_factory = sqlite3.Row
         self.cursor = self.conn.cursor()
 
@@ -988,6 +1024,9 @@ class USStockTrackingAgent:
             return False
 
     def _get_trading_accounts(self) -> List[Dict[str, Any]]:
+        isolated = getattr(self, "_isolated_runtime", None)
+        if isolated is not None:
+            return isolated.accounts()
         ka = _get_kis_auth()
 
         default_mode = str(ka.getEnv().get("default_mode", "demo")).strip().lower()
@@ -1009,6 +1048,8 @@ class USStockTrackingAgent:
     @staticmethod
     def _safe_account_log_label(account: Dict[str, Any]) -> str:
         """Format account identity for logs without exposing raw account numbers."""
+        if account.get("virtual") is True:
+            return virtual_account_label(account)
         account_name = account.get("name", "unknown")
         account_key = str(account.get("account_key", "") or "")
         if not account_key:
@@ -1474,7 +1515,11 @@ class USStockTrackingAgent:
             # Retry a couple of times before giving up.
             if scenario_json is None:
                 async def _legacy_scenario():
-                    llm = await self.trading_agent.attach_llm(OpenAIAugmentedLLM)
+                    isolated_app = getattr(self, "_instance_mcp_app", None)
+                    if isolated_app is not None:
+                        llm = await attach_isolated_llm(self.trading_agent, OpenAIAugmentedLLM, isolated_app.context)
+                    else:
+                        llm = await self.trading_agent.attach_llm(OpenAIAugmentedLLM)
                     max_attempts = 3
                     legacy_scenario = None
                     for attempt in range(1, max_attempts + 1):
@@ -1509,9 +1554,10 @@ class USStockTrackingAgent:
                             await asyncio.sleep(2 * attempt)
                     return legacy_scenario
 
-                if _us_codex_runtime_enabled():
+                legacy_app = getattr(self, "_instance_mcp_app", None) or app
+                if _us_codex_runtime_enabled() or getattr(self, "_instance_mcp_app", None) is not None:
                     async with self._get_legacy_fallback_lock():
-                        async with app.run():
+                        async with legacy_app.run():
                             scenario_json = await _legacy_scenario()
                 else:
                     scenario_json = await _legacy_scenario()
@@ -1720,6 +1766,7 @@ class USStockTrackingAgent:
                         scenario: Dict[str, Any], rank_change_msg: str = "", is_add: bool = False) -> bool:
         """Preserve the public bool contract while exposing an internal typed result."""
 
+        require_execution_runtime(self)
         result = await self._buy_stock_with_position(
             ticker,
             company_name,
@@ -2446,9 +2493,11 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
 
             if response is None:
                 async def _legacy_sell_response():
-                    llm = await self.sell_decision_agent.attach_llm(
-                        OpenAIAugmentedLLM
-                    )
+                    isolated_app = getattr(self, "_instance_mcp_app", None)
+                    if isolated_app is not None:
+                        llm = await attach_isolated_llm(self.sell_decision_agent, OpenAIAugmentedLLM, isolated_app.context)
+                    else:
+                        llm = await self.sell_decision_agent.attach_llm(OpenAIAugmentedLLM)
                     return await llm.generate_str(
                         message=prompt_message,
                         request_params=RequestParams(
@@ -2458,8 +2507,9 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                         ),
                     )
 
-                if _us_codex_runtime_enabled():
-                    async with app.run():
+                legacy_app = getattr(self, "_instance_mcp_app", None) or app
+                if _us_codex_runtime_enabled() or getattr(self, "_instance_mcp_app", None) is not None:
+                    async with legacy_app.run():
                         response = await _legacy_sell_response()
                 else:
                     response = await _legacy_sell_response()
@@ -3174,6 +3224,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
         Returns:
             bool: Sell success status
         """
+        require_execution_runtime(self)
         try:
             ticker = stock_data.get('ticker', '')
             company_name = stock_data.get('company_name', '')
@@ -3384,6 +3435,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
         Returns:
             List[Dict]: List of sold stock information
         """
+        require_execution_runtime(self)
         try:
             logger.info("Starting US holdings update")
 
@@ -3872,6 +3924,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
         Returns:
             Tuple[int, int]: Buy count, sell count
         """
+        require_execution_runtime(self)
         try:
             logger.info(f"Processing {len(pdf_report_paths)} US reports")
 

--- a/prism_core/isolated_agent_runtime.py
+++ b/prism_core/isolated_agent_runtime.py
@@ -1,0 +1,237 @@
+"""Opt-in agent initialization seams, NOT a runner or MCP capability audit.
+
+Factories supply explicit plain mappings. Init-only settings ignore environment
+and dotenv sources, including unused nested provider factories. The reviewed
+profile/namespace must still enforce read-only tools and provider bridge policy.
+The private root marker has schema_version=1, purpose=PRISM_AGENT_SHADOW,
+market=KR/US and runtime_id; existing unmarked databases are never adopted.
+Execution entrypoints remain blocked until a reviewed no-order adapter exists.
+"""
+from copy import deepcopy
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import sqlite3
+import stat
+from urllib.parse import urlsplit
+
+from mcp_agent.config import (
+    Settings, OpenAISettings, MCPSettings, LoggerSettings,
+    OpenTelemetrySettings, UsageTelemetrySettings,
+)
+
+ROOT_MARKER = ".prism-agent-isolation.json"
+_ACCOUNT_FIELDS = {"name", "account_key", "market", "virtual"}
+_SETTINGS_FIELDS = {
+    "name", "description", "mcp", "execution_engine", "temporal", "anthropic", "bedrock",
+    "cohere", "openai", "lm_studio", "workflow_task_modules", "workflow_task_retry_policies",
+    "azure", "google", "otel", "logger", "usage_telemetry", "agents", "authorization", "oauth", "env",
+}
+_OPENAI_FIELDS = {"api_key", "reasoning_effort", "base_url", "user", "default_headers", "default_model"}
+
+
+class _InitOnly:
+    @classmethod
+    def settings_customise_sources(cls, settings_cls, init_settings, env_settings,
+                                   dotenv_settings, file_secret_settings):
+        return (init_settings,)
+
+
+class _ExplicitOpenAISettings(_InitOnly, OpenAISettings):
+    model_config = {**OpenAISettings.model_config, "env_file": None, "secrets_dir": None}
+
+
+class _ExplicitSettings(_InitOnly, Settings):
+    model_config = {**Settings.model_config, "env_file": None, "secrets_dir": None}
+    # BaseSettings may turn nested model inputs back into dictionaries. Keep
+    # revalidation on the init-only subtype, never ambient OpenAISettings.
+    openai: _ExplicitOpenAISettings | None = None
+
+
+def validated_mcp_settings(factory):
+    """Type-validate explicit inputs; this is NOT proof of capability safety."""
+    try:
+        if not callable(factory):
+            raise ValueError()
+        config = factory()
+        if type(config) is not dict or set(config) != {"openai", "mcp"}:
+            raise ValueError()
+        provider, mcp = config["openai"], config["mcp"]
+        if type(provider) is not dict or not {"base_url", "api_key"} <= provider.keys():
+            raise ValueError()
+        if set(OpenAISettings.model_fields) != _OPENAI_FIELDS or not set(provider) <= _OPENAI_FIELDS:
+            raise ValueError()
+        if any(not isinstance(provider[key], str) or not provider[key].strip() for key in ("base_url", "api_key")):
+            raise ValueError()
+        url = urlsplit(provider["base_url"])
+        if url.scheme not in {"http", "https"} or not url.netloc:
+            raise ValueError()
+        if type(mcp) is not dict or set(mcp) != {"servers"} or type(mcp["servers"]) is not dict:
+            raise ValueError()
+        if set(Settings.model_fields) != _SETTINGS_FIELDS:
+            raise ValueError()
+        # Explicit None suppresses nested BaseSettings default factories.
+        return _ExplicitSettings(
+            _env_file=None, openai=_ExplicitOpenAISettings(_env_file=None, **deepcopy(provider)),
+            mcp=MCPSettings(**deepcopy(mcp)), execution_engine="asyncio",
+            anthropic=None, bedrock=None, cohere=None, lm_studio=None, azure=None, google=None,
+            temporal=None, agents=None, authorization=None, oauth=None,
+            logger=LoggerSettings(type="none", transports=["none"], progress_display=False),
+            otel=OpenTelemetrySettings(enabled=False, exporters=[]),
+            usage_telemetry=UsageTelemetrySettings(enabled=False, enable_detailed_telemetry=False),
+            workflow_task_modules=[], workflow_task_retry_policies={}, env=[],
+        )
+    except Exception:
+        raise ValueError("Explicit isolated MCP settings mapping is invalid") from None
+
+
+def configured_mcp_app(app_class, name, factory):
+    """Version-sensitive SDK seam: explicit config must not load ambient dotenv."""
+    instance = app_class(name=name, settings=validated_mcp_settings(factory))
+    if not hasattr(instance, "_dotenv_loaded") or type(instance._dotenv_loaded) is not bool:
+        raise ValueError("Unsupported MCPApp dotenv compatibility contract")
+    # Per-instance SDK bypass, not global monkeypatching or environment mutation.
+    instance._dotenv_loaded = True
+    return instance
+
+
+async def attach_isolated_llm(agent, llm_class, context):
+    """Bind both Agent and LLM directly; never discover a global context."""
+    if context is None:
+        raise ValueError("Explicit isolated MCP context is not active")
+    agent.context = context
+    return await agent.attach_llm(lambda **kwargs: llm_class(context=context, **kwargs))
+
+
+def require_execution_runtime(agent):
+    if getattr(agent, "_isolated_runtime", None) is not None:
+        raise RuntimeError("Virtual execution requires a reviewed no-order adapter")
+
+
+def _validated_account(record, market=None):
+    if (type(record) is not dict or set(record) != _ACCOUNT_FIELDS or record["virtual"] is not True
+            or record["market"] not in {"kr", "us"} or (market and record["market"] != market.lower())
+            or not isinstance(record["name"], str) or not record["name"].startswith("SHADOW ")
+            or not re.fullmatch(r"[A-Za-z0-9가-힣 ._-]{1,64}", record["name"])
+            or not isinstance(record["account_key"], str)
+            or not re.fullmatch(r"virtual:[A-Za-z0-9._:-]{1,96}", record["account_key"])):
+        raise ValueError("Invalid explicit virtual account record")
+    return dict(record)
+
+
+def virtual_account_label(account):
+    return _validated_account(account)["name"] + " (가상 계정)"
+
+
+def _private(path, *, directory=False):
+    info = path.lstat()
+    expected = stat.S_ISDIR(info.st_mode) if directory else stat.S_ISREG(info.st_mode)
+    if (not expected or info.st_mode & 0o077 or info.st_uid != os.getuid()
+            or (not directory and info.st_nlink != 1)):
+        raise ValueError("Isolation path must be private, owned, and unlinked")
+
+
+def _paths(db_path, root_path, market):
+    root = Path(root_path)
+    path = Path(db_path)
+    if os.name != "posix" or not root.is_absolute() or not path.is_absolute():
+        raise ValueError("Isolation requires explicit absolute POSIX paths")
+    try:
+        _private(root, directory=True)
+        root = root.resolve()
+        if root.is_relative_to(Path(__file__).resolve().parents[1]):
+            raise ValueError("Isolation root cannot be inside source repository")
+        if not path.resolve().is_relative_to(root) or path.resolve() == root:
+            raise ValueError("Database escapes isolation root")
+        if path.suffix not in {".sqlite", ".sqlite3", ".db"}:
+            raise ValueError("Isolated database filename required")
+        current = path
+        while True:
+            if current.is_symlink():
+                raise ValueError("Symlink in isolated database path")
+            if current.resolve() == root:
+                break
+            if current.parent == current:
+                raise ValueError("Database path cannot reach isolation root")
+            current = current.parent
+        if not path.parent.is_dir():
+            raise ValueError("Database parent directory missing")
+        marker = root / ROOT_MARKER
+        _private(marker)
+        if marker.stat().st_size > 4096:
+            raise ValueError("Invalid isolation root marker")
+        data = json.loads(marker.read_text())
+        if (set(data) != {"schema_version", "purpose", "market", "runtime_id"}
+                or type(data["schema_version"]) is not int or data["schema_version"] != 1
+                or data["purpose"] != "PRISM_AGENT_SHADOW"
+                or data["market"] != market or not isinstance(data["runtime_id"], str)
+                or not re.fullmatch(r"[A-Za-z0-9._-]{1,64}", data["runtime_id"])):
+            raise ValueError("Invalid isolation root marker")
+        if path.exists():
+            _private(path)
+        return str(path.resolve()), root, data
+    except (OSError, TypeError, KeyError, json.JSONDecodeError):
+        raise ValueError("Private marked isolation root required") from None
+
+
+@dataclass(frozen=True)
+class IsolatedAgentRuntime:
+    db_path: str
+    root: Path
+    market: str
+    root_marker: dict
+    _accounts: tuple
+
+    def accounts(self):
+        return deepcopy(list(self._accounts))
+
+    def connect(self):
+        path, _, marker = _paths(self.db_path, self.root, self.market)
+        if marker != self.root_marker:
+            raise ValueError("Isolation root identity changed")
+        payload = json.dumps({"schema_version": 1, "root": marker, "accounts": self.accounts()},
+                             sort_keys=True, separators=(",", ":"))
+        marker_hash = hashlib.sha256(payload.encode()).hexdigest()
+        if Path(path).exists():
+            try:
+                check = sqlite3.connect(Path(path).as_uri() + "?mode=ro", uri=True)
+                try:
+                    row = check.execute("SELECT owner_hash FROM prism_virtual_runtime WHERE id=1").fetchone()
+                finally:
+                    check.close()
+                if row != (marker_hash,):
+                    raise ValueError("Foreign isolated database")
+            except sqlite3.Error:
+                raise ValueError("Existing unmarked database cannot be adopted") from None
+        else:
+            descriptor = os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0), 0o600)
+            os.close(descriptor)
+            initial = sqlite3.connect(path)
+            try:
+                initial.execute("CREATE TABLE prism_virtual_runtime (id INTEGER PRIMARY KEY CHECK(id=1), owner_hash TEXT NOT NULL)")
+                initial.execute("INSERT INTO prism_virtual_runtime VALUES (1,?)", (marker_hash,))
+                initial.commit()
+            finally:
+                initial.close()
+        return sqlite3.connect(path)
+
+
+def prepare_isolated_runtime(db_path, virtual_accounts, isolated_db_root, mcp_settings_factory, market):
+    if mcp_settings_factory is not None and not callable(mcp_settings_factory):
+        raise ValueError("MCP settings factory must be callable")
+    if virtual_accounts is None:
+        if isolated_db_root is not None or mcp_settings_factory is not None:
+            raise ValueError("Virtual accounts, isolated root and MCP settings factory must be supplied together")
+        return None
+    if isolated_db_root is None or mcp_settings_factory is None:
+        raise ValueError("Virtual accounts require isolated root and explicit MCP settings factory")
+    if not isinstance(virtual_accounts, (list, tuple)) or not 1 <= len(virtual_accounts) <= 10:
+        raise ValueError("One to ten explicit virtual accounts required")
+    accounts = tuple(_validated_account(record, market) for record in virtual_accounts)
+    if len({a["account_key"] for a in accounts}) != len(accounts) or len({a["name"] for a in accounts}) != len(accounts):
+        raise ValueError("Duplicate virtual account identity")
+    path, root, marker = _paths(db_path, isolated_db_root, market)
+    return IsolatedAgentRuntime(path, root, market, marker, accounts)

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -49,6 +49,10 @@ from mcp_agent.workflows.llm.augmented_llm import RequestParams
 from cores.llm.openai_responses_llm import OpenAIResponsesLLM as OpenAIAugmentedLLM
 from cores.llm.codex_oauth_fast_backend import generate_codex_fast_async
 from prism_core.codex_config import resolve_buy_codex_settings
+from prism_core.isolated_agent_runtime import (
+    prepare_isolated_runtime, configured_mcp_app, attach_isolated_llm,
+    virtual_account_label, require_execution_runtime,
+)
 from prism_core.trading_scenario_contract import apply_buy_scenario_contract
 
 # Core agent imports
@@ -117,14 +121,32 @@ from tracking import (
 # Delay MCPApp construction so a successful Codex+MCP path never nests two
 # MCP hosts in one process. Legacy mode still constructs the same app at run().
 class _LazyMCPApp:
-    def __init__(self, name: str):
+    def __init__(self, name: str, settings_factory=None):
         self.name = name
+        self.settings_factory = settings_factory
+        self.context = None
+        self._run_reserved = False
 
     @asynccontextmanager
     async def run(self):
-        instance = MCPApp(name=self.name)
-        async with instance.run():
-            yield
+        if self.settings_factory is None:
+            instance = MCPApp(name=self.name)
+            async with instance.run():
+                yield
+            return
+        if self._run_reserved or self.context is not None:
+            raise RuntimeError("Isolated MCP context is already active")
+        self._run_reserved = True  # Reserve before the first startup await.
+        try:
+            instance = configured_mcp_app(MCPApp, self.name, self.settings_factory)
+            async with instance.run():
+                if instance.context is None:
+                    raise RuntimeError("Isolated MCP context unavailable")
+                self.context = instance.context
+                yield
+        finally:
+            self.context = None
+            self._run_reserved = False
 
 
 app = _LazyMCPApp(name="stock_tracking")
@@ -277,7 +299,8 @@ class StockTrackingAgent:
     SCORE_CONSIDER = 7  # Consider buying
     SCORE_UNSUITABLE = 6  # Unsuitable for buying
 
-    def __init__(self, db_path: str = "stock_tracking_db.sqlite", telegram_token: str = None, enable_journal: bool = None):
+    def __init__(self, db_path: str = "stock_tracking_db.sqlite", telegram_token: str = None, enable_journal: bool = None,
+                 *, virtual_accounts=None, isolated_db_root=None, mcp_settings_factory=None):
         """
         Initialize agent
 
@@ -285,7 +308,19 @@ class StockTrackingAgent:
             db_path: SQLite database file path
             telegram_token: Telegram bot token
             enable_journal: Enable trading journal feature (default: False, reads from ENABLE_TRADING_JOURNAL env)
+            virtual_accounts: Explicit SHADOW identities; requires a private marked DB root.
+            isolated_db_root: Opt-in private root, never an existing unmarked DB.
+            mcp_settings_factory: Lazy explicit openai+mcp mapping, not a capability-safety guarantee.
         """
+        self._isolated_runtime = prepare_isolated_runtime(
+            db_path, virtual_accounts, isolated_db_root, mcp_settings_factory, "KR",
+        )
+        if self._isolated_runtime is not None and telegram_token is not None:
+            raise ValueError("Virtual runtime forbids direct Telegram credentials")
+        self._instance_mcp_app = (
+            _LazyMCPApp("stock_tracking_isolated", mcp_settings_factory)
+            if mcp_settings_factory is not None else None
+        )
         self.max_slots = self.MAX_SLOTS
         self.message_queue = []  # For storing Telegram messages
         self._msg_types = []  # msg_type for each message in queue
@@ -293,7 +328,7 @@ class StockTrackingAgent:
         self.last_batch_messages: list[tuple[str | None, str]] = []
         self._broadcast_task = None  # Track broadcast translation task
         self.trading_agent = None
-        self.db_path = db_path
+        self.db_path = self._isolated_runtime.db_path if self._isolated_runtime is not None else db_path
         self.conn = None
         self.cursor = None
         self.account_configs: list[dict[str, Any]] = []
@@ -320,7 +355,7 @@ class StockTrackingAgent:
             self.enable_journal = env_value in ("true", "1", "yes")
 
         # Set Telegram bot token
-        self.telegram_token = telegram_token or os.environ.get("TELEGRAM_BOT_TOKEN")
+        self.telegram_token = None if self._isolated_runtime is not None else (telegram_token or os.environ.get("TELEGRAM_BOT_TOKEN"))
         self.telegram_bot = None
         if self.telegram_token:
             self.telegram_bot = Bot(token=self.telegram_token)
@@ -347,7 +382,8 @@ class StockTrackingAgent:
         self.language = language
 
         # Initialize SQLite connection
-        self.conn = sqlite3.connect(self.db_path)
+        isolated = getattr(self, "_isolated_runtime", None)
+        self.conn = isolated.connect() if isolated is not None else sqlite3.connect(self.db_path)
         self.conn.row_factory = sqlite3.Row  # Return results as dictionary
         self.cursor = self.conn.cursor()
 
@@ -586,6 +622,9 @@ class StockTrackingAgent:
             return False
 
     def _get_trading_accounts(self) -> List[Dict[str, Any]]:
+        isolated = getattr(self, "_isolated_runtime", None)
+        if isolated is not None:
+            return isolated.accounts()
         from trading import kis_auth as ka
 
         default_mode = str(ka.getEnv().get("default_mode", "demo")).strip().lower()
@@ -607,6 +646,8 @@ class StockTrackingAgent:
     @staticmethod
     def _safe_account_log_label(account: Dict[str, Any]) -> str:
         """Format account identity for logs without exposing raw account numbers."""
+        if account.get("virtual") is True:
+            return virtual_account_label(account)
         account_name = account.get("name", "unknown")
         account_key = str(account.get("account_key", "") or "")
         if not account_key:
@@ -1201,15 +1242,20 @@ class StockTrackingAgent:
 
             if scenario_json is None:
                 async def _legacy_scenario():
-                    llm = await self.trading_agent.attach_llm(OpenAIAugmentedLLM)
+                    isolated_app = getattr(self, "_instance_mcp_app", None)
+                    if isolated_app is not None:
+                        llm = await attach_isolated_llm(self.trading_agent, OpenAIAugmentedLLM, isolated_app.context)
+                    else:
+                        llm = await self.trading_agent.attach_llm(OpenAIAugmentedLLM)
                     return await _generate_trading_scenario_json(
                         llm,
                         prompt_message,
                     )
 
-                if _kr_codex_runtime_enabled():
+                legacy_app = getattr(self, "_instance_mcp_app", None) or app
+                if _kr_codex_runtime_enabled() or getattr(self, "_instance_mcp_app", None) is not None:
                     async with self._get_legacy_fallback_lock():
-                        async with app.run():
+                        async with legacy_app.run():
                             scenario_json = await _legacy_scenario()
                 else:
                     scenario_json = await _legacy_scenario()
@@ -2557,6 +2603,7 @@ class StockTrackingAgent:
     async def buy_stock(self, ticker: str, company_name: str, current_price: float, scenario: Dict[str, Any], rank_change_msg: str = "", is_add: bool = False) -> bool:
         """Preserve the public bool contract while exposing an internal typed result."""
 
+        require_execution_runtime(self)
         result = await self._buy_stock_with_position(
             ticker,
             company_name,
@@ -3168,6 +3215,7 @@ class StockTrackingAgent:
         Returns:
             bool: Sell success status
         """
+        require_execution_runtime(self)
         try:
             ticker = stock_data.get('ticker', '')
             company_name = stock_data.get('company_name', '')
@@ -3699,6 +3747,7 @@ class StockTrackingAgent:
         Returns:
             List[Dict]: List of sold stock information
         """
+        require_execution_runtime(self)
         try:
             logger.info("Starting holdings info update")
 
@@ -4127,6 +4176,7 @@ class StockTrackingAgent:
         Returns:
             Tuple[int, int]: Buy count, sell count
         """
+        require_execution_runtime(self)
         try:
             logger.info(f"Starting processing of {len(pdf_report_paths)} reports")
 

--- a/stock_tracking_enhanced_agent.py
+++ b/stock_tracking_enhanced_agent.py
@@ -10,6 +10,9 @@ from stock_tracking_agent import (
     _kr_codex_runtime_enabled,
     app,
 )
+from prism_core.isolated_agent_runtime import (
+    attach_isolated_llm, require_execution_runtime,
+)
 from prism_core.positions import LegacyPositionWriteResult, legacy_position_id
 import asyncio
 import logging
@@ -61,11 +64,16 @@ TRADING_ANALYSIS_CONCURRENCY = _resolve_trading_analysis_concurrency()
 class EnhancedStockTrackingAgent(StockTrackingAgent):
     """Enhanced stock tracking and trading agent"""
 
-    def __init__(self, db_path: str = "stock_tracking_db.sqlite", telegram_token: str = None):
+    def __init__(self, db_path: str = "stock_tracking_db.sqlite", telegram_token: str = None,
+                 *, enable_journal: bool = None, virtual_accounts=None, isolated_db_root=None, mcp_settings_factory=None):
         """Initialize agent"""
-        super().__init__(db_path, telegram_token)
+        super().__init__(
+            db_path, telegram_token, enable_journal=enable_journal,
+            virtual_accounts=virtual_accounts, isolated_db_root=isolated_db_root,
+            mcp_settings_factory=mcp_settings_factory,
+        )
         # Market condition storage variable (1: bull market, 0: neutral, -1: bear market)
-        self.simple_market_condition = 0
+        self.simple_market_condition = None if self._isolated_runtime is not None else 0
         # Volatility table (store volatility per stock)
         self.volatility_table = {}
 
@@ -160,7 +168,10 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
         self.conn.commit()
 
         # Run market condition analysis
-        await self._analyze_simple_market_condition()
+        if getattr(self, "_isolated_runtime", None) is not None:
+            self.initialization_deviations = ["ISOLATED_INDEX_PREFETCH_UNAVAILABLE"]
+        else:
+            await self._analyze_simple_market_condition()
 
         # Clean up old watchlist data (older than 1 month)
         await self._cleanup_old_watchlist()
@@ -395,6 +406,7 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
         Returns:
             Tuple[int, int]: Buy count, Sell count
         """
+        require_execution_runtime(self)
         try:
             logger.info(f"Starting processing of {len(pdf_report_paths)} reports")
 
@@ -1568,9 +1580,11 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
 
             if response is None:
                 async def _legacy_sell_response():
-                    llm = await self.sell_decision_agent.attach_llm(
-                        OpenAIAugmentedLLM
-                    )
+                    isolated_app = getattr(self, "_instance_mcp_app", None)
+                    if isolated_app is not None:
+                        llm = await attach_isolated_llm(self.sell_decision_agent, OpenAIAugmentedLLM, isolated_app.context)
+                    else:
+                        llm = await self.sell_decision_agent.attach_llm(OpenAIAugmentedLLM)
                     return await llm.generate_str(
                         message=prompt_message,
                         request_params=RequestParams(
@@ -1580,9 +1594,10 @@ class EnhancedStockTrackingAgent(StockTrackingAgent):
                         )
                     )
 
-                if _kr_codex_runtime_enabled():
+                legacy_app = getattr(self, "_instance_mcp_app", None) or app
+                if _kr_codex_runtime_enabled() or getattr(self, "_instance_mcp_app", None) is not None:
                     async with self._get_legacy_fallback_lock():
-                        async with app.run():
+                        async with legacy_app.run():
                             response = await _legacy_sell_response()
                 else:
                     response = await _legacy_sell_response()

--- a/tests/test_agent_instance_mcp_fallback.py
+++ b/tests/test_agent_instance_mcp_fallback.py
@@ -1,0 +1,189 @@
+"""Execute the real fallback branches, without model/network or broker calls."""
+import ast
+import asyncio
+from contextlib import asynccontextmanager
+import json
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from prism_core.isolated_agent_runtime import configured_mcp_app, attach_isolated_llm
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def lazy_class(path, app_class):
+    tree = ast.parse((ROOT / path).read_text())
+    node = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "_LazyMCPApp")
+    namespace = {"MCPApp": app_class, "configured_mcp_app": configured_mcp_app,
+                 "asynccontextmanager": asynccontextmanager}
+    exec(compile(ast.Module(body=[node], type_ignores=[]), path, "exec"), namespace)
+    return namespace["_LazyMCPApp"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path,market,side", [
+    ("stock_tracking_agent.py", "kr", "buy"),
+    ("stock_tracking_enhanced_agent.py", "kr", "sell"),
+    ("prism-us/us_stock_tracking_agent.py", "us", "buy"),
+    ("prism-us/us_stock_tracking_agent.py", "us", "sell"),
+])
+@pytest.mark.parametrize("codex_runtime", [False, True])
+async def test_every_fallback_uses_instance_app_and_binds_agent_llm_context(path, market, side, codex_runtime):
+    host_calls, llm_calls = [], []
+    class App:
+        def __init__(self, **kwargs):
+            self._dotenv_loaded = False
+            self.context = SimpleNamespace(config=kwargs["settings"])
+            self.kwargs = kwargs
+        @asynccontextmanager
+        async def run(self):
+            assert self._dotenv_loaded is True
+            host_calls.append(self.kwargs)
+            yield self
+    class LLM:
+        def __init__(self, *, context, agent):
+            assert context is not None and agent.context is context
+            self.context = context
+        async def generate_str(self, **kwargs):
+            llm_calls.append(self.context.config.openai.base_url)
+            return '{"decision":"hold"}'
+    class Agent:
+        context = None
+        async def attach_llm(self, factory):
+            return factory(agent=self)
+    @asynccontextmanager
+    async def forbidden_global_host():
+        raise AssertionError("global MCP app must not be used")
+        yield
+    async def kr_scenario(llm, message):
+        return json.loads(await llm.generate_str(message=message))
+
+    lazy_path = "stock_tracking_agent.py" if market == "kr" else "prism-us/us_stock_tracking_agent.py"
+    Lazy = lazy_class(lazy_path, App)
+    tree = ast.parse((ROOT / path).read_text())
+    method_name = "_extract_trading_scenario" if side == "buy" else "_analyze_sell_decision"
+    method = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef) and n.name == method_name)
+    variable = "scenario_json" if side == "buy" else "response"
+    branch = next(n for n in ast.walk(method) if isinstance(n, ast.If)
+                  and ast.unparse(n.test) == variable + " is None"
+                  and any(isinstance(child, ast.AsyncFunctionDef) for child in n.body))
+    body = [ast.Assign(targets=[ast.Name(id=variable, ctx=ast.Store())], value=ast.Constant(None)),
+            branch, ast.Return(value=ast.Name(id=variable, ctx=ast.Load()))]
+    wrapper = ast.AsyncFunctionDef(name="dispatch", args=ast.arguments(
+        posonlyargs=[], args=[], kwonlyargs=[], kw_defaults=[], defaults=[]), body=body, decorator_list=[])
+    harness = ast.fix_missing_locations(ast.Module(body=[wrapper], type_ignores=[]))
+    for number in (1, 2):
+        base_url = f"http://127.0.0.1:{9000 + number}/v1"
+        factory = lambda url=base_url: {"mcp": {"servers": {}}, "openai": {"base_url": url, "api_key": "explicit-test-key"}}
+        instance_app = Lazy("isolated-" + str(number), factory)
+        instance = SimpleNamespace(_instance_mcp_app=instance_app, trading_agent=Agent(),
+                                   sell_decision_agent=Agent(), _get_legacy_fallback_lock=asyncio.Lock)
+        namespace = {"self": instance, "app": SimpleNamespace(run=forbidden_global_host),
+                     "attach_isolated_llm": attach_isolated_llm, "OpenAIAugmentedLLM": LLM,
+                     "RequestParams": SimpleNamespace, "prompt_message": "synthetic no-order analysis",
+                     "parse_llm_json": lambda text, **kwargs: json.loads(text),
+                     "_generate_trading_scenario_json": kr_scenario,
+                     "asyncio": asyncio, "logger": logging.getLogger("isolated-test"), "ticker_tag": "SYNTHETIC",
+                     f"_{market}_codex_runtime_enabled": lambda: codex_runtime}
+        exec(compile(harness, path, "exec"), namespace)
+        result = await namespace["dispatch"]()
+        assert result == ({"decision": "hold"} if side == "buy" else '{"decision":"hold"}')
+        assert instance_app.context is None
+        assert host_calls[-1]["settings"].openai.base_url == base_url
+    assert llm_calls == ["http://127.0.0.1:9001/v1", "http://127.0.0.1:9002/v1"]
+    assert len(host_calls) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["stock_tracking_agent.py", "prism-us/us_stock_tracking_agent.py"])
+async def test_default_lazy_app_constructor_contract_unchanged(path):
+    calls = []
+    class App:
+        def __init__(self, **kwargs):
+            calls.append(kwargs)
+        @asynccontextmanager
+        async def run(self):
+            yield self
+    Lazy = lazy_class(path, App)
+    default = Lazy("production-default")
+    assert calls == []
+    async with default.run():
+        pass
+    assert calls == [{"name": "production-default"}]
+
+
+def explicit_factory():
+    return {"mcp": {"servers": {}},
+            "openai": {"base_url": "http://127.0.0.1:9999/v1", "api_key": "explicit-test-key"}}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["stock_tracking_agent.py", "prism-us/us_stock_tracking_agent.py"])
+async def test_delayed_start_reserves_before_first_await(path):
+    entered, release = asyncio.Event(), asyncio.Event()
+    created = []
+    class App:
+        def __init__(self, **kwargs):
+            self._dotenv_loaded = False
+            self.context = None
+            created.append(self)
+        @asynccontextmanager
+        async def run(self):
+            entered.set()
+            await release.wait()
+            self.context = SimpleNamespace()
+            yield self
+    instance = lazy_class(path, App)("isolated", explicit_factory)
+    async def run():
+        async with instance.run():
+            assert instance.context is not None
+    first = asyncio.create_task(run())
+    await entered.wait()
+    try:
+        with pytest.raises(RuntimeError, match="already active"):
+            await asyncio.wait_for(run(), timeout=0.03)
+        assert len(created) == 1
+    finally:
+        release.set()
+        await first
+    assert instance.context is None and instance._run_reserved is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["stock_tracking_agent.py", "prism-us/us_stock_tracking_agent.py"])
+@pytest.mark.parametrize("outcome", ["error", "cancel"])
+async def test_startup_failure_or_cancellation_releases_reservation(path, outcome):
+    entered, never = asyncio.Event(), asyncio.Event()
+    created = []
+    class App:
+        def __init__(self, **kwargs):
+            self._dotenv_loaded = False
+            self.context = None
+            self.first = not created
+            created.append(self)
+        @asynccontextmanager
+        async def run(self):
+            if self.first:
+                entered.set()
+                if outcome == "error":
+                    raise RuntimeError("startup failed")
+                await never.wait()
+            self.context = SimpleNamespace()
+            yield self
+    instance = lazy_class(path, App)("isolated", explicit_factory)
+    async def run():
+        async with instance.run():
+            assert instance.context is not None
+    first = asyncio.create_task(run())
+    await entered.wait()
+    if outcome == "cancel":
+        first.cancel()
+    with pytest.raises(asyncio.CancelledError if outcome == "cancel" else RuntimeError):
+        await first
+    assert instance.context is None and instance._run_reserved is False
+    await run()
+    assert len(created) == 2
+    assert instance.context is None and instance._run_reserved is False

--- a/tests/test_agent_virtual_initialization.py
+++ b/tests/test_agent_virtual_initialization.py
@@ -1,0 +1,142 @@
+"""Real initialization in isolated subprocesses, without broker/credential access."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = r'''
+import asyncio
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sys
+
+source, kind = Path(sys.argv[1]), sys.argv[2]
+market = "US" if kind == "US" else "KR"
+sys.dont_write_bytecode = True
+sys.path.insert(0, str(source))
+if market == "US":
+    sys.path.insert(0, str(source / "prism-us"))
+root = Path.cwd() / "arm"
+root.mkdir(mode=0o700)
+marker = root / ".prism-agent-isolation.json"
+marker.write_text(json.dumps({"schema_version": 1, "purpose": "PRISM_AGENT_SHADOW",
+                             "market": market, "runtime_id": "baseline-test"}))
+marker.chmod(0o600)
+blocked = []
+phase = "IMPORT"
+def audit(event, args):
+    if event.startswith("socket.") and event not in {"socket.__new__", "socket.gethostname"}:
+        # urllib3 checks IPv6 support by binding an ephemeral loopback socket
+        # during import. Deny it too, but distinguish this capability probe
+        # from any initializer/provider network operation.
+        if phase == "IMPORT" and event == "socket.bind" and args[1] in {("::1", 0), ("::1", 0, 0, 0)}:
+            raise RuntimeError("IMPORT_IPV6_PROBE_DENIED")
+        blocked.append(event)
+        raise RuntimeError("NETWORK_FORBIDDEN")
+    if event == "import" and str(args[0]).split(".")[-1] == "kis_auth":
+        blocked.append("broker_import")
+        raise RuntimeError("BROKER_IMPORT_FORBIDDEN")
+    if event == "exec" and str(getattr(args[0], "co_filename", "")).endswith("kis_auth.py"):
+        blocked.append("broker_exec")
+        raise RuntimeError("BROKER_EXEC_FORBIDDEN")
+    if event == "open" and isinstance(args[0], (str, bytes)):
+        if Path(os.fsdecode(args[0])).name in {".env", ".env.mcp-cloud", "kis_devlp.yaml",
+                "mcp_agent.secrets.yaml", "mcp_agent.config.yaml", "mcp-agent.secrets.yaml", "mcp-agent.config.yaml"}:
+            blocked.append("credential_read")
+            raise RuntimeError("CREDENTIAL_CONFIG_FORBIDDEN")
+sys.addaudithook(audit)
+if market == "US":
+    import cores, tracking, trading
+    spec = importlib.util.spec_from_file_location("real_virtual_us_agent", source / "prism-us/us_stock_tracking_agent.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    cls = module.USStockTrackingAgent
+elif kind == "KR_ENHANCED":
+    from stock_tracking_enhanced_agent import EnhancedStockTrackingAgent as cls
+else:
+    from stock_tracking_agent import StockTrackingAgent as cls
+
+phase = "INITIALIZE"
+calls = []
+def settings_factory():
+    calls.append("factory")
+    return {"openai": {"base_url": "http://127.0.0.1:9999/v1", "api_key": "explicit-test-placeholder"},
+            "mcp": {"servers": {}}}
+accounts = [{"name": "SHADOW baseline", "account_key": "virtual:baseline", "market": market.lower(), "virtual": True}]
+kwargs = {"db_path": str(root / "state.sqlite"), "enable_journal": False,
+          "virtual_accounts": accounts, "isolated_db_root": str(root),
+          "mcp_settings_factory": settings_factory}
+async def main():
+    try:
+        cls(mcp_settings_factory=settings_factory)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("factory-only opt-in must not leave production execution enabled")
+    try:
+        cls(**kwargs, telegram_token="123456:EXPLICIT_TOKEN_FORBIDDEN_IN_VIRTUAL_MODE")
+    except ValueError as error:
+        assert "Telegram" in str(error)
+    else:
+        raise AssertionError("virtual mode must reject direct Telegram credentials")
+    assert not (root / "state.sqlite").exists()
+    agent = cls(**kwargs)
+    accounts[0]["name"] = "caller mutation"
+    assert await agent.initialize()
+    assert agent.account_configs[0]["name"] == "SHADOW baseline"
+    assert agent._safe_account_log_label(agent.active_account) == "SHADOW baseline (가상 계정)"
+    assert agent.telegram_token is None and agent.telegram_bot is None
+    assert agent.trading_agent is not None and agent.trading_agent.instruction
+    if kind in {"US", "KR_ENHANCED"}:
+        assert agent.sell_decision_agent is not None and agent.sell_decision_agent.instruction
+    if kind == "KR_ENHANCED":
+        assert agent.simple_market_condition is None
+        assert agent.initialization_deviations == ["ISOLATED_INDEX_PREFETCH_UNAVAILABLE"]
+        assert agent.cursor.execute("SELECT COUNT(*) FROM market_condition").fetchone()[0] == 0
+    assert calls == []  # MCP settings and hosts are still lazy.
+    table = "us_stock_holdings" if market == "US" else "stock_holdings"
+    assert agent.cursor.execute("SELECT COUNT(*) FROM " + table).fetchone()[0] == 0
+    for name, args in [
+        ("process_reports", ([],)), ("buy_stock", ("SYNTHETIC", "합성 예시", 100, {})),
+        ("sell_stock", ({}, "test")), ("update_holdings", ()),
+    ]:
+        try:
+            await getattr(agent, name)(*args)
+        except RuntimeError as error:
+            assert "no-order adapter" in str(error)
+        else:
+            raise AssertionError(name + " must fail before execution")
+    agent.conn.close()
+    accounts[0]["name"] = "SHADOW baseline"
+    resumed = cls(**kwargs)
+    assert await resumed.initialize()
+    assert resumed.cursor.execute("SELECT COUNT(*) FROM " + table).fetchone()[0] == 0
+    resumed.conn.close()
+    assert blocked == [], blocked
+    print(json.dumps({"real_initialize": kind, "broker_or_network_attempts": 0, "restart": "PASS",
+                      "execution_guarded": True, "mcp_still_lazy": True}))
+asyncio.run(main())
+'''
+
+
+@pytest.mark.parametrize("kind", ["KR", "KR_ENHANCED", "US"])
+def test_real_virtual_initialize_without_credentials_network_or_execution(tmp_path, kind):
+    env = {key: value for key, value in os.environ.items()
+           if not any(secret in key.upper() for secret in ("KIS", "TOKEN", "SECRET", "API_KEY", "APP_KEY"))}
+    env.update(HOME=str(tmp_path), KIS_CONFIG_ROOT=str(tmp_path / "absent-kis"),
+               PYTHON_DOTENV_DISABLED="1", PYTHONDONTWRITEBYTECODE="1",
+               TELEGRAM_BOT_TOKEN="123456:AMBIENT_TEST_TOKEN_MUST_NOT_BE_USED")
+    result = subprocess.run([sys.executable, "-I", "-c", SCRIPT, str(ROOT), kind],
+                            cwd=tmp_path, env=env, text=True, capture_output=True, timeout=90)
+    assert result.returncode == 0, result.stderr[-5000:]
+    assert json.loads(result.stdout.strip().splitlines()[-1]) == {
+        "real_initialize": kind, "broker_or_network_attempts": 0, "restart": "PASS",
+        "execution_guarded": True, "mcp_still_lazy": True,
+    }

--- a/tests/test_codex_oauth_fast_backend.py
+++ b/tests/test_codex_oauth_fast_backend.py
@@ -238,7 +238,7 @@ def test_us_trading_wires_codex_primary_before_legacy_fallback() -> None:
     assert 'mcp_profile="us_trading"' in method
     assert "require_mcp_calls=True" in method
     assert "falling back to mcp-agent" in method
-    assert "async with app.run()" in method
+    assert "async with legacy_app.run()" in method  # Per-instance override; default remains module app.
     assert method.index("generate_codex_fast") < method.index("attach_llm(")
 
 
@@ -254,7 +254,7 @@ def test_kr_trading_wires_same_codex_primary_and_legacy_fallback() -> None:
     assert 'mcp_profile="kr_trading"' in method
     assert "require_mcp_calls=True" in method
     assert "falling back to mcp-agent" in method
-    assert "async with app.run()" in method
+    assert "async with legacy_app.run()" in method  # Per-instance override; default remains module app.
     assert method.index("generate_codex_fast") < method.index("attach_llm(")
 
 
@@ -354,7 +354,7 @@ def test_us_sell_wires_codex_mcp_before_legacy_fallback() -> None:
     assert 'mcp_profile="us_trading"' in method
     assert "require_mcp_calls=True" in method
     assert "falling back to mcp-agent" in method
-    assert "async with app.run()" in method
+    assert "async with legacy_app.run()" in method  # Per-instance override; default remains module app.
     assert method.index("generate_codex_fast") < method.index("attach_llm(")
 
 
@@ -370,7 +370,7 @@ def test_kr_sell_wires_codex_mcp_before_legacy_fallback() -> None:
     assert 'mcp_profile="kr_trading"' in method
     assert "require_mcp_calls=True" in method
     assert "falling back to mcp-agent" in method
-    assert "async with app.run()" in method
+    assert "async with legacy_app.run()" in method  # Per-instance override; default remains module app.
     assert method.index("generate_codex_fast") < method.index("attach_llm(")
 
 

--- a/tests/test_isolated_agent_runtime.py
+++ b/tests/test_isolated_agent_runtime.py
@@ -1,0 +1,250 @@
+import json
+import os
+from pathlib import Path
+import sqlite3
+
+import pytest
+from mcp_agent.config import Settings
+
+from prism_core.isolated_agent_runtime import (
+    ROOT_MARKER, prepare_isolated_runtime, validated_mcp_settings, virtual_account_label,
+    configured_mcp_app, attach_isolated_llm,
+)
+
+
+def settings():
+    return {"mcp": {"servers": {}},
+            "openai": {"base_url": "http://127.0.0.1:9999/v1", "api_key": "explicit-test-placeholder"}}
+
+
+def private_root(tmp_path, market="KR"):
+    root = tmp_path / "isolated"
+    root.mkdir(mode=0o700)
+    marker = root / ROOT_MARKER
+    marker.write_text(json.dumps({"schema_version": 1, "purpose": "PRISM_AGENT_SHADOW",
+                                 "market": market, "runtime_id": "baseline-test"}))
+    marker.chmod(0o600)
+    return root
+
+
+def account(market="kr"):
+    return {"name": "SHADOW baseline", "account_key": "virtual:baseline",
+            "market": market, "virtual": True}
+
+
+def prepare(root, accounts=None, **kwargs):
+    values = {"db_path": str(root / "state.sqlite"), "virtual_accounts": [account()] if accounts is None else accounts,
+              "isolated_db_root": str(root), "mcp_settings_factory": settings, "market": "KR"}
+    values.update(kwargs)
+    return prepare_isolated_runtime(**values)
+
+
+def test_default_requires_no_paths_or_settings():
+    assert prepare_isolated_runtime("legacy.sqlite", None, None, None, "KR") is None
+
+
+@pytest.mark.parametrize("accounts_on,root_on,factory_on", [
+    (False, False, True), (False, True, False), (False, True, True),
+    (True, False, False), (True, False, True), (True, True, False),
+])
+def test_incomplete_opt_in_never_enables_production_execution(tmp_path, accounts_on, root_on, factory_on):
+    root = private_root(tmp_path)
+    with pytest.raises(ValueError):
+        prepare_isolated_runtime(str(root / "state.sqlite"), [account()] if accounts_on else None,
+                                 str(root) if root_on else None, settings if factory_on else None, "KR")
+    assert not (root / "state.sqlite").exists()
+
+
+def test_private_marked_database_initialization_restart_and_copy(tmp_path):
+    root = private_root(tmp_path)
+    records = [account()]
+    runtime = prepare(root, records)
+    records[0]["name"] = "CHANGED"
+    assert runtime.accounts()[0]["name"] == "SHADOW baseline"
+    one = runtime.accounts()
+    one[0]["account_key"] = "vps:real:01"
+    assert runtime.accounts()[0]["account_key"] == "virtual:baseline"
+    conn = runtime.connect()
+    conn.execute("CREATE TABLE local_state (value TEXT)")
+    conn.execute("INSERT INTO local_state VALUES ('retained')")
+    conn.commit()
+    conn.close()
+    resumed = prepare(root).connect()
+    assert resumed.execute("SELECT value FROM local_state").fetchone()[0] == "retained"
+    resumed.close()
+    assert os.stat(root / "state.sqlite").st_mode & 0o077 == 0
+
+
+@pytest.mark.parametrize("change", [{"account_key": "vps:123:01"}, {"name": "primary"},
+                                   {"virtual": False}, {"market": "us"},
+                                   {"buy_amount_krw": 100000}, {"app_key": "SECRET"},
+                                   {"account": "12345678"}])
+def test_virtual_records_reject_broker_cash_or_identity_fields(tmp_path, change):
+    root = private_root(tmp_path)
+    with pytest.raises(ValueError):
+        prepare(root, [{**account(), **change}])
+    assert not (root / "state.sqlite").exists()
+
+
+def test_root_must_be_explicit_private_marked_and_matching_market(tmp_path):
+    root = tmp_path / "unmarked"
+    root.mkdir()
+    with pytest.raises(ValueError):
+        prepare(root)
+    root = private_root(tmp_path, "US")
+    with pytest.raises(ValueError):
+        prepare(root)
+    root.chmod(0o755)
+    with pytest.raises(ValueError):
+        prepare(root)
+
+
+def test_path_escape_symlink_and_unmarked_existing_db_rejected(tmp_path):
+    root = private_root(tmp_path)
+    with pytest.raises(ValueError):
+        prepare(root, db_path=str(tmp_path / "outside.sqlite"))
+    outside = tmp_path / "outside.sqlite"
+    sqlite3.connect(outside).close()
+    (root / "state.sqlite").symlink_to(outside)
+    with pytest.raises(ValueError):
+        prepare(root)
+    (root / "state.sqlite").unlink()
+    sqlite3.connect(root / "state.sqlite").close()
+    with pytest.raises(ValueError):
+        prepare(root).connect()
+    assert outside.stat().st_size == 0
+
+
+def test_hard_link_and_foreign_runtime_marker_rejected(tmp_path):
+    root = private_root(tmp_path)
+    runtime = prepare(root)
+    runtime.connect().close()
+    os.link(root / "state.sqlite", root / "alias.sqlite")
+    with pytest.raises(ValueError):
+        prepare(root).connect()
+    (root / "alias.sqlite").unlink()
+    changed = [{**account(), "account_key": "virtual:other"}]
+    with pytest.raises(ValueError):
+        prepare(root, changed).connect()
+
+
+def test_virtual_account_log_is_explicit_and_never_contains_broker_key():
+    assert virtual_account_label(account()) == "SHADOW baseline (가상 계정)"
+    with pytest.raises(ValueError):
+        virtual_account_label({**account(), "account_key": "vps:12345678:01"})
+
+
+@pytest.mark.parametrize("factory", [None, "settings.yaml", lambda: None, lambda: {},
+                                     lambda: "mcp_agent.config.yaml",
+                                     lambda: Settings(_env_file=None)])
+def test_invalid_factory_result_cannot_fall_back_to_global_settings(factory):
+    with pytest.raises(ValueError):
+        validated_mcp_settings(factory)
+
+
+def test_explicit_mcp_and_openai_provider_required_and_copy_isolated():
+    for factory in (
+        lambda: {},
+        lambda: {"mcp": {"servers": {}}},
+        lambda: {"mcp": {"servers": {}}, "openai": {"api_key": "placeholder"}},
+        lambda: {"mcp": {"servers": {}}, "openai": {"base_url": "http://127.0.0.1:9999"}},
+    ):
+        with pytest.raises(ValueError):
+            validated_mcp_settings(factory)
+    original = settings()
+    first = validated_mcp_settings(lambda: original)
+    second = validated_mcp_settings(lambda: original)
+    first.openai.base_url = "http://127.0.0.1:9998"
+    assert original["openai"]["base_url"] == second.openai.base_url == "http://127.0.0.1:9999/v1"
+
+
+def test_all_ambient_provider_config_canaries_absent_without_config_reads(tmp_path, monkeypatch):
+    import builtins
+    import io
+    canary = "AMBIENT_CREDENTIAL_CANARY"
+    for name in ("OPENAI_API_KEY", "OPENAI_BASE_URL", "ANTHROPIC_API_KEY", "COHERE_API_KEY",
+                 "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AZURE_API_KEY", "GOOGLE_API_KEY",
+                 "LM_STUDIO_API_KEY", "OAUTH__TOKEN_STORE__REDIS_URL", "ENV", "LOGGER__HTTP_ENDPOINT",
+                 "OTEL__ENABLED", "USAGE_TELEMETRY__ENABLED"):
+        monkeypatch.setenv(name, canary)
+    monkeypatch.chdir(tmp_path)
+    names = {".env", ".env.mcp-cloud", "mcp_agent.config.yaml", "mcp_agent.secrets.yaml"}
+    for name in names:
+        (tmp_path / name).write_text("OPENAI_API_KEY=" + canary)
+    opened = []
+    for owner in (builtins, io):
+        original = owner.open
+        def guarded(path, *args, _original=original, **kwargs):
+            if isinstance(path, (str, Path)) and Path(path).name in names:
+                opened.append(str(path))
+                raise AssertionError("ambient file read")
+            return _original(path, *args, **kwargs)
+        monkeypatch.setattr(owner, "open", guarded)
+    before = dict(os.environ)
+    result = validated_mcp_settings(settings)
+    assert canary not in json.dumps(result.model_dump(mode="json"))
+    assert opened == [] and dict(os.environ) == before
+    assert all(getattr(result, field) is None for field in
+               ("anthropic", "bedrock", "cohere", "azure", "google", "lm_studio", "oauth", "authorization", "agents", "temporal"))
+    assert result.logger.type == "none" and not result.otel.enabled and not result.usage_telemetry.enabled
+    assert result.env == []
+
+
+@pytest.mark.parametrize("flag", [None, "false", 0])
+def test_unknown_sdk_dotenv_bypass_contract_fails_closed(flag):
+    class UnsupportedApp:
+        def __init__(self, **kwargs):
+            if flag is not None:
+                self._dotenv_loaded = flag
+    with pytest.raises(ValueError, match="compatibility"):
+        configured_mcp_app(UnsupportedApp, "test", settings)
+
+
+@pytest.mark.asyncio
+async def test_actual_mcp_app_and_llm_use_explicit_context_without_ambient_discovery(tmp_path, monkeypatch):
+    import builtins
+    import io
+    import socket
+    import sys
+    from mcp_agent.app import MCPApp
+    from mcp_agent.agents.agent import Agent
+    from cores.llm.openai_responses_llm import OpenAIResponsesLLM
+
+    monkeypatch.chdir(tmp_path)
+    canary = "ALL_AMBIENT_PROVIDER_CANARY"
+    for name in ("OPENAI_API_KEY", "OPENAI_BASE_URL", "ANTHROPIC_API_KEY", "COHERE_API_KEY",
+                 "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AZURE_API_KEY", "GOOGLE_API_KEY",
+                 "LM_STUDIO_API_KEY", "ENV"):
+        monkeypatch.setenv(name, canary)
+    for name in (".env", ".env.mcp-cloud", "mcp_agent.config.yaml", "mcp_agent.secrets.yaml"):
+        (tmp_path / name).write_text("OPENAI_API_KEY=" + canary)
+    forbidden_calls = []
+    def forbid(*args, **kwargs):
+        forbidden_calls.append("ambient")
+        raise AssertionError("ambient settings/context/network discovery forbidden")
+    # Trap all already-imported SDK aliases as well as the originating modules.
+    for module in list(sys.modules.values()):
+        if module is not None and getattr(module, "__name__", "").startswith("mcp_agent"):
+            for name in ("get_settings", "get_current_context", "aget_current_context", "load_dotenv"):
+                if hasattr(module, name):
+                    monkeypatch.setattr(module, name, forbid)
+    monkeypatch.setattr(socket.socket, "connect", forbid)
+    for owner in (builtins, io):
+        original = owner.open
+        def guarded(path, *args, _original=original, **kwargs):
+            if isinstance(path, (str, Path)) and Path(path).name in {
+                ".env", ".env.mcp-cloud", "mcp_agent.config.yaml", "mcp_agent.secrets.yaml",
+            }:
+                return forbid()
+            return _original(path, *args, **kwargs)
+        monkeypatch.setattr(owner, "open", guarded)
+    environment = dict(os.environ)
+    app = configured_mcp_app(MCPApp, "isolated-settings-test", settings)
+    async with app.run():
+        assert app.context is not None
+        agent = Agent(name="isolated-no-tools", instruction="synthetic test", server_names=[])
+        llm = await attach_isolated_llm(agent, OpenAIResponsesLLM, app.context)
+        assert agent.context is app.context and llm._context is app.context
+        assert canary not in json.dumps(app.context.config.model_dump(mode="json"))
+    assert forbidden_calls == []
+    assert dict(os.environ) == environment

--- a/tests/test_sell_claim_concurrency.py
+++ b/tests/test_sell_claim_concurrency.py
@@ -69,7 +69,13 @@ def _load_real_sell_method(market):
 
     method = copy.deepcopy(method)
     method.decorator_list = []
-    module = ast.Module(body=[method], type_ignores=[])
+    # The new guard is itself pure. Compile its real definition alongside the
+    # real method rather than substituting a no-op or importing the heavy SDK.
+    guard_path = PROJECT_ROOT / "prism_core" / "isolated_agent_runtime.py"
+    guard_tree = ast.parse(guard_path.read_text(encoding="utf-8"), filename=str(guard_path))
+    guard = next(node for node in guard_tree.body
+                 if isinstance(node, ast.FunctionDef) and node.name == "require_execution_runtime")
+    module = ast.Module(body=[copy.deepcopy(guard), method], type_ignores=[])
     ast.fix_missing_locations(module)
     namespace = {
         "Any": Any,
@@ -82,6 +88,13 @@ def _load_real_sell_method(market):
     }
     exec(compile(module, str(path), "exec"), namespace)
     return namespace["sell_stock"]
+
+
+@pytest.mark.parametrize("market", ["KR", "US"])
+def test_real_sell_guard_blocks_virtual_execution_before_sql(market):
+    agent = type("VirtualAgent", (), {"_isolated_runtime": object()})()
+    with pytest.raises(RuntimeError, match="reviewed no-order adapter"):
+        asyncio.run(_load_real_sell_method(market)(agent, {}, "guard regression"))
 
 
 def _create_schema(conn, market):


### PR DESCRIPTION
Analysis-only initialization seam, not a full SHADOW runner. Strict private marked DB root and virtual account records; partial opt-in rejected. Per-instance MCP mapping factory uses init-only settings/provider subtypes and explicit Agent/LLM contexts, without global environment clearing or ambient config lookup. SDK dotenv bypass is per-instance, contract-checked and version-sensitive. Startup reserves before first await and resets on failure/cancellation. Virtual process_reports/buy/sell/update_holdings fail closed until a reviewed no-order adapter exists; production defaults preserved. Root independently reran 82 targeted tests; owner KR 241/US 113/lazy-import 7 also passed. Independent architect approved including delayed-start and partial-opt-in fixes. Actual 3-agent initialize/restart and real SDK context tests are offline with credential/network guards. Capability safety, real models, vendor parity and full end-to-end SHADOW remain separate gates.