### PR TITLE
feat: disabled strategy history, HOLD marks and receipt-only repair

### DIFF
--- a/prism-us/us_stock_tracking_agent.py
+++ b/prism-us/us_stock_tracking_agent.py
@@ -3548,7 +3548,7 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     if effects is not None:
                         effects.observe("broker_window", status="NOT_APPLICABLE_NO_ORDER", ticker=ticker)
                         current_price = effects.quote(ticker)
-                        applied = effects.record_exit(ticker=ticker, price=current_price)
+                        applied = effects.record_exit(ticker=ticker, price=current_price, sell_reason=sell_reason)
                         effects.observe("strategy_exit", status="RECORDED" if applied else "REPLAYED", ticker=ticker)
                         if applied:
                             sold_stocks.append({"ticker": ticker, "company_name": company_name,
@@ -3785,6 +3785,11 @@ Use yahoo_finance and sqlite tools to check latest data, then decide whether to 
                     await self._save_holding_decision(ticker, current_price, should_sell, sell_reason, stock)
 
                     # Update current price
+                    if effects is not None:
+                        current_price = effects.quote(ticker)
+                        applied = effects.record_mark(ticker=ticker, price=current_price)
+                        effects.observe("strategy_mark", status="RECORDED" if applied else "REPLAYED", ticker=ticker)
+                        continue
                     self.cursor.execute(
                         """UPDATE us_stock_holdings
                            SET current_price = ?, last_updated = ?

--- a/prism_core/isolated_strategy_effects.py
+++ b/prism_core/isolated_strategy_effects.py
@@ -8,7 +8,7 @@ reviewed. Projection failure never rolls back a committed strategy event.
 from dataclasses import dataclass
 from contextlib import closing
 from datetime import datetime, timezone
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal, InvalidOperation, localcontext
 import hashlib
 import json
 from pathlib import Path
@@ -23,6 +23,14 @@ EFFECTS_RUNTIME_ENABLED = False
 
 def _source_now():
     return datetime.now(timezone.utc).isoformat()
+
+
+def _encoded(value):
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+
+
+def _digest(value):
+    return hashlib.sha256(_encoded(value).encode()).hexdigest()
 
 
 class EffectsFailure(RuntimeError):
@@ -193,6 +201,16 @@ class IsolatedStrategyEffects:
         self.pipeline_context = pipeline_context
         self.observations = []
         self._validate_binding()
+        with self.agent.conn:
+            self.agent.conn.execute("CREATE TABLE IF NOT EXISTS prism_strategy_history_projection (event_id TEXT PRIMARY KEY, campaign_id TEXT UNIQUE NOT NULL, history_id INTEGER NOT NULL, payload_hash TEXT NOT NULL)")
+            self.agent.conn.execute("CREATE TABLE IF NOT EXISTS prism_isolated_effect_preparations (event_id TEXT PRIMARY KEY, campaign_id TEXT NOT NULL, spec_hash TEXT NOT NULL, spec_json TEXT NOT NULL)")
+            self.agent.conn.execute("CREATE TABLE IF NOT EXISTS prism_isolated_effect_receipts (event_id TEXT PRIMARY KEY, ledger_digest TEXT NOT NULL, projected_row_hash TEXT NOT NULL)")
+            self.agent.conn.execute("CREATE TRIGGER IF NOT EXISTS prism_effect_prep_immutable_update BEFORE UPDATE ON prism_isolated_effect_preparations BEGIN SELECT RAISE(ABORT,'immutable preparation'); END")
+            self.agent.conn.execute("CREATE TRIGGER IF NOT EXISTS prism_effect_prep_immutable_delete BEFORE DELETE ON prism_isolated_effect_preparations BEGIN SELECT RAISE(ABORT,'immutable preparation'); END")
+            self.agent.conn.execute("CREATE TRIGGER IF NOT EXISTS prism_effect_receipt_immutable_update BEFORE UPDATE ON prism_isolated_effect_receipts BEGIN SELECT RAISE(ABORT,'immutable projection receipt'); END")
+            self.agent.conn.execute("CREATE TRIGGER IF NOT EXISTS prism_effect_receipt_immutable_delete BEFORE DELETE ON prism_isolated_effect_receipts BEGIN SELECT RAISE(ABORT,'immutable projection receipt'); END")
+            self.agent.conn.execute("CREATE TRIGGER IF NOT EXISTS prism_history_projection_immutable_update BEFORE UPDATE ON prism_strategy_history_projection BEGIN SELECT RAISE(ABORT,'immutable history projection'); END")
+            self.agent.conn.execute("CREATE TRIGGER IF NOT EXISTS prism_history_projection_immutable_delete BEFORE DELETE ON prism_strategy_history_projection BEGIN SELECT RAISE(ABORT,'immutable history projection'); END")
 
     def require_pipeline_context(self):
         context = self.pipeline_context
@@ -232,7 +250,7 @@ class IsolatedStrategyEffects:
 
     def observe(self, kind, *, status, ticker=None):
         self.require_pipeline_context()
-        if kind not in {"broker_window", "analysis_failure", "strategy_exit", "strategy_entry", "analysis_message", "watchlist", "journal", "observation"}:
+        if kind not in {"broker_window", "analysis_failure", "strategy_exit", "strategy_entry", "strategy_mark", "analysis_message", "watchlist", "journal", "observation"}:
             raise EffectsFailure("Unsupported local observation category")
         if not isinstance(status, str) or not re.fullmatch(r"[A-Z0-9_]{1,64}", status) or len(self.observations) >= 4096:
             raise EffectsFailure("Invalid or exhausted local observation sink")
@@ -269,7 +287,7 @@ class IsolatedStrategyEffects:
         campaign = dict(self.registration.campaigns).get(ticker)
         if campaign is None:
             raise EffectsFailure("Ticker is not registered for this case")
-        if operation in {"exit", "pilot_advance"}:
+        if operation in {"exit", "pilot_advance", "mark"}:
             candidates = self.ledger.snapshot(self.registration.book_id)["campaigns"]
             if not any(c["campaign_id"] == campaign and c["book_id"] == self.registration.book_id
                        and c["symbol"] == ticker for c in candidates):
@@ -277,12 +295,125 @@ class IsolatedStrategyEffects:
         payload = [self.registration.case_id, self.registration.book_id, campaign, operation]
         return campaign, "isolated:" + hashlib.sha256(json.dumps(payload).encode()).hexdigest()
 
-    def _finish(self, snapshot, ticker, company_name, scenario):
+    def _finish(self, snapshot, ticker, company_name, scenario, projection_spec=None):
         try:
-            self._project(snapshot, ticker, company_name, scenario)
+            if projection_spec is not None:
+                company_name, scenario = projection_spec["company_name"], projection_spec["scenario"]
+            self._project(snapshot, ticker, company_name, scenario, projection_spec)
         except Exception:
             raise EffectsFailure("Strategy committed; isolated projection requires recovery") from None
         return snapshot["event_applied"]
+
+    def _row_state(self, ticker):
+        sql = "SELECT company_name,buy_price,buy_date,current_price,last_updated,scenario,target_price,stop_loss,sector FROM stock_holdings WHERE account_key=? AND ticker=?"
+        if self.runtime.market == "US":
+            sql = sql.replace("stock_holdings", "us_stock_holdings")
+        rows = self.agent.conn.execute(sql, (self.runtime.accounts()[0]["account_key"], ticker)).fetchall()
+        if len(rows) > 1:
+            raise EffectsFailure("Duplicate projected campaign rows")
+        if not rows:
+            return "ABSENT", ticker, {}
+        values = list(rows[0])
+        values[5] = json.loads(values[5])
+        return _digest(values), values[0], values[5]
+
+    def _prepare_spec(self, event, campaign, ticker, action, facts, company_name, scenario, *, supplied_scenario=False):
+        """PREPARED is durable, but is explicitly NOT proof of ledger commit."""
+        spec = {"schema_version": 1, "event_id": event, "case_id": self.registration.case_id,
+            "book_id": self.registration.book_id, "campaign_id": campaign, "ticker": ticker,
+            "source_hash": self.registration.source_hash, "occurred_at": self.registration.occurred_at,
+            "clock_timezone": self.registration.clock_timezone, "action": action, "facts": facts,
+            "company_name": company_name, "scenario": scenario, "prior_row_hash": self._row_state(ticker)[0]}
+        encoded = _encoded(spec)
+        if len(encoded) > 1024 * 1024:
+            raise EffectsFailure("Projection preparation exceeds bound")
+        with self.agent.conn:
+            existing = self.agent.conn.execute("SELECT spec_hash,spec_json FROM prism_isolated_effect_preparations WHERE event_id=?", (event,)).fetchone()
+            if existing:
+                stored = json.loads(existing[1])
+                fields = set(spec) - {"prior_row_hash", "company_name", "scenario"}
+                if (existing[0] != _digest(stored) or any(stored[k] != spec[k] for k in fields)
+                        or (supplied_scenario and (stored["scenario"] != scenario or stored["company_name"] != company_name))):
+                    raise EffectsFailure("Conflicting immutable projection preparation")
+                return stored
+            self.agent.conn.execute("INSERT INTO prism_isolated_effect_preparations VALUES (?,?,?,?)",
+                (event, campaign, _digest(spec), encoded))
+        return spec
+
+    def _expected_payload(self, spec):
+        """Encode fixed ledger-call metadata, never recompute eligibility."""
+        facts, action = spec["facts"], spec["action"]
+        stamp = datetime.fromisoformat(spec["occurred_at"].replace("Z", "+00:00")).astimezone(timezone.utc).isoformat()
+        common = {"campaign_id": spec["campaign_id"], "occurred_at": stamp}
+        if action == "entry":
+            return {**common, "kind": "target", "book_id": spec["book_id"], "symbol": spec["ticker"],
+                "target_pct": "100", "price": facts["price"], "policy_version": "split-ledger-v1",
+                "reason": "ISOLATED_AGENT_SELECTED_ENTRY", "regime": facts["regime"],
+                "source_hash": spec["source_hash"], "fee_rate": "0", "slippage_rate": "0"}
+        if action == "mark":
+            return {**common, "kind": "mark", "price": facts["price"], "source_hash": spec["source_hash"]}
+        if action == "exit":
+            value = {**common, "kind": "sell", "price": facts["price"], "normalized_units": facts["quantity"],
+                "fee_rate": "0", "slippage_rate": "0", "source_hash": spec["source_hash"]}
+            for key in ("expected_campaign_hash", "expected_normalized_units"):
+                if facts.get(key) is not None:
+                    value[key] = facts[key]
+            return value
+        if action == "pilot_advance":
+            return {**common, "kind": "pilot_advance", "expected_revision": facts["expected_revision"], "evidence": facts["evidence"]}
+        if action == "pilot_open":
+            from prism_core.pilot_lifecycle import create_pilot
+            pilot = create_pilot(market=self.runtime.market, mode="SHADOW", owner="split-pilot-v1",
+                entry_at=stamp, entry_price=Decimal(facts["price"]), signal_bar=facts["signal_bar"],
+                calendar=facts["calendar"], entry_eligible=facts["entry_eligible"])
+            return {"kind": "pilot_open", "book_id": spec["book_id"], "campaign_id": spec["campaign_id"],
+                "symbol": spec["ticker"], "pilot": pilot, "signal_bar": facts["signal_bar"]}
+        raise EffectsFailure("Unsupported prepared ledger action")
+
+    def _verify_projection_source(self, spec):
+        row = self.agent.conn.execute("SELECT spec_hash,spec_json FROM prism_isolated_effect_preparations WHERE event_id=?", (spec["event_id"],)).fetchone()
+        latest = self.agent.conn.execute("SELECT event_id FROM prism_isolated_effect_preparations WHERE campaign_id=? ORDER BY rowid DESC LIMIT 1", (spec["campaign_id"],)).fetchone()
+        if (row is None or row[0] != _digest(spec) or json.loads(row[1]) != spec
+                or latest[0] != spec["event_id"]):
+            raise EffectsFailure("Missing or superseded projection preparation")
+        receipt = self.ledger.event_receipt(spec["event_id"])
+        if (receipt["latest_strategy_event_id"] != spec["event_id"]
+                or receipt["book_id"] != self.registration.book_id
+                or receipt["campaign_id"] != spec["campaign_id"] or receipt["symbol"] != spec["ticker"]
+                or receipt["payload"] != self._expected_payload(spec)
+                or receipt["digest"] != _digest(self._expected_payload(spec))):
+            raise EffectsFailure("Canonical event proof does not match projection preparation")
+        previous = self.agent.conn.execute("SELECT ledger_digest,projected_row_hash FROM prism_isolated_effect_receipts WHERE event_id=?", (spec["event_id"],)).fetchone()
+        row_hash = self._row_state(spec["ticker"])[0]
+        if previous and previous[0] != receipt["digest"]:
+            raise EffectsFailure("Canonical receipt digest changed")
+        allowed = {"ABSENT", spec["prior_row_hash"]}
+        if previous:
+            allowed.add(previous[1])
+        if row_hash not in allowed:
+            raise EffectsFailure("Uncommitted or newer projection inputs require newer-spec recovery")
+        return receipt, previous, row_hash
+
+    def repair_projection(self, *, ticker, operation):
+        """Replay ONLY a proved projection. No ledger/model/quote/order writes."""
+        if operation not in {"entry", "exit", "mark", "pilot_open", "pilot_advance"}:
+            raise EffectsFailure("Unsupported projection repair operation")
+        campaign, event = self._identity(ticker, operation)
+        try:
+            row = self.agent.conn.execute("SELECT spec_hash,spec_json FROM prism_isolated_effect_preparations WHERE event_id=?", (event,)).fetchone()
+            if row is None:
+                raise ValueError()
+            spec = json.loads(row[1])
+            if (row[0] != _digest(spec) or spec["case_id"] != self.registration.case_id
+                    or spec["book_id"] != self.registration.book_id or spec["campaign_id"] != campaign
+                    or spec["ticker"] != ticker or spec["source_hash"] != self.registration.source_hash
+                    or spec["occurred_at"] != self.registration.occurred_at or spec["action"] != operation):
+                raise ValueError()
+            self._verify_projection_source(spec)
+            snapshot = self.ledger.snapshot(self.registration.book_id)
+            return self._project(snapshot, ticker, spec["company_name"], spec["scenario"], spec)
+        except Exception:
+            raise EffectsFailure("Projection-only repair proof unavailable or superseded") from None
 
     def record_entry(self, *, ticker, company_name, price, scenario, is_add):
         campaign, event = self._identity(ticker, "entry")
@@ -295,34 +426,43 @@ class IsolatedStrategyEffects:
                 or scenario.get("regime_entry_policy", {}).get("mode") == "rebound_pilot"):
             raise EffectsFailure("Explicit pilot entry contract required")
         try:
+            regime = self.market_regime() if self.pipeline_context is not None else "isolated_unverified"
+            spec = self._prepare_spec(event, campaign, ticker, "entry", {"price": str(Decimal(str(price))), "regime": regime},
+                company_name, scenario, supplied_scenario=True)
             snapshot = self.ledger.apply_target(event, self.registration.book_id, campaign,
                 ticker, 100, price, self.registration.occurred_at,
-                source_hash=self.registration.source_hash, reason="ISOLATED_AGENT_SELECTED_ENTRY")
+                source_hash=self.registration.source_hash, reason="ISOLATED_AGENT_SELECTED_ENTRY", regime=regime)
         except Exception:
             raise EffectsFailure("Strategy entry failed") from None
-        return self._finish(snapshot, ticker, company_name, scenario)
+        return self._finish(snapshot, ticker, company_name, scenario, spec)
 
     def open_pilot(self, *, ticker, company_name, price, scenario, signal_bar, calendar, entry_eligible):
         campaign, event = self._identity(ticker, "pilot_open")
         self._validate_effect_price(ticker, price)
         try:
+            spec = self._prepare_spec(event, campaign, ticker, "pilot_open", {"price": str(Decimal(str(price))),
+                "signal_bar": signal_bar, "calendar": calendar, "entry_eligible": entry_eligible},
+                company_name, scenario, supplied_scenario=True)
             snapshot = self.ledger.open_pilot(event, self.registration.book_id, campaign,
                 ticker, price, self.registration.occurred_at, owner="split-pilot-v1",
                 signal_bar=signal_bar, calendar=calendar, entry_eligible=entry_eligible)
         except Exception:
             raise EffectsFailure("Strategy pilot entry failed") from None
-        return self._finish(snapshot, ticker, company_name, scenario)
+        return self._finish(snapshot, ticker, company_name, scenario, spec)
 
     def advance_pilot(self, *, ticker, company_name, scenario, expected_revision, evidence):
         campaign, event = self._identity(ticker, "pilot_advance")
         try:
+            spec = self._prepare_spec(event, campaign, ticker, "pilot_advance",
+                {"expected_revision": expected_revision, "evidence": evidence}, company_name, scenario,
+                supplied_scenario=True)
             snapshot = self.ledger.advance_pilot(event, campaign, expected_revision=expected_revision,
                 evidence=evidence, occurred_at=self.registration.occurred_at)
         except Exception:
             raise EffectsFailure("Strategy pilot transition failed") from None
-        return self._finish(snapshot, ticker, company_name, scenario)
+        return self._finish(snapshot, ticker, company_name, scenario, spec)
 
-    def record_exit(self, *, ticker, price, fraction=1):
+    def record_exit(self, *, ticker, price, fraction=1, sell_reason=None):
         campaign, event = self._identity(ticker, "exit")
         self._validate_effect_price(ticker, price)
         try:
@@ -334,16 +474,52 @@ class IsolatedStrategyEffects:
             basis = next((b for b in self.registration.exit_bases if b[0] == ticker), None)
             if fraction != 1 and basis is None:
                 raise ValueError("Partial exits require a registered unit basis")
+            if sell_reason is not None and (not isinstance(sell_reason, str) or len(sell_reason) > 8192):
+                raise ValueError()
             kwargs, scenario = {}, {}
             if basis is not None:
-                kwargs = {"quantity": Decimal(basis[2]) * fraction, "expected_campaign_hash": basis[1],
+                with localcontext() as context:
+                    context.prec = 40  # Match the canonical ledger's unit arithmetic.
+                    quantity = Decimal(basis[2]) if fraction == 1 else Decimal(basis[2]) * fraction
+                kwargs = {"quantity": quantity, "expected_campaign_hash": basis[1],
                           "expected_normalized_units": basis[2]}
                 scenario = json.loads(basis[3])
+            _, company_name, current_scenario = self._row_state(ticker)
+            if basis is None:
+                scenario = current_scenario
+            facts = {"price": str(Decimal(str(price))), "fraction": str(fraction), "sell_reason": sell_reason,
+                "quantity": str(kwargs["quantity"]) if "quantity" in kwargs else None,
+                "expected_campaign_hash": kwargs.get("expected_campaign_hash"),
+                "expected_normalized_units": str(Decimal(kwargs["expected_normalized_units"])) if "expected_normalized_units" in kwargs else None}
+            spec = self._prepare_spec(event, campaign, ticker, "exit", facts, company_name, scenario)
             snapshot = self.ledger.sell(event, campaign, price, self.registration.occurred_at,
                 source_hash=self.registration.source_hash, **kwargs)
         except Exception:
             raise EffectsFailure("Strategy exit failed") from None
-        return self._finish(snapshot, ticker, holding["symbol"], scenario)
+        return self._finish(snapshot, ticker, holding["symbol"], scenario, spec)
+
+    def record_mark(self, *, ticker, price):
+        campaign, event = self._identity(ticker, "mark")
+        self._validate_effect_price(ticker, price)
+        try:
+            state = self.ledger.snapshot(self.registration.book_id)
+            holding = next(c for c in state["campaigns"] if c["campaign_id"] == campaign)
+            if holding["status"] != "OPEN":
+                raise ValueError()
+            sql = "SELECT company_name, scenario FROM stock_holdings WHERE ticker=? AND account_key=?"
+            if self.runtime.market == "US":
+                sql = sql.replace("stock_holdings", "us_stock_holdings")
+            rows = self.agent.conn.execute(sql, (ticker, self.runtime.accounts()[0]["account_key"])).fetchall()
+            if len(rows) != 1:
+                raise ValueError()
+            company_name, scenario = rows[0][0], json.loads(rows[0][1])
+            spec = self._prepare_spec(event, campaign, ticker, "mark", {"price": str(Decimal(str(price)))},
+                company_name, scenario)
+            snapshot = self.ledger.mark(event, campaign, price, self.registration.occurred_at,
+                source_hash=self.registration.source_hash)
+        except Exception:
+            raise EffectsFailure("Strategy mark failed") from None
+        return self._finish(snapshot, ticker, company_name, scenario, spec)
 
     def _validate_effect_price(self, ticker, price):
         if self.pipeline_context is not None:
@@ -351,7 +527,7 @@ class IsolatedStrategyEffects:
             if Decimal(str(price)) != Decimal(str(quote)):
                 raise EffectsFailure("Effect price differs from registered source quote")
 
-    def _project(self, snapshot, ticker, company_name, scenario):
+    def _project(self, snapshot, ticker, company_name, scenario, projection_spec=None):
         if snapshot["book_id"] != self.registration.book_id:
             raise EffectsFailure("Projection book identity mismatch")
         campaign = next(c for c in snapshot["campaigns"] if c["campaign_id"] == dict(self.registration.campaigns)[ticker])
@@ -380,7 +556,8 @@ class IsolatedStrategyEffects:
             return self.agent.conn.execute(sql, values)
 
         with self.agent.conn:
-            rows = query("SELECT id, scenario FROM stock_holdings WHERE account_key=? AND ticker=?",
+            proof = self._verify_projection_source(projection_spec) if projection_spec is not None else None
+            rows = query("SELECT id, scenario, company_name FROM stock_holdings WHERE account_key=? AND ticker=?",
                 (account["account_key"], ticker)).fetchall()
             if len(rows) > 1:
                 raise ValueError("Duplicate projected slot")
@@ -390,9 +567,13 @@ class IsolatedStrategyEffects:
                         or existing.get("book_id") != self.registration.book_id):
                     raise ValueError("Foreign projected slot")
             if campaign["status"] == "CLOSED":
+                if rows:
+                    scenario = {**json.loads(rows[0][1]), **scenario}
+                self._project_closed_history(campaign, account,
+                    rows[0][2] if rows else company_name, scenario, projection_spec)
                 query("DELETE FROM stock_holdings WHERE account_key=? AND ticker=?",
                     (account["account_key"], ticker))
-                return
+                return self._save_projection_receipt(projection_spec, proof) if proof else True
             zone = ZoneInfo(self.registration.clock_timezone)
             buy_date = datetime.fromisoformat(campaign["legs"][0]["occurred_at"].replace("Z", "+00:00")).astimezone(zone).strftime("%Y-%m-%d %H:%M:%S")
             values = (account["account_key"], account["name"], ticker, company_name,
@@ -403,3 +584,79 @@ class IsolatedStrategyEffects:
                 query("UPDATE stock_holdings SET account_key=?, account_name=?, ticker=?, company_name=?, buy_price=?, buy_date=?, current_price=?, last_updated=?, scenario=?, target_price=?, stop_loss=?, sector=? WHERE id=?", (*values, rows[0][0]))
             else:
                 query("INSERT INTO stock_holdings (account_key, account_name, ticker, company_name, buy_price, buy_date, current_price, last_updated, scenario, target_price, stop_loss, sector) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)", values)
+            return self._save_projection_receipt(projection_spec, proof) if proof else True
+
+    def _save_projection_receipt(self, spec, proof):
+        receipt, previous, before_hash = proof
+        after_hash = self._row_state(spec["ticker"])[0]
+        if previous:
+            if previous[0] != receipt["digest"] or previous[1] != after_hash:
+                raise EffectsFailure("Projection receipt conflict")
+        else:
+            self.agent.conn.execute("INSERT INTO prism_isolated_effect_receipts VALUES (?,?,?)",
+                (spec["event_id"], receipt["digest"], after_hash))
+        return previous is None or before_hash != after_hash
+
+    def _project_closed_history(self, campaign, account, company_name, scenario, spec):
+        """Called inside the same arm transaction as holding deletion."""
+        with localcontext() as context:
+            context.prec = 40
+            return self._project_closed_history_precise(campaign, account, company_name, scenario, spec)
+
+    def _project_closed_history_precise(self, campaign, account, company_name, scenario, spec):
+        if not spec or spec.get("action") != "exit":
+            raise EffectsFailure("Closed history requires its canonical exit identity")
+        buys = [leg for leg in campaign["legs"] if leg["side"] == "BUY"]
+        sells = [leg for leg in campaign["legs"] if leg["side"] == "SELL"]
+        if not sells or sells[-1]["event_id"] != spec["event_id"]:
+            raise EffectsFailure("Closed history exit identity mismatch")
+        mapping = self.agent.conn.execute("SELECT event_id, history_id, payload_hash FROM prism_strategy_history_projection WHERE campaign_id=?",
+            (campaign["campaign_id"],)).fetchone()
+        select = "SELECT account_key,account_name,ticker,company_name,buy_price,buy_date,sell_price,sell_date,profit_rate,holding_days,scenario,trigger_type,trigger_mode,sector,exit_kind FROM trading_history WHERE id=?"
+        insert = "INSERT INTO trading_history (account_key,account_name,ticker,company_name,buy_price,buy_date,sell_price,sell_date,profit_rate,holding_days,scenario,trigger_type,trigger_mode,sector,exit_kind) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
+        if self.runtime.market == "US":
+            select, insert = select.replace("trading_history", "us_trading_history"), insert.replace("trading_history", "us_trading_history")
+        if mapping:
+            stored = self.agent.conn.execute(select, (mapping[1],)).fetchone()
+            if (mapping[0] != spec["event_id"] or stored is None
+                    or hashlib.sha256(json.dumps(list(stored), sort_keys=True, allow_nan=False).encode()).hexdigest() != mapping[2]):
+                raise EffectsFailure("Existing history projection identity conflict")
+            return
+        bought = sum(Decimal(leg["normalized_units"]) for leg in buys)
+        sold = sum(Decimal(leg["normalized_units"]) for leg in sells)
+        if not bought or sold != bought:
+            raise EffectsFailure("Closed campaign unit accounting does not reconcile")
+        buy_price = sum(Decimal(leg["execution_price"]) * Decimal(leg["normalized_units"]) for leg in buys) / bought
+        sell_price = sum(Decimal(leg["execution_price"]) * Decimal(leg["normalized_units"]) for leg in sells) / sold
+        contribution = Decimal(campaign["realized_contribution"])
+        profit_rate = contribution / Decimal(campaign["cumulative_deployed_allocation"]) * 100
+        zone = ZoneInfo(self.registration.clock_timezone)
+        opened = datetime.fromisoformat(buys[0]["occurred_at"]).astimezone(zone)
+        closed = datetime.fromisoformat(sells[-1]["occurred_at"]).astimezone(zone)
+        from reentry_cooldown import classify_exit_kind
+        reason = spec["facts"].get("sell_reason")
+        exit_kind = classify_exit_kind(reason) if reason else None
+        scenario = dict(scenario)
+        event_sources = []
+        for leg in campaign["legs"]:
+            receipt = self.ledger.event_receipt(leg["event_id"])
+            event_sources.append({"event_id": leg["event_id"], "payload_hash": receipt["digest"],
+                "source_hash": receipt["payload"].get("source_hash")})
+        scenario["_strategy_projection"] = {**scenario["_strategy_projection"],
+            "return_basis": "CAMPAIGN_NET_RETURN_ON_CUMULATIVE_ALLOCATION",
+            "one_slot_contribution": str(contribution), "source_event_id": spec["event_id"],
+            "price_basis": "NORMALIZED_UNIT_WEIGHTED_EXECUTION_PRICES",
+            "deterministic_exit_reason": reason, "model_generated_journal": "NOT_GENERATED",
+            "canonical_legs": campaign["legs"], "canonical_event_sources": event_sources,
+            "cost_contribution_total": str(sum(Decimal(leg["cost_contribution"]) for leg in buys)
+                + sum(Decimal(leg["normalized_units"]) * Decimal(leg["execution_price"]) * Decimal(leg["fee_rate"]) for leg in sells)),
+            "cost_basis": "ENTRY_FEES_ONCE_PLUS_EXIT_FEES; SLIPPAGE_IN_EXECUTION_PRICES"}
+        values = (account["account_key"], account["name"], campaign["symbol"], company_name,
+            float(buy_price), opened.strftime("%Y-%m-%d %H:%M:%S"), float(sell_price),
+            closed.strftime("%Y-%m-%d %H:%M:%S"), float(profit_rate), (closed - opened).days,
+            json.dumps(scenario, allow_nan=False), scenario.get("trigger_type"), scenario.get("trigger_mode"),
+            scenario.get("sector"), exit_kind)
+        cursor = self.agent.conn.execute(insert, values)
+        digest = hashlib.sha256(json.dumps(list(values), sort_keys=True, allow_nan=False).encode()).hexdigest()
+        self.agent.conn.execute("INSERT INTO prism_strategy_history_projection VALUES (?,?,?,?)",
+            (spec["event_id"], campaign["campaign_id"], cursor.lastrowid, digest))

--- a/prism_core/strategy_ledger.py
+++ b/prism_core/strategy_ledger.py
@@ -8,7 +8,7 @@ or finance larger campaigns. Re-entry requires a new campaign after closure.
 import hashlib
 import json
 import sqlite3
-from contextlib import contextmanager
+from contextlib import closing, contextmanager
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation, localcontext
 from pathlib import Path
@@ -438,6 +438,38 @@ class StrategyLedger:
             return {key: campaign[key] for key in ("campaign_id", "book_id", "symbol", "normalized_units")} | {
                 "campaign_hash": hashlib.sha256(_dump(campaign).encode()).hexdigest(),
             }
+
+    def event_receipt(self, event_id):
+        """Read immutable strategy proof and its latest campaign event identity.
+
+        Pilot internal target legs belong to the enclosing pilot event. Account
+        overlays/notices are not strategy projection revisions. This method
+        performs no inserts or updates and cannot execute a trading decision.
+        """
+        with closing(sqlite3.connect(Path(self.path).as_uri() + "?mode=ro", uri=True)) as db:
+            db.execute("PRAGMA query_only=ON")
+            db.execute("BEGIN")
+            row = db.execute("SELECT digest,payload FROM events WHERE id=?", (_text(event_id),)).fetchone()
+            if row is None:
+                raise LedgerError("committed strategy event missing")
+            payload = json.loads(row[1])
+            if hashlib.sha256(_dump(payload).encode()).hexdigest() != row[0]:
+                raise LedgerError("strategy event digest conflict")
+            kinds = {"target", "sell", "mark", "pilot_open", "pilot_advance"}
+            if payload.get("kind") not in kinds:
+                raise LedgerError("not a strategy projection event")
+            campaign = self._get(db, "campaigns", payload["campaign_id"])
+            events = []
+            for identifier, raw in db.execute("SELECT id,payload FROM events ORDER BY rowid"):
+                value = json.loads(raw)
+                if value.get("campaign_id") == campaign["campaign_id"] and value.get("kind") in kinds:
+                    events.append((identifier, value["kind"]))
+            parents = {identifier for identifier, kind in events if kind in {"pilot_open", "pilot_advance"}}
+            revisions = [identifier for identifier, kind in events
+                         if not (kind == "target" and identifier.endswith(":target") and identifier[:-7] in parents)]
+            return {"event_id": event_id, "digest": row[0], "payload": payload,
+                    "book_id": campaign["book_id"], "campaign_id": campaign["campaign_id"],
+                    "symbol": campaign["symbol"], "latest_strategy_event_id": revisions[-1]}
 
     def sell(
         self,

--- a/stock_tracking_agent.py
+++ b/stock_tracking_agent.py
@@ -3879,7 +3879,7 @@ class StockTrackingAgent:
                 if should_sell:
                     if effects is not None:
                         current_price = effects.quote(ticker)
-                        applied = effects.record_exit(ticker=ticker, price=current_price)
+                        applied = effects.record_exit(ticker=ticker, price=current_price, sell_reason=sell_reason)
                         effects.observe("strategy_exit", status="RECORDED" if applied else "REPLAYED", ticker=ticker)
                         if applied:
                             sold_stocks.append({"ticker": ticker, "company_name": company_name,
@@ -4065,6 +4065,11 @@ class StockTrackingAgent:
                         })
                 else:
                     # Update current price
+                    if effects is not None:
+                        current_price = effects.quote(ticker)
+                        applied = effects.record_mark(ticker=ticker, price=current_price)
+                        effects.observe("strategy_mark", status="RECORDED" if applied else "REPLAYED", ticker=ticker)
+                        continue
                     self.cursor.execute(
                         """UPDATE stock_holdings
                            SET current_price = ?, last_updated = ?

--- a/tests/test_isolated_agent_effect_branches.py
+++ b/tests/test_isolated_agent_effect_branches.py
@@ -18,7 +18,7 @@ from prism_core import isolated_strategy_effects as effects
 from prism_core.isolated_agent_runtime import require_execution_runtime
 from prism_core.isolated_agent_runtime import prepare_isolated_runtime
 from prism_core.strategy_ledger import StrategyLedger
-from test_isolated_strategy_effects import bound as _bound
+from test_isolated_strategy_effects import bound as _bound, create_history_table
 from test_isolated_effects_context import context, envelope
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -127,6 +127,7 @@ def bound_us(tmp_path):
     conn.row_factory = sqlite3.Row
     conn.execute("CREATE TABLE us_stock_holdings (id INTEGER PRIMARY KEY, account_key TEXT, account_name TEXT, ticker TEXT, company_name TEXT, buy_price REAL, buy_date TEXT, current_price REAL, last_updated TEXT, scenario TEXT, target_price REAL, stop_loss REAL, trigger_type TEXT, trigger_mode TEXT, sector TEXT)")
     conn.commit()
+    create_history_table(conn, "US")
     agent = SimpleNamespace(_isolated_runtime=runtime, conn=conn, cursor=conn.cursor(), db_path=runtime.db_path)
     ledger = StrategyLedger(tmp_path / "strategy.sqlite")
     ledger.create_book("book", "US", mode="SHADOW")

--- a/tests/test_isolated_agent_effects_fullclass.py
+++ b/tests/test_isolated_agent_effects_fullclass.py
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock
 import hashlib
 from prism_core import isolated_strategy_effects as effects
 from prism_core.strategy_ledger import StrategyLedger
+from dataclasses import replace
 mode = sys.argv[3]
 
 def deny(*args, **kwargs):
@@ -48,10 +49,12 @@ async def main():
         "regime": {"MARKET": envelope({"regime": "moderate_bull", "summary": "synthetic regime fixture"}, stamp)},
         "pulse": {"MARKET": envelope("UPTREND", stamp)},
         "journal": {ticker: envelope({"context": "synthetic empty-history fixture", "adjustment": 0, "reasons": []}, stamp) for ticker in (old, new)},
-        "corporate_status": {old: envelope("00", stamp)},
-        "corporate_event": {old: envelope({"should_exit": False, "reason": "synthetic no-event fixture"}, stamp)}}
+        "corporate_status": {ticker: envelope("00", stamp) for ticker in (old, new)},
+        "corporate_event": {ticker: envelope({"should_exit": False, "reason": "synthetic no-event fixture"}, stamp) for ticker in (old, new)}}
     if mode == "missing_quote":
         payload["quote"].pop(old)
+    if mode == "hold":
+        payload["quote"][old] = envelope(110, stamp)
     raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     digest = hashlib.sha256(raw.encode()).hexdigest()
     ledger = StrategyLedger(root / "strategy.sqlite")
@@ -81,6 +84,10 @@ async def main():
         adapter._project = projection_failure
     agent._analyze_report_core = AsyncMock(return_value=core)
     agent._analyze_sell_decision = AsyncMock(return_value=(True, "synthetic SELL decision double"))
+    if mode == "cooldown":
+        agent._analyze_sell_decision = AsyncMock(return_value=(True, "Stop-loss synthetic SELL decision double"))
+    if mode == "hold":
+        agent._analyze_sell_decision = AsyncMock(return_value=(False, "synthetic HOLD decision double"))
     if mode == "delayed_sell":
         async def delayed_sell(stock):
             effects._source_now = lambda: (datetime.fromisoformat(stamp) + timedelta(seconds=180)).isoformat()
@@ -98,7 +105,7 @@ async def main():
     policy.get_market_pulse_state = lambda *args: "UPTREND"
     # Fixed sources for policy evaluation; no real account cash is introduced.
     agent._get_trigger_win_rate = lambda *args, **kw: {}
-    if mode != "success":
+    if mode not in {"success", "hold", "cooldown"}:
         try:
             await agent.process_reports(["SYNTHETIC-report.pdf"])
         except effects.EffectsFailure:
@@ -113,15 +120,28 @@ async def main():
         agent.conn.close()
         return
     result = await agent.process_reports(["SYNTHETIC-report.pdf"])
-    assert result == (1, 1), (result, ledger.snapshot("book"), adapter.observations)
+    expected_sells = 0 if mode == "hold" else 1
+    assert result == (1, expected_sells), (result, ledger.snapshot("book"), adapter.observations)
     snapshot = ledger.snapshot("book")
-    assert snapshot["occupied_slots"] == 1 and snapshot["executions"] == []
-    assert next(c for c in snapshot["campaigns"] if c["symbol"] == old)["status"] == "CLOSED"
+    assert snapshot["occupied_slots"] == (2 if mode == "hold" else 1) and snapshot["executions"] == []
+    old_campaign = next(c for c in snapshot["campaigns"] if c["symbol"] == old)
+    assert old_campaign["status"] == ("OPEN" if mode == "hold" else "CLOSED")
+    if mode == "hold":
+        assert float(old_campaign["unrealized_contribution"]) == .1
     assert next(c for c in snapshot["campaigns"] if c["symbol"] == new)["status"] == "OPEN"
+    if mode == "cooldown":
+        registration2 = replace(registration, case_id="reentry", campaigns=((old, "reentry-campaign"), (new, "new-campaign")))
+        adapter2 = effects.IsolatedStrategyEffects(agent, ledger, registration2,
+            pipeline_context=effects.EffectsPipelineContext("reentry", digest, raw))
+        agent._no_order_effects = adapter2
+        agent._analyze_sell_decision = AsyncMock(return_value=(False, "synthetic HOLD on remaining campaign"))
+        agent._analyze_report_core = AsyncMock(return_value={**core, "ticker": old, "company_name": "SYNTHETIC attempted reentry"})
+        assert await agent.process_reports(["SYNTHETIC-reentry.pdf"]) == (0, 0)
+        assert not any(c["campaign_id"] == "reentry-campaign" for c in ledger.snapshot("book")["campaigns"])
     assert blocked == [], blocked
     assert agent.telegram_token is None and agent.telegram_bot is None
     assert calls == [], "No MCP/model should start in a synthetic decision test"
-    print(json.dumps({"real_class_pipeline": kind, "synthetic_decisions": True, "buy": 1, "sell": 1,
+    print(json.dumps({"real_class_pipeline": kind, "synthetic_decisions": True, "buy": 1, "sell": expected_sells,
         "broker_or_network_attempts": 0, "account_executions": 0}))
     agent.conn.close()
 asyncio.run(main())
@@ -129,7 +149,7 @@ asyncio.run(main())
 
 
 @pytest.mark.parametrize("kind", ["KR", "KR_ENHANCED", "US"])
-@pytest.mark.parametrize("mode", ["success", "missing_quote", "model_failure", "projection_failure", "delayed_sell"])
+@pytest.mark.parametrize("mode", ["success", "missing_quote", "model_failure", "projection_failure", "delayed_sell", "hold", "cooldown"])
 def test_real_class_no_order_pipeline_in_fresh_audited_process(tmp_path, kind, mode):
     env = {key: value for key, value in os.environ.items()
            if not any(secret in key.upper() for secret in ("KIS", "TOKEN", "SECRET", "API_KEY", "APP_KEY"))}
@@ -138,11 +158,11 @@ def test_real_class_no_order_pipeline_in_fresh_audited_process(tmp_path, kind, m
     result = subprocess.run([sys.executable, "-I", "-c", SCRIPT, str(ROOT), kind, mode],
         cwd=tmp_path, env=env, text=True, capture_output=True, timeout=90)
     assert result.returncode == 0, result.stderr[-9000:]
-    if mode != "success":
+    if mode not in {"success", "hold", "cooldown"}:
         assert json.loads(result.stdout.strip().splitlines()[-1]) == {
             "real_class_pipeline": kind, "failure": mode, "case_failed_closed": True}
         return
     assert json.loads(result.stdout.strip().splitlines()[-1]) == {
-        "real_class_pipeline": kind, "synthetic_decisions": True, "buy": 1, "sell": 1,
+        "real_class_pipeline": kind, "synthetic_decisions": True, "buy": 1, "sell": 0 if mode == "hold" else 1,
         "broker_or_network_attempts": 0, "account_executions": 0,
     }

--- a/tests/test_isolated_effect_repair.py
+++ b/tests/test_isolated_effect_repair.py
@@ -1,0 +1,123 @@
+"""Expired-context repair must prove an existing event, never replay trading."""
+from dataclasses import replace
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from prism_core import isolated_strategy_effects as effects
+from test_isolated_strategy_effects import bound as _bound, enter
+from test_isolated_agent_effect_branches import bind_pipeline, bound_us as _bound_us
+from test_pilot_lifecycle import calendar, signal_bar, evidence, ENTRY, NOW
+
+bound = _bound
+bound_us = _bound_us
+
+
+def test_prepared_without_ledger_commit_cannot_be_repaired(bound, monkeypatch):
+    _, ledger, adapter = bound
+    monkeypatch.setattr(ledger, "apply_target", lambda *a, **k: (_ for _ in ()).throw(ValueError("synthetic ledger failure")))
+    with pytest.raises(effects.EffectsFailure):
+        enter(adapter)
+    with pytest.raises(effects.EffectsFailure):
+        adapter.repair_projection(ticker="005930", operation="entry")
+    assert ledger.snapshot("book")["occupied_slots"] == 0
+
+
+def test_expired_context_repairs_only_committed_projection_without_ledger_mutation(bound, monkeypatch):
+    agent, ledger, adapter = bound
+    # Persist a genuine prep and strategy event but interrupt the second DB.
+    original = adapter._project
+    monkeypatch.setattr(adapter, "_project", lambda *a: (_ for _ in ()).throw(ValueError("synthetic interruption")))
+    with pytest.raises(effects.EffectsFailure):
+        enter(adapter)
+    before = ledger.snapshot("book")
+    ledger_bytes = hashlib.sha256(Path(ledger.path).read_bytes()).hexdigest()
+    adapter = bind_pipeline(agent, ledger, adapter, monkeypatch)
+    monkeypatch.setattr(effects, "_source_now", lambda: "2026-09-10T00:10:00Z")
+    # This is a different adapter instance, not retained Python callback state.
+    monkeypatch.setattr(ledger, "apply_target", lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not mutate ledger")))
+    assert adapter.repair_projection(ticker="005930", operation="entry")
+    assert not adapter.repair_projection(ticker="005930", operation="entry")
+    assert ledger.snapshot("book") == before
+    assert hashlib.sha256(Path(ledger.path).read_bytes()).hexdigest() == ledger_bytes
+    assert agent.conn.execute("SELECT COUNT(*) FROM stock_holdings").fetchone()[0] == 1
+    assert original is not None
+
+
+def test_old_entry_repair_cannot_roll_back_new_mark_or_uncommitted_stop_change(bound):
+    agent, ledger, adapter = bound
+    enter(adapter)
+    later = effects.IsolatedStrategyEffects(agent, ledger,
+        replace(adapter.registration, case_id="later", occurred_at="2026-09-10T00:01:00Z"))
+    later.record_mark(ticker="005930", price=110)
+    with pytest.raises(effects.EffectsFailure):
+        adapter.repair_projection(ticker="005930", operation="entry")
+    assert agent.conn.execute("SELECT current_price FROM stock_holdings").fetchone()[0] == 110
+    agent.conn.execute("UPDATE stock_holdings SET stop_loss=105")
+    agent.conn.commit()
+    with pytest.raises(effects.EffectsFailure):
+        later.repair_projection(ticker="005930", operation="mark")
+    assert agent.conn.execute("SELECT stop_loss FROM stock_holdings").fetchone()[0] == 105
+
+
+def test_preparation_is_immutable_and_foreign_case_has_no_repair_authority(bound):
+    agent, ledger, adapter = bound
+    enter(adapter)
+    row = agent.conn.execute("SELECT spec_json FROM prism_isolated_effect_preparations").fetchone()
+    assert json.loads(row[0])["book_id"] == "book"
+    with pytest.raises(__import__("sqlite3").IntegrityError):
+        agent.conn.execute("UPDATE prism_isolated_effect_preparations SET spec_json='{}'")
+    agent.conn.rollback()
+    foreign = effects.IsolatedStrategyEffects(agent, ledger, replace(adapter.registration, case_id="foreign"))
+    with pytest.raises(effects.EffectsFailure):
+        foreign.repair_projection(ticker="005930", operation="entry")
+
+
+def test_committed_event_with_wrong_payload_is_not_projection_authority(bound, monkeypatch):
+    agent, ledger, adapter = bound
+    real_apply = ledger.apply_target
+    monkeypatch.setattr(ledger, "apply_target", lambda *a, **k: (_ for _ in ()).throw(ValueError("synthetic precommit failure")))
+    with pytest.raises(effects.EffectsFailure):
+        enter(adapter)
+    event = agent.conn.execute("SELECT event_id FROM prism_isolated_effect_preparations").fetchone()[0]
+    real_apply(event, "book", "campaign1", "005930", 100, 101, adapter.registration.occurred_at,
+        source_hash=adapter.registration.source_hash)
+    with pytest.raises(effects.EffectsFailure):
+        adapter.repair_projection(ticker="005930", operation="entry")
+    assert agent.conn.execute("SELECT COUNT(*) FROM stock_holdings").fetchone()[0] == 0
+
+
+def test_new_uncommitted_preparation_blocks_older_stop_rollback(bound, monkeypatch):
+    agent, ledger, adapter = bound
+    enter(adapter)
+    agent.conn.execute("UPDATE stock_holdings SET stop_loss=105")
+    agent.conn.commit()
+    later = effects.IsolatedStrategyEffects(agent, ledger,
+        replace(adapter.registration, case_id="later", occurred_at="2026-09-10T00:01:00Z"))
+    monkeypatch.setattr(ledger, "mark", lambda *a, **k: (_ for _ in ()).throw(ValueError("synthetic beforemark failure")))
+    with pytest.raises(effects.EffectsFailure):
+        later.record_mark(ticker="005930", price=110)
+    with pytest.raises(effects.EffectsFailure):
+        adapter.repair_projection(ticker="005930", operation="entry")
+    with pytest.raises(effects.EffectsFailure):
+        later.repair_projection(ticker="005930", operation="mark")
+    assert agent.conn.execute("SELECT stop_loss FROM stock_holdings").fetchone()[0] == 105
+
+
+def test_old_pilot_repair_cannot_undo_later_promotion_and_stop(bound_us):
+    agent, ledger, original = bound_us
+    ledger.create_book("pilot", "US", cohort="split-pilot-v1", mode="SHADOW")
+    registration = replace(original.registration, book_id="pilot", occurred_at=ENTRY)
+    first = effects.IsolatedStrategyEffects(agent, ledger, registration)
+    assert first.open_pilot(ticker="SNDK", company_name="SYNTHETIC pilot", price=100,
+        scenario={"stop_loss": 95}, signal_bar=signal_bar(), calendar=calendar(), entry_eligible=True)
+    later = effects.IsolatedStrategyEffects(agent, ledger,
+        replace(registration, case_id="promotion", occurred_at=NOW))
+    assert later.advance_pilot(ticker="SNDK", company_name="SYNTHETIC pilot", scenario={"stop_loss": 102},
+        expected_revision=0, evidence=evidence())
+    with pytest.raises(effects.EffectsFailure):
+        first.repair_projection(ticker="SNDK", operation="pilot_open")
+    assert ledger.snapshot("pilot")["campaigns"][0]["pilot"]["state"] == "FULL_100"
+    assert agent.conn.execute("SELECT stop_loss FROM us_stock_holdings").fetchone()[0] == 102

--- a/tests/test_isolated_strategy_effects.py
+++ b/tests/test_isolated_strategy_effects.py
@@ -13,6 +13,14 @@ from prism_core.strategy_ledger import StrategyLedger
 from prism_core.strategy_ledger_outbox import StrategyLedgerOutbox
 
 
+def create_history_table(conn, market="KR"):
+    sql = "CREATE TABLE IF NOT EXISTS trading_history (id INTEGER PRIMARY KEY, account_key TEXT NOT NULL, account_name TEXT, ticker TEXT NOT NULL, company_name TEXT NOT NULL, buy_price REAL NOT NULL, buy_date TEXT NOT NULL, sell_price REAL NOT NULL, sell_date TEXT NOT NULL, profit_rate REAL NOT NULL, holding_days INTEGER NOT NULL, scenario TEXT, trigger_type TEXT, trigger_mode TEXT, sector TEXT, exit_kind TEXT)"
+    if market == "US":
+        sql = sql.replace("trading_history", "us_trading_history")
+    conn.execute(sql)
+    conn.commit()
+
+
 @pytest.fixture
 def bound(tmp_path):
     tmp_path.chmod(0o700)
@@ -25,6 +33,7 @@ def bound(tmp_path):
     conn.row_factory = __import__("sqlite3").Row
     conn.execute("CREATE TABLE stock_holdings (id INTEGER PRIMARY KEY, account_key TEXT, account_name TEXT, ticker TEXT, company_name TEXT, buy_price REAL, buy_date TEXT, current_price REAL, last_updated TEXT, scenario TEXT, target_price REAL, stop_loss REAL, trigger_type TEXT, trigger_mode TEXT, sector TEXT)")
     conn.commit()
+    create_history_table(conn)
     agent = SimpleNamespace(_isolated_runtime=runtime, conn=conn, cursor=conn.cursor(), db_path=runtime.db_path)
     ledger = StrategyLedger(tmp_path / "strategy.sqlite")
     ledger.create_book("book", "KR", mode="SHADOW")
@@ -231,6 +240,7 @@ def test_us_projection_uses_us_table_and_real_price(tmp_path, entry_at):
     try:
         conn.execute("CREATE TABLE us_stock_holdings (id INTEGER PRIMARY KEY, account_key TEXT, account_name TEXT, ticker TEXT, company_name TEXT, buy_price REAL, buy_date TEXT, current_price REAL, last_updated TEXT, scenario TEXT, target_price REAL, stop_loss REAL, sector TEXT)")
         conn.commit()
+        create_history_table(conn, "US")
         agent = SimpleNamespace(_isolated_runtime=runtime, conn=conn, db_path=runtime.db_path)
         ledger = StrategyLedger(tmp_path / "strategy.sqlite")
         ledger.create_book("book", "US", mode="SHADOW")

--- a/tests/test_isolated_strategy_history.py
+++ b/tests/test_isolated_strategy_history.py
@@ -1,0 +1,128 @@
+"""Closed strategy campaign projections, never broker fills or cash PnL."""
+from dataclasses import replace
+from datetime import datetime
+from decimal import Decimal, localcontext
+import json
+
+import pytest
+
+from prism_core.isolated_strategy_effects import EffectsFailure, IsolatedStrategyEffects
+from prism_core.strategy_ledger_outbox import StrategyLedgerOutbox
+from reentry_cooldown import reentry_block
+from test_isolated_strategy_effects import bound as _bound, enter
+
+bound = _bound
+
+
+@pytest.fixture
+def history_bound(bound):
+    agent, ledger, adapter = bound
+    return agent, ledger, adapter
+
+
+def basis(agent, ledger, adapter, case_id, occurred_at):
+    guard = ledger.campaign_guard("campaign1")
+    scenario = agent.conn.execute("SELECT scenario FROM stock_holdings").fetchone()[0]
+    registration = replace(adapter.registration, case_id=case_id, occurred_at=occurred_at,
+        exit_bases=(("005930", guard["campaign_hash"], guard["normalized_units"], scenario),))
+    return IsolatedStrategyEffects(agent, ledger, registration)
+
+
+def test_half_slot_loss_history_uses_campaign_return_not_slot_contribution(history_bound):
+    agent, ledger, adapter = history_bound
+    snapshot = ledger.apply_target("seed", "book", "campaign1", "005930", 50, 100, adapter.registration.occurred_at)
+    adapter._project(snapshot, "005930", "SYNTHETIC half slot", {"target_price": 120, "stop_loss": 95})
+    assert adapter.record_exit(ticker="005930", price=90, sell_reason="Stop-loss synthetic fixture")
+    row = dict(agent.conn.execute("SELECT * FROM trading_history").fetchone())
+    assert row["profit_rate"] == -10
+    assert Decimal(ledger.snapshot("book")["realized_contribution"]) == Decimal("-.05")
+    assert row["buy_price"] == 100 and row["sell_price"] == 90
+    assert row["exit_kind"] == "stop"
+    metadata = json.loads(row["scenario"])["_strategy_projection"]
+    assert metadata["account_execution_status"] == "UNKNOWN"
+    assert metadata["return_basis"] == "CAMPAIGN_NET_RETURN_ON_CUMULATIVE_ALLOCATION"
+    verdict = reentry_block("KR", "005930", "virtual:test", db_path=agent.db_path,
+        now=datetime(2026, 9, 10, 10, 0, 0), fail_closed=True)
+    assert verdict and verdict["after_loss"] is True
+
+
+def test_partial_then_full_has_one_history_with_weighted_execution_prices(history_bound):
+    agent, ledger, adapter = history_bound
+    enter(adapter)
+    first = basis(agent, ledger, adapter, "partial", "2026-09-10T00:01:00Z")
+    assert first.record_exit(ticker="005930", price=90, fraction=.5, sell_reason="Stop-loss synthetic partial")
+    assert agent.conn.execute("SELECT COUNT(*) FROM trading_history").fetchone()[0] == 0
+    final = basis(agent, ledger, adapter, "final", "2026-09-10T00:02:00Z")
+    assert final.record_exit(ticker="005930", price=110, sell_reason="Target synthetic close")
+    assert not final.record_exit(ticker="005930", price=110, sell_reason="Target synthetic close")
+    rows = agent.conn.execute("SELECT * FROM trading_history").fetchall()
+    assert len(rows) == 1
+    row = dict(rows[0])
+    assert row["buy_price"] == row["sell_price"] == 100
+    assert row["profit_rate"] == 0
+    assert ledger.snapshot("book")["executions"] == []
+
+
+def test_history_and_holding_delete_rollback_together_but_ledger_survives(history_bound):
+    agent, ledger, adapter = history_bound
+    enter(adapter)
+    agent.conn.execute("CREATE TRIGGER synthetic_delete_failure BEFORE DELETE ON stock_holdings BEGIN SELECT RAISE(ABORT, 'synthetic projection failure'); END")
+    agent.conn.commit()
+    with pytest.raises(EffectsFailure):
+        adapter.record_exit(ticker="005930", price=90, sell_reason="Stop-loss synthetic fixture")
+    assert ledger.snapshot("book")["occupied_slots"] == 0
+    assert agent.conn.execute("SELECT COUNT(*) FROM stock_holdings").fetchone()[0] == 1
+    assert agent.conn.execute("SELECT COUNT(*) FROM trading_history").fetchone()[0] == 0
+    agent.conn.execute("DROP TRIGGER synthetic_delete_failure")
+    agent.conn.commit()
+    assert not adapter.record_exit(ticker="005930", price=90, sell_reason="Stop-loss synthetic fixture")
+    assert agent.conn.execute("SELECT COUNT(*) FROM stock_holdings").fetchone()[0] == 0
+    assert agent.conn.execute("SELECT COUNT(*) FROM trading_history").fetchone()[0] == 1
+
+
+def test_hold_mark_updates_canonical_pnl_without_new_trade_or_notice(history_bound):
+    agent, ledger, adapter = history_bound
+    enter(adapter)
+    assert adapter.record_mark(ticker="005930", price=110)
+    assert not adapter.record_mark(ticker="005930", price=110)
+    result = ledger.snapshot("book")
+    assert Decimal(result["unrealized_contribution"]) == Decimal(".1")
+    assert agent.conn.execute("SELECT current_price FROM stock_holdings").fetchone()[0] == 110
+    assert agent.conn.execute("SELECT COUNT(*) FROM trading_history").fetchone()[0] == 0
+    assert len(StrategyLedgerOutbox(ledger).pending()) == 1
+
+
+def test_registered_full_exit_preserves_all_40_digit_normalized_units(history_bound):
+    agent, ledger, adapter = history_bound
+    adapter.record_entry(ticker="005930", company_name="SYNTHETIC repeating units", price="100.01", scenario={}, is_add=False)
+    final = basis(agent, ledger, adapter, "final", "2026-09-10T00:01:00Z")
+    assert final.record_exit(ticker="005930", price=110, sell_reason="Target synthetic full close")
+    assert ledger.snapshot("book")["occupied_slots"] == 0
+    assert agent.conn.execute("SELECT COUNT(*) FROM trading_history").fetchone()[0] == 1
+
+
+def test_history_execution_prices_and_net_return_keep_modeled_costs_separate(history_bound):
+    agent, ledger, adapter = history_bound
+    snapshot = ledger.apply_target("cost-seed", "book", "campaign1", "005930", 100, 100,
+        adapter.registration.occurred_at, fee_rate=".01", slippage_rate=".02")
+    adapter._project(snapshot, "005930", "SYNTHETIC cost fixture", {})
+    with localcontext() as context:
+        context.prec = 40
+        half = Decimal(ledger.campaign_guard("campaign1")["normalized_units"]) / 2
+    snapshot = ledger.sell("cost-partial", "campaign1", 110, "2026-09-10T00:01:00Z",
+        quantity=half, fee_rate=".01", slippage_rate=".02")
+    adapter._project(snapshot, "005930", "SYNTHETIC cost fixture", {})
+    final = basis(agent, ledger, adapter, "final", "2026-09-10T00:02:00Z")
+    assert final.record_exit(ticker="005930", price=90, sell_reason="Stop-loss synthetic close")
+    row = dict(agent.conn.execute("SELECT * FROM trading_history").fetchone())
+    assert row["buy_price"] == pytest.approx(102)
+    assert row["sell_price"] == pytest.approx(98.9)
+    expected_net = float(Decimal(ledger.snapshot("book")["realized_contribution"]) * 100)
+    assert row["profit_rate"] == pytest.approx(expected_net)
+    assert row["profit_rate"] < (row["sell_price"] / row["buy_price"] - 1) * 100
+    metadata = json.loads(row["scenario"])["_strategy_projection"]
+    with localcontext() as context:
+        context.prec = 40
+        expected_cost = Decimal(".01") + half * Decimal("107.8") * Decimal(".01")
+    assert Decimal(metadata["cost_contribution_total"]) == expected_cost
+    assert len(metadata["canonical_event_sources"]) == 3


### PR DESCRIPTION
Closed campaign history uses weighted actual leg prices and campaign net return, with slot contribution separate; history/delete/mapping commit atomically in arm DB. HOLD marks canonical ledger. Immutable prep specs plus real canonical receipts support projection-only repair with no new model/quote/ledger writes, rejecting stale rollback. Fix full-exit Decimal precision and fee metadata duplication. Gate remainsFALSE. Root65 targeted tests pass incl21 fresh fullclass cases; owner223 core/KR regressions +US27 pass; architect83 independent approval. No activation, operator disposition or model call. Fresh context lifecycle, observability payloads and E2E remain pending.