### PR TITLE
fix: preserve helper EOF finalization before signalling

### DIFF
--- a/tests/test_isolated_trading_case_supervisor.py
+++ b/tests/test_isolated_trading_case_supervisor.py
@@ -280,6 +280,65 @@ def test_helper_kill_without_receipt_is_unknown_not_zero_requests(root, monkeypa
     asyncio.run(run())
 
 
+def test_helper_eof_finalization_is_not_killed_by_redundant_signal(root, monkeypatch):
+    """A scheduler pause can put SIGTERM after asyncio restored its default."""
+    import time
+    code = _FAKE_HELPER.replace("listener.close();os.unlink(sys.argv[4])",
+        "listener.close();os.unlink(sys.argv[4]);import time;signal.signal(signal.SIGTERM,signal.SIG_DFL);"
+        "open(sys.argv[4]+'.finalizing','w').close();time.sleep(.5)")
+    monkeypatch.setattr(supervisor, "TRUSTED_HOST_PYTHON", sys.executable)
+    monkeypatch.setattr(supervisor, "_HELPER_BOOTSTRAP", code)
+    reg = SimpleNamespace(helper_source_root=root, auth_snapshot=root / "unused-auth", case_deadline=5)
+    async def run():
+        signals = []
+        async with supervisor._responses_helper(reg, root / "response.sock", {"time-get_current_time"}) as (process, _, evidence):
+            original = process.terminate
+            def scheduled_late_signal():
+                end = time.monotonic() + 1
+                while not (root / "response.sock.finalizing").exists() and time.monotonic() < end:
+                    time.sleep(.005)
+                assert (root / "response.sock.finalizing").exists()
+                signals.append("SIGTERM")
+                original()
+            monkeypatch.setattr(process, "terminate", scheduled_late_signal)
+        assert process.returncode == 0
+        assert evidence["cleanup_confirmed"] is True and evidence["requests"] == 0
+        assert signals == []
+    asyncio.run(run())
+
+
+def test_helper_grace_timeout_stays_unknown_even_after_clean_sigterm(root, monkeypatch):
+    code = _FAKE_HELPER.replace(
+        "while not stopped and not select.select([int(sys.argv[2])],[],[],.02)[0]:pass",
+        "import time\nwhile not stopped:time.sleep(.005)")
+    monkeypatch.setattr(supervisor, "TRUSTED_HOST_PYTHON", sys.executable)
+    monkeypatch.setattr(supervisor, "_HELPER_BOOTSTRAP", code)
+    monkeypatch.setattr(supervisor, "_RESPONSES_EXIT_GRACE_SECONDS", .03)
+    reg = SimpleNamespace(helper_source_root=root, auth_snapshot=root / "unused-auth", case_deadline=5)
+    async def run():
+        receipt = {}
+        with pytest.raises(supervisor.CaseRejected, match="responses_grace_timeout"):
+            async with supervisor._responses_helper(reg, root / "response.sock", {"time-get_current_time"}, cleanup_receipt=receipt) as (process, drains, evidence):
+                pass
+        assert process.returncode == 0 and all(task.done() for task in drains)
+        assert receipt["grace_expired"] is True and receipt["graceful_exit"] is False
+        assert evidence["cleanup_confirmed"] is False
+    asyncio.run(run())
+
+
+def test_graceful_exit_with_bad_receipt_is_not_acknowledged(root, monkeypatch):
+    code = _FAKE_HELPER.replace("{'schema_version':1,'requests':0}", "{'invalid':'SYNTHETIC'}")
+    monkeypatch.setattr(supervisor, "TRUSTED_HOST_PYTHON", sys.executable)
+    monkeypatch.setattr(supervisor, "_HELPER_BOOTSTRAP", code)
+    reg = SimpleNamespace(helper_source_root=root, auth_snapshot=root / "unused-auth", case_deadline=5)
+    async def run():
+        with pytest.raises(supervisor.CaseRejected, match="responses_receipt_unknown"):
+            async with supervisor._responses_helper(reg, root / "response.sock", {"time-get_current_time"}) as (_, _, evidence):
+                pass
+        assert evidence["cleanup_confirmed"] is False
+    asyncio.run(run())
+
+
 @pytest.mark.parametrize("status", ["ok", "UNKNOWN"])
 def test_rule_fallback_is_distinct_and_only_terminal_attempts_are_cacheable(root, status):
     reg, invoker = outcome_fixture(root, status="SOURCE_RULE_FALLBACK", attempts=[

--- a/tools/isolated_case_journal.py
+++ b/tools/isolated_case_journal.py
@@ -14,12 +14,13 @@ STAGES = frozenset({"CLAIMED", "SERVICES_READY", "AGENT_STARTED", "AGENT_REAPED"
 CATEGORIES = frozenset({"NONE", "INTERNAL_FAILURE", "JOURNAL_FAILURE", "CANCELLED",
     "responses_helper_not_ready", "responses_helper_socket_invalid", "responses_cleanup_unknown",
     "responses_receipt_unknown", "invoker_cleanup_unknown", "read_bridge_cleanup_unknown",
+    "responses_grace_timeout",
     "child_output_limit", "case_deadline_or_helper_failure", "case_deadline", "case_activity_uncertain",
     "case_result_invalid", "case_result_missing", "existing_case_artifact", "agent_cleanup_unknown",
     "agent_nonzero_exit", "case_result_identity_mismatch", "case_result_not_final",
     "validation_outcome_uncertain", "case_outcome_uncertain", "case_result_limit"})
 _COUNTS = {"stdout_bytes", "stderr_bytes", "helper_requests", "unjoined_count", "elapsed_ms"}
-_BOOLS = {"receipt_valid", "forced_kill", "poisoned"}
+_BOOLS = {"receipt_valid", "forced_kill", "poisoned", "graceful_exit", "grace_expired"}
 _FIELDS = _COUNTS | _BOOLS | {"returncode", "terminal_categories", "snapshot_hashes", "failure_category", "component"}
 
 

--- a/tools/isolated_trading_case_supervisor.py
+++ b/tools/isolated_trading_case_supervisor.py
@@ -355,6 +355,28 @@ def _joined_bridge(context, journal, component):
 
 
 _HELPER_BOOTSTRAP = "import sys;sys.path.insert(0,sys.argv[1]);from tools.isolated_trading_case_supervisor import _responses_child;_responses_child(sys.argv[2:])"
+_RESPONSES_EXIT_GRACE_SECONDS = 1.0
+
+
+async def _wait_responses_exit(process, receipt):
+    """EOF is already sent; avoid killing a child that is printing its receipt.
+
+    This adds at most one second before the existing bounded terminate/kill
+    cleanup. A grace timeout is still uncertain even if SIGTERM later exits 0.
+    """
+    receipt.update(graceful_exit=False, grace_expired=False, forced_kill=False)
+    try:
+        await asyncio.wait_for(process.wait(), timeout=_RESPONSES_EXIT_GRACE_SECONDS)
+    except asyncio.TimeoutError:
+        receipt["grace_expired"] = True
+        await _stop_process(process, receipt)
+        return False
+    except BaseException:
+        await _stop_process(process, receipt)
+        raise
+    receipt["returncode"] = process.returncode
+    receipt["graceful_exit"] = process.returncode == 0
+    return receipt["graceful_exit"]
 
 
 def _metered_app_factory(original, counter):
@@ -434,7 +456,7 @@ async def _responses_helper(reg, socket_path, read_tools, *, cleanup_receipt=Non
         if reader is not None:
             os.close(reader)
         if process is not None:
-            clean = await _stop_process(process, cleanup_receipt)
+            clean = await _wait_responses_exit(process, cleanup_receipt)
         try:
             results = await asyncio.wait_for(asyncio.gather(*drains, return_exceptions=True), timeout=1)
         except asyncio.TimeoutError:
@@ -445,7 +467,7 @@ async def _responses_helper(reg, socket_path, read_tools, *, cleanup_receipt=Non
             if len(results) > 1 and type(results[1]) is int:
                 cleanup_receipt["stderr_bytes"] = results[1]
             if not clean or any(isinstance(result, BaseException) for result in results):
-                raise CaseRejected("responses_cleanup_unknown")
+                raise CaseRejected("responses_grace_timeout" if cleanup_receipt.get("grace_expired") else "responses_cleanup_unknown")
             try:
                 receipt = json.loads(results[0])
                 if (type(receipt) is not dict or set(receipt) != {"schema_version", "requests"} or receipt["schema_version"] != 1


### PR DESCRIPTION
Deterministic harmless helper reproduction showed redundant SIGTERM can interrupt post-EOF receipt finalization. Add fixed one-second Responses-only grace before existing bounded termination; grace timeout remains UNKNOWN even if SIGTERM later exits0. Retain rc0 AND validreceipt requirement, active drains/whole-case lease; record graceful/graceexpired metadata. Root51 local and51 Linux tests pass plus independent51 architect approval and Ruff. This is a reproduced race class, NOT proof of the exact earlier UNKNOWN cause. No claim rewrite, operator disposition, model calls or runtime policy change.