### PR TITLE
feat: durable safe diagnostic stage and cleanup receipts

### DIFF
--- a/tests/test_isolated_case_journal.py
+++ b/tests/test_isolated_case_journal.py
@@ -1,0 +1,67 @@
+import json
+import os
+
+import pytest
+
+from tools.isolated_case_journal import CaseJournal, JournalRejected
+
+
+def test_journal_private_bound_and_fsynced(tmp_path, monkeypatch):
+    calls = []
+    original = os.fsync
+    monkeypatch.setattr(os, "fsync", lambda fd: (calls.append(fd), original(fd))[1])
+    journal = CaseJournal(tmp_path, "case1", "a" * 64)
+    journal.record("CLAIMED")
+    journal.record("AGENT_REAPED", receipt_valid=True, returncode=0, forced_kill=False,
+                   stdout_bytes=12, stderr_bytes=0)
+    rows = [json.loads(row) for row in journal.path.read_text().splitlines()]
+    assert len(calls) >= 3
+    assert [row["sequence"] for row in rows] == [1, 2]
+    assert all(row["payload_sha256"] == "a" * 64 for row in rows)
+    assert journal.path.stat().st_mode & 0o777 == 0o600
+    with pytest.raises(JournalRejected):
+        CaseJournal(tmp_path, "case1", "a" * 64)
+
+
+@pytest.mark.parametrize("fields", [{"stderr": "SECRET_CANARY"}, {"returncode": "SECRET_CANARY"},
+    {"stdout_bytes": -1}, {"receipt_valid": 1}, {"terminal_categories": ["SECRET_CANARY"]},
+    {"snapshot_hashes": ["SECRET_CANARY"]}])
+def test_journal_rejects_nonallowlisted_fields_without_writing(tmp_path, fields):
+    journal = CaseJournal(tmp_path, "case1", "a" * 64)
+    with pytest.raises(JournalRejected):
+        journal.record("AGENT_REAPED", **fields)
+    assert journal.path.read_bytes() == b""
+
+
+def test_journal_fsync_failure_never_reports_success(tmp_path, monkeypatch):
+    journal = CaseJournal(tmp_path, "case1", "a" * 64)
+    monkeypatch.setattr(os, "fsync", lambda fd: (_ for _ in ()).throw(OSError("SECRET_CANARY")))
+    with pytest.raises(JournalRejected, match="journal_write_failed"):
+        journal.record("CLAIMED")
+
+
+def test_replaced_inode_and_partial_write_poison_journal(tmp_path, monkeypatch):
+    journal = CaseJournal(tmp_path, "case1", "a" * 64)
+    calls = []
+    original = os.write
+    def partial(fd, value):
+        calls.append(True)
+        if len(calls) == 1:
+            return original(fd, value[:5])
+        raise OSError("SECRET_PARTIAL_CANARY")
+    monkeypatch.setattr(os, "write", partial)
+    with pytest.raises(JournalRejected):
+        journal.record("CLAIMED")
+    assert journal.path.read_bytes() and not journal.path.read_bytes().endswith(b"\n")
+    with pytest.raises(JournalRejected):
+        journal.record("FINALIZATION_READY", receipt_valid=True)
+    with pytest.raises(JournalRejected):
+        CaseJournal(tmp_path, "case1", "a" * 64)
+
+
+def test_symlink_or_hardlink_journal_not_appended(tmp_path):
+    journal = CaseJournal(tmp_path, "case1", "a" * 64)
+    os.link(journal.path, tmp_path / "link")
+    with pytest.raises(JournalRejected):
+        journal.record("CLAIMED")
+    assert journal.path.read_bytes() == b""

--- a/tests/test_isolated_trading_case_supervisor.py
+++ b/tests/test_isolated_trading_case_supervisor.py
@@ -88,7 +88,7 @@ def composition(root, monkeypatch, *, script=None, poison=False, cleanup_error=F
         async def wait(self):
             await asyncio.sleep(30)
     @asynccontextmanager
-    async def services(registration, connection, private):
+    async def services(registration, connection, private, journal=None):
         assert connection.execute("PRAGMA query_only").fetchone() == (1,)
         events.append("services_started")
         try:
@@ -143,6 +143,10 @@ def test_case_timeout_reaps_harmless_agent_and_poisons_lane(root, monkeypatch):
     with pytest.raises(supervisor.CaseRejected):
         asyncio.run(supervisor.run_case(reg, state))
     assert len(processes) == 1 and processes[0].returncode is not None
+    stages = [json.loads(line) for line in next(state.glob("*.stages.jsonl")).read_text().splitlines()]
+    origin = next(row for row in stages if row.get("failure_category") == "case_deadline_or_helper_failure")
+    assert origin["stage"] == "AGENT_STARTED" and origin["receipt_valid"] is False
+    assert origin["elapsed_ms"] >= 0
     with supervisor.CaseLane(state) as lane:
         with pytest.raises(supervisor.CaseRejected, match="lane_uncertain"):
             lane.claim("newcase", "a" * 64)
@@ -310,6 +314,104 @@ def test_empty_attempts_cannot_claim_analysis_complete(root):
 def test_agent_refuses_non_namespace_executable():
     with pytest.raises(supervisor.CaseRejected, match="fixed_namespace_executable_required"):
         asyncio.run(supervisor._agent([sys.executable, "-c", "raise AssertionError()"], 1, None, []))
+
+
+@pytest.mark.parametrize("code", [0, 2, -9])
+def test_process_lookup_race_awaits_owned_handle_not_blind_ack(code):
+    class Process:
+        returncode = None
+        waited = False
+        def terminate(self):
+            raise ProcessLookupError("SECRET_PROCESS_CANARY")
+        async def wait(self):
+            self.waited = True
+            self.returncode = code
+            return code
+    process, receipt = Process(), {}
+    assert asyncio.run(supervisor._stop_process(process, receipt)) is (code == 0)
+    assert process.waited and receipt["returncode"] == code
+
+
+def test_early_cleanup_failure_survives_later_masking_exception(root):
+    from contextlib import AsyncExitStack
+    journal = supervisor.CaseJournal(root, "case1", "a" * 64)
+    @asynccontextmanager
+    async def resource(category):
+        try:
+            yield None
+        finally:
+            raise supervisor.CaseRejected(category)
+    async def run():
+        with pytest.raises(supervisor.CaseRejected, match="responses_cleanup_unknown"):
+            async with AsyncExitStack() as stack:
+                await stack.enter_async_context(supervisor._joined_context(
+                    resource("responses_cleanup_unknown"), journal, "RESPONSES_JOINED", "responses", lambda: {}))
+                await stack.enter_async_context(supervisor._joined_context(
+                    resource("invoker_cleanup_unknown"), journal, "INVOKER_JOINED", "invoker", lambda: {}))
+    asyncio.run(run())
+    rows = [json.loads(row) for row in journal.path.read_text().splitlines()]
+    assert [row["failure_category"] for row in rows] == ["invoker_cleanup_unknown", "responses_cleanup_unknown"]
+    assert all(row["receipt_valid"] is False for row in rows)
+
+
+def test_journal_failure_leaves_claim_unknown_and_does_not_start_agent(root, monkeypatch):
+    reg, state, events = composition(root, monkeypatch)
+    def fail(*args, **kwargs):
+        raise supervisor.JournalRejected("SECRET_JOURNAL_CANARY")
+    monkeypatch.setattr(supervisor.CaseJournal, "record", fail)
+    with pytest.raises(supervisor.CaseRejected, match="case_or_cleanup_uncertain"):
+        asyncio.run(supervisor.run_case(reg, state))
+    assert events == []
+    with sqlite3.connect(state / "case-claims.sqlite") as db:
+        assert db.execute("SELECT state FROM cases").fetchone() == ("UNKNOWN",)
+
+
+def test_success_stage_journal_has_safe_counts_not_output(root, monkeypatch):
+    reg, state, _ = composition(root, monkeypatch)
+    asyncio.run(supervisor.run_case(reg, state))
+    path = next(state.glob("*.stages.jsonl"))
+    rows = [json.loads(line) for line in path.read_text().splitlines()]
+    assert rows[-1]["stage"] == "FINALIZATION_READY"
+    reap = next(row for row in rows if row["stage"] == "AGENT_REAPED")
+    assert reap["returncode"] == 0 and reap["stdout_bytes"] > 0
+    assert "PENDING_PARENT_NAMESPACE" not in path.read_text()
+
+
+def test_forced_kill_lookup_race_never_clean_even_zero_final_code():
+    class Process:
+        returncode = None
+        calls = 0
+        def terminate(self):
+            pass
+        def kill(self):
+            raise ProcessLookupError()
+        async def wait(self):
+            self.calls += 1
+            if self.calls == 1:
+                raise asyncio.TimeoutError()
+            self.returncode = 0
+            return 0
+    process, receipt = Process(), {}
+    assert asyncio.run(supervisor._stop_process(process, receipt)) is False
+    assert process.calls == 2 and receipt == {"returncode": 0, "forced_kill": True}
+
+
+def test_helper_rc_zero_without_valid_receipt_is_journaled_unknown(root, monkeypatch):
+    monkeypatch.setattr(supervisor, "TRUSTED_HOST_PYTHON", sys.executable)
+    monkeypatch.setattr(supervisor, "_HELPER_BOOTSTRAP", _FAKE_HELPER.replace("'requests':0", "'requests':'SECRET_CANARY'"))
+    reg = SimpleNamespace(helper_source_root=root, auth_snapshot=root / "unused-auth", case_deadline=5)
+    journal = supervisor.CaseJournal(root, "case1", "a" * 64)
+    receipt = {}
+    async def run():
+        with pytest.raises(supervisor.CaseRejected, match="responses_receipt_unknown"):
+            helper = supervisor._responses_helper(reg, root / "response.sock", set(), cleanup_receipt=receipt)
+            async with supervisor._joined_context(helper, journal, "RESPONSES_JOINED", "responses", lambda: receipt):
+                pass
+    asyncio.run(run())
+    row = json.loads(journal.path.read_text())
+    assert row["returncode"] == 0 and row["receipt_valid"] is False
+    assert row["failure_category"] == "responses_receipt_unknown"
+    assert row["stdout_bytes"] > 0 and "SECRET_CANARY" not in journal.path.read_text()
 
 
 @pytest.mark.parametrize("mismatch", ["absent_record", "wrong_status", "wrong_snapshot", "hidden_http"])

--- a/tools/isolated_case_journal.py
+++ b/tools/isolated_case_journal.py
@@ -1,0 +1,108 @@
+"""Private, bounded stage receipts. No model or exception text is accepted."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import stat
+
+STAGES = frozenset({"CLAIMED", "SERVICES_READY", "AGENT_STARTED", "AGENT_REAPED",
+                    "INVOKER_JOINED", "RESPONSES_JOINED", "READ_BRIDGES_JOINED",
+                    "OUTCOME_VALIDATED", "FINALIZATION_READY"})
+CATEGORIES = frozenset({"NONE", "INTERNAL_FAILURE", "JOURNAL_FAILURE", "CANCELLED",
+    "responses_helper_not_ready", "responses_helper_socket_invalid", "responses_cleanup_unknown",
+    "responses_receipt_unknown", "invoker_cleanup_unknown", "read_bridge_cleanup_unknown",
+    "child_output_limit", "case_deadline_or_helper_failure", "case_deadline", "case_activity_uncertain",
+    "case_result_invalid", "case_result_missing", "existing_case_artifact", "agent_cleanup_unknown",
+    "agent_nonzero_exit", "case_result_identity_mismatch", "case_result_not_final",
+    "validation_outcome_uncertain", "case_outcome_uncertain", "case_result_limit"})
+_COUNTS = {"stdout_bytes", "stderr_bytes", "helper_requests", "unjoined_count", "elapsed_ms"}
+_BOOLS = {"receipt_valid", "forced_kill", "poisoned"}
+_FIELDS = _COUNTS | _BOOLS | {"returncode", "terminal_categories", "snapshot_hashes", "failure_category", "component"}
+
+
+class JournalRejected(ValueError):
+    pass
+
+
+class CaseJournal:
+    """Exclusive creation; never resume or reinterpret a previous case journal."""
+    def __init__(self, root, case_id, payload_sha256):
+        root = Path(root)
+        info = root.lstat()
+        if (not stat.S_ISDIR(info.st_mode) or root.is_symlink() or info.st_uid != os.getuid()
+                or stat.S_IMODE(info.st_mode) & 0o077 or root.resolve() != root
+                or not isinstance(case_id, str) or re.fullmatch(r"[A-Za-z0-9_-]{1,64}", case_id) is None
+                or not isinstance(payload_sha256, str) or re.fullmatch(r"[0-9a-f]{64}", payload_sha256) is None):
+            raise JournalRejected("invalid_journal_identity")
+        self.case_ref = hashlib.sha256(case_id.encode()).hexdigest()
+        self.payload_sha256 = payload_sha256
+        self.path = root / (self.case_ref + ".stages.jsonl")
+        self.sequence = 0
+        self.stage = "CLAIMED"
+        self.broken = False
+        try:
+            fd = os.open(self.path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+            info = os.fstat(fd)
+            self.identity = (info.st_dev, info.st_ino)
+            os.close(fd)
+            directory = os.open(root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+            try:
+                os.fsync(directory)
+            finally:
+                os.close(directory)
+        except OSError:
+            raise JournalRejected("journal_create_failed") from None
+
+    def record(self, stage, **fields):
+        if not isinstance(stage, str) or stage not in STAGES or self.sequence >= 64 or self.broken or set(fields) - _FIELDS:
+            raise JournalRejected("invalid_journal_record")
+        for key, value in fields.items():
+            valid = False
+            if key in _COUNTS:
+                valid = type(value) is int and 0 <= value <= 1000000000
+            elif key in _BOOLS:
+                valid = type(value) is bool
+            elif key == "returncode":
+                valid = value is None or type(value) is int and -65536 <= value <= 65536
+            elif key == "failure_category":
+                valid = isinstance(value, str) and value in CATEGORIES
+            elif key == "component":
+                valid = isinstance(value, str) and value in {"invoker", "responses", "perplexity", "market", "agent", "case"}
+            elif key in {"terminal_categories", "snapshot_hashes"}:
+                valid = isinstance(value, list) and len(value) <= 16 and all(
+                    isinstance(v, str) and (v in {"ok", "model_error", "model_timeout", "UNKNOWN"}
+                        if key == "terminal_categories" else re.fullmatch(r"[0-9a-f]{64}", v) is not None)
+                    for v in value)
+            if not valid:
+                raise JournalRejected("invalid_journal_record")
+        record = {"schema_version": 1, "case_ref": self.case_ref, "payload_sha256": self.payload_sha256,
+                  "sequence": self.sequence + 1, "stage": stage, **fields}
+        encoded = (json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n").encode()
+        if len(encoded) > 4096:
+            raise JournalRejected("invalid_journal_record")
+        fd = None
+        try:
+            fd = os.open(self.path, os.O_WRONLY | os.O_APPEND | os.O_NOFOLLOW)
+            info = os.fstat(fd)
+            if (not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or info.st_nlink != 1
+                    or stat.S_IMODE(info.st_mode) != 0o600 or info.st_size > 64 * 4096
+                    or (info.st_dev, info.st_ino) != self.identity):
+                raise OSError()
+            offset = 0
+            while offset < len(encoded):
+                count = os.write(fd, encoded[offset:])
+                if count <= 0:
+                    raise OSError()
+                offset += count
+            os.fsync(fd)
+        except OSError:
+            self.broken = True
+            raise JournalRejected("journal_write_failed") from None
+        finally:
+            if fd is not None:
+                os.close(fd)
+        self.sequence += 1
+        self.stage = stage

--- a/tools/isolated_trading_case_supervisor.py
+++ b/tools/isolated_trading_case_supervisor.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import fcntl
 import asyncio
 from collections import Counter
-from contextlib import AsyncExitStack, asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager, contextmanager
 from dataclasses import dataclass, replace
 import hashlib
 import json
@@ -20,12 +20,14 @@ from pathlib import Path
 import re
 import sqlite3
 import stat
+import sys
 import time
 
 from tools import isolated_agent_namespace as namespace
 from tools.codex_probe_sandbox import ParentLease, TRUSTED_HOST_PYTHON, load_host_manifest
 from tools.isolated_codex_binding import FixedCodexBinding
 from tools.isolated_codex_invoker import CodexInvoker, InvocationScope
+from tools.isolated_case_journal import CaseJournal, JournalRejected, CATEGORIES
 
 
 class CaseRejected(ValueError):
@@ -234,18 +236,109 @@ async def _drain(stream, *, capture=False, limit=8 * 1024 * 1024):
             chunks.append(chunk)
 
 
-async def _stop_process(process):
+async def _stop_process(process, receipt=None):
     """Only an owned child handle. A forced helper kill is NOT a clean ACK."""
+    if receipt is None:
+        receipt = {}
+    receipt.update(forced_kill=False, returncode=process.returncode)
     if process.returncode is not None:
+        await asyncio.wait_for(process.wait(), timeout=2)
         return process.returncode == 0
-    process.terminate()
     try:
-        await asyncio.wait_for(process.wait(), timeout=2)
-    except asyncio.TimeoutError:
-        process.kill()
-        await asyncio.wait_for(process.wait(), timeout=2)
-        return False
-    return process.returncode == 0
+        try:
+            process.terminate()
+        except ProcessLookupError:
+            pass  # Wait for the OWNED handle; a missing PID is not a cleanup ACK.
+        try:
+            await asyncio.wait_for(process.wait(), timeout=2)
+        except asyncio.TimeoutError:
+            receipt["forced_kill"] = True
+            try:
+                process.kill()
+            except ProcessLookupError:
+                pass
+            await asyncio.wait_for(process.wait(), timeout=2)
+        return not receipt["forced_kill"] and process.returncode == 0
+    finally:
+        receipt["returncode"] = process.returncode
+
+
+def _failure_category(error):
+    if isinstance(error, asyncio.CancelledError):
+        return "CANCELLED"
+    if isinstance(error, JournalRejected):
+        return "JOURNAL_FAILURE"
+    if isinstance(error, CaseRejected) and str(error) in CATEGORIES:
+        return str(error)
+    return "INTERNAL_FAILURE"
+
+
+def _invoker_receipt(invoker):
+    categories, snapshots = [], []
+    for _, task, _ in invoker.records.values():
+        try:
+            value = task.result() if task.done() and not task.cancelled() else {}
+            category, snapshot = value.get("category"), value.get("snapshot_sha256")
+            categories.append(category if category in {"ok", "model_error", "model_timeout"} else "UNKNOWN")
+            if isinstance(snapshot, str) and re.fullmatch(r"[0-9a-f]{64}", snapshot):
+                snapshots.append(snapshot)
+        except BaseException:
+            categories.append("UNKNOWN")
+    return {"terminal_categories": categories, "snapshot_hashes": snapshots,
+            "poisoned": bool(invoker.poisoned), "unjoined_count": len(invoker.unjoined_callbacks)}
+
+
+@asynccontextmanager
+async def _joined_context(context, journal, stage, component, receipt):
+    """Receipt per callback, including an early failure later exits can mask."""
+    entered, clean, failure = False, False, "NONE"
+    try:
+        value = await context.__aenter__()
+        entered = True
+        try:
+            yield value
+        finally:
+            try:
+                await context.__aexit__(*sys.exc_info())
+                clean = True
+            except BaseException as error:
+                failure = _failure_category(error)
+                raise
+    except BaseException as error:
+        if not entered:
+            failure = _failure_category(error)
+        raise
+    finally:
+        if journal is not None:
+            details = receipt()
+            if details.get("poisoned") or details.get("unjoined_count", 0):
+                clean, failure = False, "invoker_cleanup_unknown"
+            journal.record(stage, component=component, receipt_valid=clean,
+                           failure_category=failure, **details)
+
+
+@contextmanager
+def _joined_bridge(context, journal, component):
+    clean, failure = False, "NONE"
+    try:
+        try:
+            value = context.__enter__()
+        except BaseException:
+            failure = "read_bridge_cleanup_unknown"
+            raise
+        try:
+            yield value
+        finally:
+            try:
+                context.__exit__(*sys.exc_info())
+                clean = True
+            except BaseException:
+                failure = "read_bridge_cleanup_unknown"
+                raise
+    finally:
+        if journal is not None:
+            journal.record("READ_BRIDGES_JOINED", component=component,
+                           receipt_valid=clean, failure_category=failure)
 
 
 _HELPER_BOOTSTRAP = "import sys;sys.path.insert(0,sys.argv[1]);from tools.isolated_trading_case_supervisor import _responses_child;_responses_child(sys.argv[2:])"
@@ -296,12 +389,14 @@ def _responses_child(args):
 
 
 @asynccontextmanager
-async def _responses_helper(reg, socket_path, read_tools):
+async def _responses_helper(reg, socket_path, read_tools, *, cleanup_receipt=None):
     reader, writer = os.pipe()
     process = None
     drains = []
     clean = False
     evidence = {"cleanup_confirmed": False, "requests": None}
+    if cleanup_receipt is None:
+        cleanup_receipt = {}
     try:
         # Fixed helper and interpreter only; no agent-configurable command/env.
         process = await asyncio.create_subprocess_exec(
@@ -326,14 +421,18 @@ async def _responses_helper(reg, socket_path, read_tools):
         if reader is not None:
             os.close(reader)
         if process is not None:
-            clean = await _stop_process(process)
+            clean = await _stop_process(process, cleanup_receipt)
         try:
             results = await asyncio.wait_for(asyncio.gather(*drains, return_exceptions=True), timeout=1)
         except asyncio.TimeoutError:
             raise CaseRejected("responses_cleanup_unknown") from None
-        if process is not None and (not clean or any(isinstance(result, BaseException) for result in results)):
-            raise CaseRejected("responses_cleanup_unknown")
         if process is not None:
+            if results and isinstance(results[0], bytes):
+                cleanup_receipt["stdout_bytes"] = len(results[0])
+            if len(results) > 1 and type(results[1]) is int:
+                cleanup_receipt["stderr_bytes"] = results[1]
+            if not clean or any(isinstance(result, BaseException) for result in results):
+                raise CaseRejected("responses_cleanup_unknown")
             try:
                 receipt = json.loads(results[0])
                 if (type(receipt) is not dict or set(receipt) != {"schema_version", "requests"} or receipt["schema_version"] != 1
@@ -342,10 +441,11 @@ async def _responses_helper(reg, socket_path, read_tools):
             except (ValueError, TypeError, IndexError):
                 raise CaseRejected("responses_receipt_unknown") from None
             evidence.update(cleanup_confirmed=True, requests=receipt["requests"])
+            cleanup_receipt["helper_requests"] = receipt["requests"]
 
 
 @asynccontextmanager
-async def _services(reg, connection, private_root):
+async def _services(reg, connection, private_root, journal=None):
     env = json.loads(reg.binding.environment_json)
     module, manifest = load_host_manifest(Path(env["PRISM_PROBE_HOST_MANIFEST"]), reg.binding.model_root)
     market = json.loads(reg.namespace_json)["controls"]["market"]
@@ -362,24 +462,34 @@ async def _services(reg, connection, private_root):
         tools.update(f"{server}-{name}" for name in module.TOOLS[server])
     async with AsyncExitStack() as stack:
         for name, server in (("perplexity", "perplexity"), ("market", market_server)):
-            stack.enter_context(module.ReadMcpBridge(sockets[name], server_name=server, **configs[server]))
-        helper, drains, evidence = await stack.enter_async_context(_responses_helper(reg, sockets["responses"], tools))
-        await stack.enter_async_context(invoker.serve(sockets["codex-invoke"]))
+            stack.enter_context(_joined_bridge(module.ReadMcpBridge(sockets[name], server_name=server, **configs[server]), journal, name))
+        helper_receipt = {}
+        helper_context = _responses_helper(reg, sockets["responses"], tools, cleanup_receipt=helper_receipt)
+        helper, drains, evidence = await stack.enter_async_context(
+            _joined_context(helper_context, journal, "RESPONSES_JOINED", "responses", lambda: helper_receipt))
+        await stack.enter_async_context(_joined_context(invoker.serve(sockets["codex-invoke"]), journal,
+                                                       "INVOKER_JOINED", "invoker", lambda: _invoker_receipt(invoker)))
         yield sockets, invoker, helper, drains, evidence
     if invoker.poisoned or invoker.unjoined_callbacks:
         raise CaseRejected("invoker_cleanup_unknown")
 
 
-async def _agent(command, deadline, helper, helper_drains):
+async def _agent(command, deadline, helper, helper_drains, journal=None):
     if not isinstance(command, list) or not command or command[0] != "/usr/bin/bwrap":
         raise CaseRejected("fixed_namespace_executable_required")
     process = None
     tasks = []
     completion = None
+    receipt = {"forced_kill": False, "returncode": None}
+    started = time.monotonic()
     try:
+        if journal is not None:
+            journal.record("AGENT_STARTED", component="agent", receipt_valid=False)
         # Remaining argv is the reviewed fixed namespace builder, never shell text.
         process = await asyncio.create_subprocess_exec("/usr/bin/bwrap", *command[1:], env={}, close_fds=True,  # nosemgrep
                                                        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+        if journal is not None:
+            journal.record("AGENT_STARTED", component="agent", receipt_valid=True)
         stdout = asyncio.create_task(_drain(process.stdout, capture=True, limit=65536))
         stderr = asyncio.create_task(_drain(process.stderr))
         tasks = [stdout, stderr, asyncio.create_task(process.wait())]
@@ -389,20 +499,35 @@ async def _agent(command, deadline, helper, helper_drains):
             done, _ = await asyncio.wait({completion, helper_exit, *helper_drains}, timeout=deadline, return_when=asyncio.FIRST_COMPLETED)
             if completion not in done:
                 raise CaseRejected("case_deadline_or_helper_failure")
-            output, _, returncode = completion.result()
+            output, stderr_bytes, returncode = completion.result()
+            receipt.update(stdout_bytes=len(output), stderr_bytes=stderr_bytes, returncode=returncode)
             return returncode, output
         finally:
             helper_exit.cancel()
             await asyncio.gather(helper_exit, return_exceptions=True)
+    except BaseException as error:
+        if journal is not None:
+            journal.record("AGENT_STARTED", component="agent", receipt_valid=False,
+                           failure_category=_failure_category(error),
+                           elapsed_ms=max(0, int((time.monotonic() - started) * 1000)))
+        raise
     finally:
-        if process is not None and process.returncode is None:
-            await _stop_process(process)
-        for task in tasks:
-            if not task.done():
-                task.cancel()
-        await asyncio.gather(*tasks, return_exceptions=True)
-        if completion is not None:
-            await asyncio.gather(completion, return_exceptions=True)
+        clean = False
+        try:
+            if process is not None:
+                await _stop_process(process, receipt)
+                clean = process.returncode is not None
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            if completion is not None:
+                await asyncio.gather(completion, return_exceptions=True)
+        finally:
+            if journal is not None:
+                journal.record("AGENT_REAPED", component="agent", receipt_valid=clean,
+                               failure_category="NONE" if clean else "agent_cleanup_unknown",
+                               elapsed_ms=max(0, int((time.monotonic() - started) * 1000)), **receipt)
 
 
 def _verify_activity(attempts, invoker, helper_evidence):
@@ -518,8 +643,11 @@ async def run_case(registration, state_root):
         if previous is not None:
             return previous
         connection = None
+        journal = None
         deadline = time.monotonic() + reg.case_deadline
         try:
+            journal = CaseJournal(state_root, reg.case_id, payload_hash)
+            journal.record("CLAIMED")
             writer = reg.runtime.connect()  # verifies/initializes marked owner
             writer.close()
             connection = sqlite3.connect(Path(reg.runtime.db_path).as_uri() + "?mode=ro", uri=True)
@@ -528,18 +656,31 @@ async def run_case(registration, state_root):
             private.mkdir(mode=0o700)
             if (Path(reg.runtime.root) / "case-result.json").exists():
                 raise CaseRejected("existing_case_artifact")
-            async with _services(reg, connection, private) as (sockets, invoker, helper, drains, helper_evidence):
+            journal.record("SERVICES_READY", receipt_valid=False)
+            async with _services(reg, connection, private, journal) as (sockets, invoker, helper, drains, helper_evidence):
+                journal.record("SERVICES_READY", receipt_valid=True)
                 command = namespace.command(**inputs, sockets=sockets)
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     raise CaseRejected("case_deadline")
-                returncode, stdout = await _agent(command, remaining, helper, drains)
+                returncode, stdout = await _agent(command, remaining, helper, drains, journal)
             if invoker.poisoned or invoker.unjoined_callbacks:
                 raise CaseRejected("invoker_cleanup_unknown")
+            journal.record("OUTCOME_VALIDATED", receipt_valid=False)
             result = _outcome(reg, returncode, stdout, invoker, helper_evidence)
+            journal.record("OUTCOME_VALIDATED", receipt_valid=True)
+            # Finalization receipt precedes the authoritative DB update. Never
+            # use a journal receipt to override CLAIMED/UNKNOWN database state.
+            journal.record("FINALIZATION_READY", receipt_valid=True)
             lane.finish(reg.case_id, payload_hash, result, cleanup_confirmed=True)
             return result
         except BaseException as error:
+            if journal is not None:
+                try:
+                    journal.record(journal.stage, component="case", receipt_valid=False,
+                                   failure_category=_failure_category(error))
+                except BaseException:
+                    pass  # The durable claim below remains UNKNOWN regardless.
             lane.finish(reg.case_id, payload_hash, {"status": "UNKNOWN", "category": "CASE_OR_CLEANUP_UNCERTAIN"}, cleanup_confirmed=False)
             if isinstance(error, asyncio.CancelledError):
                 raise


### PR DESCRIPTION
Persist private fsynced case/payload-bound stage receipts with fixed enums/counts/hashes only, including each cleanup boundary and original failure stage. No raw stdout/stderr, prompts, exceptions or secrets. FINALIZATION_READY is not DB completion authority; journal failure remains UNKNOWN. Handle process-exit race by bounded owned wait and validated return code. Root88 tests pass and independent architect approval. Existing UNKNOWN is not cleared and no actual model calls or runtime policy enabled by this PR.