### PR TITLE
feat: offline operator disposition with immutable unknown cases

### DIFF
--- a/tests/test_isolated_case_disposition.py
+++ b/tests/test_isolated_case_disposition.py
@@ -1,0 +1,237 @@
+import sqlite3
+import hashlib
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from tools.isolated_trading_case_supervisor import CaseLane, CaseRejected
+from tools.isolated_case_disposition import migrate_v1_to_v2
+from tools import isolated_case_disposition as disposition
+from tools import isolated_trading_case_supervisor as supervisor
+
+
+def unknown(root):
+    with CaseLane(root) as lane:
+        lane.claim("original", "a" * 64)
+        lane.finish("original", "a" * 64, {"status": "UNKNOWN"}, cleanup_confirmed=False)
+
+
+def test_opening_lane_never_migrates_or_releases(tmp_path):
+    unknown(tmp_path)
+    with CaseLane(tmp_path) as lane:
+        assert lane.db.execute("SELECT version FROM metadata").fetchall() == [(1,)]
+        with pytest.raises(CaseRejected, match="lane_uncertain"):
+            lane.claim("fresh", "b" * 64)
+    with sqlite3.connect(tmp_path / "case-claims.sqlite") as db:
+        assert db.execute("SELECT version FROM metadata").fetchall() == [(1,)]
+
+
+def test_explicit_migration_preserves_unknown_and_blocks_claims(tmp_path):
+    unknown(tmp_path)
+    with CaseLane(tmp_path) as lane:
+        before = lane.db.execute("SELECT * FROM cases").fetchall()
+        migrate_v1_to_v2(lane)
+        assert lane.db.execute("SELECT version FROM metadata").fetchall() == [(2,)]
+        assert lane.db.execute("SELECT * FROM cases").fetchall() == before
+        assert lane.db.execute("SELECT * FROM dispositions").fetchall() == []
+        with pytest.raises(sqlite3.IntegrityError):
+            lane.db.execute("UPDATE cases SET state='FINISHED' WHERE case_id='original'")
+    with CaseLane(tmp_path) as lane:
+        with pytest.raises(CaseRejected, match="lane_uncertain"):
+            lane.claim("fresh", "b" * 64)
+
+
+def test_migration_failure_rolls_back_every_schema_change(tmp_path):
+    unknown(tmp_path)
+    with CaseLane(tmp_path) as lane:
+        def authorize(action, arg1, arg2, db, source):
+            return sqlite3.SQLITE_DENY if action == sqlite3.SQLITE_CREATE_TRIGGER else sqlite3.SQLITE_OK
+        lane.db.set_authorizer(authorize)
+        with pytest.raises(Exception):
+            migrate_v1_to_v2(lane)
+        lane.db.set_authorizer(None)
+        assert lane.db.execute("SELECT version FROM metadata").fetchall() == [(1,)]
+        assert lane.db.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall() == [("metadata",), ("cases",)]
+
+
+def fixture_approval(root, monkeypatch, *, probe=True):
+    monkeypatch.setattr(disposition.time, "time", lambda: 2000)
+    unknown(root)
+    monkeypatch.setattr(disposition.time, "time", lambda: 3000)
+    reg = SimpleNamespace(case_id="original", case_deadline=5, mode="EXECUTE_REGISTERED",
+                          helper_source_files_json="{}", helper_python_sha256="c" * 64,
+                          binding=SimpleNamespace(wrapper_sha256="d" * 64))
+    inputs = {"source_files": {}, "runtime_files": {}, "script_hash": "e" * 64}
+    monkeypatch.setattr(supervisor, "_registration", lambda registration, state: (inputs, "a" * 64 if registration.case_id == "original" else "b" * 64))
+    monkeypatch.setattr(disposition, "_validated_registration", lambda *args: supervisor._registration(*args))
+    monkeypatch.setattr(disposition, "_original_artifact_hash", lambda reg: "f" * 64)
+    pin = {**inputs, "helper_source": {}, "helper_python": "c" * 64, "wrapper": "d" * 64}
+    scope_hash = hashlib.sha256(json.dumps(pin, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+    with sqlite3.connect(root / "case-claims.sqlite") as db:
+        row = db.execute("SELECT case_id,payload_sha256,state,claimed_at,finished_at,summary FROM cases").fetchone()
+    evidence = {"schema_version": 1, "case_id": "original", "payload_sha256": "a" * 64,
+                "historical_start_identity": "NOT_CAPTURED", "historical_cleanup_receipt": "NOT_CAPTURED",
+                "original_claim_sha256": disposition._claim_hash(row), "original_artifact_sha256": "f" * 64,
+                "original_deadline_seconds": 5}
+    def artifact(filename, value):
+        data = json.dumps(value).encode()
+        path = root / filename
+        path.write_bytes(data)
+        path.chmod(0o600)
+        return hashlib.sha256(data).hexdigest()
+    evidence_hash = artifact("operator-disposition-evidence.json", evidence)
+    approval = {"schema_version": 1, "case_id": "original", "payload_sha256": "a" * 64,
+                "evidence_sha256": evidence_hash, "operator_authorization_ref": "fixture-not-real-authorization",
+                "decision": disposition.DECISION, "scope_sha256": scope_hash,
+                "historical_receipt": "NOT_CAPTURED", "risk_acceptance": "ACCEPT_MISSING_HISTORICAL_RECEIPT_NO_ORDER_ONLY",
+                "scope": "ISOLATED_NO_ORDER_DIAGNOSTICS_ONLY", "original_outcome": "UNKNOWN",
+                "same_case_retry": "FORBIDDEN", "approved_at": 3000}
+    approval_hash = artifact("operator-disposition-approval.json", approval)
+    if probe:
+        # Unit-only stub. The production dependency is intentionally unavailable.
+        monkeypatch.setattr(disposition, "_host_probe", lambda *_: {
+            "observed_at": 3000, "current_matches": 0, "historical_start_identity": "NOT_CAPTURED"})
+    return reg, approval_hash
+
+
+def test_disposition_preserves_unknown_and_only_allows_distinct_scoped_case(tmp_path, monkeypatch):
+    reg, approval_hash = fixture_approval(tmp_path, monkeypatch)
+    with CaseLane(tmp_path) as lane:
+        migrate_v1_to_v2(lane)
+        before = lane.db.execute("SELECT * FROM cases").fetchall()
+        disposition.record_operator_disposition(lane, expected_approval_sha256=approval_hash, original_registration=reg)
+        assert lane.db.execute("SELECT * FROM cases").fetchall() == before
+        for payload in ("a" * 64, "b" * 64):
+            with pytest.raises(CaseRejected, match="original_case_permanently_forbidden"):
+                lane.claim("original", payload)
+        for forged in (None, True, disposition.DECISION, {}, object()):
+            with pytest.raises(CaseRejected, match="lane_uncertain"):
+                lane.claim("fresh", "b" * 64, diagnostic_scope=forged)
+        reg.case_id = "fresh"
+        token = disposition.diagnostic_scope(reg, tmp_path)
+        assert lane.claim("fresh", "b" * 64, diagnostic_scope=token) is None
+        assert lane.db.execute("SELECT state FROM cases WHERE case_id='original'").fetchone() == ("UNKNOWN",)
+        with pytest.raises(sqlite3.IntegrityError):
+            lane.db.execute("DELETE FROM dispositions")
+
+
+def test_missing_reviewed_probe_cannot_record_disposition(tmp_path, monkeypatch):
+    reg, approval_hash = fixture_approval(tmp_path, monkeypatch, probe=False)
+    with CaseLane(tmp_path) as lane:
+        migrate_v1_to_v2(lane)
+        with pytest.raises(disposition.DispositionRejected, match="reviewed_host_probe_unavailable"):
+            disposition.record_operator_disposition(lane, expected_approval_sha256=approval_hash, original_registration=reg)
+        assert lane.db.execute("SELECT * FROM dispositions").fetchall() == []
+
+
+@pytest.mark.parametrize("failure", ["hash", "claimed", "window", "reconstruction", "busy", "stale"])
+def test_disposition_requires_all_host_evidence(tmp_path, monkeypatch, failure):
+    reg, approval_hash = fixture_approval(tmp_path, monkeypatch)
+    with CaseLane(tmp_path) as lane:
+        if failure == "claimed":
+            # Pre-migration fixture, never an operator recovery behavior.
+            lane.db.execute("UPDATE cases SET state='CLAIMED'")
+        migrate_v1_to_v2(lane)
+        if failure == "hash":
+            approval_hash = "f" * 64
+        elif failure == "window":
+            reg.case_deadline = 1500
+        elif failure == "reconstruction":
+            monkeypatch.setattr(supervisor, "_registration", lambda *_: ({}, "b" * 64))
+        elif failure in {"busy", "stale"}:
+            monkeypatch.setattr(disposition, "_host_probe", lambda *_: {
+                "observed_at": 2000 if failure == "stale" else 3000,
+                "current_matches": 1 if failure == "busy" else 0, "historical_start_identity": "NOT_CAPTURED"})
+        with pytest.raises(disposition.DispositionRejected):
+            disposition.record_operator_disposition(lane, expected_approval_sha256=approval_hash, original_registration=reg)
+        assert lane.db.execute("SELECT * FROM dispositions").fetchall() == []
+
+
+def test_scope_wrong_case_payload_pin_or_live_mode_is_rejected(tmp_path, monkeypatch):
+    reg, approval_hash = fixture_approval(tmp_path, monkeypatch)
+    with CaseLane(tmp_path) as lane:
+        migrate_v1_to_v2(lane)
+        disposition.record_operator_disposition(lane, expected_approval_sha256=approval_hash, original_registration=reg)
+        reg.case_id = "fresh"
+        token = disposition.diagnostic_scope(reg, tmp_path)
+        for case, payload in (("different", "b" * 64), ("fresh", "c" * 64)):
+            with pytest.raises(CaseRejected):
+                lane.claim(case, payload, diagnostic_scope=token)
+        reg.binding.wrapper_sha256 = "f" * 64
+        wrong_pin = disposition.diagnostic_scope(reg, tmp_path)
+        with pytest.raises(CaseRejected):
+            lane.claim("fresh", "b" * 64, diagnostic_scope=wrong_pin)
+        reg.mode = "LIVE"
+        with pytest.raises(disposition.DispositionRejected):
+            disposition.diagnostic_scope(reg, tmp_path)
+
+
+def test_duplicate_disposition_is_not_update_or_second_authorization(tmp_path, monkeypatch):
+    reg, approval_hash = fixture_approval(tmp_path, monkeypatch)
+    with CaseLane(tmp_path) as lane:
+        migrate_v1_to_v2(lane)
+        disposition.record_operator_disposition(lane, expected_approval_sha256=approval_hash, original_registration=reg)
+        before = lane.db.execute("SELECT * FROM dispositions").fetchall()
+        with pytest.raises(sqlite3.IntegrityError):
+            disposition.record_operator_disposition(lane, expected_approval_sha256=approval_hash, original_registration=reg)
+        assert lane.db.execute("SELECT * FROM dispositions").fetchall() == before
+
+
+@pytest.mark.parametrize("bad", ["changed", "symlink", "hardlink", "scope"])
+def test_replaced_or_unsafe_approval_is_rejected(tmp_path, monkeypatch, bad):
+    import os
+    reg, approval_hash = fixture_approval(tmp_path, monkeypatch)
+    path = tmp_path / "operator-disposition-approval.json"
+    if bad == "changed":
+        path.write_text("{}")
+    elif bad == "symlink":
+        other = tmp_path / "other.json"
+        path.rename(other)
+        path.symlink_to(other)
+    elif bad == "hardlink":
+        os.link(path, tmp_path / "other.json")
+    else:
+        payload = json.loads(path.read_text())
+        payload["scope"] = "LIVE"
+        data = json.dumps(payload).encode()
+        path.write_bytes(data)
+        approval_hash = hashlib.sha256(data).hexdigest()
+    with CaseLane(tmp_path) as lane:
+        migrate_v1_to_v2(lane)
+        with pytest.raises(disposition.DispositionRejected):
+            disposition.record_operator_disposition(lane, expected_approval_sha256=approval_hash, original_registration=reg)
+        assert lane.db.execute("SELECT * FROM dispositions").fetchall() == []
+
+
+def test_missing_history_disposition_cannot_release_new_claimed_case(tmp_path, monkeypatch):
+    reg, approval_hash = fixture_approval(tmp_path, monkeypatch)
+    with CaseLane(tmp_path) as lane:
+        migrate_v1_to_v2(lane)
+        disposition.record_operator_disposition(lane, expected_approval_sha256=approval_hash, original_registration=reg)
+        reg.case_id = "fresh"
+        lane.claim("fresh", "b" * 64, diagnostic_scope=disposition.diagnostic_scope(reg, tmp_path))
+    with CaseLane(tmp_path) as lane:
+        reg.case_id = "third"
+        with pytest.raises(CaseRejected, match="lane_uncertain"):
+            lane.claim("third", "b" * 64, diagnostic_scope=disposition.diagnostic_scope(reg, tmp_path))
+
+
+@pytest.mark.parametrize("addition", ["view", "index", "default"])
+def test_malformed_v1_never_migrated_or_adopted(tmp_path, addition):
+    unknown(tmp_path)
+    with CaseLane(tmp_path) as lane:
+        if addition == "view":
+            lane.db.execute("CREATE VIEW unexpected AS SELECT * FROM cases")
+        elif addition == "index":
+            lane.db.execute("CREATE INDEX unexpected ON cases(state)")
+        else:
+            lane.db.execute("DROP TABLE cases")
+            lane.db.execute("CREATE TABLE cases(case_id TEXT PRIMARY KEY,payload_sha256 TEXT NOT NULL,state TEXT NOT NULL DEFAULT 'FINISHED',claimed_at REAL NOT NULL,finished_at REAL,summary TEXT)")
+        with pytest.raises(disposition.DispositionRejected, match="unknown_claim_database"):
+            migrate_v1_to_v2(lane)
+        assert lane.db.execute("SELECT version FROM metadata").fetchall() == [(1,)]
+        assert lane.db.execute("SELECT name FROM sqlite_master WHERE name='dispositions'").fetchall() == []
+    with pytest.raises(CaseRejected, match="unknown_claim_database"):
+        with CaseLane(tmp_path):
+            pass

--- a/tools/isolated_case_disposition.py
+++ b/tools/isolated_case_disposition.py
@@ -1,0 +1,274 @@
+"""Host-operator-only additive disposition, never an automatic retry/reset.
+
+Opening a lane does not migrate it. No approval is created by this module.
+An UNKNOWN row and its original case ID remain permanently unusable.
+One original case permits exactly one immutable future source/runtime scope;
+later revisions need a separately reviewed authorization design, not a new lane.
+Operator attestations are not cryptographic authentication. No invocation has
+been approved, and the mandatory real-host probe remains unavailable.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import re
+import stat
+import time
+
+DECISION = "ACCEPT_DISTINCT_NO_ORDER_DIAGNOSTICS"
+_BASE_SQL = {
+    "metadata": "CREATE TABLE metadata(version INTEGER NOT NULL)",
+    "cases": "CREATE TABLE cases(case_id TEXT PRIMARY KEY,payload_sha256 TEXT NOT NULL,state TEXT NOT NULL,claimed_at REAL NOT NULL,finished_at REAL,summary TEXT)",
+}
+_TABLE_SQL = (
+    "CREATE TABLE dispositions(case_id TEXT PRIMARY KEY,payload_sha256 TEXT NOT NULL,"
+    "evidence_sha256 TEXT NOT NULL,operator_authorization_ref TEXT NOT NULL,"
+    "approval_sha256 TEXT NOT NULL,scope_sha256 TEXT NOT NULL,quiescence_json TEXT NOT NULL,"
+    "decision TEXT NOT NULL CHECK(decision='ACCEPT_DISTINCT_NO_ORDER_DIAGNOSTICS'))"
+)
+_TRIGGERS = {
+    "unknown_case_no_update": "CREATE TRIGGER unknown_case_no_update BEFORE UPDATE ON cases WHEN OLD.state='UNKNOWN' BEGIN SELECT RAISE(ABORT,'immutable_unknown'); END",
+    "unknown_case_no_delete": "CREATE TRIGGER unknown_case_no_delete BEFORE DELETE ON cases WHEN OLD.state='UNKNOWN' BEGIN SELECT RAISE(ABORT,'immutable_unknown'); END",
+    "disposition_no_update": "CREATE TRIGGER disposition_no_update BEFORE UPDATE ON dispositions BEGIN SELECT RAISE(ABORT,'immutable_disposition'); END",
+    "disposition_no_delete": "CREATE TRIGGER disposition_no_delete BEFORE DELETE ON dispositions BEGIN SELECT RAISE(ABORT,'immutable_disposition'); END",
+}
+
+
+class DispositionRejected(ValueError):
+    pass
+
+
+def validate_lane_schema(db):
+    """Read-only schema check; reject unknown additions and changed triggers."""
+    tables = {row[0] for row in db.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    version = db.execute("SELECT version FROM metadata").fetchall()
+    if version not in ([(1,)], [(2,)]):
+        raise DispositionRejected("unknown_claim_database")
+    version = version[0][0]
+    if tables != ({"metadata", "cases"} if version == 1 else {"metadata", "cases", "dispositions"}):
+        raise DispositionRejected("unknown_claim_database")
+    for name, sql in _BASE_SQL.items():
+        actual = db.execute("SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (name,)).fetchone()
+        if actual != (sql,):
+            raise DispositionRejected("unknown_claim_database")
+    expected_indexes = {("sqlite_autoindex_cases_1", "cases", None)}
+    if version == 2:
+        expected_indexes.add(("sqlite_autoindex_dispositions_1", "dispositions", None))
+    indexes = set(db.execute("SELECT name,tbl_name,sql FROM sqlite_master WHERE type='index'"))
+    if indexes != expected_indexes or db.execute("SELECT 1 FROM sqlite_master WHERE type NOT IN ('table','index','trigger') LIMIT 1").fetchone():
+        raise DispositionRejected("unknown_claim_database")
+    metadata = db.execute("PRAGMA table_info(metadata)").fetchall()
+    cases = db.execute("PRAGMA table_info(cases)").fetchall()
+    if ([row[1:4] for row in metadata] != [("version", "INTEGER", 1)]
+            or [row[1:4] for row in cases] != [("case_id", "TEXT", 0), ("payload_sha256", "TEXT", 1),
+                ("state", "TEXT", 1), ("claimed_at", "REAL", 1), ("finished_at", "REAL", 0), ("summary", "TEXT", 0)]
+            or cases[0][5] != 1):
+        raise DispositionRejected("unknown_claim_database")
+    triggers = dict(db.execute("SELECT name,sql FROM sqlite_master WHERE type='trigger'"))
+    if triggers != ({} if version == 1 else _TRIGGERS):
+        raise DispositionRejected("unknown_claim_database")
+    if version == 2:
+        sql = db.execute("SELECT sql FROM sqlite_master WHERE type='table' AND name='dispositions'").fetchone()[0]
+        if sql != _TABLE_SQL:
+            raise DispositionRejected("unknown_claim_database")
+    return version
+
+
+def migrate_v1_to_v2(lane):
+    """Explicit operator API under the existing lane lock. Never called by claim."""
+    from tools.isolated_trading_case_supervisor import CaseLane
+    if not isinstance(lane, CaseLane) or lane.fd is None or lane.db is None or lane.db.in_transaction:
+        raise DispositionRejected("locked_lane_required")
+    db = lane.db
+    db.execute("BEGIN IMMEDIATE")
+    try:
+        if validate_lane_schema(db) != 1:
+            raise DispositionRejected("explicit_v1_migration_required")
+        db.execute(_TABLE_SQL)
+        for sql in _TRIGGERS.values():
+            db.execute(sql)
+        db.execute("UPDATE metadata SET version=2")
+        validate_lane_schema(db)
+        db.execute("COMMIT")
+    except BaseException:
+        if db.in_transaction:
+            db.execute("ROLLBACK")
+        raise
+
+
+def _hash(value):
+    return isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value) is not None
+
+
+def _artifact(root, filename, expected_hash):
+    if not _hash(expected_hash) or filename not in {"operator-disposition-approval.json", "operator-disposition-evidence.json"}:
+        raise DispositionRejected("invalid_operator_artifact")
+    path = Path(root) / filename
+    fd = None
+    try:
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        info = os.fstat(fd)
+        if (not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or info.st_nlink != 1
+                or stat.S_IMODE(info.st_mode) != 0o600 or not 1 <= info.st_size <= 65536):
+            raise DispositionRejected("invalid_operator_artifact")
+        raw = os.read(fd, 65537)
+        if len(raw) != info.st_size or hashlib.sha256(raw).hexdigest() != expected_hash:
+            raise DispositionRejected("operator_artifact_hash_mismatch")
+        value = json.loads(raw)
+        if type(value) is not dict:
+            raise DispositionRejected("invalid_operator_artifact")
+        return value
+    except (OSError, ValueError):
+        raise DispositionRejected("invalid_operator_artifact") from None
+    finally:
+        if fd is not None:
+            os.close(fd)
+
+
+def _host_probe(original_registration, state_root):
+    """INTENTIONALLY UNAVAILABLE until separately reviewed Linux probe exists.
+
+    Must observe actual current /proc identities/namespaces and registered paths,
+    never trust a caller boolean or infer historical cleanup from current absence.
+    Old PID start identities were not captured: retain that explicit limitation.
+    No runtime setter, callback parameter, CLI or RPC can replace this dependency.
+    """
+    raise DispositionRejected("reviewed_host_probe_unavailable")
+
+
+def _validated_registration(registration, root):
+    from tools.isolated_trading_case_supervisor import _registration, namespace
+    inputs, payload = _registration(registration, root)
+    namespace.validate_python_source(inputs["source_root"], inputs["script_hash"], inputs["source_files"])
+    namespace.validate_tree(inputs["runtime_root"], inputs["runtime_files"])
+    return inputs, payload
+
+
+def _original_artifact_hash(registration):
+    from tools.isolated_trading_case_supervisor import _private_file
+    path = Path(registration.runtime.root) / "case-result.json"
+    _private_file(path)
+    if path.resolve() != path or path.stat().st_size > 256 * 1024:
+        raise DispositionRejected("original_artifact_unverified")
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _claim_hash(row):
+    return hashlib.sha256(json.dumps(row, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()).hexdigest()
+
+
+def record_operator_disposition(lane, *, expected_approval_sha256, original_registration):
+    """Trusted host operator API only; currently cannot succeed without probe.
+
+    An expected hash/reference is NOT authentication. Authority is operator-owned
+    approval/evidence files in the structurally unmounted private state root.
+    This API does not create approval, migrate, repair UNKNOWN, or launch work.
+    """
+    from tools.isolated_trading_case_supervisor import CaseLane
+    if not isinstance(lane, CaseLane) or lane.db is None or lane.fd is None or lane.db.in_transaction:
+        raise DispositionRejected("locked_lane_required")
+    approval = _artifact(lane.root, "operator-disposition-approval.json", expected_approval_sha256)
+    fields = {"schema_version", "case_id", "payload_sha256", "evidence_sha256", "operator_authorization_ref",
+              "decision", "scope_sha256", "historical_receipt", "risk_acceptance", "scope", "original_outcome",
+              "same_case_retry", "approved_at"}
+    if (set(approval) != fields or type(approval["schema_version"]) is not int or approval["schema_version"] != 1
+            or approval["decision"] != DECISION or approval["historical_receipt"] != "NOT_CAPTURED"
+            or approval["risk_acceptance"] != "ACCEPT_MISSING_HISTORICAL_RECEIPT_NO_ORDER_ONLY"
+            or approval["scope"] != "ISOLATED_NO_ORDER_DIAGNOSTICS_ONLY" or approval["original_outcome"] != "UNKNOWN"
+            or approval["same_case_retry"] != "FORBIDDEN" or type(approval["approved_at"]) not in {int, float}
+            or not math.isfinite(approval["approved_at"]) or not 0 <= time.time() - approval["approved_at"] <= 3600
+            or any(not _hash(approval[k]) for k in ("payload_sha256", "evidence_sha256", "scope_sha256"))
+            or not isinstance(approval["operator_authorization_ref"], str)
+            or re.fullmatch(r"[A-Za-z0-9_-]{1,64}", approval["operator_authorization_ref"]) is None
+            or approval["case_id"] != original_registration.case_id):
+        raise DispositionRejected("invalid_operator_approval")
+    evidence = _artifact(lane.root, "operator-disposition-evidence.json", approval["evidence_sha256"])
+    if (set(evidence) != {"schema_version", "case_id", "payload_sha256", "historical_start_identity", "historical_cleanup_receipt",
+                         "original_claim_sha256", "original_artifact_sha256", "original_deadline_seconds"}
+            or type(evidence["schema_version"]) is not int or evidence["schema_version"] != 1
+            or evidence["case_id"] != approval["case_id"] or evidence["payload_sha256"] != approval["payload_sha256"]
+            or evidence["historical_start_identity"] != "NOT_CAPTURED"
+            or evidence["historical_cleanup_receipt"] != "NOT_CAPTURED"
+            or not _hash(evidence["original_claim_sha256"]) or not _hash(evidence["original_artifact_sha256"])
+            or evidence["original_deadline_seconds"] != original_registration.case_deadline):
+        raise DispositionRejected("invalid_operator_evidence")
+    _, reconstructed_hash = _validated_registration(original_registration, lane.root)
+    if reconstructed_hash != approval["payload_sha256"]:
+        raise DispositionRejected("original_registration_mismatch")
+    if _original_artifact_hash(original_registration) != evidence["original_artifact_sha256"]:
+        raise DispositionRejected("original_artifact_mismatch")
+    db = lane.db
+    db.execute("BEGIN IMMEDIATE")
+    try:
+        if validate_lane_schema(db) != 2:
+            raise DispositionRejected("explicit_v2_migration_required")
+        row = db.execute("SELECT payload_sha256,state,claimed_at FROM cases WHERE case_id=?", (approval["case_id"],)).fetchone()
+        if row is None or row[:2] != (approval["payload_sha256"], "UNKNOWN"):
+            raise DispositionRejected("only_original_unknown_disposable")
+        original = db.execute("SELECT case_id,payload_sha256,state,claimed_at,finished_at,summary FROM cases WHERE case_id=?", (approval["case_id"],)).fetchone()
+        if _claim_hash(original) != evidence["original_claim_sha256"]:
+            raise DispositionRejected("original_claim_mismatch")
+        if not time.time() > row[2] + original_registration.case_deadline:
+            raise DispositionRejected("original_window_not_expired")
+        # A future reviewed probe must return this bounded observation, never
+        # infer missing historical identities or claim the old case completed.
+        observation = _host_probe(original_registration, lane.root)
+        if (type(observation) is not dict or set(observation) != {"observed_at", "current_matches", "historical_start_identity"}
+                or type(observation["observed_at"]) not in {int, float}
+                or not 0 <= time.time() - observation["observed_at"] <= 5
+                or type(observation["current_matches"]) is not int or observation["current_matches"] != 0
+                or observation["historical_start_identity"] != "NOT_CAPTURED"):
+            raise DispositionRejected("current_quiescence_unverified")
+        db.execute("INSERT INTO dispositions(case_id,payload_sha256,evidence_sha256,operator_authorization_ref,approval_sha256,scope_sha256,quiescence_json,decision) VALUES(?,?,?,?,?,?,?,?)",
+                   (approval["case_id"], approval["payload_sha256"], approval["evidence_sha256"],
+                    approval["operator_authorization_ref"], expected_approval_sha256, approval["scope_sha256"],
+                    json.dumps(observation, sort_keys=True, separators=(",", ":"), allow_nan=False), DECISION))
+        db.execute("COMMIT")
+    except BaseException:
+        if db.in_transaction:
+            db.execute("ROLLBACK")
+        raise
+
+
+_SCOPES = {}
+
+
+def diagnostic_scope(registration, state_root):
+    """Process-local, nonserializable capability for a validated analysis case.
+
+    This is not user authentication: only trusted host registration may call it.
+    It cannot be supplied over model RPC or reconstructed from a caller string.
+    Current run_case intentionally does not request/use this capability.
+    """
+    from tools.isolated_trading_case_supervisor import _private_root
+    root = _private_root(state_root)
+    inputs, payload = _validated_registration(registration, root)
+    if registration.mode not in {"VALIDATE_ONLY", "EXECUTE_REGISTERED"}:
+        raise DispositionRejected("analysis_only_scope_required")
+    pin = {"source_files": inputs["source_files"], "runtime_files": inputs["runtime_files"],
+           "script_hash": inputs["script_hash"], "helper_source": json.loads(registration.helper_source_files_json),
+           "helper_python": registration.helper_python_sha256, "wrapper": registration.binding.wrapper_sha256}
+    scope_hash = hashlib.sha256(json.dumps(pin, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()).hexdigest()
+    now = time.monotonic()
+    for token in list(_SCOPES):
+        if now - _SCOPES[token][-1] > 60:
+            del _SCOPES[token]
+    if len(_SCOPES) >= 64:
+        raise DispositionRejected("scope_capacity")
+    token = object()
+    _SCOPES[token] = (str(root), registration.case_id, payload, scope_hash, now)
+    return token
+
+
+def scope_hash_for_claim(token, root, case_id, payload):
+    """Only CaseLane consults a capability; caller strings/booleans never work."""
+    try:
+        value = _SCOPES.get(token)
+    except TypeError:
+        return None
+    if value is None or value[:3] != (str(root), case_id, payload) or time.monotonic() - value[-1] > 60:
+        return None
+    return value[3]

--- a/tools/isolated_trading_case_supervisor.py
+++ b/tools/isolated_trading_case_supervisor.py
@@ -78,8 +78,10 @@ class CaseLane:
                 _private_file(path)
                 check = sqlite3.connect(path.as_uri() + "?mode=ro", uri=True)
                 try:
-                    tables = {row[0] for row in check.execute("SELECT name FROM sqlite_master WHERE type='table'")}
-                    if tables != {"metadata", "cases"} or check.execute("SELECT version FROM metadata").fetchall() != [(1,)]:
+                    from tools.isolated_case_disposition import validate_lane_schema, DispositionRejected
+                    try:
+                        validate_lane_schema(check)
+                    except (DispositionRejected, sqlite3.Error):
                         raise CaseRejected("unknown_claim_database")
                 finally:
                     check.close()
@@ -99,12 +101,23 @@ class CaseLane:
                 raise
             raise CaseRejected("claim_store_unavailable") from None
 
-    def claim(self, case_id, payload_sha256):
+    def claim(self, case_id, payload_sha256, *, diagnostic_scope=None):
         _identity(case_id, payload_sha256)
         self.db.execute("BEGIN IMMEDIATE")
         try:
-            if self.db.execute("SELECT 1 FROM cases WHERE state IS NULL OR state!='FINISHED' LIMIT 1").fetchone():
-                raise CaseRejected("lane_uncertain")
+            unresolved = self.db.execute("SELECT case_id,payload_sha256,state FROM cases WHERE state IS NULL OR state!='FINISHED'").fetchall()
+            if unresolved:
+                from tools.isolated_case_disposition import scope_hash_for_claim, DECISION
+                version = self.db.execute("SELECT version FROM metadata").fetchone()[0]
+                scope_hash = scope_hash_for_claim(diagnostic_scope, self.root, case_id, payload_sha256)
+                for old_id, old_payload, state in unresolved:
+                    if version != 2 or state != "UNKNOWN":
+                        raise CaseRejected("lane_uncertain")
+                    disposition = self.db.execute("SELECT payload_sha256,scope_sha256,decision FROM dispositions WHERE case_id=?", (old_id,)).fetchone()
+                    if disposition is not None and old_id == case_id:
+                        raise CaseRejected("original_case_permanently_forbidden")
+                    if scope_hash is None or disposition != (old_payload, scope_hash, DECISION):
+                        raise CaseRejected("lane_uncertain")
             previous = self.db.execute("SELECT payload_sha256,summary FROM cases WHERE case_id=?", (case_id,)).fetchone()
             if previous:
                 if previous[0] != payload_sha256:


### PR DESCRIPTION
Private explicit schema migration and append-only operator disposition. Original UNKNOWN and original case ID never become retryable; later claims need a nonserializable exact-source/runtime no-order capability. Scope is one immutable future revision. Current host probe remains deliberately unavailable and run_case does not opt in, so no real release or new model invocation is enabled. Root109 tests pass plus Ruff; independent69 tests and architect offline approval. Immutable full approval/evidence archive, real host probe and explicit operator decision remain prerequisites before use.