### PR TITLE
fix: preserve report evidence, leader context and bar finality

### DIFF
--- a/cores/agents/__init__.py
+++ b/cores/agents/__init__.py
@@ -32,6 +32,8 @@ def get_agent_directory(company_name, company_code, reference_date, base_section
         create_sell_decision_agent
     )
     from cores.utils import get_wise_report_url
+    from dataclasses import replace
+    from cores.agents.report_agent import report_time_contract
 
     # Create URL mapping
     urls = {k: get_wise_report_url(k, company_code) for k in [
@@ -55,7 +57,7 @@ def get_agent_directory(company_name, company_code, reference_date, base_section
         ),
         "investor_trading_analysis": lambda: create_investor_trading_analysis_agent(
             company_name, company_code, reference_date, max_years_ago, max_years, language,
-            prefetched_data=pf.get("trading_volume")
+            prefetched_data=pf.get("trading_volume"), prefetched_prices=pf.get("stock_ohlcv")
         ),
         "company_status": lambda: create_company_status_agent(
             company_name, company_code, reference_date, urls, language
@@ -76,6 +78,7 @@ def get_agent_directory(company_name, company_code, reference_date, base_section
     agents = {}
     for section in base_sections:
         if section in agent_creators:
-            agents[section] = agent_creators[section]()
+            agent = agent_creators[section]()
+            agents[section] = replace(agent, instruction=agent.instruction + report_time_contract(reference_date, language))
     
     return agents

--- a/cores/agents/company_info_agents.py
+++ b/cores/agents/company_info_agents.py
@@ -21,7 +21,7 @@ def create_company_status_agent(company_name, company_code, reference_date, urls
                         When collecting data, focus on tables rather than charts.
                         Please write as detailed, accurate, and rich as possible.
 
-                        ## Data to Collect (From Company Status Page Only)
+                        ## Data to Collect (Company Status First; Conditional Supplement Below)
                         1. From the Company Status page (Access URL: {urls['기업현황']}) :
                            - Basic Information: Company name, stock code, industry, closing month, market capitalization, 52-week high/low, stock price information
                            - Fundamental Indicators: Current values (as of current reference date: {reference_date}(YYYYMMDD format)) and past 3 years of data (example: if current year is 2025, then 2021-2024) for EPS, BPS, PER, PBR, PCR, EV/EBITDA, dividend yield, payout ratio, etc., forward consensus (Fwd 12M) data, comparison with industry average PER
@@ -101,7 +101,7 @@ def create_company_status_agent(company_name, company_code, reference_date, urls
                         데이터 수집 시 차트보다는 테이블 위주로 데이터를 수집하세요.
                         가능한한 자세하고 정확하고 풍부하게 작성해주세요.
 
-                        ## 수집해야 할 데이터 (기업현황 페이지에서만)
+                        ## 수집해야 할 데이터 (기업현황 우선, 누락 시 아래 조건부 보완)
                         1. 기업현황 페이지에서 (접속 URL: {urls['기업현황']}) :
                            - 기본 정보: 회사명, 종목코드, 업종, 결산월, 시가총액, 52주 최고/최저가, 주가 정보
                            - 펀더멘털 지표: EPS, BPS, PER, PBR, PCR, EV/EBITDA, 배당수익률, 배당성향 등의 현재값(현재 기준일 : {reference_date}(YYYYMMDD 형식)) 및 과거 3개년도(예시 : 현재가 2025년이면, 2021-2024년) 데이터, 향후 컨센서스(Fwd 12M) 데이터, 업종 평균 PER과의 비교
@@ -176,6 +176,28 @@ def create_company_status_agent(company_name, company_code, reference_date, urls
                         ##분석일: {reference_date}(YYYYMMDD 형식)
                         """
 
+    financial_url = urls.get("재무분석") or "URL_UNAVAILABLE"
+    if language == "en":
+        instruction += f"""
+                        ## CAN SLIM Evidence Priority and Bounded Supplement
+                        - Prioritize quarterly EPS and its comparable prior-year quarter over repetitive valuation commentary. Keep the existing sections; a concise evidence table is sufficient.
+                        - Collect latest reported quarterly EPS and YoY first. Supplement only if missing (including the comparable baseline) from the status page: financial analysis URL {financial_url}. Read at most 1 supplemental page, once, for these missing facts only; no recursive searches or new providers. If supplied facts are sufficient, do not supplement.
+                        - URL_UNAVAILABLE means no supplemental access: do not invent URLs. If inaccessible or still absent, mark the specific field UNKNOWN and explain the missing evidence briefly, without tool-process narration.
+                        - Label each figure with fiscal quarter/year, quarterly/annual/cumulative scope, actual/estimate, consolidated/separate, units, data/publication date and source URL. Only use information available by {reference_date}; unavailable dates or accounting scope remain UNKNOWN.
+                        - Never substitute annual EPS, cumulative EPS, forward EPS or net income for quarterly EPS. Do not combine actual and estimate or different accounting bases. Without a comparable prior-year quarter, YoY is UNKNOWN; zero/negative prior EPS requires explicit turnaround/loss context, not a fabricated positive growth rate.
+                        - Company identity must match {company_name} ({company_code}). Distinguish the parent, subsidiary and any separately listed entities: subsidiary earnings are not parent EPS. Label the reporting entity and accounting scope; use parent consolidated results only when explicitly sourced as such.
+                        """
+    else:
+        instruction += f"""
+                        ## CAN SLIM 핵심 근거 우선순위와 제한적 보완
+                        - 반복적인 밸류에이션 설명보다 최근 분기 EPS(quarterly EPS)와 비교 가능한 전년 동기 근거를 우선 확보하세요. 기존 섹션 안에 간결한 근거 표로 제시하세요.
+                        - 기업현황에서 최근 확정 분기 EPS 또는 YoY 근거(비교 기준 포함)가 누락된 경우에만 재무분석 URL {financial_url}을 보완 조회하세요. 누락 항목에 한해 최대 1개 보완 페이지를 1회 조회하고 재귀 검색이나 새 제공자는 사용하지 마세요. 근거가 충분하면 추가 조회하지 마세요.
+                        - URL_UNAVAILABLE이면 보완 조회를 생략하고 URL을 추측하지 마세요. 접근 실패 또는 여전히 없는 항목은 UNKNOWN으로 표기하고 부족한 근거만 짧게 설명하세요. 도구 처리 과정은 서술하지 마세요.
+                        - 각 수치에 회계 분기·연도, 분기/연간/누적 구분, 실적/추정(actual/estimate), 연결/별도(consolidated/separate), 단위, 데이터 기준일·공시일, 출처 URL을 명시하세요. {reference_date}까지 알려진 자료만 사용하고 날짜나 회계 기준을 확인할 수 없으면 UNKNOWN으로 남기세요.
+                        - 연간 EPS(annual EPS), 누적 EPS, 선행 EPS 또는 순이익을 분기 EPS로 대체하지 마세요. 실적과 추정 또는 서로 다른 회계 기준을 혼합하지 마세요. 비교 가능한 전년 동기 EPS가 없으면 YoY는 UNKNOWN입니다. 전년 EPS가 0이나 음수라면 흑자전환·적자 맥락을 구분하고 임의의 양수 성장률을 만들지 마세요.
+                        - 분석 대상은 {company_name} ({company_code})입니다. 모회사·자회사·별도 상장 법인을 구분하고 자회사 이익을 모회사 EPS로 사용하지 마세요. 보고 법인과 회계 범위를 명시하고 모회사 연결 실적으로 명시된 자료만 해당 기준으로 사용하세요.
+                        """
+
     return Agent(
         name="company_status_agent",
         instruction=instruction,
@@ -202,7 +224,7 @@ def create_company_overview_agent(company_name, company_code, reference_date, ur
                         When accessing URLs, use the firecrawl_scrape tool and set the formats parameter to ["markdown"] and the onlyMainContent parameter to true.
                         When collecting data, focus on tables rather than charts.
 
-                        ## Data to Collect (From Company Overview Page Only)
+                        ## Data to Collect (Company Overview First; Conditional Supplement Below)
                         1. From the Company Overview page (Access URL: {urls['기업개요']}) :
                            - Detailed Company Overview: Headquarters address, CEO, main contact, auditor, establishment date, listing date, number of issued shares (common/preferred), etc.
                            - Business Structure: Main product sales composition and proportions, market share, domestic and export composition, etc.
@@ -276,7 +298,7 @@ def create_company_overview_agent(company_name, company_code, reference_date, ur
                         URL 접속 시 firecrawl_scrape tool을 사용하고 formats 파라미터는 ["markdown"]로, onlyMainContent 파라미터는 true로 설정하세요.
                         데이터 수집 시 차트보다는 테이블 위주로 데이터를 수집하세요.
 
-                        ## 수집해야 할 데이터 (기업개요 페이지에서만)
+                        ## 수집해야 할 데이터 (기업개요 우선, 누락 시 아래 조건부 보완)
                         1. 기업개요 페이지에서 (접속 URL: {urls['기업개요']}) :
                            - 기업 세부개요: 본사 주소, 대표이사, 대표 연락처, 감사인, 설립일, 상장일, 발행주식수(보통주/우선주) 등
                            - 사업 구조: 주요제품 매출구성 및 비중, 시장점유율, 내수 및 수출구성 등
@@ -344,6 +366,31 @@ def create_company_overview_agent(company_name, company_code, reference_date, ur
 
                         기업: {company_name} ({company_code})
                         ##분석일: {reference_date}(YYYYMMDD 형식)
+                        """
+
+    competitors_url = urls.get("경쟁사분석") or "URL_UNAVAILABLE"
+    industry_url = urls.get("업종분석") or "URL_UNAVAILABLE"
+    if language == "en":
+        instruction += f"""
+                        ## CAN SLIM Leadership Evidence and Bounded Supplement
+                        - Prioritize business competitiveness and comparable peer evidence over address/contact/personnel detail; preserve existing sections.
+                        - Supplement only if missing: when the overview lacks peer comparison or leadership evidence, read the provided competitor URL {competitors_url}, then industry URL {industry_url} only if evidence is still missing. Read at most 2 supplemental pages, once each, for missing facts only. Stop when sufficient; no recursive searches or new providers.
+                        - URL_UNAVAILABLE means skip that page; do not invent URLs. If evidence remains absent or inaccessible, record UNKNOWN and the missing evidence, not a confident conclusion.
+                        - Report industry_leadership (business/earnings/market-share leadership), price_RS (relative price strength), and sector_tailwind (sector environment) separately. One does not establish another. UNKNOWN is neither a leader pass nor a non-leader fail; do not manufacture a trading verdict or score.
+                        - Before claiming a rank/leader position, state the peer universe, comparable metric and units, period, data/publication date and source URL. Small selected peer lists do not establish a whole-market rank. No comparable peer evidence means leadership UNKNOWN.
+                        - Financial comparisons must distinguish quarterly/annual/cumulative, actual/estimate and consolidated/separate. Use only evidence available by {reference_date}; missing dates or scope remain UNKNOWN.
+                        - Match evidence to {company_name} ({company_code}). Distinguish the parent, subsidiary and any separately listed entities. A subsidiary's industry leadership or returns do not establish the parent's leadership or price_RS; explicitly label the reporting entity, accounting scope and any group exposure.
+                        """
+    else:
+        instruction += f"""
+                        ## CAN SLIM 리더 근거와 제한적 보완
+                        - 주소·연락처·인원 세부 설명보다 사업 경쟁력과 비교 가능한 동종 기업 근거를 우선 확보하고 기존 섹션을 유지하세요.
+                        - 기업개요에서 비교군 또는 리더 근거가 누락된 경우에만 제공된 경쟁사분석 URL {competitors_url}을 조회하고, 여전히 근거가 부족할 때 업종분석 URL {industry_url}을 조회하세요. 누락 항목에 한해 최대 2개 보완 페이지를 각각 1회 조회하세요. 근거가 충분하면 중단하고 재귀 검색이나 새 제공자는 사용하지 마세요.
+                        - URL_UNAVAILABLE인 페이지는 건너뛰고 URL을 추측하지 마세요. 접근 실패 또는 근거가 여전히 없으면 UNKNOWN과 부족한 근거를 명시하고 단정하지 마세요.
+                        - 사업·실적·시장점유율 기준 산업 리더(industry_leadership), 주가 상대강도(price_RS), 업종 환경(sector_tailwind)을 각각 구분하세요. 하나로 다른 항목을 입증할 수 없습니다. UNKNOWN을 리더 통과나 비리더 탈락으로 해석하지 말고 매매 판정·점수를 임의로 만들지 마세요.
+                        - 순위나 리더 위치를 주장하려면 비교군, 비교 가능한 지표·단위, 기간, 데이터 기준일·공시일, 출처 URL을 명시하세요. 일부 선택된 경쟁사 목록만으로 전체 시장 순위를 주장하지 마세요. 비교 가능한 근거가 없으면 리더 여부는 UNKNOWN입니다.
+                        - 재무 비교는 분기/연간/누적, 실적/추정(actual/estimate), 연결/별도(consolidated/separate)를 구분하세요. {reference_date}까지 알려진 근거만 사용하고 날짜나 기준이 없으면 UNKNOWN으로 남기세요.
+                        - 근거의 대상은 {company_name} ({company_code})이어야 합니다. 모회사·자회사·별도 상장 법인을 구분하세요. 자회사의 산업 리더 지위나 수익률로 모회사의 리더 여부·price_RS를 입증하지 말고 보고 법인·회계 범위와 그룹 사업 노출을 구분해서 설명하세요.
                         """
 
     return Agent(

--- a/cores/agents/report_agent.py
+++ b/cores/agents/report_agent.py
@@ -4,6 +4,21 @@ from dataclasses import dataclass
 from typing import Iterable
 
 
+def report_time_contract(reference_date: str, language: str = "ko") -> str:
+    """Date-only reference is not evidence that a current daily bar is final."""
+    if language == "ko":
+        return (f"\n\n## 자료 시점과 확정 여부\n작성 기준일 {reference_date}는 개별 자료의 관측 시각이나 마감 확인이 아닙니다. "
+                "가격·수급·재무의 출처와 각 기준일/시각을 따로 보존하세요. "
+                "당일 OHLCV의 Close라는 열 이름만으로 확정 종가·최종 거래량·마감 완료를 단정하지 마세요. "
+                "명시적 마감/확정 근거가 없으면 BAR_FINALITY_UNKNOWN으로 취급하고, 본문에는 조회 당시 가격/거래량 또는 확정 여부 미확인으로 표현하세요. "
+                "요약·투자전략에서도 미확정 자료를 확정값으로 바꾸지 마세요.")
+    return (f"\n\n## Evidence time and finality\nReference date {reference_date} is not an observation timestamp or proof of market close. "
+            "Preserve separate source dates/times for prices, flows and financials. "
+            "A current-day OHLCV column named Close does not establish a final close or final daily volume. "
+            "Without explicit finality evidence, treat it as BAR_FINALITY_UNKNOWN and describe an observed price/volume, not a completed session. "
+            "Summaries and strategies must preserve that uncertainty.")
+
+
 @dataclass(frozen=True)
 class ReportAgent:
     """Describe one report agent without constructing an SDK-specific object."""

--- a/cores/agents/stock_price_agents.py
+++ b/cores/agents/stock_price_agents.py
@@ -163,7 +163,7 @@ def create_price_volume_analysis_agent(company_name, company_code, reference_dat
     )
 
 
-def create_investor_trading_analysis_agent(company_name, company_code, reference_date, max_years_ago, max_years, language: str = "ko", prefetched_data: str = None):
+def create_investor_trading_analysis_agent(company_name, company_code, reference_date, max_years_ago, max_years, language: str = "ko", prefetched_data: str = None, prefetched_prices: str = None):
     """Create investor trading trend analysis agent
 
     Args:
@@ -308,6 +308,17 @@ def create_investor_trading_analysis_agent(company_name, company_code, reference
             )
         instruction = instruction.replace("- 반드시 tool call을 해야 합니다", "- 사전 수집된 데이터를 기반으로 분석합니다")
         instruction = instruction.replace("- You must make a tool call", "- Analyze based on the pre-collected data provided above")
+
+    if prefetched_prices:
+        instruction += (
+            "\n\n## Pre-collected price context\nUse the existing OHLCV below; no additional price fetch is needed. "
+            "Align prices and investor flows by the SAME dates and observation scope; do not compare a partial day with a finalized session. "
+            "Distinguish correlation from causation. If overlap is insufficient, identify the missing interval rather than claiming all price data is absent.\n\n"
+            if language == "en" else
+            "\n\n## 함께 수집된 가격 자료\n아래 기존 OHLCV를 사용하세요. 가격을 추가 조회할 필요는 없습니다. "
+            "수급과 가격은 동일 날짜 및 관측 범위로 맞추고 장중 값과 확정 일간 값을 섞어 비교하지 마세요. "
+            "동행과 인과를 구분하고, 겹치는 기간이 부족하면 그 기간을 명시하세요. 제공된 가격 자료 전체가 없다고 서술하지 마세요.\n\n"
+        ) + prefetched_prices
 
     return Agent(
         name="investor_trading_analysis_agent",

--- a/cores/data_prefetch.py
+++ b/cores/data_prefetch.py
@@ -42,13 +42,26 @@ def _dict_to_markdown(data: dict, title: str = "") -> str:
         return ""
 
     df.index.name = "Date"
+    # Library/provider responses may arrive newest-first. Preserve every row,
+    # but use chronological order when all labels are valid dates.
+    dates = pd.to_datetime(df.index, errors="coerce")
+    if dates.notna().all():
+        df = df.iloc[np.argsort(dates, kind="stable")]
 
     result = ""
     if title:
         result += f"### {title}\n\n"
 
-    if metadata and metadata.get("note"):
-        result += f"> **데이터 상태:** {metadata['note']}\n\n"
+    if isinstance(metadata, dict):
+        if metadata.get("note"):
+            result += f"> **데이터 상태:** {metadata['note']}\n\n"
+        fields = []
+        for key in ("data_status", "as_of", "observed_at", "source", "provider", "bar_status"):
+            value = metadata.get(key)
+            if isinstance(value, (str, int, float, bool)) and value != "":
+                fields.append(f"{key}={str(value).replace(chr(10), ' ')[:256]}")
+        if fields:
+            result += "> **원천 메타데이터:** " + "; ".join(fields) + "\n\n"
 
     result += df.to_markdown(index=True) + "\n"
     return result

--- a/cores/report_generation.py
+++ b/cores/report_generation.py
@@ -1,5 +1,5 @@
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
-from cores.agents.report_agent import ReportAgent
+from cores.agents.report_agent import ReportAgent, report_time_contract
 from cores.llm.agent_bridge import ensure_openai_agents_configured
 from cores.llm.backends.openai_agents_backend import OpenAIAgentsBackend
 from cores.llm.config_loader import load_report_mcp_registry
@@ -145,7 +145,7 @@ async def generate_report(agent, section, company_name, company_code, reference_
     try:
         report = await _generate_agent_text(
             agent,
-            message,
+            message + report_time_contract(reference_date, language),
             max_tokens=32000,
             max_iterations=10,
         )
@@ -233,7 +233,7 @@ async def generate_market_report(agent, section, reference_date, logger, languag
     try:
         report = await _generate_agent_text(
             agent,
-            message,
+            message + report_time_contract(reference_date, language),
             max_tokens=32000,
             max_iterations=3,
         )
@@ -337,7 +337,7 @@ Comprehensive Analysis Report:
 
         executive_summary = await _generate_agent_text(
             summary_agent,
-            message,
+            message + report_time_contract(reference_date, language),
             max_tokens=16000,
             max_iterations=2,
         )
@@ -565,7 +565,7 @@ Please present a consistent and executable investment strategy that investors ca
 
         investment_strategy = await _generate_agent_text(
             investment_strategy_agent,
-            message,
+            message + report_time_contract(reference_date, language),
             max_tokens=32000,
             max_iterations=3,
         )

--- a/tests/test_company_evidence_contract.py
+++ b/tests/test_company_evidence_contract.py
@@ -1,0 +1,82 @@
+"""Prompt contracts only: no SDK initialization, reports, or network calls."""
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def factories():
+    source = Path(__file__).resolve().parents[1] / "cores/agents/company_info_agents.py"
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    tree.body = [node for node in tree.body if not isinstance(node, ast.ImportFrom)]
+    namespace = {"Agent": SimpleNamespace}
+    exec(compile(tree, str(source), "exec"), namespace)
+    return namespace
+
+
+URLS = {
+    "기업현황": "https://example.test/status",
+    "기업개요": "https://example.test/overview",
+    "재무분석": "https://example.test/financial",
+    "경쟁사분석": "https://example.test/peers",
+    "업종분석": "https://example.test/industry",
+}
+
+
+@pytest.mark.parametrize("language", ["ko", "en"])
+@pytest.mark.parametrize("kind,section", [("status", "2-1"), ("overview", "2-2")])
+def test_existing_agent_shape_and_sections_are_preserved(factories, language, kind, section):
+    agent = factories[f"create_company_{kind}_agent"]("HDC", "012630", "20260910", URLS, language)
+    assert agent.name == f"company_{kind}_agent"
+    assert agent.server_names == ["firecrawl"]
+    assert f"### {section}." in agent.instruction
+    assert "012630" in agent.instruction
+    assert 'formats' in agent.instruction
+
+
+@pytest.mark.parametrize("language", ["ko", "en"])
+def test_status_has_bounded_conditional_financial_supplement(factories, language):
+    prompt = factories["create_company_status_agent"]("HDC", "012630", "20260910", URLS, language).instruction
+    assert URLS["재무분석"] in prompt
+    assert "Page Only" not in prompt and "페이지에서만" not in prompt
+    for term in ("quarterly EPS", "YoY", "UNKNOWN", "actual/estimate", "consolidated/separate", "annual EPS", "CAN SLIM"):
+        assert term in prompt
+    assert ("최대 1개" if language == "ko" else "at most 1") in prompt
+    assert ("누락된 경우에만" if language == "ko" else "only if missing") in prompt
+
+
+@pytest.mark.parametrize("language", ["ko", "en"])
+def test_overview_separates_leadership_from_price_and_sector(factories, language):
+    prompt = factories["create_company_overview_agent"]("HDC", "012630", "20260910", URLS, language).instruction
+    assert URLS["경쟁사분석"] in prompt and URLS["업종분석"] in prompt
+    assert "Page Only" not in prompt and "페이지에서만" not in prompt
+    for term in ("industry_leadership", "price_RS", "sector_tailwind", "UNKNOWN", "012630", "CAN SLIM"):
+        assert term in prompt
+    assert ("최대 2개" if language == "ko" else "at most 2") in prompt
+    assert ("누락된 경우에만" if language == "ko" else "only if missing") in prompt
+    for term in (("비교군", "기간", "출처") if language == "ko" else ("peer universe", "period", "source")):
+        assert term in prompt
+
+
+@pytest.mark.parametrize("language", ["ko", "en"])
+@pytest.mark.parametrize("kind", ["status", "overview"])
+def test_missing_optional_urls_are_explicit_not_invented(factories, language, kind):
+    minimal = {key: URLS[key] for key in ("기업현황", "기업개요")}
+    prompt = factories[f"create_company_{kind}_agent"]("HDC", "012630", "20260910", minimal, language).instruction
+    assert "URL_UNAVAILABLE" in prompt
+    assert "None" not in prompt
+    assert ("URL을 추측" if language == "ko" else "invent URLs") in prompt
+
+
+@pytest.mark.parametrize("language", ["ko", "en"])
+@pytest.mark.parametrize("kind", ["status", "overview"])
+def test_entity_scope_is_generic_and_does_not_leak_another_company(factories, language, kind):
+    prompt = factories[f"create_company_{kind}_agent"]("삼성전자", "005930", "20260910", URLS, language).instruction
+    assert "삼성전자" in prompt and "005930" in prompt
+    for unrelated in ("HDC", "012630", "294870"):
+        assert unrelated not in prompt
+    for term in (("모회사", "자회사", "별도 상장") if language == "ko" else ("parent", "subsidiary", "separately listed")):
+        assert term in prompt

--- a/tests/test_report_generation_backend.py
+++ b/tests/test_report_generation_backend.py
@@ -83,6 +83,7 @@ async def test_four_report_paths_preserve_limits_and_prompts(monkeypatch):
         "summary_agent",
         "investment_strategy_agent",
     ]
+    assert all("BAR_FINALITY_UNKNOWN" in message for _, message in backend.calls)
     assert [call[0].params.max_tokens for call in backend.calls] == [
         32000,
         32000,

--- a/tests/test_report_input_evidence.py
+++ b/tests/test_report_input_evidence.py
@@ -1,0 +1,40 @@
+"""Report input contracts only; no model calls or trading rule changes."""
+from cores.data_prefetch import _dict_to_markdown
+from cores.agents import get_agent_directory
+
+
+def test_metadata_without_note_keeps_source_time_and_status():
+    text = _dict_to_markdown({"2026-09-10": {"Close": 27200}, "__meta__": {
+        "data_status": "intraday_estimate", "as_of": "2026-09-10T14:50:00+09:00",
+        "source": "registered_quote_source", "secret": "DO_NOT_RENDER"}})
+    assert "intraday_estimate" in text
+    assert "2026-09-10T14:50:00+09:00" in text
+    assert "registered_quote_source" in text
+    assert "DO_NOT_RENDER" not in text
+
+
+def test_dated_rows_are_chronological_without_changing_prices():
+    text = _dict_to_markdown({"2026-09-10": {"Close": 27200}, "2026-09-09": {"Close": 24700}})
+    assert text.index("2026-09-09") < text.index("2026-09-10")
+    assert "27200" in text and "24700" in text
+
+
+def test_existing_ohlcv_reaches_investor_analysis_without_extra_tools():
+    agents = get_agent_directory("HDC", "012630", "20260910", ["investor_trading_analysis"],
+        prefetched_data={"stock_ohlcv": "PRICE_SERIES_CANARY", "trading_volume": "FLOW_SERIES_CANARY"})
+    agent = agents["investor_trading_analysis"]
+    assert "PRICE_SERIES_CANARY" in agent.instruction
+    assert "FLOW_SERIES_CANARY" in agent.instruction
+    assert tuple(agent.server_names) == ()
+    assert "동일 날짜" in agent.instruction
+
+
+def test_all_report_sections_get_current_row_finality_contract():
+    for language in ("ko", "en"):
+        agents = get_agent_directory("HDC", "012630", "20260910",
+            ["price_volume_analysis", "investor_trading_analysis", "company_status",
+             "company_overview", "news_analysis", "market_index_analysis"], language,
+            prefetched_data={"stock_ohlcv": "prices", "trading_volume": "flows"})
+        for agent in agents.values():
+            assert "20260910" in agent.instruction
+            assert "BAR_FINALITY_UNKNOWN" in agent.instruction


### PR DESCRIPTION
HDC actual report audit found missing quarterly EPS/peer evidence, investor section without already-collected prices, and pre-close final-close wording. Expand company source instructions only for missing required evidence using existing financial/competitor/industry URLs; keep UNKNOWN and separate parent/subsidiary scopes. Reuse existing OHLCV in investor analysis, sort valid dated rows, preserve allowlisted source/time/status metadata even without note, and carry finality caution through reports/summary/strategy. No trading gates, model or timeout changes, no extra price tool calls. Supplemental-page limits are prompt contracts not hard runtime caps. Root40 relevant tests pass, compile/diff checks; independent reviewer28 tests approved. Actual future model adherence/supplement fetch success remains pending, no HDC regeneration or diagnostic model calls performed. Existing Ruff F401/F841 warnings outside modified logic remain unchanged.