### PR TITLE
feat: disabled no-order ledger effects and fast-stop comparison

### DIFF
--- a/prism_core/isolated_strategy_effects.py
+++ b/prism_core/isolated_strategy_effects.py
@@ -1,0 +1,255 @@
+"""Disabled no-order effects seam; not an eligibility engine or execution receipt.
+
+The supervisor must authenticate registration provenance. This in-process type
+check is not a security boundary; the namespace supplies that boundary. Legacy
+execution guards deliberately remain unchanged until all helper effects are
+reviewed. Projection failure never rolls back a committed strategy event.
+"""
+from dataclasses import dataclass
+from contextlib import closing
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+import hashlib
+import json
+from pathlib import Path
+import re
+from zoneinfo import ZoneInfo
+
+from prism_core.isolated_agent_runtime import IsolatedAgentRuntime
+from prism_core.strategy_ledger import StrategyLedger
+
+EFFECTS_RUNTIME_ENABLED = False
+
+
+class EffectsFailure(RuntimeError):
+    """Sanitized case failure, never a successful empty batch."""
+
+
+@dataclass(frozen=True)
+class EffectsRegistration:
+    case_id: str
+    book_id: str
+    source_hash: str
+    occurred_at: str
+    campaigns: tuple
+    clock_timezone: str = "Asia/Seoul"
+    # (ticker, canonical campaign hash, original normalized units, frozen scenario JSON)
+    exit_bases: tuple = ()
+
+    def __post_init__(self):
+        try:
+            identifiers = [self.case_id, self.book_id]
+            if type(self.campaigns) is not tuple or not 1 <= len(self.campaigns) <= 10:
+                raise ValueError()
+            for pair in self.campaigns:
+                if type(pair) is not tuple or len(pair) != 2:
+                    raise ValueError()
+                identifiers.extend(pair)
+            if any(not isinstance(v, str) or not re.fullmatch(r"[A-Za-z0-9._:-]{1,128}", v)
+                   for v in identifiers):
+                raise ValueError()
+            if len(dict(self.campaigns)) != len(self.campaigns) or len({c for _, c in self.campaigns}) != len(self.campaigns):
+                raise ValueError()
+            if not isinstance(self.source_hash, str) or not re.fullmatch(r"[a-f0-9]{64}", self.source_hash):
+                raise ValueError()
+            if datetime.fromisoformat(self.occurred_at.replace("Z", "+00:00")).utcoffset() is None:
+                raise ValueError()
+            # This must match the fixed isolated namespace TZ, NOT exchange TZ.
+            # Legacy KR and US analyzers both use naive datetime.now().
+            if self.clock_timezone != "Asia/Seoul":
+                raise ValueError()
+            if type(self.exit_bases) is not tuple or len(self.exit_bases) > len(self.campaigns):
+                raise ValueError()
+            seen = set()
+            for basis in self.exit_bases:
+                if type(basis) is not tuple or len(basis) != 4:
+                    raise ValueError()
+                ticker, digest, units, scenario_json = basis
+                if ticker in seen or ticker not in dict(self.campaigns):
+                    raise ValueError()
+                seen.add(ticker)
+                if not isinstance(digest, str) or not re.fullmatch(r"[a-f0-9]{64}", digest):
+                    raise ValueError()
+                if not isinstance(units, str) or not Decimal(units).is_finite() or Decimal(units) <= 0:
+                    raise ValueError()
+                if not isinstance(scenario_json, str) or len(scenario_json) > 262144 or type(json.loads(scenario_json)) is not dict:
+                    raise ValueError()
+        except (TypeError, ValueError, AttributeError, InvalidOperation):
+            raise EffectsFailure("Invalid effects registration") from None
+
+
+def effects_for(agent, operation):
+    if getattr(agent, "_isolated_runtime", None) is None:
+        return None
+    if not EFFECTS_RUNTIME_ENABLED:
+        raise RuntimeError("No-order effects require independent runtime review")
+    adapter = getattr(agent, "_no_order_effects", None)
+    if (operation not in {"process_reports", "update_holdings"}
+            or type(adapter) is not IsolatedStrategyEffects or adapter.agent is not agent):
+        raise EffectsFailure("Unbound or unsupported no-order operation")
+    adapter._validate_binding()
+    return adapter
+
+
+class IsolatedStrategyEffects:
+    def __init__(self, agent, ledger, registration):
+        if type(registration) is not EffectsRegistration or type(ledger) is not StrategyLedger:
+            raise EffectsFailure("Typed effects registration and ledger required")
+        self.agent, self.ledger, self.registration = agent, ledger, registration
+        self.runtime = getattr(agent, "_isolated_runtime", None)
+        self._validate_binding()
+
+    def _validate_binding(self):
+        try:
+            runtime = self.runtime
+            if type(runtime) is not IsolatedAgentRuntime or self.agent._isolated_runtime is not runtime:
+                raise ValueError()
+            # Multi-account production passes must not multiply strategy rows.
+            # This first integration supports one explicit virtual portfolio.
+            if len(runtime.accounts()) != 1 or self.agent.db_path != runtime.db_path:
+                raise ValueError()
+            with closing(runtime.connect()) as check:
+                check.execute("SELECT owner_hash FROM prism_virtual_runtime WHERE id=1").fetchone()
+            databases = self.agent.conn.execute("PRAGMA database_list").fetchall()
+            if len(databases) != 1 or Path(databases[0][2]).resolve() != Path(runtime.db_path):
+                raise ValueError()
+            ledger_path = Path(self.ledger.path)
+            if (not ledger_path.is_relative_to(runtime.root) or ledger_path == Path(runtime.db_path)
+                    or ledger_path.is_symlink()):
+                raise ValueError()
+            book = self.ledger.snapshot(self.registration.book_id)
+            if book["market"] != runtime.market or book["mode"] != "SHADOW":
+                raise ValueError()
+        except Exception:
+            raise EffectsFailure("Isolated effects binding is invalid") from None
+
+    def _identity(self, ticker, operation):
+        self._validate_binding()
+        campaign = dict(self.registration.campaigns).get(ticker)
+        if campaign is None:
+            raise EffectsFailure("Ticker is not registered for this case")
+        if operation in {"exit", "pilot_advance"}:
+            candidates = self.ledger.snapshot(self.registration.book_id)["campaigns"]
+            if not any(c["campaign_id"] == campaign and c["book_id"] == self.registration.book_id
+                       and c["symbol"] == ticker for c in candidates):
+                raise EffectsFailure("Registered campaign identity does not match the book and ticker")
+        payload = [self.registration.case_id, self.registration.book_id, campaign, operation]
+        return campaign, "isolated:" + hashlib.sha256(json.dumps(payload).encode()).hexdigest()
+
+    def _finish(self, snapshot, ticker, company_name, scenario):
+        try:
+            self._project(snapshot, ticker, company_name, scenario)
+        except Exception:
+            raise EffectsFailure("Strategy committed; isolated projection requires recovery") from None
+        return snapshot["event_applied"]
+
+    def record_entry(self, *, ticker, company_name, price, scenario, is_add):
+        campaign, event = self._identity(ticker, "entry")
+        if is_add is not False:
+            raise EffectsFailure("Ordinary pyramiding is unavailable; use the pilot lifecycle")
+        if (type(scenario) is not dict
+                or self.ledger.snapshot(self.registration.book_id)["cohort"] == "split-pilot-v1"
+                or not isinstance(scenario.get("regime_entry_policy", {}), dict)
+                or scenario.get("regime_entry_policy", {}).get("mode") == "rebound_pilot"):
+            raise EffectsFailure("Explicit pilot entry contract required")
+        try:
+            snapshot = self.ledger.apply_target(event, self.registration.book_id, campaign,
+                ticker, 100, price, self.registration.occurred_at,
+                source_hash=self.registration.source_hash, reason="ISOLATED_AGENT_SELECTED_ENTRY")
+        except Exception:
+            raise EffectsFailure("Strategy entry failed") from None
+        return self._finish(snapshot, ticker, company_name, scenario)
+
+    def open_pilot(self, *, ticker, company_name, price, scenario, signal_bar, calendar, entry_eligible):
+        campaign, event = self._identity(ticker, "pilot_open")
+        try:
+            snapshot = self.ledger.open_pilot(event, self.registration.book_id, campaign,
+                ticker, price, self.registration.occurred_at, owner="split-pilot-v1",
+                signal_bar=signal_bar, calendar=calendar, entry_eligible=entry_eligible)
+        except Exception:
+            raise EffectsFailure("Strategy pilot entry failed") from None
+        return self._finish(snapshot, ticker, company_name, scenario)
+
+    def advance_pilot(self, *, ticker, company_name, scenario, expected_revision, evidence):
+        campaign, event = self._identity(ticker, "pilot_advance")
+        try:
+            snapshot = self.ledger.advance_pilot(event, campaign, expected_revision=expected_revision,
+                evidence=evidence, occurred_at=self.registration.occurred_at)
+        except Exception:
+            raise EffectsFailure("Strategy pilot transition failed") from None
+        return self._finish(snapshot, ticker, company_name, scenario)
+
+    def record_exit(self, *, ticker, price, fraction=1):
+        campaign, event = self._identity(ticker, "exit")
+        try:
+            fraction = Decimal(str(fraction))
+            if not fraction.is_finite() or not 0 < fraction <= 1:
+                raise ValueError()
+            state = self.ledger.snapshot(self.registration.book_id)
+            holding = next(c for c in state["campaigns"] if c["campaign_id"] == campaign)
+            basis = next((b for b in self.registration.exit_bases if b[0] == ticker), None)
+            if fraction != 1 and basis is None:
+                raise ValueError("Partial exits require a registered unit basis")
+            kwargs, scenario = {}, {}
+            if basis is not None:
+                kwargs = {"quantity": Decimal(basis[2]) * fraction, "expected_campaign_hash": basis[1],
+                          "expected_normalized_units": basis[2]}
+                scenario = json.loads(basis[3])
+            snapshot = self.ledger.sell(event, campaign, price, self.registration.occurred_at,
+                source_hash=self.registration.source_hash, **kwargs)
+        except Exception:
+            raise EffectsFailure("Strategy exit failed") from None
+        return self._finish(snapshot, ticker, holding["symbol"], scenario)
+
+    def _project(self, snapshot, ticker, company_name, scenario):
+        if snapshot["book_id"] != self.registration.book_id:
+            raise EffectsFailure("Projection book identity mismatch")
+        campaign = next(c for c in snapshot["campaigns"] if c["campaign_id"] == dict(self.registration.campaigns)[ticker])
+        if campaign["book_id"] != self.registration.book_id or campaign["symbol"] != ticker:
+            raise EffectsFailure("Projection campaign identity mismatch")
+        account = self.runtime.accounts()[0]
+        # Projection is explicitly price/weight based; no fictional cash or
+        # whole-share quantity is introduced to satisfy a legacy schema.
+        scenario = dict(scenario)
+        scenario["_strategy_projection"] = {
+            "book_id": self.registration.book_id, "campaign_id": campaign["campaign_id"],
+            "units_basis": "NORMALIZED_UNITS_NOT_SHARES", "account_execution_status": "UNKNOWN",
+            "normalized_units": campaign["normalized_units"],
+            "remaining_allocation": campaign["remaining_allocation"],
+            "cumulative_deployed_allocation": campaign["cumulative_deployed_allocation"],
+            "source_hash": self.registration.source_hash,
+            "strategy_event_at": campaign["last_event_at"],
+            "strategy_entry_at": campaign["legs"][0]["occurred_at"],
+        }
+        serialized = json.dumps(scenario, allow_nan=False)
+        # Only these two source-defined table names exist. No registration,
+        # model output, or caller-provided SQL participates in this mapping.
+        def query(sql, values):
+            if self.runtime.market == "US":
+                sql = sql.replace("stock_holdings", "us_stock_holdings")
+            return self.agent.conn.execute(sql, values)
+
+        with self.agent.conn:
+            rows = query("SELECT id, scenario FROM stock_holdings WHERE account_key=? AND ticker=?",
+                (account["account_key"], ticker)).fetchall()
+            if len(rows) > 1:
+                raise ValueError("Duplicate projected slot")
+            if rows:
+                existing = json.loads(rows[0][1]).get("_strategy_projection", {})
+                if (existing.get("campaign_id") != campaign["campaign_id"]
+                        or existing.get("book_id") != self.registration.book_id):
+                    raise ValueError("Foreign projected slot")
+            if campaign["status"] == "CLOSED":
+                query("DELETE FROM stock_holdings WHERE account_key=? AND ticker=?",
+                    (account["account_key"], ticker))
+                return
+            zone = ZoneInfo(self.registration.clock_timezone)
+            buy_date = datetime.fromisoformat(campaign["legs"][0]["occurred_at"].replace("Z", "+00:00")).astimezone(zone).strftime("%Y-%m-%d %H:%M:%S")
+            values = (account["account_key"], account["name"], ticker, company_name,
+                float(campaign["average_cost"]), buy_date,
+                float(campaign["mark_price"]), campaign["last_event_at"], serialized,
+                scenario.get("target_price"), scenario.get("stop_loss"), scenario.get("sector"))
+            if rows:
+                query("UPDATE stock_holdings SET account_key=?, account_name=?, ticker=?, company_name=?, buy_price=?, buy_date=?, current_price=?, last_updated=?, scenario=?, target_price=?, stop_loss=?, sector=? WHERE id=?", (*values, rows[0][0]))
+            else:
+                query("INSERT INTO stock_holdings (account_key, account_name, ticker, company_name, buy_price, buy_date, current_price, last_updated, scenario, target_price, stop_loss, sector) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)", values)

--- a/prism_core/shadow_fastlane.py
+++ b/prism_core/shadow_fastlane.py
@@ -1,0 +1,163 @@
+"""Disabled, pure no-order fast-lane comparison; not a scheduler or fill model.
+
+Source cron matching is not an exchange calendar. The caller must supply frozen
+session evidence and timestamped quotes/bars; this module retrieves nothing.
+Only deterministic ordinary TIER1 stops differ. Agent/fallback exits are outside
+this component and must never be vetoed by its WAIT/UNKNOWN observations.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import math
+from typing import Mapping, Sequence
+from zoneinfo import ZoneInfo
+
+from cores.oneil_fallback import SellInputs, evaluate_tier1_hardstop
+
+POLICY = "stop-fastlane-5m-v1"
+ENABLED = False
+_ZONES = {"KR": "Asia/Seoul", "US": "America/New_York"}
+
+
+@dataclass(frozen=True)
+class Holding:
+    holding_id: str
+    symbol: str
+    buy_price: float
+    stop_loss: float
+    entered_at: datetime
+
+
+@dataclass(frozen=True)
+class Quote:
+    price: float
+    observed_at: datetime
+    available_at: datetime
+    source_id: str
+
+
+@dataclass(frozen=True)
+class Bar:
+    start: datetime
+    end: datetime
+    close: float
+    available_at: datetime
+    source_id: str
+
+
+@dataclass(frozen=True)
+class Session:
+    opens_at: datetime
+    closes_at: datetime
+    source_id: str
+
+
+@dataclass(frozen=True)
+class Observation:
+    holding_id: str
+    at: datetime
+    baseline: str
+    candidate: str
+    catastrophic: bool | None
+    reason: str
+    quote_source_id: str | None
+    bar_source_id: str | None
+    session_source_id: str | None
+    source_cadence_match: bool
+
+
+def _aware(value: object) -> bool:
+    return isinstance(value, datetime) and value.utcoffset() is not None
+
+
+def _finite(value: object, *, zero: bool = False) -> bool:
+    return (not isinstance(value, bool) and isinstance(value, (int, float))
+            and math.isfinite(value) and (value >= 0 if zero else value > 0))
+
+
+def source_cadence_matches(market: str, at: datetime) -> bool:
+    """Frozen source cron union, including pre/post-session cron matches.
+
+    KR: 0-50/10 and 6-56/10, hours 9-15 weekdays, Seoul.
+    US: 4-54/10 and 8-58/10, hours 9-16 weekdays, New York (DST aware).
+    This does not assert that production has an exchange-holiday guard.
+    """
+    if market not in _ZONES or not _aware(at):
+        raise ValueError("invalid market or timestamp")
+    local = at.astimezone(ZoneInfo(_ZONES[market]))
+    residues, last_hour = ((0, 6), 15) if market == "KR" else ((4, 8), 16)
+    return (local.weekday() < 5 and 9 <= local.hour <= last_hour
+            and local.minute % 10 in residues)
+
+
+def observe(holdings: Sequence[Holding], quotes: Mapping[str, Quote],
+            bars: Mapping[str, Bar], *, at: datetime, market: str,
+            session: Session | None, max_quote_age_seconds: float) -> tuple[Observation, ...]:
+    """Evaluate every supplied holding once, with one shared source quote.
+
+    Quote-age tolerance is explicit caller policy, never a hidden global tuning.
+    The bar must be the latest completed aligned five-minute regular-session bar
+    available by this observation. No continuous-breach inference or execution
+    price is produced. Missing observations cannot be backfilled as successes.
+    """
+    cadence = source_cadence_matches(market, at)
+    if not _finite(max_quote_age_seconds, zero=True):
+        raise ValueError("invalid quote age limit")
+    ids = [h.holding_id for h in holdings]
+    if any(not isinstance(i, str) or not i for i in ids) or len(set(ids)) != len(ids):
+        raise ValueError("invalid or duplicate holding identity")
+    valid_session = (isinstance(session, Session) and bool(session.source_id)
+                     and _aware(session.opens_at) and _aware(session.closes_at)
+                     and session.opens_at <= at <= session.closes_at)
+    output = []
+    for holding in holdings:
+        quote = quotes.get(holding.symbol)
+        bar = bars.get(holding.symbol)
+
+        def result(baseline, candidate, catastrophic, reason):
+            return Observation(holding.holding_id, at, baseline, candidate,
+                               catastrophic, reason,
+                               quote.source_id if isinstance(quote, Quote) else None,
+                               bar.source_id if isinstance(bar, Bar) else None,
+                               session.source_id if isinstance(session, Session) else None,
+                               cadence)
+
+        if (not _finite(holding.buy_price) or not _finite(holding.stop_loss, zero=True)
+                or not _aware(holding.entered_at) or holding.entered_at > at):
+            output.append(result("UNKNOWN", "UNKNOWN", None, "HOLDING_INVALID"))
+            continue
+        if (not isinstance(quote, Quote) or not quote.source_id or not _finite(quote.price)
+                or not _aware(quote.observed_at) or not _aware(quote.available_at)
+                or not holding.entered_at <= quote.observed_at <= quote.available_at <= at
+                or (at - quote.observed_at).total_seconds() > max_quote_age_seconds):
+            output.append(result("UNKNOWN", "UNKNOWN", None, "QUOTE_UNAVAILABLE_OR_STALE"))
+            continue
+        baseline, _ = evaluate_tier1_hardstop(
+            SellInputs(holding.buy_price, quote.price, holding.stop_loss))
+        # Disable only scenario threshold to query the canonical absolute rule.
+        catastrophic, _ = evaluate_tier1_hardstop(SellInputs(holding.buy_price, quote.price))
+        if catastrophic:
+            output.append(result("EXIT", "EXIT", True, "CATASTROPHIC"))
+        elif not baseline:
+            output.append(result("HOLD", "HOLD", False, "NO_CURRENT_BREACH"))
+        elif not valid_session:
+            # Production hardstop has no calendar guard: do not suppress its
+            # baseline or catastrophic evaluation when session data is absent.
+            output.append(result("EXIT", "UNKNOWN", False, "SESSION_UNAVAILABLE_OR_CLOSED"))
+        else:
+            local = at.astimezone(ZoneInfo(_ZONES[market]))
+            latest_end = local.replace(minute=local.minute // 5 * 5, second=0, microsecond=0)
+            valid_bar = (isinstance(bar, Bar) and bool(bar.source_id) and _finite(bar.close)
+                         and all(_aware(t) for t in (bar.start, bar.end, bar.available_at))
+                         and bar.end == latest_end and bar.end - bar.start == timedelta(minutes=5)
+                         and max(session.opens_at, holding.entered_at) <= bar.start
+                         and bar.end <= session.closes_at and bar.end <= bar.available_at <= at)
+            if not valid_bar:
+                output.append(result("EXIT", "UNKNOWN", False, "COMPLETED_BAR_UNAVAILABLE"))
+            else:
+                confirmed, _ = evaluate_tier1_hardstop(
+                    SellInputs(holding.buy_price, bar.close, holding.stop_loss))
+                output.append(result("EXIT", "EXIT" if confirmed else "WAIT", False,
+                                     "ORDINARY_CONFIRMED" if confirmed else "ORDINARY_UNCONFIRMED"))
+    return tuple(output)

--- a/prism_core/strategy_ledger.py
+++ b/prism_core/strategy_ledger.py
@@ -431,6 +431,14 @@ class StrategyLedger:
                 self._notice(db, event_id, campaign_id, "PILOT_STATE")
             return {**self._snapshot(db, book["book_id"]), "event_applied": True}
 
+    def campaign_guard(self, campaign_id):
+        """Register a canonical strategy-unit basis, never a broker quantity."""
+        with self._transaction() as db:
+            campaign = self._get(db, "campaigns", campaign_id)
+            return {key: campaign[key] for key in ("campaign_id", "book_id", "symbol", "normalized_units")} | {
+                "campaign_hash": hashlib.sha256(_dump(campaign).encode()).hexdigest(),
+            }
+
     def sell(
         self,
         event_id,
@@ -441,6 +449,8 @@ class StrategyLedger:
         fee_rate=0,
         slippage_rate=0,
         source_hash=None,
+        expected_campaign_hash=None,
+        expected_normalized_units=None,
     ):
         """Reduce normalized units (quantity is NOT a broker share quantity)."""
         price = _number(price, positive=True)
@@ -457,11 +467,27 @@ class StrategyLedger:
             "slippage_rate": str(slippage_rate),
             "source_hash": source_hash,
         }
+        if expected_campaign_hash is not None:
+            if (not isinstance(expected_campaign_hash, str) or len(expected_campaign_hash) != 64
+                    or any(c not in "0123456789abcdef" for c in expected_campaign_hash)):
+                raise LedgerError("invalid expected campaign revision hash")
+            # Omitted on the default path: historical event hashes are stable.
+            payload["expected_campaign_hash"] = expected_campaign_hash
+        if expected_normalized_units is not None:
+            if expected_campaign_hash is None:
+                raise LedgerError("expected units require campaign revision hash")
+            payload["expected_normalized_units"] = str(_number(expected_normalized_units, positive=True))
         with self._transaction() as db:
             campaign = self._get(db, "campaigns", campaign_id)
             book_id = campaign["book_id"]
             if not self._event(db, event_id, payload):
                 return {**self._snapshot(db, book_id), "event_applied": False}
+            if (expected_campaign_hash is not None
+                    and hashlib.sha256(_dump(campaign).encode()).hexdigest() != expected_campaign_hash):
+                raise LedgerError("campaign revision conflict")
+            if (expected_normalized_units is not None
+                    and Decimal(campaign["normalized_units"]) != Decimal(payload["expected_normalized_units"])):
+                raise LedgerError("campaign normalized-unit basis conflict")
             book = self._get(db, "books", book_id)
             self._book_chronology(db, book, timestamp)
             self._chronology(campaign, timestamp)

--- a/tests/test_isolated_strategy_effects.py
+++ b/tests/test_isolated_strategy_effects.py
@@ -1,0 +1,279 @@
+"""No-order effects are unit-only until the independent runtime gate review."""
+import json
+from dataclasses import replace
+from datetime import datetime
+from zoneinfo import ZoneInfo
+from types import SimpleNamespace
+
+import pytest
+
+from prism_core.isolated_agent_runtime import prepare_isolated_runtime
+from prism_core import isolated_strategy_effects as effects
+from prism_core.strategy_ledger import StrategyLedger
+from prism_core.strategy_ledger_outbox import StrategyLedgerOutbox
+
+
+@pytest.fixture
+def bound(tmp_path):
+    tmp_path.chmod(0o700)
+    marker = tmp_path / ".prism-agent-isolation.json"
+    marker.write_text(json.dumps({"schema_version": 1, "purpose": "PRISM_AGENT_SHADOW", "market": "KR", "runtime_id": "test"}))
+    marker.chmod(0o600)
+    account = {"name": "SHADOW test", "account_key": "virtual:test", "market": "kr", "virtual": True}
+    runtime = prepare_isolated_runtime(str(tmp_path / "state.sqlite"), [account], tmp_path, lambda: {}, "KR")
+    conn = runtime.connect()
+    conn.row_factory = __import__("sqlite3").Row
+    conn.execute("CREATE TABLE stock_holdings (id INTEGER PRIMARY KEY, account_key TEXT, account_name TEXT, ticker TEXT, company_name TEXT, buy_price REAL, buy_date TEXT, current_price REAL, last_updated TEXT, scenario TEXT, target_price REAL, stop_loss REAL, trigger_type TEXT, trigger_mode TEXT, sector TEXT)")
+    conn.commit()
+    agent = SimpleNamespace(_isolated_runtime=runtime, conn=conn, cursor=conn.cursor(), db_path=runtime.db_path)
+    ledger = StrategyLedger(tmp_path / "strategy.sqlite")
+    ledger.create_book("book", "KR", mode="SHADOW")
+    registration = effects.EffectsRegistration(case_id="case1", book_id="book", source_hash="a" * 64,
+        occurred_at="2026-09-10T00:00:00Z", campaigns=(("005930", "campaign1"),))
+    adapter = effects.IsolatedStrategyEffects(agent, ledger, registration)
+    yield agent, ledger, adapter
+    conn.close()
+
+
+def enter(adapter):
+    return adapter.record_entry(ticker="005930", company_name="SYNTHETIC test", price=100,
+        scenario={"target_price": 120, "stop_loss": 90, "sector": "Technology"}, is_add=False)
+
+
+def test_gate_closed_and_direct_helpers_never_authorized(bound, monkeypatch):
+    agent, _, adapter = bound
+    agent._no_order_effects = adapter
+    with pytest.raises(RuntimeError, match="review"):
+        effects.effects_for(agent, "process_reports")
+    monkeypatch.setattr(effects, "EFFECTS_RUNTIME_ENABLED", True)
+    assert effects.effects_for(agent, "process_reports") is adapter
+    with pytest.raises(RuntimeError):
+        effects.effects_for(agent, "buy_stock")
+    assert effects.effects_for(SimpleNamespace(), "process_reports") is None
+
+
+@pytest.mark.parametrize("cash", [None, 0, 100000])
+def test_cash_never_changes_strategy_or_creates_execution(bound, cash):
+    agent, ledger, adapter = bound
+    agent.untrusted_account_cash = cash
+    assert enter(adapter)
+    snapshot = ledger.snapshot("book")
+    assert snapshot["occupied_slots"] == 1 and snapshot["executions"] == []
+    assert len(StrategyLedgerOutbox(ledger).pending()) == 1
+    row = dict(agent.cursor.execute("SELECT * FROM stock_holdings").fetchone())
+    projection = json.loads(row["scenario"])["_strategy_projection"]
+    assert projection["account_execution_status"] == "UNKNOWN"
+    assert projection["units_basis"] == "NORMALIZED_UNITS_NOT_SHARES"
+    assert row["buy_price"] == 100
+    assert row["buy_date"] == "2026-09-10 09:00:00"
+    assert not {"quantity", "cash", "investment_amount"} & row.keys()
+
+
+def test_duplicate_event_repairs_projection_without_new_notice(bound):
+    agent, ledger, adapter = bound
+    assert enter(adapter)
+    agent.cursor.execute("DELETE FROM stock_holdings")
+    agent.conn.commit()
+    assert not enter(adapter)
+    assert agent.cursor.execute("SELECT COUNT(*) FROM stock_holdings").fetchone()[0] == 1
+    assert len(StrategyLedgerOutbox(ledger).pending()) == 1
+    with pytest.raises(effects.EffectsFailure):
+        adapter.record_entry(ticker="005930", company_name="test", price=99, scenario={}, is_add=True)
+
+
+def test_projection_failure_keeps_committed_ledger_event(bound, monkeypatch):
+    _, ledger, adapter = bound
+    monkeypatch.setattr(adapter, "_project", lambda *args: (_ for _ in ()).throw(ValueError("secret")))
+    with pytest.raises(effects.EffectsFailure) as error:
+        enter(adapter)
+    assert "secret" not in str(error.value)
+    assert ledger.snapshot("book")["occupied_slots"] == 1
+    assert len(StrategyLedgerOutbox(ledger).pending()) == 1
+
+
+def test_exit_is_strategy_only_and_retry_idempotent(bound):
+    agent, ledger, adapter = bound
+    enter(adapter)
+    assert adapter.record_exit(ticker="005930", price=110)
+    assert not adapter.record_exit(ticker="005930", price=110)
+    snapshot = ledger.snapshot("book")
+    assert snapshot["occupied_slots"] == 0
+    assert snapshot["executions"] == []
+    assert agent.conn.execute("SELECT COUNT(*) FROM stock_holdings").fetchone()[0] == 0
+    assert len(StrategyLedgerOutbox(ledger).pending()) == 2
+
+
+@pytest.mark.parametrize("change", [
+    {"source_hash": "bad"}, {"occurred_at": "2026-09-10"},
+    {"campaigns": (("005930", "c"), ("005930", "d"))},
+    {"campaigns": (("005930", "c"), ("005931", "c"))},
+    {"case_id": []},
+])
+def test_invalid_registration_fails_before_effect(bound, change):
+    _, ledger, adapter = bound
+    with pytest.raises(effects.EffectsFailure):
+        replace(adapter.registration, **change)
+    assert ledger.snapshot("book")["occupied_slots"] == 0
+
+
+def test_binding_swap_and_unregistered_ticker_fail_closed(bound):
+    agent, ledger, adapter = bound
+    with pytest.raises(effects.EffectsFailure):
+        adapter.record_exit(ticker="OTHER", price=100)
+    agent._isolated_runtime = None
+    with pytest.raises(effects.EffectsFailure):
+        enter(adapter)
+    assert ledger.snapshot("book")["occupied_slots"] == 0
+
+
+def test_projection_refuses_foreign_holding(bound):
+    agent, ledger, adapter = bound
+    agent.conn.execute("INSERT INTO stock_holdings(account_key,ticker,scenario) VALUES(?,?,?)",
+                       ("virtual:test", "005930", "{}"))
+    agent.conn.commit()
+    with pytest.raises(effects.EffectsFailure, match="projection"):
+        enter(adapter)
+    assert agent.conn.execute("SELECT scenario FROM stock_holdings").fetchone()[0] == "{}"
+    assert ledger.snapshot("book")["occupied_slots"] == 1
+
+
+def test_partial_exit_denied_without_stable_registered_units(bound):
+    _, ledger, adapter = bound
+    enter(adapter)
+    with pytest.raises(effects.EffectsFailure):
+        adapter.record_exit(ticker="005930", price=100, fraction=.5)
+    assert ledger.snapshot("book")["remaining_allocation"] == "1"
+
+
+def test_registered_partial_exit_preserves_residual_scenario_and_repairs_once(bound):
+    agent, ledger, adapter = bound
+    enter(adapter)
+    guard = ledger.campaign_guard("campaign1")
+    original_scenario = agent.conn.execute("SELECT scenario FROM stock_holdings").fetchone()[0]
+    basis = ("005930", guard["campaign_hash"], guard["normalized_units"], original_scenario)
+    registration = replace(adapter.registration, exit_bases=(basis,))
+    adapter = effects.IsolatedStrategyEffects(agent, ledger, registration)
+    assert adapter.record_exit(ticker="005930", price=110, fraction=.5)
+    state = ledger.snapshot("book")
+    assert state["remaining_allocation"] == "0.5" and state["occupied_slots"] == 1
+    # Loss of a projection is repairable from the frozen registered scenario,
+    # not by recomputing half of the now-reduced holding.
+    agent.conn.execute("DELETE FROM stock_holdings")
+    agent.conn.commit()
+    assert not adapter.record_exit(ticker="005930", price=110, fraction=.5)
+    assert ledger.snapshot("book") == state
+    row = agent.conn.execute("SELECT scenario,target_price,stop_loss FROM stock_holdings").fetchone()
+    assert json.loads(row[0])["target_price"] == row[1] == 120
+    assert json.loads(row[0])["stop_loss"] == row[2] == 90
+    assert len(StrategyLedgerOutbox(ledger).pending()) == 2
+    stale = effects.IsolatedStrategyEffects(agent, ledger, replace(registration, case_id="stale"))
+    with pytest.raises(effects.EffectsFailure):
+        stale.record_exit(ticker="005930", price=110, fraction=.5)
+    assert ledger.snapshot("book") == state
+
+
+def test_exit_basis_units_must_match_canonical_hash_state(bound):
+    agent, ledger, adapter = bound
+    enter(adapter)
+    guard = ledger.campaign_guard("campaign1")
+    scenario = agent.conn.execute("SELECT scenario FROM stock_holdings").fetchone()[0]
+    registration = replace(adapter.registration,
+        exit_bases=(("005930", guard["campaign_hash"], "0.02", scenario),))
+    adapter = effects.IsolatedStrategyEffects(agent, ledger, registration)
+    before = ledger.snapshot("book")
+    with pytest.raises(effects.EffectsFailure):
+        adapter.record_exit(ticker="005930", price=110, fraction=.5)
+    assert ledger.snapshot("book") == before
+
+
+def test_pilot_scenario_cannot_silently_become_full_entry(bound):
+    _, ledger, adapter = bound
+    with pytest.raises(effects.EffectsFailure):
+        adapter.record_entry(ticker="005930", company_name="test", price=100,
+            scenario={"regime_entry_policy": {"mode": "rebound_pilot"}}, is_add=False)
+    assert ledger.snapshot("book")["occupied_slots"] == 0
+
+
+@pytest.mark.parametrize("operation", ["exit", "advance"])
+@pytest.mark.parametrize("foreign", ["book", "symbol"])
+def test_registered_campaign_cannot_mutate_foreign_identity(bound, operation, foreign):
+    agent, ledger, adapter = bound
+    ledger.create_book("other", "KR", cohort="other-v1", mode="SHADOW")
+    ledger.apply_target("foreign", "other" if foreign == "book" else "book", "campaign1",
+        "OTHER" if foreign == "symbol" else "005930", 100, 100, adapter.registration.occurred_at)
+    before = ledger.snapshot("other" if foreign == "book" else "book")
+    with pytest.raises(effects.EffectsFailure, match="identity"):
+        if operation == "exit":
+            adapter.record_exit(ticker="005930", price=110)
+        else:
+            adapter.advance_pilot(ticker="005930", company_name="test", scenario={}, expected_revision=0, evidence={})
+    assert ledger.snapshot("other" if foreign == "book" else "book") == before
+    assert agent.conn.execute("SELECT COUNT(*) FROM stock_holdings").fetchone()[0] == 0
+
+
+@pytest.mark.parametrize("entry_at", ["2026-03-08T07:00:00Z", "2026-11-01T06:00:00Z"])
+def test_us_projection_uses_us_table_and_real_price(tmp_path, entry_at):
+    tmp_path.chmod(0o700)
+    marker = tmp_path / ".prism-agent-isolation.json"
+    marker.write_text(json.dumps({"schema_version": 1, "purpose": "PRISM_AGENT_SHADOW", "market": "US", "runtime_id": "test"}))
+    marker.chmod(0o600)
+    runtime = prepare_isolated_runtime(str(tmp_path / "state.sqlite"),
+        [{"name": "SHADOW test", "account_key": "virtual:test", "market": "us", "virtual": True}], tmp_path, lambda: {}, "US")
+    conn = runtime.connect()
+    try:
+        conn.execute("CREATE TABLE us_stock_holdings (id INTEGER PRIMARY KEY, account_key TEXT, account_name TEXT, ticker TEXT, company_name TEXT, buy_price REAL, buy_date TEXT, current_price REAL, last_updated TEXT, scenario TEXT, target_price REAL, stop_loss REAL, sector TEXT)")
+        conn.commit()
+        agent = SimpleNamespace(_isolated_runtime=runtime, conn=conn, db_path=runtime.db_path)
+        ledger = StrategyLedger(tmp_path / "strategy.sqlite")
+        ledger.create_book("book", "US", mode="SHADOW")
+        registration = effects.EffectsRegistration("case", "book", "a" * 64, entry_at, (("SNDK", "campaign"),))
+        adapter = effects.IsolatedStrategyEffects(agent, ledger, registration)
+        assert adapter.record_entry(ticker="SNDK", company_name="SYNTHETIC test", price=100, scenario={}, is_add=False)
+        assert conn.execute("SELECT buy_price FROM us_stock_holdings").fetchone()[0] == 100
+        buy_date, scenario = conn.execute("SELECT buy_date, scenario FROM us_stock_holdings").fetchone()
+        aware = datetime.fromisoformat(entry_at.replace("Z", "+00:00"))
+        runtime_now = aware.astimezone(ZoneInfo("Asia/Seoul")).replace(tzinfo=None)
+        assert runtime_now - datetime.strptime(buy_date, "%Y-%m-%d %H:%M:%S") == __import__("datetime").timedelta(0)
+        assert datetime.fromisoformat(json.loads(scenario)["_strategy_projection"]["strategy_entry_at"]) == aware
+        assert adapter.record_exit(ticker="SNDK", price=101)
+        assert conn.execute("SELECT COUNT(*) FROM us_stock_holdings").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_pilot_uses_one_slot_and_only_remaining_half_once(bound):
+    agent, ledger, adapter = bound
+    ledger.create_book("pilot", "KR", cohort="split-pilot-v1", mode="SHADOW")
+    registration = replace(adapter.registration, book_id="pilot", occurred_at="2026-09-10T09:05:00+09:00")
+    adapter = effects.IsolatedStrategyEffects(agent, ledger, registration)
+    calendar = {"market": "KR", "timezone": "Asia/Seoul", "source_kind": "test_fixture",
+        "source_ref": "synthetic-session-fixture", "verification_status": "VERIFIED",
+        "sessions": [{"date": day, "open_at": day + "T09:00:00+09:00", "close_at": day + "T15:30:00+09:00"}
+                     for day in ("2026-09-10", "2026-09-11", "2026-09-14", "2026-09-15")]}
+    bar = {"open_at": "2026-09-10T09:00:00+09:00", "close_at": registration.occurred_at,
+        "close": 100, "high": 102, "completed": True, "observed_at": registration.occurred_at}
+    args = dict(ticker="005930", company_name="SYNTHETIC test", price=100, scenario={},
+                signal_bar=bar, calendar=calendar, entry_eligible=True)
+    assert adapter.open_pilot(**args)
+    assert not adapter.open_pilot(**args)
+    assert ledger.snapshot("pilot")["remaining_allocation"] == "0.5"
+    assert ledger.snapshot("pilot")["occupied_slots"] == 1
+    with pytest.raises(effects.EffectsFailure):
+        adapter.record_entry(ticker="005930", company_name="test", price=105, scenario={}, is_add=True)
+    now = "2026-09-11T09:35:00+09:00"
+    adapter = effects.IsolatedStrategyEffects(agent, ledger, replace(registration, case_id="next", occurred_at=now))
+    evidence = {"observed_at": now, "thesis_valid": True, "market_regime": "sideways", "pulse": "UPTREND",
+        "bar": {"open_at": "2026-09-11T09:05:00+09:00", "close_at": "2026-09-11T09:30:00+09:00",
+                "close": 103, "high": 104, "completed": True, "observed_at": now},
+        "quote": {"price": 104, "observed_at": now},
+        "ai": {"decision": "Enter", "score": 7, "ordinary_min_score": 7, "observed_at": now},
+        "gates": {name: True for name in ("risk", "regime", "pulse", "risk_reward", "sector", "slot")}}
+    advance = dict(ticker="005930", company_name="test", scenario={}, expected_revision=0, evidence=evidence)
+    assert adapter.advance_pilot(**advance)
+    assert not adapter.advance_pilot(**advance)
+    result = ledger.snapshot("pilot")
+    assert result["occupied_slots"] == 1
+    assert result["campaigns"][0]["cumulative_deployed_allocation"] == "1.0"
+    assert len(result["campaigns"][0]["legs"]) == 2
+    assert agent.conn.execute("SELECT COUNT(*) FROM stock_holdings").fetchone()[0] == 1
+    assert result["executions"] == []

--- a/tests/test_shadow_fastlane.py
+++ b/tests/test_shadow_fastlane.py
@@ -1,0 +1,124 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from cores.oneil_fallback import SellInputs, evaluate_tier1_hardstop
+from prism_core.shadow_fastlane import (
+    Bar, Holding, Quote, Session, observe, source_cadence_matches,
+)
+
+NOW = datetime(2026, 9, 10, 1, 6, tzinfo=timezone.utc)
+SESSION = Session(NOW.replace(hour=0, minute=0), NOW.replace(hour=6, minute=30), "fixture-calendar")
+H = Holding("one", "005930", 100, 98, NOW - timedelta(hours=1))
+
+
+def run(price=97, bar=None, quote=True, session=SESSION):
+    quotes = {H.symbol: Quote(price, NOW, NOW, "source-1")} if quote else {}
+    return observe((H,), quotes, {H.symbol: bar} if bar else {}, at=NOW,
+                   market="KR", session=session, max_quote_age_seconds=30)[0]
+
+
+def bar(close=97, **kw):
+    return Bar(kw.get("start", NOW.replace(minute=0)),
+               kw.get("end", NOW.replace(minute=5)), close,
+               kw.get("available_at", NOW), "bar-source-1")
+
+
+def test_baseline_reuses_exact_production_predicate():
+    for price in [90, 93, 93.00001, 97, 97.51, 98, 110]:
+        result = run(price, bar(price))
+        expected = evaluate_tier1_hardstop(SellInputs(100, price, 98))[0]
+        assert result.baseline == ("EXIT" if expected else "HOLD")
+
+
+def test_ordinary_requires_completed_confirmation_not_wick():
+    assert run(bar=bar()).candidate == "EXIT"
+    assert run(bar=bar(99)).candidate == "WAIT"
+    assert run().candidate == "UNKNOWN"
+    assert run(price=99, bar=bar()).candidate == "HOLD"
+
+
+@pytest.mark.parametrize("bad_bar", [bar(end=NOW + timedelta(minutes=4)),
+    bar(available_at=NOW + timedelta(seconds=1)),
+    bar(start=NOW.replace(minute=0)-timedelta(minutes=5), end=NOW.replace(minute=0)),
+    bar(close=float("nan"))])
+def test_missing_future_stale_invalid_bar_never_confirms(bad_bar):
+    assert run(bar=bad_bar).candidate == "UNKNOWN"
+
+
+def test_catastrophic_never_waits_for_bar_even_when_scenario_reason_wins():
+    result = run(90)
+    assert result.baseline == result.candidate == "EXIT"
+    assert result.catastrophic is True
+    assert result.quote_source_id == "source-1"
+    assert result.at == NOW
+
+
+def test_missing_quote_and_session_are_explicit_unknown():
+    assert run(quote=False).baseline == "UNKNOWN"
+    assert run(session=None).candidate == "UNKNOWN"
+    assert run(session=None).baseline == "EXIT"
+    assert run(90, session=None).candidate == "EXIT"
+
+
+@pytest.mark.parametrize("quote", [
+    Quote(float("inf"), NOW, NOW, "q"),
+    Quote(97, NOW - timedelta(seconds=31), NOW, "q"),
+    Quote(97, NOW, NOW + timedelta(seconds=1), "q"),
+    Quote(97, NOW.replace(tzinfo=None), NOW, "q"),
+])
+def test_bad_quote_is_unknown_in_both_arms(quote):
+    result = observe((H,), {H.symbol: quote}, {}, at=NOW, market="KR",
+                     session=SESSION, max_quote_age_seconds=30)[0]
+    assert result.baseline == result.candidate == "UNKNOWN"
+
+
+def test_pre_entry_bar_and_closed_session_do_not_delay_catastrophic():
+    closed = Session(NOW-timedelta(hours=2), NOW-timedelta(hours=1), "early-close")
+    assert run(90, session=closed).candidate == "EXIT"
+    assert run(session=closed).candidate == "UNKNOWN"
+    holding = Holding("new", H.symbol, 100, 98, NOW-timedelta(minutes=2))
+    result = observe((holding,), {H.symbol: Quote(97, NOW, NOW, "q")},
+                     {H.symbol: bar()}, at=NOW, market="KR", session=SESSION,
+                     max_quote_age_seconds=30)[0]
+    assert result.baseline == "EXIT" and result.candidate == "UNKNOWN"
+
+
+def test_pure_module_has_no_runtime_action_capability():
+    import ast
+    import inspect
+    import prism_core.shadow_fastlane as module
+    tree = ast.parse(inspect.getsource(module))
+    imports = {node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)}
+    assert imports == {"__future__", "dataclasses", "datetime", "typing", "zoneinfo",
+                       "cores.oneil_fallback"}
+    assert module.ENABLED is False
+    assert not any(isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+                   and node.func.id in {"open", "exec", "eval", "__import__"}
+                   for node in ast.walk(tree))
+
+
+def test_all_holdings_covered_with_no_llm_budget_or_broker_arguments():
+    holdings = (H, Holding("two", "other", 100, 98, H.entered_at))
+    results = observe(holdings, {}, {}, at=NOW, market="KR", session=SESSION,
+                      max_quote_age_seconds=30)
+    assert [r.holding_id for r in results] == ["one", "two"]
+    assert all(r.baseline == r.candidate == "UNKNOWN" for r in results)
+
+
+@pytest.mark.parametrize("market,stamp,match", [
+    ("KR", "2026-09-10T09:00:00+09:00", True),
+    ("KR", "2026-09-10T15:56:00+09:00", True),
+    ("KR", "2026-09-10T09:04:00+09:00", False),
+    ("US", "2026-09-10T09:04:00-04:00", True),
+    ("US", "2026-12-10T16:58:00-05:00", True),
+    ("US", "2026-09-12T10:04:00-04:00", False),
+])
+def test_source_cadence_not_exchange_calendar(market, stamp, match):
+    assert source_cadence_matches(market, datetime.fromisoformat(stamp)) is match
+
+
+def test_duplicate_holding_identity_rejected():
+    with pytest.raises(ValueError):
+        observe((H, H), {}, {}, at=NOW, market="KR", session=SESSION,
+                max_quote_age_seconds=30)

--- a/tests/test_strategy_ledger_effects_cas.py
+++ b/tests/test_strategy_ledger_effects_cas.py
@@ -1,0 +1,45 @@
+"""Optional normalized-unit CAS preserves historical default sell events."""
+import json
+import sqlite3
+
+import pytest
+
+from prism_core.strategy_ledger import LedgerError, StrategyLedger
+
+
+@pytest.fixture
+def ledger(tmp_path):
+    ledger = StrategyLedger(tmp_path / "ledger.sqlite")
+    ledger.create_book("book", "KR", mode="SHADOW")
+    ledger.apply_target("entry", "book", "campaign", "005930", 100, 100, "2026-09-10T00:00:00Z")
+    return ledger
+
+
+def test_default_sell_payload_and_retry_remain_unchanged(ledger):
+    assert ledger.sell("sell", "campaign", 110, "2026-09-10T01:00:00Z", quantity=".005")["event_applied"]
+    assert not ledger.sell("sell", "campaign", 110, "2026-09-10T01:00:00Z", quantity=".005")["event_applied"]
+    with sqlite3.connect(ledger.path) as db:
+        payload = json.loads(db.execute("SELECT payload FROM events WHERE id='sell'").fetchone()[0])
+    assert set(payload) == {"kind", "campaign_id", "price", "occurred_at", "normalized_units", "fee_rate", "slippage_rate", "source_hash"}
+
+
+def test_partial_cas_duplicate_after_hash_change_is_idempotent(ledger):
+    guard = ledger.campaign_guard("campaign")
+    assert guard["normalized_units"] == "0.01"
+    assert guard["book_id"] == "book" and guard["symbol"] == "005930"
+    args = dict(quantity=".005", expected_campaign_hash=guard["campaign_hash"])
+    assert ledger.sell("sell", "campaign", 110, "2026-09-10T01:00:00Z", **args)["event_applied"]
+    assert ledger.campaign_guard("campaign")["campaign_hash"] != guard["campaign_hash"]
+    assert not ledger.sell("sell", "campaign", 110, "2026-09-10T01:00:00Z", **args)["event_applied"]
+    before = ledger.snapshot("book")
+    with pytest.raises(LedgerError, match="campaign revision"):
+        ledger.sell("stale", "campaign", 110, "2026-09-10T02:00:00Z", **args)
+    assert ledger.snapshot("book") == before
+
+
+@pytest.mark.parametrize("invalid", [True, "x" * 64, "a", 42])
+def test_invalid_optional_hash_fails_before_mutation(ledger, invalid):
+    before = ledger.snapshot("book")
+    with pytest.raises(LedgerError):
+        ledger.sell("sell", "campaign", 110, "2026-09-10T01:00:00Z", expected_campaign_hash=invalid)
+    assert ledger.snapshot("book") == before


### PR DESCRIPTION
Add disabled case-bound strategy effects using slot/weight ledger, account UNKNOWN overlay and durable notices. Campaign identity and optional atomic sell CAS verify original normalized units without fictional cash/shares; duplicate projection repair and runtime clock preserve source parser compatibility. Add pure disabled baseline/5m ordinary-stop comparison reusing production catastrophic predicate. No agent guard, orders, notification transport or schedule enabled. Root183 tests pass plus Ruff; architect reviewed components and CAS fixes. Real pipeline contexts, side-effect diversion and E2E SHADOW remain separate gates.