### PR TITLE
feat: fixed invocation and readonly diagnostic agent transports

### DIFF
--- a/tests/test_isolated_codex_invoker.py
+++ b/tests/test_isolated_codex_invoker.py
@@ -1,0 +1,398 @@
+"""No model, broker, production database or credentials are used."""
+import asyncio
+import json
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from tools import isolated_codex_invoker as rpc
+
+
+@pytest.fixture
+def tmp_path():
+    # AF_UNIX has a small path limit on both supported operating systems.
+    with tempfile.TemporaryDirectory(prefix="ipc-", dir="/tmp") as directory:
+        yield Path(directory).resolve()
+
+
+def setup(tmp_path, callback, **kwargs):
+    source = sqlite3.connect(tmp_path / "agent.db")
+    source.execute("CREATE TABLE holding(ticker TEXT)")
+    source.execute("INSERT INTO holding VALUES ('FIXTURE')")
+    source.commit()
+    private = tmp_path / "host"
+    private.mkdir(mode=0o700)
+    scope = rpc.InvocationScope("arm1", "profile1", "case1", "revision1", '{"model":"fixed"}', .15, source)
+    service = rpc.CodexInvoker([scope], callback, private, window_seconds=5, cleanup_slack=.5, **kwargs)
+    return service, source, private / "invoke.sock"
+
+
+def request(**changes):
+    return {"request_id": "request1", "arm_id": "arm1", "profile_id": "profile1", "case_id": "case1",
+            "system_prompt": "system", "user_prompt": "user", **changes}
+
+
+def test_completed_duplicate_is_cached_with_frozen_snapshot(tmp_path):
+    async def run():
+        calls = []
+        async def callback(invocation):
+            calls.append(invocation)
+            assert invocation.snapshot.path.stat().st_mode & 0o777 == 0o400
+            with sqlite3.connect(f"file:{invocation.snapshot.path}?mode=ro", uri=True) as db:
+                assert db.execute("SELECT ticker FROM holding").fetchone() == ("FIXTURE",)
+            return rpc.BackendCompletion('{"answer":1}')
+        service, source, socket = setup(tmp_path, callback)
+        async with service.serve(socket):
+            first = await rpc.invoke(socket, request(), deadline=2)
+            source.execute("UPDATE holding SET ticker='LATER'")
+            source.commit()
+            assert await rpc.invoke(socket, request(), deadline=2) == first
+            assert first["cleanup_ack"] is True and first["fallback_allowed"] is False
+            assert first["revision_basis"] == "HOST_REGISTERED_CASE_REVISION"
+            assert len(calls) == 1
+        source.close()
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize("change", [{"argv": ["/bin/sh"]}, {"profile_id": "unknown"}, {"user_prompt": "x" * 1048577}])
+def test_unregistered_or_extra_capability_is_abort_not_fallback(tmp_path, change):
+    async def run():
+        async def callback(_):
+            pytest.fail("must not invoke")
+        service, source, socket = setup(tmp_path, callback)
+        async with service.serve(socket):
+            with pytest.raises(rpc.InvocationAborted):
+                await rpc.invoke(socket, request(**change), deadline=2)
+        source.close()
+    asyncio.run(run())
+
+
+def test_conflict_cannot_reexecute_and_model_error_requires_explicit_receipt(tmp_path):
+    async def run():
+        calls = []
+        async def callback(_):
+            calls.append(1)
+            return rpc.BackendCompletion(None, error="model_error")
+        service, source, socket = setup(tmp_path, callback)
+        async with service.serve(socket):
+            reply = await rpc.invoke(socket, request(), deadline=2)
+            assert reply["fallback_allowed"] is True and reply["cleanup_ack"] is True
+            with pytest.raises(rpc.InvocationAborted):
+                await rpc.invoke(socket, request(user_prompt="different"), deadline=2)
+            assert calls == [1]
+        source.close()
+    asyncio.run(run())
+
+
+def test_timeout_waits_for_cancellation_cleanup_before_ack(tmp_path):
+    async def run():
+        cleaned = asyncio.Event()
+        async def callback(_):
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                await asyncio.sleep(.04)
+                cleaned.set()
+                raise
+        service, source, socket = setup(tmp_path, callback)
+        async with service.serve(socket):
+            reply = await rpc.invoke(socket, request(), deadline=2)
+            assert cleaned.is_set()
+            assert reply["category"] == "model_timeout" and reply["cleanup_ack"] is True
+        source.close()
+    asyncio.run(run())
+
+
+def test_active_duplicate_aborts_without_cancelling_original(tmp_path):
+    async def run():
+        entered, release = asyncio.Event(), asyncio.Event()
+        calls = []
+        async def callback(_):
+            calls.append(1)
+            entered.set()
+            await release.wait()
+            return rpc.BackendCompletion("{}")
+        service, source, socket = setup(tmp_path, callback)
+        async with service.serve(socket):
+            original = asyncio.create_task(rpc.invoke(socket, request(), deadline=2))
+            await entered.wait()
+            with pytest.raises(rpc.InvocationAborted):
+                await rpc.invoke(socket, request(), deadline=2)
+            release.set()
+            assert (await original)["category"] == "ok"
+            assert calls == [1]
+        source.close()
+    asyncio.run(run())
+
+
+def test_snapshot_is_standalone_from_wal_and_has_actual_hash(tmp_path):
+    import hashlib
+    source = sqlite3.connect(tmp_path / "source.db")
+    source.execute("PRAGMA journal_mode=WAL")
+    source.execute("CREATE TABLE value(n)")
+    source.execute("INSERT INTO value VALUES(7)")
+    source.commit()
+    host = tmp_path / "host"
+    host.mkdir(mode=0o700)
+    snapshot = rpc.snapshot_sqlite(source, host, "opaque")
+    assert snapshot.sha256 == hashlib.sha256(snapshot.path.read_bytes()).hexdigest()
+    assert not list(host.glob("*-wal")) and not list(host.glob("*-shm"))
+    assert json.loads(json.dumps(snapshot.sha256)) == snapshot.sha256
+    source.close()
+
+
+def test_disconnect_cancels_and_reaps_harmless_child_before_next_call(tmp_path):
+    async def run():
+        entered, cleaned = asyncio.Event(), asyncio.Event()
+        children = []
+        async def callback(_):
+            child = await asyncio.create_subprocess_exec(sys.executable, "-c", "import time;time.sleep(30)")
+            children.append(child)
+            entered.set()
+            try:
+                await child.wait()
+            except asyncio.CancelledError:
+                child.terminate()
+                await child.wait()
+                cleaned.set()
+                raise
+        service, source, socket = setup(tmp_path, callback)
+        async with service.serve(socket):
+            client = asyncio.create_task(rpc.invoke(socket, request(), deadline=2))
+            await entered.wait()
+            client.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await client
+            await asyncio.wait_for(cleaned.wait(), 2)
+            assert children[0].returncode is not None
+            with pytest.raises(rpc.InvocationAborted):
+                await rpc.invoke(socket, request(), deadline=2)
+            assert len(children) == 1
+        source.close()
+    asyncio.run(run())
+
+
+def test_cleanup_unknown_poison_blocks_new_model_calls(tmp_path):
+    async def run():
+        release = asyncio.Event()
+        tasks = []
+        async def callback(_):
+            tasks.append(asyncio.current_task())
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                await release.wait()  # deliberately violates timely-cleanup contract
+                return rpc.BackendCompletion("{}")
+        service, source, socket = setup(tmp_path, callback)
+        service.cleanup_slack = .02
+        async with service.serve(socket):
+            with pytest.raises(rpc.InvocationAborted):
+                await rpc.invoke(socket, request(), deadline=2)
+            assert service.poisoned
+            with pytest.raises(rpc.InvocationAborted):
+                await rpc.invoke(socket, request(request_id="request2"), deadline=2)
+            assert len(tasks) == 1
+            release.set()
+            await asyncio.gather(*tasks)
+        source.close()
+    asyncio.run(run())
+
+
+def test_arbitrary_callback_error_is_sanitized_abort_not_fallback(tmp_path, caplog):
+    async def run():
+        async def callback(_):
+            raise RuntimeError("SECRET_CALLBACK_CANARY")
+        service, source, socket = setup(tmp_path, callback)
+        async with service.serve(socket):
+            with pytest.raises(rpc.InvocationAborted) as error:
+                await rpc.invoke(socket, request(), deadline=2)
+            assert "SECRET" not in str(error.value)
+            assert service.poisoned
+        source.close()
+    asyncio.run(run())
+    assert "SECRET_CALLBACK_CANARY" not in caplog.text
+
+
+def test_request_cap_never_evicts_or_reexecutes_completed_ids(tmp_path):
+    async def run():
+        calls = []
+        async def callback(_):
+            calls.append(1)
+            return rpc.BackendCompletion("{}")
+        service, source, socket = setup(tmp_path, callback, max_requests=1)
+        async with service.serve(socket):
+            first = await rpc.invoke(socket, request(), deadline=2)
+            with pytest.raises(rpc.InvocationAborted):
+                await rpc.invoke(socket, request(request_id="request2"), deadline=2)
+            assert await rpc.invoke(socket, request(), deadline=2) == first
+            assert calls == [1]
+        source.close()
+    asyncio.run(run())
+
+
+def test_partial_frame_and_transport_timeout_abort_without_fallback(tmp_path):
+    async def run():
+        async def partial(reader, writer):
+            await reader.read(4)
+            writer.write(b"\x00\x00")
+            await writer.drain()
+            writer.close()
+        socket = tmp_path / "fake.sock"
+        server = await asyncio.start_unix_server(partial, str(socket))
+        try:
+            with pytest.raises(rpc.InvocationAborted):
+                await rpc.invoke(socket, request(), deadline=.2)
+        finally:
+            server.close()
+            await server.wait_closed()
+    asyncio.run(run())
+
+
+def test_server_close_waits_for_active_cleanup(tmp_path):
+    async def run():
+        entered, cleaned = asyncio.Event(), asyncio.Event()
+        async def callback(_):
+            entered.set()
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                await asyncio.sleep(.02)
+                cleaned.set()
+                raise
+        service, source, socket = setup(tmp_path, callback)
+        async with service.serve(socket):
+            client = asyncio.create_task(rpc.invoke(socket, request(), deadline=2))
+            await entered.wait()
+        assert cleaned.is_set() and not socket.exists()
+        with pytest.raises(rpc.InvocationAborted):
+            await client
+        source.close()
+    asyncio.run(run())
+
+
+def test_different_request_cannot_queue_behind_active_call(tmp_path):
+    async def run():
+        entered, release = asyncio.Event(), asyncio.Event()
+        calls = []
+        async def callback(_):
+            calls.append(1)
+            entered.set()
+            await release.wait()
+            return rpc.BackendCompletion("{}")
+        service, source, socket = setup(tmp_path, callback)
+        async with service.serve(socket):
+            first = asyncio.create_task(rpc.invoke(socket, request(), deadline=2))
+            await entered.wait()
+            with pytest.raises(rpc.InvocationAborted):
+                await rpc.invoke(socket, request(request_id="other"), deadline=2)
+            release.set()
+            await first
+            assert calls == [1]
+        source.close()
+    asyncio.run(run())
+
+
+def test_client_deadline_is_uncertain_abort_and_host_joins_cleanup(tmp_path):
+    async def run():
+        cleaned = asyncio.Event()
+        async def callback(_):
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                await asyncio.sleep(.01)
+                cleaned.set()
+                raise
+        service, source, socket = setup(tmp_path, callback)
+        async with service.serve(socket):
+            with pytest.raises(rpc.InvocationAborted):
+                await rpc.invoke(socket, request(), deadline=.04)
+            await asyncio.wait_for(cleaned.wait(), 2)
+            assert not service.poisoned
+        source.close()
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize("raw", [b'{"request_id":"a","request_id":"b"}', b'[]', b'not-json'])
+def test_malformed_raw_frame_never_reaches_callback(tmp_path, raw):
+    async def run():
+        async def callback(_):
+            pytest.fail("invalid wire data invoked model")
+        service, source, socket = setup(tmp_path, callback)
+        async with service.serve(socket):
+            reader, writer = await asyncio.open_unix_connection(str(socket))
+            writer.write(len(raw).to_bytes(4, "big") + raw)
+            await writer.drain()
+            reply = await rpc._read(reader)
+            assert reply["cleanup_ack"] is False and reply["fallback_allowed"] is False
+            writer.close()
+        source.close()
+    asyncio.run(run())
+
+
+def test_window_with_insufficient_cleanup_slack_never_launches(tmp_path):
+    async def run():
+        async def callback(_):
+            pytest.fail("insufficient bounded window")
+        service, source, socket = setup(tmp_path, callback)
+        service.window_seconds = .1
+        async with service.serve(socket):
+            with pytest.raises(rpc.InvocationAborted):
+                await rpc.invoke(socket, request(), deadline=2)
+        source.close()
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize("failure", ["exception", "invalid_receipt"])
+def test_cleanup_failure_never_grants_timeout_fallback(tmp_path, failure):
+    async def run():
+        async def callback(_):
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                if failure == "exception":
+                    raise RuntimeError("SECRET_FAILED_CLEANUP") from None
+                return "not-a-cleanup-receipt"
+        service, source, socket = setup(tmp_path, callback)
+        async with service.serve(socket):
+            with pytest.raises(rpc.InvocationAborted):
+                await rpc.invoke(socket, request(), deadline=2)
+            assert service.poisoned
+            response = service.records["request1"][1].result()
+            assert response["cleanup_ack"] is False and response["fallback_allowed"] is False
+        source.close()
+    asyncio.run(run())
+
+
+def test_expired_window_never_replays_cached_fallback_permission(tmp_path):
+    async def run():
+        async def callback(_):
+            return rpc.BackendCompletion(None, error="model_error")
+        service, source, socket = setup(tmp_path, callback)
+        async with service.serve(socket):
+            assert (await rpc.invoke(socket, request(), deadline=2))["fallback_allowed"] is True
+            service.started -= 6
+            with pytest.raises(rpc.InvocationAborted):
+                await rpc.invoke(socket, request(), deadline=2)
+        source.close()
+    asyncio.run(run())
+
+
+def test_slow_snapshot_cannot_start_model_without_remaining_cleanup_slack(tmp_path, monkeypatch):
+    async def run():
+        async def callback(_):
+            pytest.fail("slow snapshot consumed registered window")
+        service, source, socket = setup(tmp_path, callback)
+        original = rpc.snapshot_sqlite
+        def slow_snapshot(*args, **kwargs):
+            snapshot = original(*args, **kwargs)
+            service.started -= 4.5
+            return snapshot
+        monkeypatch.setattr(rpc, "snapshot_sqlite", slow_snapshot)
+        async with service.serve(socket):
+            with pytest.raises(rpc.InvocationAborted):
+                await rpc.invoke(socket, request(), deadline=2)
+        source.close()
+    asyncio.run(run())

--- a/tests/test_isolated_responses_relay.py
+++ b/tests/test_isolated_responses_relay.py
@@ -1,0 +1,175 @@
+import contextlib
+import asyncio
+import json
+from pathlib import Path
+import socket
+import tempfile
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from tools import isolated_responses_relay as relay
+
+
+@contextlib.contextmanager
+def endpoint(monkeypatch, handler):
+    with tempfile.TemporaryDirectory(prefix="rr-", dir=Path("/tmp").resolve()) as directory:
+        path = Path(directory) / "responses.sock"
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        listener.bind(str(path))
+        path.chmod(0o600)
+        listener.listen(4)
+        listener.settimeout(3)
+        failures = []
+        def serve():
+            try:
+                connection, _ = listener.accept()
+                with connection:
+                    connection.settimeout(3)
+                    handler(connection)
+            except Exception as error:
+                failures.append(type(error).__name__)
+        thread = threading.Thread(target=serve, daemon=True)
+        thread.start()
+        monkeypatch.setattr(relay, "RESPONSES_SOCKET", str(path))
+        try:
+            yield path, failures
+        finally:
+            listener.close()
+            thread.join(timeout=4)
+
+
+def connect(instance):
+    return socket.create_connection(instance.server.server_address, timeout=3)
+
+
+def test_large_final_response_survives_upstream_eof_and_backpressure(monkeypatch):
+    payload = ("합성 응답📈" * 50000).encode()
+    received = []
+    def handler(connection):
+        received.append(connection.recv(100))
+        connection.sendall(payload)
+    with endpoint(monkeypatch, handler) as (_, failures):
+        with relay.ResponsesRelay() as instance, connect(instance) as client:
+            client.sendall(b"synthetic request")
+            time.sleep(.1)
+            output = bytearray()
+            while True:
+                part = client.recv(65536)
+                if not part:
+                    break
+                output.extend(part)
+            assert bytes(output) == payload
+        assert received == [b"synthetic request"] and not failures
+
+
+def test_shutdown_closes_owned_blocked_connection(monkeypatch):
+    closed = threading.Event()
+    def handler(connection):
+        while connection.recv(100):
+            pass
+        closed.set()
+    with endpoint(monkeypatch, handler):
+        instance = relay.ResponsesRelay().__enter__()
+        with connect(instance) as client:
+            client.sendall(b"x")
+            time.sleep(.05)
+            started = time.monotonic()
+            instance.close()
+            assert time.monotonic() - started < 3
+            assert closed.wait(2)
+
+
+def test_idle_and_client_disconnect_do_not_retry(monkeypatch):
+    seen = []
+    def handler(connection):
+        seen.append(connection.recv(100))
+        assert connection.recv(100) == b""
+    with endpoint(monkeypatch, handler) as (_, failures):
+        with relay.ResponsesRelay(idle_seconds=.05) as instance, connect(instance) as client:
+            client.sendall(b"x")
+            assert client.recv(100) == b""
+        assert seen == [b"x"] and not failures
+
+
+def test_missing_or_nonprivate_socket_fails_before_listen(tmp_path, monkeypatch):
+    path = tmp_path / "not-a-socket"
+    path.write_text("SYNTHETIC")
+    monkeypatch.setattr(relay, "RESPONSES_SOCKET", str(path))
+    with pytest.raises(relay.RelayRejected):
+        relay.ResponsesRelay().__enter__()
+
+
+def test_connection_cap_rejects_before_second_upstream_or_thread(monkeypatch):
+    entered = threading.Event()
+    def handler(connection):
+        entered.set()
+        while connection.recv(100):
+            pass
+    with endpoint(monkeypatch, handler):
+        with relay.ResponsesRelay(max_connections=1) as instance, connect(instance) as first:
+            first.sendall(b"x")
+            assert entered.wait(2)
+            with connect(instance) as second:
+                assert second.recv(10) == b""
+            assert len(instance.server.pairs) == 1
+            with pytest.raises(relay.RelayRejected, match="already_started"):
+                instance.__enter__()
+
+
+@pytest.mark.parametrize("kwargs", [{"idle_seconds": float("inf")}, {"idle_seconds": True}, {"max_connections": 5}])
+def test_invalid_budgets_rejected(kwargs):
+    with pytest.raises(relay.RelayRejected):
+        relay.ResponsesRelay(**kwargs)
+
+
+def test_real_sdk_through_relay_and_native_proxy_with_fake_upstream(monkeypatch):
+    import httpx
+    from openai import AsyncOpenAI
+    from tools import isolated_responses_proxy as proxy
+    calls = []
+    class Upstream:
+        async def __aenter__(self):
+            async def text():
+                return json.dumps({"id": "synthetic", "object": "response", "created_at": 1,
+                                   "model": "gpt-5.6-sol", "status": "completed", "output": []})
+            return SimpleNamespace(status=200, headers={"Content-Type": "application/json"}, text=text)
+        async def __aexit__(self, *_):
+            return False
+    class Session:
+        def __init__(self, *_):
+            pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *_):
+            return False
+        def post(self, url, **kwargs):
+            calls.append(url)
+            return Upstream()
+    monkeypatch.setattr(proxy, "_BoundedSession", Session)
+    async def run(directory):
+        auth = directory / "auth.json"
+        auth.write_text(json.dumps({"access_token": "SYNTHETIC", "account_id": "synthetic-account",
+                                    "expires_at": time.time() + 3600}))
+        auth.chmod(0o600)
+        sock = directory / "responses.sock"
+        monkeypatch.setattr(relay, "RESPONSES_SOCKET", str(sock))
+        stop, ready = asyncio.Event(), asyncio.Event()
+        server = asyncio.create_task(proxy.serve(sock, auth, allowed_tools={"time-get_current_time"},
+                                                  run_seconds=10, stop_event=stop, ready=ready))
+        try:
+            await asyncio.wait_for(ready.wait(), 3)
+            with relay.ResponsesRelay() as instance:
+                async with AsyncOpenAI(api_key="dummy", base_url=instance.base_url, max_retries=0,
+                                       http_client=httpx.AsyncClient(trust_env=False)) as client:
+                    result = await client.responses.create(model="gpt-5.6-sol", input="synthetic")
+                    assert result.id == "synthetic" and result.status == "completed"
+        finally:
+            stop.set()
+            await asyncio.wait_for(server, 3)
+        assert not sock.exists() and not proxy._ACTIVE
+    with tempfile.TemporaryDirectory(prefix="rrp-", dir=Path("/tmp").resolve()) as directory:
+        asyncio.run(run(Path(directory)))
+    assert calls == ["https://chatgpt.com/backend-api/codex/responses"]

--- a/tests/test_isolated_sqlite_mcp.py
+++ b/tests/test_isolated_sqlite_mcp.py
@@ -1,0 +1,228 @@
+import ast
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from mcp import types
+
+from tools.isolated_sqlite_mcp import (
+    ReadOnlyDatabase, ReadOnlyError, call_read_tool, read_tools, read_authorizer, create_server,
+)
+from tools import isolated_sqlite_mcp as implementation
+
+
+@pytest.fixture
+def database(tmp_path):
+    path = tmp_path / "arm.sqlite"
+    with sqlite3.connect(path) as conn:
+        conn.execute("CREATE TABLE positions (ticker TEXT, price REAL, scenario TEXT)")
+        conn.execute("INSERT INTO positions VALUES (?,?,?)", ("SYNTHETIC", 100, '{"sector":"test"}'))
+        conn.execute("CREATE TABLE numbers (value INTEGER)")
+        conn.executemany("INSERT INTO numbers VALUES (?)", [(i,) for i in range(1000)])
+    return path
+
+
+def test_tools_advertise_exact_three_read_contracts():
+    tools = read_tools()
+    assert [t.name for t in tools] == ["list_tables", "describe_table", "read_query"]
+    assert tools[0].inputSchema["properties"] == {}
+    assert tools[1].inputSchema["required"] == ["table_name"]
+    assert tools[2].inputSchema["required"] == ["query"]
+
+
+def test_real_read_results_and_live_committed_updates(database):
+    db = ReadOnlyDatabase(database)
+    assert {"name": "positions"} in db.list_tables()
+    assert [c["name"] for c in db.describe_table("positions")] == ["ticker", "price", "scenario"]
+    assert db.read_query("SELECT ticker, json_extract(scenario, '$.sector') AS sector FROM positions") == [
+        {"ticker": "SYNTHETIC", "sector": "test"}]
+    with sqlite3.connect(database) as writer:
+        writer.execute("UPDATE positions SET price=110")
+    assert db.read_query("SELECT price FROM positions") == [{"price": 110.0}]
+
+
+@pytest.mark.parametrize("query", [
+    "INSERT INTO positions VALUES ('x',1,'{}')",
+    "UPDATE positions SET price=0", "DELETE FROM positions", "DROP TABLE positions",
+    "CREATE TABLE bad (value TEXT)", "PRAGMA query_only=OFF",
+    "ATTACH DATABASE ':memory:' AS other", "DETACH DATABASE main",
+    "SELECT load_extension('/SECRET_EXTENSION_PATH')",
+    "SELECT writefile('/SECRET_PATH', 'data')",
+    "SELECT readfile('/SECRET_PATH')",
+    "SELECT * FROM pragma_writable_schema(1)",
+    "WITH data AS (SELECT 1) SELECT * FROM data",
+])
+def test_forbidden_sql_cannot_change_database_or_echo_query(database, query):
+    before = database.read_bytes()
+    db = ReadOnlyDatabase(database)
+    with pytest.raises(ReadOnlyError) as error:
+        db.read_query(query)
+    assert "SECRET" not in str(error.value)
+    assert query not in str(error.value)
+    assert database.read_bytes() == before
+
+
+@pytest.mark.parametrize("query", [
+    "UPDATE positions SET price=0", "PRAGMA query_only=OFF",
+    "ATTACH DATABASE ':memory:' AS other", "SELECT load_extension('bad')",
+])
+def test_authorizer_blocks_even_when_select_prefix_guard_bypassed(database, query):
+    db = ReadOnlyDatabase(database)
+    with pytest.raises(ReadOnlyError):
+        db._execute(query)
+    assert db.read_query("SELECT price FROM positions") == [{"price": 100.0}]
+
+
+def test_uri_readonly_survives_removing_additional_connection_guards(database):
+    db = ReadOnlyDatabase(database)
+    conn = db._connect()
+    try:
+        conn.set_authorizer(None)
+        assert conn.execute("PRAGMA query_only").fetchone()[0] == 1
+        conn.execute("PRAGMA query_only=OFF")
+        with pytest.raises(sqlite3.OperationalError, match="readonly"):
+            conn.execute("UPDATE positions SET price=0")
+    finally:
+        conn.close()
+
+
+def test_missing_path_never_creates_directory_or_database(tmp_path):
+    path = tmp_path / "missing" / "missing.sqlite"
+    with pytest.raises(ReadOnlyError, match="INVALID_DATABASE"):
+        ReadOnlyDatabase(path)
+    assert not path.parent.exists()
+
+
+def test_symlink_database_is_rejected(database, tmp_path):
+    link = tmp_path / "link.sqlite"
+    link.symlink_to(database)
+    with pytest.raises(ReadOnlyError, match="INVALID_DATABASE"):
+        ReadOnlyDatabase(link)
+
+
+def test_table_identifier_cannot_inject_sql_or_echo_paths(database):
+    with pytest.raises(ReadOnlyError, match="UNKNOWN_TABLE"):
+        ReadOnlyDatabase(database).describe_table('positions); ATTACH "/SECRET_PATH" AS extra; --')
+    assert ReadOnlyDatabase(database).read_query("SELECT COUNT(*) AS count FROM positions") == [{"count": 1}]
+
+
+def test_row_result_sql_and_time_limits_are_explicit(database):
+    db = ReadOnlyDatabase(database, max_rows=2)
+    with pytest.raises(ReadOnlyError, match="ROW_LIMIT"):
+        db.read_query("SELECT value FROM numbers")
+    assert len(db.read_query("SELECT value FROM numbers LIMIT 2")) == 2
+    tiny = ReadOnlyDatabase(database, max_result_bytes=16)
+    with pytest.raises(ReadOnlyError, match="RESULT_LIMIT"):
+        tiny.read_query("SELECT ticker FROM positions")
+    with pytest.raises(ReadOnlyError, match="INVALID_QUERY"):
+        db.read_query("SELECT '" + "x" * 20000 + "'")
+    timed = ReadOnlyDatabase(database, query_timeout=0.001)
+    with pytest.raises(ReadOnlyError, match="QUERY_TIMEOUT"):
+        timed.read_query("SELECT sum(a.value*b.value*c.value) FROM numbers a, numbers b, numbers c")
+
+
+def test_dangerous_allocation_function_denied(database):
+    with pytest.raises(ReadOnlyError, match="QUERY_REJECTED"):
+        ReadOnlyDatabase(database).read_query("SELECT randomblob(1000000000)")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_preserves_text_row_format_and_fixed_errors(database):
+    db = ReadOnlyDatabase(database)
+    result = await call_read_tool(db, "read_query", {"query": "SELECT price FROM positions"})
+    assert not result.isError
+    assert ast.literal_eval(result.content[0].text) == [{"price": 100.0}]
+    for name, args in [
+        ("write_query", {"query": "DELETE FROM positions"}),
+        ("create_table", {"query": "CREATE TABLE bad(x)"}),
+        ("read_query", {"query": "SELECT * FROM SECRET_MISSING_TABLE"}),
+        ("read_query", {"query": "SELECT 1", "path": "/SECRET_PATH"}),
+    ]:
+        error = await call_read_tool(db, name, args)
+        assert error.isError
+        assert "SECRET" not in error.content[0].text
+        assert error.content[0].text.startswith("Error: ")
+
+
+def test_count_optimization_only_allows_verified_main_tables():
+    assert read_authorizer(sqlite3.SQLITE_READ, "positions", "", None, None) == sqlite3.SQLITE_DENY
+    assert read_authorizer(sqlite3.SQLITE_READ, "positions", "", None, None,
+                           main_tables={"positions"}) == sqlite3.SQLITE_OK
+    assert read_authorizer(sqlite3.SQLITE_READ, "positions", "", "temp", None,
+                           main_tables={"positions"}) == sqlite3.SQLITE_DENY
+
+
+def test_vacuum_into_and_attach_cannot_create_external_files(database, tmp_path):
+    db = ReadOnlyDatabase(database)
+    for command in ("VACUUM INTO", "ATTACH DATABASE"):
+        target = tmp_path / ("forbidden-" + command.split()[0] + ".sqlite")
+        query = command + " '" + str(target) + "'" + (" AS other" if command.startswith("ATTACH") else "")
+        with pytest.raises(ReadOnlyError):
+            db._execute(query)
+        assert not target.exists()
+
+
+@pytest.mark.asyncio
+async def test_actual_sdk_handlers_advertise_only_read_tools_and_fixed_error(database):
+    server = create_server(ReadOnlyDatabase(database))
+    advertised = await server.request_handlers[types.ListToolsRequest](types.ListToolsRequest(method="tools/list"))
+    assert [t.name for t in advertised.root.tools] == ["list_tables", "describe_table", "read_query"]
+    capabilities = server.create_initialization_options().capabilities
+    assert capabilities.prompts is None and capabilities.resources is None
+    response = await server.request_handlers[types.CallToolRequest](types.CallToolRequest(
+        method="tools/call", params=types.CallToolRequestParams(name="read_query",
+            arguments={"query": "SELECT * FROM SECRET_MISSING_TABLE"})))
+    assert response.root.isError
+    assert response.root.content[0].text == "Error: QUERY_REJECTED"
+
+
+@pytest.mark.parametrize("args", [
+    ["--db-path", "/SECRET_MISSING_DIRECTORY/SECRET_DATABASE.sqlite"],
+    ["--unrecognized-secret", "/SECRET_PATH"],
+])
+def test_cli_errors_never_echo_paths_or_arguments(args, tmp_path):
+    script = Path(__file__).resolve().parents[1] / "tools/isolated_sqlite_mcp.py"
+    result = subprocess.run([sys.executable, str(script), *args], cwd=tmp_path,
+                            text=True, capture_output=True, timeout=20)
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert result.stderr.strip() == "Error: READ_ONLY_SERVICE_UNAVAILABLE"
+
+
+@pytest.mark.parametrize("proof", ["disabled", "unverified_error", "unexpected_success"])
+def test_missing_extension_setter_requires_actual_disabled_sql_proof(database, monkeypatch, proof):
+    original_connect = sqlite3.connect
+    probes = []
+    class WithoutSetter:
+        def __init__(self, conn):
+            object.__setattr__(self, "conn", conn)
+        def __getattr__(self, name):
+            if name == "enable_load_extension":
+                raise AttributeError(name)
+            return getattr(self.conn, name)
+        def __setattr__(self, name, value):
+            setattr(self.conn, name, value)
+        def execute(self, query, parameters=()):
+            if query == "SELECT load_extension(?)":
+                probes.append(parameters[0])
+                if proof == "unverified_error":
+                    raise sqlite3.OperationalError("SECRET_UNVERIFIED_EXTENSION_ERROR")
+                if proof == "unexpected_success":
+                    return self.conn.execute("SELECT 1")
+            return self.conn.execute(query, parameters)
+    monkeypatch.setattr(implementation.sqlite3, "connect",
+                        lambda *args, **kwargs: WithoutSetter(original_connect(*args, **kwargs)))
+    db = ReadOnlyDatabase(database)
+    if proof == "disabled":
+        assert db.read_query("SELECT COUNT(*) AS count FROM positions") == [{"count": 1}]
+        with pytest.raises(ReadOnlyError):
+            db.read_query("SELECT load_extension('unsafe')")
+        with pytest.raises(ReadOnlyError):
+            db._execute("UPDATE positions SET price=0")
+    else:
+        with pytest.raises(ReadOnlyError, match="UNSUPPORTED_SQLITE_RUNTIME") as error:
+            db.read_query("SELECT 1")
+        assert "SECRET" not in str(error.value)
+    assert probes and all(Path(p).is_absolute() and not Path(p).exists() for p in probes)

--- a/tools/isolated_codex_invoker.py
+++ b/tools/isolated_codex_invoker.py
@@ -1,0 +1,399 @@
+"""Fixed-capability invocation primitive; NOT a production launcher.
+
+Only a trusted supervisor registers scopes, settings and already-authorized
+SQLite connections. Requests cannot choose executable, environment, filesystem
+paths, endpoints, model or deadline. One active invocation, no queue, bounded
+in-memory deduplication for this service lifetime; restarting requires a NEW
+window/case registration, not replaying uncertain IDs.
+
+The callback MUST join its owned resources before returning/raising cancellation.
+An ACK proves that callback contract was joined, not independent process cleanup.
+Production binding must reuse verified generate_codex_fast_async and add a
+supervisor-loss watchdog BEFORE deployment. SIGKILL/parent-loss cleanup is NOT
+implemented here. There is deliberately no executable CLI or backend import.
+"""
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager, closing
+from dataclasses import dataclass, field
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import re
+import sqlite3
+import stat
+import struct
+import time
+
+MAX_FRAME = 2 * 1024 * 1024
+MAX_PROMPT = 1024 * 1024
+MAX_RESULT = 1024 * 1024
+_ID = re.compile(r"[A-Za-z0-9_-]{1,64}\Z")
+_FIELDS = {"request_id", "arm_id", "profile_id", "case_id", "system_prompt", "user_prompt"}
+
+
+class InvocationAborted(asyncio.CancelledError):
+    """Unknown/invalid transport MUST bypass ordinary model-error fallback."""
+
+
+def _identifier(value):
+    if not isinstance(value, str) or not _ID.fullmatch(value):
+        raise ValueError("invalid_identifier")
+    return value
+
+
+def _bounded_seconds(value, maximum):
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) or not .01 <= value <= maximum:
+        raise ValueError("invalid_deadline")
+    return float(value)
+
+
+def _private_directory(path):
+    path = Path(path)
+    if (not path.is_absolute() or ".." in path.parts or path.resolve() != path or not path.is_dir()
+            or path.stat().st_uid != os.getuid() or stat.S_IMODE(path.stat().st_mode) != 0o700):
+        raise ValueError("unsafe_private_directory")
+    return path
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    path: Path
+    sha256: str
+
+
+def snapshot_sqlite(source, private_root, invocation_id, *, timeout=2):
+    """Backup an already-authorized connection; never infer revision from DB.
+
+    The supervisor must open/authorize source BEFORE exposing untrusted agents.
+    SQLite backup includes committed WAL state. No live DB is model-mounted.
+    """
+    if not isinstance(source, sqlite3.Connection) or source.in_transaction:
+        raise ValueError("committed_sqlite_connection_required")
+    root = _private_directory(private_root)
+    name = hashlib.sha256(_identifier(invocation_id).encode()).hexdigest() + ".sqlite"
+    target = root / name
+    end = time.monotonic() + _bounded_seconds(timeout, 10)
+    page_size = source.execute("PRAGMA page_size").fetchone()[0]
+    fd = os.open(target, os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_NOFOLLOW, 0o600)
+    os.close(fd)
+    try:
+        def progress(status, remaining, total):
+            if time.monotonic() >= end or total * page_size > 256 * 1024 * 1024:
+                raise ValueError("snapshot_limit")
+        with closing(sqlite3.connect(target, timeout=0)) as destination:
+            source.backup(destination, pages=128, progress=progress, sleep=.01)
+            destination.execute("PRAGMA journal_mode=DELETE")
+        if any(Path(str(target) + suffix).exists() for suffix in ("-wal", "-shm", "-journal")):
+            raise ValueError("snapshot_not_standalone")
+        target.chmod(0o400)
+        digest = hashlib.sha256()
+        with target.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return Snapshot(target, digest.hexdigest())
+    except BaseException:
+        for suffix in ("", "-wal", "-shm", "-journal"):
+            Path(str(target) + suffix).unlink(missing_ok=True)
+        raise
+
+
+@dataclass(frozen=True)
+class InvocationScope:
+    arm_id: str
+    profile_id: str
+    case_id: str
+    revision: str
+    fixed_settings_json: str
+    model_deadline: float
+    sqlite_source: sqlite3.Connection = field(repr=False, compare=False)
+
+    def __post_init__(self):
+        for value in (self.arm_id, self.profile_id, self.case_id, self.revision):
+            _identifier(value)
+        _bounded_seconds(self.model_deadline, 600)
+        if (not isinstance(self.fixed_settings_json, str) or len(self.fixed_settings_json.encode()) > 65536
+                or not isinstance(json.loads(self.fixed_settings_json), dict)):
+            raise ValueError("invalid_host_settings")
+        if not isinstance(self.sqlite_source, sqlite3.Connection):
+            raise ValueError("authorized_connection_required")
+
+
+@dataclass(frozen=True)
+class Invocation:
+    scope: InvocationScope
+    system_prompt: str
+    user_prompt: str
+    snapshot: Snapshot
+
+
+@dataclass(frozen=True)
+class BackendCompletion:
+    """Trusted callback receipt: construct only AFTER owned cleanup completes."""
+    result_json: str | None
+    error: str | None = None
+
+
+def _valid_receipt(receipt):
+    if not isinstance(receipt, BackendCompletion):
+        return False
+    if receipt.error == "model_error" and receipt.result_json is None:
+        return True
+    if receipt.error is not None or not isinstance(receipt.result_json, str) or len(receipt.result_json.encode()) > MAX_RESULT:
+        return False
+    try:
+        json.loads(receipt.result_json)
+    except (ValueError, RecursionError):
+        return False
+    return True
+
+
+def _json(data):
+    return json.dumps(data, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+
+
+def _unique_object(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate_key")
+        result[key] = value
+    return result
+
+
+async def _read(reader):
+    size = struct.unpack("!I", await reader.readexactly(4))[0]
+    if not 1 <= size <= MAX_FRAME:
+        raise ValueError("frame_limit")
+    return json.loads(await reader.readexactly(size), object_pairs_hook=_unique_object)
+
+
+async def _write(writer, value):
+    data = _json(value)
+    if len(data) > MAX_FRAME:
+        raise ValueError("frame_limit")
+    writer.write(struct.pack("!I", len(data)) + data)
+    await writer.drain()
+
+
+def _abort(category="invocation_aborted"):
+    return {"category": category, "cleanup_ack": False, "fallback_allowed": False}
+
+
+class CodexInvoker:
+    def __init__(self, scopes, callback, private_snapshot_root, *, window_seconds=600, max_requests=32, cleanup_slack=10):
+        self.root = _private_directory(private_snapshot_root)
+        self.window_seconds = _bounded_seconds(window_seconds, 3600)
+        self.cleanup_slack = _bounded_seconds(cleanup_slack, 60)
+        if type(max_requests) is not int or not 1 <= max_requests <= 64 or not callable(callback):
+            raise ValueError("invalid_host_registration")
+        self.scopes = {}
+        for scope in scopes:
+            key = (scope.arm_id, scope.profile_id, scope.case_id)
+            if key in self.scopes:
+                raise ValueError("duplicate_scope")
+            self.scopes[key] = scope
+        if not self.scopes or len(self.scopes) > 64:
+            raise ValueError("invalid_host_registration")
+        self.callback, self.max_requests = callback, max_requests
+        self.records, self.handlers, self.unjoined_callbacks = {}, set(), set()
+        self.active = None
+        self.poisoned = self.closed = False
+        self.started = None
+
+    async def _cancel_join(self, task):
+        task.cancel()
+        done, _ = await asyncio.wait({task}, timeout=self.cleanup_slack)
+        if not done:
+            self.poisoned = True
+            self.unjoined_callbacks.add(task)
+            def finished_callback(finished):
+                self.unjoined_callbacks.discard(finished)
+                if not finished.cancelled():
+                    finished.exception()
+            task.add_done_callback(finished_callback)
+            return False
+        try:
+            receipt = task.result()
+        except asyncio.CancelledError:
+            # Explicit registered callback cancellation contract, not OS proof.
+            return True
+        except BaseException:
+            self.poisoned = True
+            return False
+        if not _valid_receipt(receipt):
+            self.poisoned = True
+            return False
+        return True
+
+    async def _run(self, scope, request, cancel):
+        callback_task = None
+        cancelled = None
+        try:
+            snapshot = snapshot_sqlite(scope.sqlite_source, self.root, request["request_id"])
+            if self.window_seconds - (time.monotonic() - self.started) < scope.model_deadline + self.cleanup_slack:
+                return _abort("window_unavailable")
+            metadata = {"snapshot_sha256": snapshot.sha256, "revision": scope.revision,
+                        "revision_basis": "HOST_REGISTERED_CASE_REVISION",
+                        "settings_sha256": hashlib.sha256(scope.fixed_settings_json.encode()).hexdigest(),
+                        "cleanup_basis": "TRUSTED_CALLBACK_CONTRACT_NOT_EXTERNAL_PROCESS_PROOF"}
+            callback_task = asyncio.create_task(self.callback(Invocation(scope, request["system_prompt"], request["user_prompt"], snapshot)))
+            cancelled = asyncio.create_task(cancel.wait())
+            done, _ = await asyncio.wait({callback_task, cancelled}, timeout=scope.model_deadline, return_when=asyncio.FIRST_COMPLETED)
+            if callback_task not in done:
+                joined = await self._cancel_join(callback_task)
+                if not joined:
+                    return _abort("cleanup_unknown")
+                if cancel.is_set():
+                    return {**_abort("cancelled"), "cleanup_ack": True, **metadata}
+                return {"category": "model_timeout", "cleanup_ack": True, "fallback_allowed": True, **metadata}
+            receipt = callback_task.result()
+            if not _valid_receipt(receipt):
+                self.poisoned = True
+                return _abort("invalid_callback_receipt")
+            if receipt.error == "model_error" and receipt.result_json is None:
+                return {"category": "model_error", "cleanup_ack": True, "fallback_allowed": True, **metadata}
+            return {"category": "ok", "cleanup_ack": True, "fallback_allowed": False,
+                    "result_json": receipt.result_json, **metadata}
+        except BaseException:
+            if callback_task is not None:
+                self.poisoned = True
+            if callback_task is not None and not callback_task.done():
+                await self._cancel_join(callback_task)
+            return _abort()
+        finally:
+            if cancelled is not None:
+                cancelled.cancel()
+                await asyncio.gather(cancelled, return_exceptions=True)
+
+    def _accept(self, request):
+        if not isinstance(request, dict) or set(request) != _FIELDS:
+            raise ValueError("invalid_request")
+        for key in ("request_id", "arm_id", "profile_id", "case_id"):
+            _identifier(request[key])
+        for key in ("system_prompt", "user_prompt"):
+            if not isinstance(request[key], str) or len(request[key].encode()) > MAX_PROMPT:
+                raise ValueError("prompt_limit")
+        scope = self.scopes.get(tuple(request[key] for key in ("arm_id", "profile_id", "case_id")))
+        if scope is None:
+            raise ValueError("unregistered_scope")
+        # Never replay fallback permission while any other invocation is active
+        # or cleanup is uncertain, even if this particular ID completed earlier.
+        if (self.closed or self.poisoned or time.monotonic() - self.started >= self.window_seconds
+                or self.active is not None and not self.active.done()):
+            raise ValueError("window_unavailable")
+        digest = hashlib.sha256(_json(request)).hexdigest()
+        prior = self.records.get(request["request_id"])
+        if prior is not None:
+            if prior[0] != digest or not prior[1].done():
+                raise ValueError("duplicate_active_or_conflicting")
+            return prior[1], None
+        if (self.closed or self.poisoned or self.window_seconds - (time.monotonic() - self.started) < scope.model_deadline + self.cleanup_slack + 2
+                or len(self.records) >= self.max_requests or self.active is not None and not self.active.done()):
+            raise ValueError("window_unavailable")
+        cancel = asyncio.Event()
+        task = asyncio.create_task(self._run(scope, request, cancel))
+        self.records[request["request_id"]] = (digest, task, cancel)
+        self.active = task
+        return task, cancel
+
+    async def _handle(self, reader, writer):
+        if len(self.handlers) >= 8:
+            writer.close()
+            return
+        handler = asyncio.current_task()
+        self.handlers.add(handler)
+        disconnected = None
+        task = cancel = None
+        try:
+            request = await asyncio.wait_for(_read(reader), timeout=3)
+            task, cancel = self._accept(request)
+            disconnected = asyncio.create_task(reader.read(1))
+            done, _ = await asyncio.wait({task, disconnected}, return_when=asyncio.FIRST_COMPLETED)
+            if disconnected in done and cancel is not None:
+                cancel.set()
+                await asyncio.shield(task)
+                return
+            await asyncio.wait_for(_write(writer, task.result()), timeout=2)
+        except asyncio.CancelledError:
+            if cancel is not None:
+                cancel.set()
+                await asyncio.shield(task)
+            raise
+        except (ValueError, OSError, asyncio.IncompleteReadError, asyncio.TimeoutError, RecursionError):
+            if cancel is not None:
+                cancel.set()
+                await asyncio.shield(task)
+            try:
+                await asyncio.wait_for(_write(writer, _abort()), timeout=1)
+            except (OSError, asyncio.TimeoutError):
+                pass
+        finally:
+            if disconnected is not None:
+                disconnected.cancel()
+                await asyncio.gather(disconnected, return_exceptions=True)
+            writer.close()
+            self.handlers.discard(handler)
+
+    @asynccontextmanager
+    async def serve(self, socket_path):
+        path = Path(socket_path)
+        if self.started is not None or path.parent != self.root or path.exists() or path.is_symlink():
+            raise ValueError("new_private_socket_required")
+        self.started = time.monotonic()
+        server = await asyncio.start_unix_server(self._handle, path=str(path), limit=MAX_FRAME + 4)
+        path.chmod(0o600)
+        try:
+            yield self
+        finally:
+            self.closed = True
+            server.close()
+            for _, task, cancel in self.records.values():
+                if not task.done():
+                    cancel.set()
+            await asyncio.gather(*(record[1] for record in self.records.values()), return_exceptions=True)
+            for handler in tuple(self.handlers):
+                handler.cancel()
+            await asyncio.gather(*tuple(self.handlers), return_exceptions=True)
+            await server.wait_closed()
+            path.unlink(missing_ok=True)
+
+
+async def invoke(socket_path, request, *, deadline):
+    """Unknown transport is cancellation-class, NEVER an ordinary fallback."""
+    writer = None
+    try:
+        async def exchange():
+            nonlocal writer
+            reader, writer = await asyncio.open_unix_connection(str(socket_path), limit=MAX_FRAME + 4)
+            await _write(writer, request)
+            response = await _read(reader)
+            if (not isinstance(response, dict) or response.get("cleanup_ack") is not True
+                    or response.get("category") not in {"ok", "model_error", "model_timeout"}
+                    or response.get("fallback_allowed") is not (response.get("category") != "ok")
+                    or response.get("cleanup_basis") != "TRUSTED_CALLBACK_CONTRACT_NOT_EXTERNAL_PROCESS_PROOF"
+                    or response.get("revision_basis") != "HOST_REGISTERED_CASE_REVISION"
+                    or any(not isinstance(response.get(key), str) or re.fullmatch(r"[0-9a-f]{64}", response[key]) is None
+                           for key in ("snapshot_sha256", "settings_sha256"))
+                    or not isinstance(response.get("revision"), str)):
+                raise InvocationAborted("invocation_aborted")
+            expected = {"category", "cleanup_ack", "fallback_allowed", "cleanup_basis", "revision_basis",
+                        "snapshot_sha256", "settings_sha256", "revision"}
+            if response["category"] == "ok":
+                expected.add("result_json")
+                if not isinstance(response.get("result_json"), str) or len(response["result_json"].encode()) > MAX_RESULT:
+                    raise InvocationAborted("invocation_aborted")
+            if set(response) != expected:
+                raise InvocationAborted("invocation_aborted")
+            return response
+        return await asyncio.wait_for(exchange(), timeout=_bounded_seconds(deadline, 700))
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        raise InvocationAborted("invocation_transport_unknown") from None
+    finally:
+        if writer is not None:
+            writer.close()

--- a/tools/isolated_responses_relay.py
+++ b/tools/isolated_responses_relay.py
@@ -1,0 +1,168 @@
+"""Agent-side loopback relay to ONE fixed Responses socket, not a host proxy.
+
+The parent must mount the reviewed Responses service at /responses.sock inside
+the strong agent namespace. This component alone does not establish OS isolation.
+No destination/route comes from the model; the host service validates HTTP bodies.
+"""
+import math
+import os
+from pathlib import Path
+import select
+import socket
+import socketserver
+import stat
+import threading
+import time
+
+RESPONSES_SOCKET = "/responses.sock"
+MAX_BUFFER = 256 * 1024
+
+
+class RelayRejected(ValueError):
+    pass
+
+
+class _Handler(socketserver.BaseRequestHandler):
+    def handle(self):
+        server = self.server
+        upstream = None
+        try:
+            if server.stopping.is_set():
+                return
+            upstream = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            upstream.settimeout(2)
+            upstream.connect(RESPONSES_SOCKET)
+            self.request.setblocking(False)
+            upstream.setblocking(False)
+            pair = (self.request, upstream)
+            with server.lock:
+                if server.stopping.is_set():
+                    return
+                server.pairs.add(pair)
+            pending = {self.request: b"", upstream: b""}
+            peer = {self.request: upstream, upstream: self.request}
+            server_eof = False
+            last_io = time.monotonic()
+            while not server.stopping.is_set():
+                if time.monotonic() - last_io >= server.idle_seconds:
+                    return
+                if server_eof and not pending[self.request]:
+                    return
+                readable = [] if server_eof else [s for s in pair if len(pending[peer[s]]) < MAX_BUFFER]
+                writable = [s for s in pair if pending[s] and (s is self.request or not server_eof)]
+                ready_read, ready_write, _ = select.select(readable, writable, [], .1)
+                for current in ready_read:
+                    try:
+                        data = current.recv(min(65536, MAX_BUFFER - len(pending[peer[current]])))
+                    except BlockingIOError:
+                        continue
+                    if not data:
+                        if current is self.request:
+                            return  # Client disconnect cancels; never replay a request.
+                        server_eof = True
+                        break
+                    pending[peer[current]] += data
+                    last_io = time.monotonic()
+                for current in ready_write:
+                    if server_eof and current is upstream:
+                        continue
+                    try:
+                        sent = current.send(pending[current])
+                    except BlockingIOError:
+                        continue
+                    if sent <= 0:
+                        return
+                    pending[current] = pending[current][sent:]
+                    last_io = time.monotonic()
+        except (OSError, ValueError):
+            pass  # No bytes, URLs, headers, exception messages or credentials logged.
+        finally:
+            if upstream is not None:
+                with server.lock:
+                    server.pairs.discard((self.request, upstream))
+                upstream.close()
+            server.slots.release()
+
+
+class _Server(socketserver.ThreadingTCPServer):
+    daemon_threads = False
+    block_on_close = True
+    allow_reuse_address = False
+
+    def process_request(self, request, client_address):
+        # Reserve before spawning a worker, not after accepting an unbounded
+        # number of handler threads under a connection burst.
+        if self.stopping.is_set() or not self.slots.acquire(blocking=False):
+            self.shutdown_request(request)
+            return
+        try:
+            super().process_request(request, client_address)
+        except BaseException:
+            self.slots.release()
+            self.shutdown_request(request)
+            raise
+
+    def handle_error(self, *_):
+        pass
+
+
+class ResponsesRelay:
+    def __init__(self, *, idle_seconds=330, max_connections=4):
+        if (isinstance(idle_seconds, bool) or not isinstance(idle_seconds, (int, float))
+                or not math.isfinite(idle_seconds) or not .01 <= idle_seconds <= 600
+                or type(max_connections) is not int or not 1 <= max_connections <= 4):
+            raise RelayRejected("invalid_relay_budget")
+        self.idle_seconds, self.max_connections = idle_seconds, max_connections
+        self.server = self.thread = None
+
+    def __enter__(self):
+        if self.server is not None:
+            raise RelayRejected("relay_already_started")
+        path = Path(RESPONSES_SOCKET)
+        try:
+            info = path.stat()
+            if path.is_symlink() or not stat.S_ISSOCK(info.st_mode) or info.st_uid != os.getuid() or info.st_mode & 0o077:
+                raise RelayRejected("invalid_fixed_responses_socket")
+        except OSError:
+            raise RelayRejected("fixed_responses_socket_missing") from None
+        server = _Server(("127.0.0.1", 0), _Handler)
+        server.idle_seconds = self.idle_seconds
+        server.stopping = threading.Event()
+        server.lock = threading.Lock()
+        server.pairs = set()
+        server.slots = threading.BoundedSemaphore(self.max_connections)
+        self.server = server
+        self.thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": .05}, daemon=True)
+        try:
+            self.thread.start()
+        except BaseException:
+            server.server_close()
+            self.server = None
+            raise
+        return self
+
+    @property
+    def base_url(self):
+        if self.server is None:
+            raise RelayRejected("relay_not_started")
+        return "http://127.0.0.1:" + str(self.server.server_address[1]) + "/v1"
+
+    def close(self):
+        if self.server is None:
+            return
+        self.server.stopping.set()
+        self.server.shutdown()
+        with self.server.lock:
+            pairs = tuple(self.server.pairs)
+        for pair in pairs:
+            for connection in pair:
+                try:
+                    connection.shutdown(socket.SHUT_RDWR)
+                except OSError:
+                    pass
+        self.server.server_close()
+        self.thread.join(timeout=1)
+        self.server = None
+
+    def __exit__(self, *_):
+        self.close()

--- a/tools/isolated_sqlite_mcp.py
+++ b/tools/isolated_sqlite_mcp.py
@@ -1,0 +1,258 @@
+"""Research-only SQLite MCP with three read contracts and connection-level denial.
+
+The parent must bind the intended arm DB and enforce its model namespace/mount
+boundary. This service is NOT proof of whole-process or whole-OS isolation.
+It opens fresh read-only connections so committed agent-side changes remain
+visible; it never creates a database or substitutes a frozen portfolio.
+"""
+import argparse
+import asyncio
+from contextlib import closing
+import math
+from pathlib import Path
+import sqlite3
+import sys
+import time
+import uuid
+
+from mcp import types
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+
+MAX_SQL_BYTES = 16384
+MAX_CELL_OR_ROW_BYTES = 65536
+PURE_FUNCTIONS = frozenset({
+    "abs", "round", "coalesce", "ifnull", "nullif", "length", "lower", "upper",
+    "trim", "ltrim", "rtrim", "substr", "substring", "replace", "instr",
+    "like", "glob", "typeof", "date", "datetime", "julianday", "strftime",
+    "unixepoch", "timediff", "sum", "total", "avg", "count", "min", "max",
+    "group_concat", "json_extract", "json_valid", "json_type",
+    "json_array_length", "->", "->>", "sqlite_version",
+})
+ERROR_CODES = frozenset({
+    "INVALID_DATABASE", "INVALID_ARGUMENTS", "INVALID_QUERY", "QUERY_REJECTED",
+    "QUERY_TIMEOUT", "ROW_LIMIT", "RESULT_LIMIT", "UNKNOWN_TABLE", "UNKNOWN_TOOL",
+    "UNSUPPORTED_SQLITE_RUNTIME",
+})
+
+
+class ReadOnlyError(ValueError):
+    def __init__(self, code):
+        self.code = code if code in ERROR_CODES else "QUERY_REJECTED"
+        super().__init__(self.code)
+
+
+def read_authorizer(action, first, second, database, _trigger, *, main_tables=frozenset()):
+    """Default deny, including ATTACH, writes, transaction control and functions."""
+    if action == sqlite3.SQLITE_SELECT:
+        return sqlite3.SQLITE_OK
+    if action == sqlite3.SQLITE_READ and database == "main":
+        return sqlite3.SQLITE_OK
+    # SQLite's COUNT(*) optimization sometimes omits the database name. Only
+    # allow that form for a table verified on this fresh main connection.
+    if action == sqlite3.SQLITE_READ and database is None and second == "" and first in main_tables:
+        return sqlite3.SQLITE_OK
+    if action == sqlite3.SQLITE_FUNCTION and (second or first or "").lower() in PURE_FUNCTIONS:
+        return sqlite3.SQLITE_OK
+    if action == sqlite3.SQLITE_PRAGMA and first == "table_info":
+        return sqlite3.SQLITE_OK
+    return sqlite3.SQLITE_DENY
+
+
+def _disable_extensions(conn):
+    setter = getattr(conn, "enable_load_extension", None)
+    if callable(setter):
+        setter(False)
+        return
+    # Some Python builds omit the setter while SQLite still exposes the SQL
+    # function. Verify its fresh-connection disabled state BEFORE installing
+    # our authorizer. Only the exact authorization denial is accepted.
+    probe = Path("/") / (".prism-extension-probe-" + uuid.uuid4().hex + "-absent")
+    if probe.exists():
+        raise ReadOnlyError("UNSUPPORTED_SQLITE_RUNTIME")
+    try:
+        conn.execute("SELECT load_extension(?)", (str(probe),))
+    except sqlite3.Error as error:
+        if str(error).strip().lower() == "not authorized":
+            return
+    raise ReadOnlyError("UNSUPPORTED_SQLITE_RUNTIME")
+
+
+class ReadOnlyDatabase:
+    def __init__(self, db_path, *, max_rows=200, max_result_bytes=131072, query_timeout=2.0):
+        try:
+            path = Path(db_path)
+            if not path.is_absolute() or path.is_symlink() or not path.is_file():
+                raise ValueError()
+            self.path = path.resolve(strict=True)
+        except (ValueError, TypeError, OSError):
+            raise ReadOnlyError("INVALID_DATABASE") from None
+        if (type(max_rows) is not int or not 1 <= max_rows <= 1000
+                or type(max_result_bytes) is not int or not 1 <= max_result_bytes <= 1048576
+                or isinstance(query_timeout, bool) or not isinstance(query_timeout, (int, float))
+                or not math.isfinite(query_timeout) or not 0 < query_timeout <= 5):
+            raise ReadOnlyError("INVALID_ARGUMENTS")
+        self.max_rows, self.max_result_bytes, self.query_timeout = max_rows, max_result_bytes, query_timeout
+
+    def _connect(self, progress=None):
+        try:
+            conn = sqlite3.connect(self.path.as_uri() + "?mode=ro", uri=True, timeout=min(0.25, self.query_timeout))
+        except sqlite3.Error:
+            raise ReadOnlyError("INVALID_DATABASE") from None
+        try:
+            conn.row_factory = sqlite3.Row
+            if progress is not None:
+                conn.set_progress_handler(progress, 1000)
+            _disable_extensions(conn)
+            conn.setlimit(sqlite3.SQLITE_LIMIT_LENGTH, MAX_CELL_OR_ROW_BYTES)
+            conn.setlimit(sqlite3.SQLITE_LIMIT_SQL_LENGTH, MAX_SQL_BYTES)
+            conn.setlimit(sqlite3.SQLITE_LIMIT_COLUMN, 128)
+            conn.setlimit(sqlite3.SQLITE_LIMIT_EXPR_DEPTH, 100)
+            conn.setlimit(sqlite3.SQLITE_LIMIT_COMPOUND_SELECT, 16)
+            conn.setlimit(sqlite3.SQLITE_LIMIT_VDBE_OP, 50000)
+            conn.setlimit(sqlite3.SQLITE_LIMIT_ATTACHED, 0)
+            conn.execute("PRAGMA query_only=ON")
+            if conn.execute("PRAGMA query_only").fetchone()[0] != 1:
+                raise ReadOnlyError("UNSUPPORTED_SQLITE_RUNTIME")
+            names = conn.execute("SELECT name FROM main.sqlite_master WHERE type IN ('table','view')").fetchmany(1001)
+            if len(names) > 1000:
+                raise ReadOnlyError("UNSUPPORTED_SQLITE_RUNTIME")
+            main_tables = frozenset(row[0] for row in names) | {"sqlite_master", "sqlite_schema"}
+            conn.set_authorizer(lambda *args: read_authorizer(*args, main_tables=main_tables))
+            return conn
+        except Exception:
+            conn.close()
+            raise ReadOnlyError("UNSUPPORTED_SQLITE_RUNTIME") from None
+
+    def _execute(self, query, parameters=()):
+        deadline = time.monotonic() + self.query_timeout
+        timed_out = False
+        def progress():
+            nonlocal timed_out
+            timed_out = time.monotonic() >= deadline
+            return 1 if timed_out else 0
+        try:
+            with closing(self._connect(progress)) as conn:
+                with closing(conn.cursor()) as cursor:
+                    cursor.execute(query, parameters)
+                    records = cursor.fetchmany(self.max_rows + 1)
+                    if len(records) > self.max_rows:
+                        raise ReadOnlyError("ROW_LIMIT")
+                    result = [dict(row) for row in records]
+                    if len(str(result).encode("utf-8")) > self.max_result_bytes:
+                        raise ReadOnlyError("RESULT_LIMIT")
+                    if time.monotonic() >= deadline:
+                        raise ReadOnlyError("QUERY_TIMEOUT")
+                    return result
+        except ReadOnlyError:
+            if timed_out:
+                raise ReadOnlyError("QUERY_TIMEOUT") from None
+            raise
+        except (sqlite3.Error, MemoryError, OverflowError, UnicodeError):
+            raise ReadOnlyError("QUERY_TIMEOUT" if timed_out or time.monotonic() >= deadline else "QUERY_REJECTED") from None
+
+    def list_tables(self):
+        return self._execute("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+
+    def describe_table(self, table_name):
+        try:
+            valid = isinstance(table_name, str) and bool(table_name) and len(table_name.encode("utf-8")) <= 256
+        except UnicodeError:
+            valid = False
+        if not valid:
+            raise ReadOnlyError("UNKNOWN_TABLE")
+        existing = self._execute("SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table_name,))
+        if not existing:
+            raise ReadOnlyError("UNKNOWN_TABLE")
+        escaped = table_name.replace('"', '""')
+        return self._execute('PRAGMA table_info("' + escaped + '")')
+
+    def read_query(self, query):
+        try:
+            valid = isinstance(query, str) and 0 < len(query.encode("utf-8")) <= MAX_SQL_BYTES
+        except UnicodeError:
+            valid = False
+        # Compatibility syntax check only; the connection/authorizer enforce safety.
+        if not valid or not query.strip().upper().startswith("SELECT"):
+            raise ReadOnlyError("INVALID_QUERY")
+        return self._execute(query)
+
+
+def read_tools():
+    return [
+        types.Tool(name="list_tables", description="List tables in the bound read-only database.",
+                   inputSchema={"type": "object", "properties": {}, "additionalProperties": False}),
+        types.Tool(name="describe_table", description="Describe columns of an existing table.",
+                   inputSchema={"type": "object", "properties": {"table_name": {"type": "string"}},
+                                "required": ["table_name"], "additionalProperties": False}),
+        types.Tool(name="read_query", description="Run a bounded read-only SELECT. Narrow results with LIMIT; excess rows are rejected, not truncated.",
+                   inputSchema={"type": "object", "properties": {"query": {"type": "string"}},
+                                "required": ["query"], "additionalProperties": False}),
+    ]
+
+
+async def call_read_tool(database, name, arguments):
+    try:
+        if type(arguments) is not dict:
+            raise ReadOnlyError("INVALID_ARGUMENTS")
+        if name == "list_tables":
+            if arguments:
+                raise ReadOnlyError("INVALID_ARGUMENTS")
+            result = await asyncio.to_thread(database.list_tables)
+        elif name == "describe_table":
+            if set(arguments) != {"table_name"}:
+                raise ReadOnlyError("INVALID_ARGUMENTS")
+            result = await asyncio.to_thread(database.describe_table, arguments["table_name"])
+        elif name == "read_query":
+            if set(arguments) != {"query"}:
+                raise ReadOnlyError("INVALID_ARGUMENTS")
+            result = await asyncio.to_thread(database.read_query, arguments["query"])
+        else:
+            raise ReadOnlyError("UNKNOWN_TOOL")
+        return types.CallToolResult(content=[types.TextContent(type="text", text=str(result))], isError=False)
+    except ReadOnlyError as error:
+        return types.CallToolResult(content=[types.TextContent(type="text", text="Error: " + error.code)], isError=True)
+    except Exception:
+        return types.CallToolResult(content=[types.TextContent(type="text", text="Error: QUERY_REJECTED")], isError=True)
+
+
+def create_server(database):
+    server = Server("isolated-sqlite-readonly")
+    lock = asyncio.Semaphore(1)
+    @server.list_tools()
+    async def list_tools():
+        return read_tools()
+    # Validate ourselves so SDK schema errors cannot echo raw arguments.
+    @server.call_tool(validate_input=False)
+    async def call_tool(name, arguments):
+        async with lock:
+            return await call_read_tool(database, name, arguments if arguments is not None else {})
+    return server
+
+
+async def serve(db_path):
+    database = ReadOnlyDatabase(db_path)
+    server = create_server(database)
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, server.create_initialization_options())
+
+
+class _SafeArgumentParser(argparse.ArgumentParser):
+    def error(self, _message):
+        raise ReadOnlyError("INVALID_ARGUMENTS")
+
+
+def main():
+    try:
+        parser = _SafeArgumentParser(description=__doc__)
+        parser.add_argument("--db-path", required=True)
+        args = parser.parse_args()
+        asyncio.run(serve(args.db_path))
+    except Exception:
+        print("Error: READ_ONLY_SERVICE_UNAVAILABLE", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Add supervisor-registered bounded Codex invocation RPC, read-only SQLite MCP and fixed Unix Responses relay. These components do not enable any trading path or schedule. No model/order/production DB invoked by tests. Local 67 tests pass; affected SQLite3.26 Linux compatibility and real SDK relay tests passed. Independent architect component approvals obtained. Whole-case cleanup and real SHADOW are separate remaining gates.