### PR TITLE
fix: trace KR buy evidence gaps and permit bounded supplementation

### DIFF
--- a/cores/agents/company_info_agents.py
+++ b/cores/agents/company_info_agents.py
@@ -177,24 +177,27 @@ def create_company_status_agent(company_name, company_code, reference_date, urls
                         """
 
     financial_url = urls.get("재무분석") or "URL_UNAVAILABLE"
+    eps_supplement_url = urls.get("투자지표") or financial_url
     if language == "en":
         instruction += f"""
                         ## CAN SLIM Evidence Priority and Bounded Supplement
                         - Prioritize quarterly EPS and its comparable prior-year quarter over repetitive valuation commentary. Keep the existing sections; a concise evidence table is sufficient.
-                        - Collect latest reported quarterly EPS and YoY first. Supplement only if missing (including the comparable baseline) from the status page: financial analysis URL {financial_url}. Read at most 1 supplemental page, once, for these missing facts only; no recursive searches or new providers. If supplied facts are sufficient, do not supplement.
+                        - Collect latest reported quarterly EPS and YoY first. Supplement only if missing (including the comparable baseline) from the status page. EPS_SUPPLEMENT_URL: {eps_supplement_url}. Prefer the supplied investment indicators URL for a consistent quarterly/annual EPS series; financial analysis URL {financial_url} is selected only when the indicators URL is not supplied. Read at most 1 supplemental page, once, for these missing facts only; do not try the other page after failure, use recursive searches or new providers. If supplied facts are sufficient, do not supplement.
                         - URL_UNAVAILABLE means no supplemental access: do not invent URLs. If inaccessible or still absent, mark the specific field UNKNOWN and explain the missing evidence briefly, without tool-process narration.
                         - Label each figure with fiscal quarter/year, quarterly/annual/cumulative scope, actual/estimate, consolidated/separate, units, data/publication date and source URL. Only use information available by {reference_date}; unavailable dates or accounting scope remain UNKNOWN.
-                        - Never substitute annual EPS, cumulative EPS, forward EPS or net income for quarterly EPS. Do not combine actual and estimate or different accounting bases. Without a comparable prior-year quarter, YoY is UNKNOWN; zero/negative prior EPS requires explicit turnaround/loss context, not a fabricated positive growth rate.
+                        - Never substitute annual EPS, cumulative EPS, forward EPS or net income for quarterly EPS. Do not combine actual and estimate or different accounting bases. Distinguish statutory/basic/diluted EPS from provider-adjusted-share EPS, including the share denominator; do not merge the series. SOURCE_REPORTED_YOY may be quoted as source-reported with its period/basis even when the prior value is not shown, but is not independently recomputed. COMPUTED_YOY requires comparable current/prior EPS; otherwise computed YoY is UNKNOWN. Never invent the denominator; zero/negative prior EPS requires explicit turnaround/loss context, not a fabricated positive growth rate.
+                        - HTTP 200 or HTML placeholders do not establish coverage. Confirm actual numeric table rows, period headers and accounting basis are present; if rendering supplied only a shell, the relevant fields remain UNKNOWN.
                         - Company identity must match {company_name} ({company_code}). Distinguish the parent, subsidiary and any separately listed entities: subsidiary earnings are not parent EPS. Label the reporting entity and accounting scope; use parent consolidated results only when explicitly sourced as such.
                         """
     else:
         instruction += f"""
                         ## CAN SLIM 핵심 근거 우선순위와 제한적 보완
                         - 반복적인 밸류에이션 설명보다 최근 분기 EPS(quarterly EPS)와 비교 가능한 전년 동기 근거를 우선 확보하세요. 기존 섹션 안에 간결한 근거 표로 제시하세요.
-                        - 기업현황에서 최근 확정 분기 EPS 또는 YoY 근거(비교 기준 포함)가 누락된 경우에만 재무분석 URL {financial_url}을 보완 조회하세요. 누락 항목에 한해 최대 1개 보완 페이지를 1회 조회하고 재귀 검색이나 새 제공자는 사용하지 마세요. 근거가 충분하면 추가 조회하지 마세요.
+                        - 기업현황에서 최근 확정 분기 EPS 또는 YoY 근거(비교 기준 포함)가 누락된 경우에만 보완 조회하세요. EPS_SUPPLEMENT_URL: {eps_supplement_url}. 일관된 분기·연간 EPS 시계열을 위해 제공된 투자지표 URL을 우선하고, 해당 URL이 제공되지 않은 경우에만 재무분석 URL {financial_url}을 선택하세요. 누락 항목에 한해 최대 1개 보완 페이지를 1회 조회하고 실패 후 다른 페이지 조회, 재귀 검색이나 새 제공자는 사용하지 마세요. 근거가 충분하면 추가 조회하지 마세요.
                         - URL_UNAVAILABLE이면 보완 조회를 생략하고 URL을 추측하지 마세요. 접근 실패 또는 여전히 없는 항목은 UNKNOWN으로 표기하고 부족한 근거만 짧게 설명하세요. 도구 처리 과정은 서술하지 마세요.
                         - 각 수치에 회계 분기·연도, 분기/연간/누적 구분, 실적/추정(actual/estimate), 연결/별도(consolidated/separate), 단위, 데이터 기준일·공시일, 출처 URL을 명시하세요. {reference_date}까지 알려진 자료만 사용하고 날짜나 회계 기준을 확인할 수 없으면 UNKNOWN으로 남기세요.
-                        - 연간 EPS(annual EPS), 누적 EPS, 선행 EPS 또는 순이익을 분기 EPS로 대체하지 마세요. 실적과 추정 또는 서로 다른 회계 기준을 혼합하지 마세요. 비교 가능한 전년 동기 EPS가 없으면 YoY는 UNKNOWN입니다. 전년 EPS가 0이나 음수라면 흑자전환·적자 맥락을 구분하고 임의의 양수 성장률을 만들지 마세요.
+                        - 연간 EPS(annual EPS), 누적 EPS, 선행 EPS 또는 순이익을 분기 EPS로 대체하지 마세요. 실적과 추정 또는 서로 다른 회계 기준을 혼합하지 마세요. 법정·기본·희석 EPS(statutory/basic/diluted)와 제공자 조정 주식 수 기준 EPS(provider-adjusted-share)의 분모를 구분하고 서로 다른 시계열을 합치지 마세요. SOURCE_REPORTED_YOY는 전년 값이 표에 없어도 기간·산정 기준과 함께 출처가 제시한 성장률로 인용할 수 있지만 직접 검산한 값은 아닙니다. COMPUTED_YOY는 비교 가능한 당기·전년 EPS가 있을 때만 계산하고 없으면 직접 계산한 YoY는 UNKNOWN으로 남기세요. 분모를 만들어내지 말고 전년 EPS가 0이나 음수라면 흑자전환·적자 맥락을 구분하여 임의의 양수 성장률을 만들지 마세요.
+                        - HTTP 200이나 HTML 자리표시자만으로 수집 성공을 판단하지 마세요. 실제 숫자가 있는 표의 행, 기간 헤더, 회계 기준을 확인하고 페이지 틀만 반환되면 해당 항목은 UNKNOWN으로 남기세요.
                         - 분석 대상은 {company_name} ({company_code})입니다. 모회사·자회사·별도 상장 법인을 구분하고 자회사 이익을 모회사 EPS로 사용하지 마세요. 보고 법인과 회계 범위를 명시하고 모회사 연결 실적으로 명시된 자료만 해당 기준으로 사용하세요.
                         """
 

--- a/cores/agents/trading_agents.py
+++ b/cores/agents/trading_agents.py
@@ -296,17 +296,39 @@ def create_trading_scenario_agent(language: str = "ko", sector_names: list = Non
         - `time-get_current_time`: call FIRST. Use the returned date as the end date for ALL kospi_kosdaq queries.
         - `kospi_kosdaq-get_stock_ohlcv` / `get_stock_trading_volume` / `get_index_ohlcv`: market and stock data.
         - DO NOT call `kospi_kosdaq-load_all_tickers`.
-        - `perplexity-ask`: only when sector PER/PBR comparison is missing from the report. When called:
-          * "[Stock name] PER PBR vs [Sector] industry average comparison"
-          * "[Stock name] vs major peer competitors valuation comparison"
-          * Include the current date in the query and verify the date returned in the response
+        - Before declaring evidence missing, inspect the whole report (not just the mapped section),
+          injected facts, and already returned MCP results. The report input is text-only; do not claim
+          to inspect chart images or infer an unseen chart's values.
+        - `perplexity-ask`: only if decision-material quarterly EPS, annual EPS, industry_leadership,
+          or peer evidence (including PER/PBR) remains missing after that inspection, use
+          at most ONE consolidated query for the remaining gaps. Do not research evidence already present, repeat
+          equivalent queries, or retry an unavailable/timed-out supplemental lookup. Stay within the
+          existing execution deadline; if no time remains, record NOT_REQUESTED instead of researching.
+          Include the current date, stock name/code, required reporting periods and peer universe;
+          include major peer competitors valuation comparison only if that is a remaining material gap. Require
+          source/date, entity (parent/subsidiary), actual/estimate, consolidated/separate, units and EPS
+          definition/share denominator. Never combine incomparable EPS bases across sources or periods,
+          synthesize quarterly EPS from annual EPS, or substitute price_RS for industry_leadership.
+        - Cite the section/source, period and basis actually used in existing fundamental_check evidence
+          and rationale fields. Preserve recognized operating profit (F1), debt ratio (F2), ROE/revenue
+          (F3), and business evidence (F4); missing quarterly EPS/leadership does not mean all fundamentals
+          are absent. Distinguish NOT_IN_INPUT (not found in supplied inputs), NOT_REQUESTED (supplement
+          not queried), SOURCE_UNAVAILABLE (queried source failed or did not supply the requested item),
+          and INCOMPARABLE (entity/period/basis mismatch); more than one may describe the provenance.
+          Unqueried evidence is not evidence that data exists nowhere. UNKNOWN is an evidence status,
+          not a new automatic pass/fail or rejection gate. Keep existing schema, F1–F4 criteria, scoring,
+          regime matrix and independent gates unchanged; do not invent evidence to complete a field.
         - `sqlite`: run `describe_table` first; filter holdings by `account_id = 'primary'` when column exists.
 
         ## Time-of-day Data Reliability
 
         - **Morning session (09:30~10:30 KST)**: today's volume/candle is in-progress. Do NOT make assertions
           like "today's volume is weak". Use prior-day confirmed data; today is reference only.
-        - **Afternoon (14:50+ KST)**: today's data is settled. All technical indicators are usable.
+        - **Afternoon (including 14:50+ KST)**: time alone does not establish finality. Use today's
+          close/volume as final only with explicit source confirmation for that trading date. Otherwise
+          label observed data intraday, or BAR_FINALITY_UNKNOWN if finality is unavailable; do not call
+          it a confirmed close. Separate confirmed prior-day indicators from provisional current-day
+          observations and cite the actual basis used, even if the report calls an intraday value a close.
 
         ## JSON Response Format
 
@@ -614,16 +636,37 @@ def create_trading_scenario_agent(language: str = "ko", sector_names: list = Non
         - `time-get_current_time`: 가장 먼저 호출하십시오. 반환된 날짜를 모든 kospi_kosdaq 조회의 종료일로 사용합니다.
         - `kospi_kosdaq-get_stock_ohlcv` / `get_stock_trading_volume` / `get_index_ohlcv`: 시장/종목 데이터.
         - `kospi_kosdaq-load_all_tickers` 호출 금지.
-        - `perplexity-ask`: 보고서에 동종업계 PER/PBR 비교가 없을 때만 호출하십시오. 호출 시:
-          * "[종목명] PER PBR vs [업종명] 업계 평균 비교"
-          * "[종목명] vs 동종업계 주요 경쟁사 비교"
-          * 질문에 현재 날짜를 포함하고, 답변의 날짜를 항상 검증하십시오
+        - 근거가 없다고 판단하기 전에 지정된 절뿐 아니라 전체 보고서, 주입된 팩트, 이미 반환된 MCP
+          결과를 확인하십시오. 보고서 입력은 텍스트이므로 차트 이미지를 직접 보았다고 하거나
+          보이지 않는 차트의 수치를 추정하지 마십시오.
+        - `perplexity-ask`: 위 확인 후에도 판단에 중요한 quarterly EPS(분기 EPS), annual EPS(연간 EPS),
+          industry_leadership(업종 리더), 동종업계 비교(PER/PBR 포함) 근거가 부족한 경우에만 남은 항목을
+          묶어 통합 질의 최대 1회로 보완하십시오. 이미 있는 근거를 재검색하거나 같은 질문을 반복하거나
+          실패·타임아웃된 보완 조회를 재시도하지 마십시오. 기존 실행 제한 시간을 지키고 시간이 부족하면
+          조회 대신 NOT_REQUESTED로 남기십시오. 종목명·코드, 현재 날짜, 필요한 결산 기간과 비교군을
+          지정하고 현재 날짜를 포함하십시오. 동종업계 주요 경쟁사 비교는 판단에 중요한 누락 항목일 때만
+          함께 조회하십시오. 출처·날짜, 법인(모회사/자회사), 실적/추정, 연결/별도, 단위, EPS 정의·주식 수 분모를
+          확인하십시오. 출처·기간별 EPS 산정 기준이 다르면 혼합하지 말고 연간 EPS로 분기 EPS를 만들거나
+          price_RS(주가 상대강도)를 industry_leadership의 대체 근거로 사용하지 마십시오.
+        - 기존 fundamental_check 근거와 rationale 필드에 실제 사용한 절·출처, 기간, 산정 기준을
+          간결하게 명시하십시오. 확인한 영업이익(F1), 부채비율(F2), ROE·매출(F3), 사업 근거(F4)는
+          유지하십시오. 분기 EPS·리더 근거의 누락을 모든 펀더멘털의 부재로 확대하지 마십시오.
+          NOT_IN_INPUT(제공된 입력에서 찾지 못함), NOT_REQUESTED(보완 조회하지 않음),
+          SOURCE_UNAVAILABLE(조회했으나 실패하거나 해당 항목을 제공하지 않음),
+          INCOMPARABLE(법인·기간·산정 기준 불일치)을 구분하고 필요하면 함께 표기하십시오.
+          조회하지 않은 것을 어디에도 데이터가 없다고 표현하지 마십시오. UNKNOWN은 근거 상태이지
+          새로운 자동 통과·실패·미진입 게이트가 아닙니다. 기존 스키마, F1–F4 기준, 점수, 시장별
+          매트릭스와 독립 게이트를 유지하고 필드를 채우기 위해 근거를 만들어내지 마십시오.
         - `sqlite`: `describe_table` 먼저 실행하고, account_id 컬럼이 있으면 `account_id = 'primary'`로 필터링하십시오.
 
         ## 시간대별 데이터 신뢰도
 
         - **오전장 (09:30~10:30 KST)**: 당일 거래량/캔들은 미완성입니다. "오늘 거래량이 약하다" 같은 확정 판단은 금지하십시오. 전일 종가/거래량 기준으로 분석하고, 당일 데이터는 추세 변화 참고용으로만 사용합니다.
-        - **오후 장 (14:50+ KST)**: 당일 데이터가 확정됩니다. 모든 기술적 지표를 사용해도 됩니다.
+        - **오후 장 (14:50+ KST 포함)**: 시각만으로 데이터 확정을 판단하지 마십시오. 해당 거래일의
+          확정 여부를 출처가 명시적으로 확인한 경우에만 당일 종가·거래량을 확정값으로 사용하십시오.
+          그 외에는 장중 관측값으로, 확정 여부를 알 수 없으면 BAR_FINALITY_UNKNOWN으로 표시하고
+          확정 종가라고 부르지 마십시오. 전일 확정 지표와 당일 잠정 관측값을 구분하고 실제 사용한
+          기준을 명시하십시오. 보고서가 장중 가격을 종가라고 썼더라도 그대로 확정값으로 취급하지 마십시오.
 
         ## 매매일지·직관 활용 (주입된 경우)
         프롬프트에 "Same Stock Trade History" 또는 "Accumulated Trading Intuitions"가 주어지면 신중히 가중하십시오:

--- a/tests/test_company_evidence_contract.py
+++ b/tests/test_company_evidence_contract.py
@@ -21,6 +21,7 @@ URLS = {
     "기업현황": "https://example.test/status",
     "기업개요": "https://example.test/overview",
     "재무분석": "https://example.test/financial",
+    "투자지표": "https://example.test/indicators",
     "경쟁사분석": "https://example.test/peers",
     "업종분석": "https://example.test/industry",
 }
@@ -46,6 +47,17 @@ def test_status_has_bounded_conditional_financial_supplement(factories, language
         assert term in prompt
     assert ("최대 1개" if language == "ko" else "at most 1") in prompt
     assert ("누락된 경우에만" if language == "ko" else "only if missing") in prompt
+
+
+@pytest.mark.parametrize("language", ["ko", "en"])
+def test_status_prefers_one_indicator_page_and_preserves_eps_basis(factories, language):
+    prompt = factories["create_company_status_agent"]("삼성전자", "005930", "20260910", URLS, language).instruction
+    assert f"EPS_SUPPLEMENT_URL: {URLS['투자지표']}" in prompt
+    for term in ("statutory/basic/diluted", "provider-adjusted-share", "SOURCE_REPORTED_YOY", "COMPUTED_YOY", "HTML", "HTTP 200"):
+        assert term in prompt
+    without_indicators = {key: value for key, value in URLS.items() if key != "투자지표"}
+    fallback = factories["create_company_status_agent"]("삼성전자", "005930", "20260910", without_indicators, language).instruction
+    assert f"EPS_SUPPLEMENT_URL: {URLS['재무분석']}" in fallback
 
 
 @pytest.mark.parametrize("language", ["ko", "en"])

--- a/tests/test_kr_buy_evidence_contract.py
+++ b/tests/test_kr_buy_evidence_contract.py
@@ -1,0 +1,64 @@
+"""KR buy evidence instructions; AST stubs avoid SDK, model, and network calls."""
+
+import ast
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+SOURCE = Path(__file__).resolve().parents[1] / "cores/agents/trading_agents.py"
+
+
+@pytest.fixture(params=["ko", "en"])
+def prompt(request):
+    tree = ast.parse(SOURCE.read_text(encoding="utf-8"))
+    tree.body = [n for n in tree.body if not isinstance(n, (ast.Import, ast.ImportFrom))]
+    namespace = {"Agent": SimpleNamespace, "buy_scenario_prompt_contract": lambda _: ""}
+    exec(compile(tree, str(SOURCE), "exec"), namespace)
+    return request.param, namespace["create_trading_scenario_agent"](request.param).instruction
+
+
+def test_missingness_is_provenance_not_invented_gate(prompt):
+    _, text = prompt
+    for marker in ("NOT_IN_INPUT", "NOT_REQUESTED", "SOURCE_UNAVAILABLE", "INCOMPARABLE"):
+        assert marker in text
+    assert "UNKNOWN" in text
+    assert "fundamental_check" in text and "rationale" in text
+
+
+def test_whole_input_checked_before_one_material_supplement(prompt):
+    language, text = prompt
+    for marker in ("quarterly EPS", "annual EPS", "industry_leadership", "price_RS"):
+        assert marker in text
+    for marker in (("전체 보고서", "주입된 팩트", "이미 반환된 MCP", "통합 질의 최대 1회", "차트 이미지", "연결/별도")
+                   if language == "ko" else
+                   ("whole report", "injected facts", "already returned MCP", "at most ONE consolidated query", "chart images", "consolidated/separate")):
+        assert marker in text
+
+
+def test_time_alone_cannot_finalize_today_bar(prompt):
+    language, text = prompt
+    assert "BAR_FINALITY_UNKNOWN" in text
+    assert "today's data is settled" not in text
+    assert "당일 데이터가 확정됩니다" not in text
+    assert ("시각만으로" if language == "ko" else "time alone") in text
+
+
+def test_decision_rules_and_json_schema_are_byte_preserved(prompt):
+    language, text = prompt
+    heading = "## 도구 사용" if language == "ko" else "## Tool Usage"
+    json_heading = "## JSON 응답 형식" if language == "ko" else "## JSON Response Format"
+    expected = {
+        "ko": ("4ae26638e5df8fcb3bc0dc25bd7ec5f8f771ebdfd0b1f7db81495dbff7d26cab", "f5f2f66de78dd7995efca999eaf82cf3a92c61834d499e17a0af6e6de30cd776"),
+        "en": ("d741596f5fa983cb1d6832d59e66900109e3ac63bce3114d251639b15fd67f80", "191df340ff09fe154a1ef67984be592293f51149dff8c83307855f1b26568051"),
+    }
+    assert hashlib.sha256(text.split(heading)[0].encode()).hexdigest() == expected[language][0]
+    assert hashlib.sha256(text[text.index(json_heading):].encode()).hexdigest() == expected[language][1]
+
+
+def test_sell_factory_is_byte_preserved():
+    source = SOURCE.read_text(encoding="utf-8")
+    node = next(n for n in ast.parse(source).body if isinstance(n, ast.FunctionDef) and n.name == "create_sell_decision_agent")
+    assert hashlib.sha256(ast.get_source_segment(source, node).encode()).hexdigest() == "020684a184329a776fb07aabced491596534f06f00723e5f402b7606bdf5dcc3"


### PR DESCRIPTION
## Scope
HDC production PDF/input audit established present F1-F4 facts, missing quarterly/annual EPS series and industry leadership evidence, no Perplexity invocation among 10 MCP calls, and a BUY instruction restricting research to missing peer PER/PBR. Report prefetch was not separately attached to BUY.

## Changes
- Inspect full extracted report, injected facts and prior MCP results before declaring missing evidence; permit one consolidated decision-material supplementary query.
- Separate missing/unqueried/unavailable/incomparable evidence without new score gates or schema changes.
- Fix KR BUY 14:50 finality assertion, preserving SELL function and existing BUY criteria/schema byte-for-byte.
- Prefer existing investment-indicators EPS source with financial-page fallback only when that URL is absent; retain one extra page cap and separate EPS definitions/source-reported versus computed YoY.

## Verification
Root targeted 80 tests pass; executor broader related 128 pass; independent review 34 pass; Ruff, compile and diff checks pass. Counts overlap, not additive. No new model/order calls. Live source retrieval demonstrates present availability, NOT historical payload delivery. Query/page caps are prompt guidance, not runtime enforcement. Historical MCP response bodies were not retained; full input-provenance persistence remains future work. Actual model compliance and performance improvement are unverified.