### PR TITLE
fix: reuse sourced competitive evidence in KR/US report inputs

### DIFF
--- a/cores/agents/news_strategy_agents.py
+++ b/cores/agents/news_strategy_agents.py
@@ -1,6 +1,56 @@
 from cores.agents.report_agent import ReportAgent as Agent
 
 
+def _competitive_evidence_contract(reference_date):
+    """Shared ko/en prompt contract; query limits are instructions, not runtime quotas."""
+    return f"""## Competitive evidence collection and reporting contract
+- Reuse already obtained input facts and source excerpts before any new search. Do not
+  repeat a query or re-read a URL whose relevant evidence is already available.
+- Use perplexity_ask only if leader/trend context or material competitive evidence is
+  missing: at most 2 consolidated queries total, not two queries per company or field.
+  Query 1 combines sector leaders (2-3 peers), their trends and cited primary sources;
+  query 2 is optional and covers only unresolved material competitive-position gaps.
+  Specify entity/ticker, market, and reference date {reference_date} in every query.
+  No blanket mandatory search if the necessary cited evidence is already supplied.
+- In addition to the cached target-news listing, use firecrawl_scrape for at most 2 additional
+  cited public primary URLs, only if material competitive claims remain unverified.
+  Prefer company filings/IR, regulators, exchanges, or industry statistics over marketing
+  summaries. Select URLs actually supplied in input or discovered in search; never invent URLs.
+  Reuse source text already read. Do not recursively scrape peer news or all articles.
+  A search answer/citation or HTTP success without the relevant source content is not
+  source verification. On access/parsing failure preserve that reason without retry loops.
+- Separate sector_tailwind, price_leadership, and business_competitive_position. Price
+  momentum, sector membership, company size, or positive news alone proves no market dominance.
+  Separate the listed parent entity from each subsidiary or separately listed affiliate;
+  a subsidiary's advantage is not automatically the parent's leadership. Identify the
+  parent's ownership/contribution if available, otherwise keep that linkage unknown.
+- Compare the same period, geography, business scope, metric definition, and unit across
+  an explicit peer_universe. Disclose partial peer coverage; do not infer an industry rank
+  from a screened subset. Separate actual and forecast values. Check publication_date and
+  information availability against the decision timestamp, not just today's access date:
+  a currently available source does not prove it was available at a historical decision.
+  Older official competitive statistics may be used with their period and staleness stated;
+  the recent-news window does not justify discarding the latest available annual statistics.
+- Include the exact standalone markdown heading below in the news output (keep the English
+  heading and field keys in both languages; write explanations in the requested language):
+#### Competitive Evidence
+- Write compact records with field, type, entity, peer_universe, metric, value, unit,
+  period, geography, source (exact URL or UNKNOWN), publication_date, status, and a short
+  supporting excerpt. Use one record per material claim, including unresolved claims.
+  field names the question being assessed; type is one of sector_tailwind,
+  price_leadership, business_competitive_position. Missing values remain UNKNOWN.
+- status must be SOURCE_CHECKED, SEARCH_ONLY, NOT_FOUND, or INCOMPARABLE.
+  SOURCE_CHECKED means the relevant original source was actually read (or its original
+  excerpt supplied), not a guarantee that the claim is true, comparable, or leadership proven.
+  SEARCH_ONLY means only discovery/search material supports it. NOT_FOUND means evidence
+  was not found in the inspected scope, not that no public data exists; state whether
+  unqueried, access failed, parsing failed, or searched without a result. INCOMPARABLE
+  means entity/period/scope/metric mismatches prevent comparison despite available data.
+  Do not fabricate quotations, peers, values, dates, URLs, or positive leadership. Preserve
+  source qualifiers and unknowns in conclusions; absence of evidence is not negative proof.
+"""
+
+
 def create_news_analysis_agent(company_name, company_code, reference_date, language: str = "ko"):
     """Create news analysis agent
 
@@ -26,50 +76,11 @@ def create_news_analysis_agent(company_name, company_code, reference_date, langu
                            - formats: ["markdown"], onlyMainContent: true, maxAge: 7200000 (2-hour cache)
                            - If no news from target date ({reference_date}), collect news from past week
                         
-                        2. Analyze using news list page titles and summaries only (do NOT scrape individual article URLs - token optimization)
+                        2. Start with news list page titles and summaries; material competitive claims follow the bounded source verification contract below.
                         
-                        ### STEP 2: Identify Sector Leaders and Analyze Trends (Mandatory - Use Perplexity)
-                        
-                        **CRITICAL: Always specify the reference date ({reference_date}) when asking Perplexity**
-                        
-                        **2-1. Ask Perplexity to find sector leaders**
-                        - **perplexity_ask** with this query structure:
-                          "As of {reference_date}, what are the 2-3 leading stocks (대장주) in the same sector as {company_name}? 
-                           Please provide recent stock codes and brief reason why they are leaders. 
-                           Focus on information from {reference_date} or the most recent available."
-                        
-                        - Perplexity will return leaders with stock codes (e.g., 크래프톤 259960, 넷마블 251270)
-                        - **IMPORTANT**: Always verify the dates in Perplexity's response match {reference_date} or are recent
-                        
-                        **2-2. Ask Perplexity for sector trend analysis**
-                        - **perplexity_ask**: "As of {reference_date}, what is the recent trend for {{sector name}} stocks in Korea? 
-                           Are the leading stocks showing positive momentum? Provide recent news from {reference_date} or close to it."
-                        - Compare: Rising with leaders → High reliability / This stock alone → Possibly temporary
-                        
-                        ## Tool Usage Principles
 
-                        1. **firecrawl 1회만 사용**: Target stock Naver Finance news page only (do NOT scrape individual articles or leader stocks)
-                        2. **perplexity for leaders & trends**: Find sector leaders and analyze trends (ALWAYS specify date: {reference_date})
-                        3. **Date verification critical**: Always check dates in Perplexity responses match {reference_date} or are recent
-                        4. **Source notation**: [NaverFinance:StockName] / [Perplexity:Number, verified date]
-                        5. **Token optimization**: Minimize firecrawl calls - use Perplexity responses for sector leader analysis instead of scraping
-                        
-                        ## Tool Guide
-                        
-                        **firecrawl_scrape**: Page scraping (PRIMARY for individual stock news)
-                        - url: Naver Finance news page (https://finance.naver.com/item/news.naver?code=STOCK_CODE)
-                        - formats: ["markdown"]
-                        - onlyMainContent: true
-                        - maxAge: 7200000 (2-hour cache - 500% performance boost, mandatory)
-                        
-                        **perplexity_ask**: AI search (PRIMARY for sector leaders and trends)
-                        - Use for: Finding sector leaders, analyzing sector trends
-                        - ALWAYS include reference date in query: "As of {reference_date}, ..."
-                        - Always verify dates in responses
-                        - Example queries:
-                          * "As of {reference_date}, what are the leading stocks in the game sector in Korea?"
-                          * "As of {reference_date}, what is the recent trend for semiconductor stocks?"
-                        
+{_competitive_evidence_contract(reference_date)}
+
                         ## News Classification and Analysis
                         
                         **Classification**:
@@ -102,15 +113,12 @@ def create_news_analysis_agent(company_name, company_code, reference_date, langu
                         - No tool usage mentions
 
                         ## Precautions
-                        - Use Perplexity to find sector leaders and their trends (do NOT scrape leader news pages)
                         - Beware perplexity hallucinations, always verify dates
                         - Prioritize same-day price cause analysis
                         - Specify stock codes for accurate news
-                        - Assess reliability via sector leader movements (using Perplexity data only, no firecrawl for leaders)
                         - Provide deep analysis and insights
                         - Clear source notation: [NaverFinance:StockName] / [Perplexity:Number, Date]
-                        - Use only recent info (within 1 month of analysis date)
-                        - Token optimization: firecrawl_scrape only 1 call for target stock news page
+                        - For news, prioritize the month up to the analysis date; dated structural competitive statistics follow the contract above
 
                         ## Output Format
                         
@@ -134,50 +142,11 @@ def create_news_analysis_agent(company_name, company_code, reference_date, langu
                            - formats: ["markdown"], onlyMainContent: true, maxAge: 7200000 (2시간 캐시)
                            - 당일({reference_date}) 뉴스가 없으면 최근 1주일 이내 뉴스 수집
                         
-                        2. 뉴스 목록 페이지의 제목과 요약만으로 분석 (개별 기사 URL 추가 스크랩 불필요 - 토큰 절약)
+                        2. 뉴스 목록의 제목과 요약을 우선 활용하되, 중요한 경쟁우위 주장은 아래의 제한적 원문 확인 규칙을 따릅니다.
                         
-                        ### STEP 2: 섹터 주도주 파악 및 동향 분석 (필수 - Perplexity 사용)
-                        
-                        **중요: Perplexity에게 질문할 때 반드시 기준일({reference_date})을 명시하세요**
-                        
-                        **2-1. Perplexity에게 섹터 주도주 질문**
-                        - **perplexity_ask**로 다음과 같은 구조로 질문:
-                          "{reference_date} 기준으로, {company_name}과(와) 같은 섹터의 주도주(대장주) 2-3개는 무엇인가요? 
-                           종목코드와 함께 최근 주도주인 이유를 간단히 설명해주세요. 
-                           {reference_date} 또는 가장 최근의 정보를 중심으로 답변해주세요."
-                        
-                        - Perplexity가 종목코드와 함께 주도주를 알려줄 것임 (예: 크래프톤 259960, 넷마블 251270)
-                        - **중요**: Perplexity 답변의 날짜가 {reference_date}와 일치하거나 최신인지 반드시 확인
-                        
-                        **2-2. Perplexity에게 섹터 동향 질문**
-                        - **perplexity_ask**: "{reference_date} 기준으로, {{섹터명}} 섹터의 최근 동향은 어떤가요? 
-                           주도주들도 상승세를 보이고 있나요? {reference_date} 또는 그 인근의 최신 뉴스를 중심으로 답변해주세요."
-                        - 비교 분석: 주도주와 동반 상승 → 신뢰도 높음 / 이 종목만 상승 → 일시적 가능성
-                        
-                        ## 도구 사용 원칙
 
-                        1. **firecrawl 1회만 사용**: 대상 종목 네이버 금융 뉴스 페이지만 스크랩 (개별 기사나 주도주 뉴스 페이지 추가 스크랩 금지)
-                        2. **perplexity로 주도주 및 동향 분석**: 섹터 주도주 파악 및 동향 분석 (반드시 날짜 명시: {reference_date})
-                        3. **날짜 검증 필수**: Perplexity 답변의 날짜가 {reference_date}와 일치하거나 최신인지 항상 확인
-                        4. **출처 표기**: [네이버금융:종목명] / [Perplexity:번호, 확인된날짜]
-                        5. **토큰 최적화**: firecrawl 호출 최소화 - 섹터 주도주 분석은 Perplexity 답변으로 충분
-                        
-                        ## 도구 가이드
-                        
-                        **firecrawl_scrape**: 페이지 스크랩 (개별 종목 뉴스 수집의 핵심)
-                        - url: 네이버 금융 뉴스 페이지 (https://finance.naver.com/item/news.naver?code=종목코드)
-                        - formats: ["markdown"]
-                        - onlyMainContent: true
-                        - maxAge: 7200000 (2시간 캐시 - 500% 성능 향상, 필수 사용)
-                        
-                        **perplexity_ask**: AI 검색 (섹터 주도주 및 동향 분석의 핵심)
-                        - 용도: 섹터 주도주 찾기, 섹터 동향 분석
-                        - 질문 시 반드시 기준일 포함: "{reference_date} 기준으로, ..."
-                        - 답변의 날짜를 항상 검증할 것
-                        - 질문 예시:
-                          * "{reference_date} 기준으로, 게임 섹터의 주도주는 무엇인가요?"
-                          * "{reference_date} 기준으로, 반도체 섹터의 최근 동향은 어떤가요?"
-                        
+{_competitive_evidence_contract(reference_date)}
+
                         ## 뉴스 구분 및 분류
                         검색된 뉴스를 다음 카테고리로 명확히 구분하여 분석:
                         1. 당일 주가 영향 요소: 분석일 기준 주가에 직접적 영향을 미친 뉴스 (최우선 분석) (예 : 정치테마 등)
@@ -217,21 +186,18 @@ def create_news_analysis_agent(company_name, company_code, reference_date, langu
                         - 일반 투자자도 이해할 수 있는 명확한 언어 사용
 
                         ## 주의사항
-                        - firecrawl_scrape는 대상 종목 뉴스 페이지 1회만 사용 (개별 기사, 주도주 뉴스 추가 스크랩 금지 - 토큰 절약)
                         - perplexity로 섹터 주도주를 찾을 때 반드시 기준일({reference_date})을 명시하여 최신 정보 요청
-                        - perplexity 답변의 날짜를 항상 검증하고, {reference_date}와 동떨어진 정보는 제외
-                        - 섹터 주도주 동향은 Perplexity 답변만으로 분석 (firecrawl 추가 호출 불필요)
+                        - 최근 뉴스·가격 동향은 기준일과의 시차를 확인하세요. 경쟁우위의 공식 통계는 더 오래된 기준기간일 수 있으므로 기간과 공시일을 명시하고 당일 동향과 구분하세요.
                         - 당일 주가 변동 원인 파악을 최우선으로 하고, 반드시 보고서 첫 부분에 상세히 분석할 것
                         - 검색할 때 반드시 종목코드를 함께 명시하여 정확한 기업의 뉴스만 수집할 것
                         - 유사한 기업명(예: 신풍제약 vs 신풍)의 뉴스를 혼동하지 말 것
                         - 단순 뉴스 나열이 아닌, 깊이 있는 분석과 인사이트 제공
                         - 주가 급등/급락의 경우 구체적인 원인 분석에 집중
-                        - 섹터 주도주 움직임은 Perplexity 답변을 기반으로 분석하여 주가 상승의 신뢰도 판단
                         - 시장 전문가처럼 통찰력 있는 분석 제공
                         - 검색된 뉴스가 부족한 경우 솔직하게 언급하고 가용한 정보만으로 분석
                         - 뉴스 내용을 카테고리별로 명확히 구분하여 정리해 통찰력 있는 분석 제공
                         - 모든 정보는 출처를 명확히 표기 (firecrawl은 [네이버금융:종목명], perplexity는 [Perplexity:번호]로 구분하고 날짜 명시)
-                        - 뉴스 날짜를 확인하여 분석일({reference_date}) 기준으로 최신 정보만 분석에 포함
+                        - 뉴스 발표 시점이 분석일({reference_date}) 이후인지 확인하고, 과거 판단에 사후 정보를 소급하지 않습니다
 
                         ## 출력 형식 주의사항
                         - 최종 보고서에는 도구 사용에 관한 언급을 포함하지 마세요 (예: "Calling tool ..." 또는 "I'll use perplexity_ask..." 등)

--- a/cores/agents/news_strategy_agents.py
+++ b/cores/agents/news_strategy_agents.py
@@ -15,7 +15,7 @@ def _competitive_evidence_contract(reference_date):
 - In addition to the cached target-news listing, use firecrawl_scrape for at most 2 additional
   cited public primary URLs, only if material competitive claims remain unverified.
   Prefer company filings/IR, regulators, exchanges, or industry statistics over marketing
-  summaries. Select URLs actually supplied in input or discovered in search; never invent URLs.
+  summaries. Choose URLs actually supplied in input or discovered in search; never invent URLs.
   Reuse source text already read. Do not recursively scrape peer news or all articles.
   A search answer/citation or HTTP success without the relevant source content is not
   source verification. On access/parsing failure preserve that reason without retry loops.

--- a/cores/analysis.py
+++ b/cores/analysis.py
@@ -37,6 +37,7 @@ from cores.stock_chart import (
     get_chart_as_base64_html
 )
 from cores.utils import clean_markdown
+from prism_core.competitive_evidence import attach_competitive_evidence
 
 
 # Market analysis cache storage (global variable)
@@ -183,6 +184,16 @@ async def analyze_stock(company_code: str = "000660", company_name: str = "SK하
                     except Exception as e:
                         logger.error(f"Final failure processing {section}: {e}")
                         section_reports[section] = f"Analysis failed: {section}"
+
+        # Reuse completed news evidence; do not rerun company/news agents.
+        section_reports, evidence_receipt = attach_competitive_evidence(
+            section_reports, "KR", company_code, reference_date, language
+        )
+        logger.info(
+            f"[COMPETITIVE_EVIDENCE] market=KR symbol={company_code} date={reference_date} "
+            f"status={evidence_receipt['status']} evidence_id={evidence_receipt['evidence_id']} "
+            f"record_chars={evidence_receipt['record_chars']}"
+        )
 
         # 6. Integrate content from other reports
         combined_reports = ""

--- a/cores/utils.py
+++ b/cores/utils.py
@@ -80,6 +80,8 @@ def clean_markdown(text: str) -> str:
     def is_valid_section_header(header_text):
         """Check if this is a valid section header"""
         header_text = header_text.strip()
+        if header_text in {"Competitive Evidence", "Competitive Evidence Handoff"}:
+            return True
         # Consider it a valid header if <= 50 chars and contains keywords
         if len(header_text) <= 50:
             for keyword in valid_section_keywords:

--- a/prism-us/cores/agents/company_info_agents.py
+++ b/prism-us/cores/agents/company_info_agents.py
@@ -539,7 +539,30 @@ Profile, Holders 페이지 firecrawl 스크랩 금지. MCP 도구 호출 금지.
             if start_idx != -1 and end_idx != -1:
                 instruction = instruction[:start_idx] + prefetch_block + "\n" + instruction[end_idx:]
 
-    # When prefetched: no MCP servers needed
+    # Basic profile coverage does not establish competitive evidence. The news
+    # section owns that research; the report pipeline attaches its record later.
+    if language == "ko":
+        instruction += """
+## 경쟁 근거의 책임 범위
+COMPETITIVE_EVIDENCE_OWNER: news
+- 기본정보·주주·사업부 자료는 사업 구조 분석에 사용하지만, 그 존재 자체는 경쟁우위의 증거가 아닙니다. profile 사전 수집 성공을 경쟁 근거 수집 완료나 리더 판정으로 해석하지 마세요.
+- 경쟁사 비교와 원문 검증은 뉴스 섹션이 담당합니다. 같은 경쟁사를 다시 조사하지 마세요. 뉴스의 Competitive Evidence 기록은 보고서 통합 단계에서 이 기업 개요에 별도로 연결됩니다. 아직 전달되지 않은 기록을 읽거나 검증한 것처럼 쓰지 마세요.
+- 이 입력에서 비교 가능한 출처·기준 기간·시장 범위·법인이 확인되지 않으면 industry_leadership은 UNKNOWN으로 두고, 뉴스 경쟁 근거와의 통합 전에는 시장 지위가 미확인임을 명시하세요. UNKNOWN은 부정적인 투자 판정이 아닙니다.
+- 경쟁사나 점유율을 만들어 내지 마세요. 회사의 자기 소개, 시가총액, 기관 보유율, 사업부 매출만으로 시장 지배력을 단정하지 마세요. 자회사 경쟁력을 모회사 전체의 우위로 확대하지 마세요.
+- industry_leadership, price_RS, sector_tailwind는 별개입니다. 주가 강세나 업종 호재를 사업 경쟁우위로 대체하지 마세요. 기존 데이터에서 확인한 주주·사업부 정보는 그대로 활용하고, 빠진 항목은 숨기지 마세요.
+"""
+    else:
+        instruction += """
+## Competitive evidence ownership
+COMPETITIVE_EVIDENCE_OWNER: news
+- Use profile, holders, and segment data for business structure analysis; their presence is not evidence of competitive advantage. Successful profile prefetch does not mean competitive coverage is complete or leadership is established.
+- The news section owns peer research and primary-source verification. Do not research the same peers again. The report pipeline separately attaches the news Competitive Evidence record to this overview. Do not imply that you have read or verified a record not yet supplied.
+- If comparable sources, period, market scope, and entity are absent from this input, keep industry_leadership UNKNOWN and identify market position as unconfirmed before the news evidence is integrated. UNKNOWN is not a negative investment verdict.
+- Do not invent competitors or market shares. A company's self-description, market capitalization, institutional ownership, or segment revenue alone does not establish market dominance. Do not extrapolate a subsidiary's advantage to its parent as a whole.
+- Keep industry_leadership, price_RS, and sector_tailwind separate. Price strength or sector news is not a substitute for business advantage. Retain available holder and segment facts and disclose missing fields rather than concealing them.
+"""
+
+    # When prefetched: no MCP servers needed for this basic-profile section.
     if has_prefetch:
         servers = []
     else:

--- a/prism-us/cores/agents/news_strategy_agents.py
+++ b/prism-us/cores/agents/news_strategy_agents.py
@@ -22,7 +22,7 @@ def _competitive_evidence_contract(reference_date):
 - In addition to the cached target-news listing, use firecrawl_scrape for at most 2 additional
   cited public primary URLs, only if material competitive claims remain unverified.
   Prefer company filings/IR, regulators, exchanges, or industry statistics over marketing
-  summaries. Select URLs actually supplied in input or discovered in search; never invent URLs.
+  summaries. Choose URLs actually supplied in input or discovered in search; never invent URLs.
   Reuse source text already read. Do not recursively scrape peer news or all articles.
   A search answer/citation or HTTP success without the relevant source content is not
   source verification. On access/parsing failure preserve that reason without retry loops.

--- a/prism-us/cores/agents/news_strategy_agents.py
+++ b/prism-us/cores/agents/news_strategy_agents.py
@@ -8,6 +8,56 @@ Uses perplexity and firecrawl for news gathering and sector analysis.
 from mcp_agent.agents.agent import Agent
 
 
+def _competitive_evidence_contract(reference_date):
+    """Shared ko/en prompt contract; query limits are instructions, not runtime quotas."""
+    return f"""## Competitive evidence collection and reporting contract
+- Reuse already obtained input facts and source excerpts before any new search. Do not
+  repeat a query or re-read a URL whose relevant evidence is already available.
+- Use perplexity_ask only if leader/trend context or material competitive evidence is
+  missing: at most 2 consolidated queries total, not two queries per company or field.
+  Query 1 combines sector leaders (2-3 peers), their trends and cited primary sources;
+  query 2 is optional and covers only unresolved material competitive-position gaps.
+  Specify entity/ticker, market, and reference date {reference_date} in every query.
+  No blanket mandatory search if the necessary cited evidence is already supplied.
+- In addition to the cached target-news listing, use firecrawl_scrape for at most 2 additional
+  cited public primary URLs, only if material competitive claims remain unverified.
+  Prefer company filings/IR, regulators, exchanges, or industry statistics over marketing
+  summaries. Select URLs actually supplied in input or discovered in search; never invent URLs.
+  Reuse source text already read. Do not recursively scrape peer news or all articles.
+  A search answer/citation or HTTP success without the relevant source content is not
+  source verification. On access/parsing failure preserve that reason without retry loops.
+- Separate sector_tailwind, price_leadership, and business_competitive_position. Price
+  momentum, sector membership, company size, or positive news alone proves no market dominance.
+  Separate the listed parent entity from each subsidiary or separately listed affiliate;
+  a subsidiary's advantage is not automatically the parent's leadership. Identify the
+  parent's ownership/contribution if available, otherwise keep that linkage unknown.
+- Compare the same period, geography, business scope, metric definition, and unit across
+  an explicit peer_universe. Disclose partial peer coverage; do not infer an industry rank
+  from a screened subset. Separate actual and forecast values. Check publication_date and
+  information availability against the decision timestamp, not just today's access date:
+  a currently available source does not prove it was available at a historical decision.
+  Older official competitive statistics may be used with their period and staleness stated;
+  the recent-news window does not justify discarding the latest available annual statistics.
+- Include the exact standalone markdown heading below in the news output (keep the English
+  heading and field keys in both languages; write explanations in the requested language):
+#### Competitive Evidence
+- Write compact records with field, type, entity, peer_universe, metric, value, unit,
+  period, geography, source (exact URL or UNKNOWN), publication_date, status, and a short
+  supporting excerpt. Use one record per material claim, including unresolved claims.
+  field names the question being assessed; type is one of sector_tailwind,
+  price_leadership, business_competitive_position. Missing values remain UNKNOWN.
+- status must be SOURCE_CHECKED, SEARCH_ONLY, NOT_FOUND, or INCOMPARABLE.
+  SOURCE_CHECKED means the relevant original source was actually read (or its original
+  excerpt supplied), not a guarantee that the claim is true, comparable, or leadership proven.
+  SEARCH_ONLY means only discovery/search material supports it. NOT_FOUND means evidence
+  was not found in the inspected scope, not that no public data exists; state whether
+  unqueried, access failed, parsing failed, or searched without a result. INCOMPARABLE
+  means entity/period/scope/metric mismatches prevent comparison despite available data.
+  Do not fabricate quotations, peers, values, dates, URLs, or positive leadership. Preserve
+  source qualifiers and unknowns in conclusions; absence of evidence is not negative proof.
+"""
+
+
 def create_us_news_analysis_agent(
     company_name: str,
     ticker: str,
@@ -44,11 +94,6 @@ def create_us_news_analysis_agent(
                 f"{prefetched_social_sentiment}\n"
             )
 
-    # Format date for display
-    ref_year = reference_date[:4]
-    ref_month = reference_date[4:6]
-    ref_day = reference_date[6:]
-
     if language == "ko":
         instruction = f"""당신은 미국 주식 기업 뉴스 분석 전문가입니다. 주어진 기업과 관련된 최근 뉴스 및 이벤트를 분석하여 심층 뉴스 동향 분석 보고서를 작성해야 합니다.
 
@@ -61,30 +106,10 @@ def create_us_news_analysis_agent(
    - formats: ["markdown"], onlyMainContent: true, maxAge: 7200000 (2시간 캐시)
    - 대상 날짜({reference_date}) 뉴스가 없으면 지난 1주일 뉴스 수집
 
-2. 뉴스 목록 페이지의 제목과 요약만으로 분석 (개별 기사 URL 추가 스크랩 불필요 - 토큰 절약)
+2. 뉴스 목록의 제목과 요약을 우선 활용하되, 중요한 경쟁우위 주장은 아래의 제한적 원문 확인 규칙을 따릅니다.
 
-### STEP 2: 섹터 리더 식별 및 동향 분석 (필수 - Perplexity 사용)
 
-**중요: Perplexity에 질문할 때 항상 기준일({ref_year}-{ref_month}-{ref_day})을 명시하세요**
-
-**2-1. Perplexity에 섹터 리더 찾기 요청**
-- **perplexity_ask** 쿼리 구조:
-  "As of {ref_year}-{ref_month}-{ref_day}, what are the 2-3 leading stocks in the same sector as {company_name} ({ticker})?
-   Please provide ticker symbols and brief reason why they are sector leaders."
-
-**2-2. Perplexity에 섹터 동향 분석 요청**
-- **perplexity_ask**: "As of {ref_year}-{ref_month}-{ref_day}, what is the recent trend for the sector containing {company_name}?"
-- 비교: 리더와 함께 상승 → 신뢰도 높음 / 이 종목만 → 일시적 가능성
-
-## 도구 가이드
-
-**firecrawl_scrape**: 페이지 스크래핑 (개별 종목 뉴스용 주력)
-- url: Yahoo Finance 뉴스 페이지
-- formats: ["markdown"], onlyMainContent: true, maxAge: 7200000
-
-**perplexity_ask**: AI 검색 (섹터 리더 및 동향용 주력)
-- 용도: 섹터 리더 찾기, 섹터 동향 분석, 최근 실적 뉴스
-- 항상 기준일 포함: "As of {ref_year}-{ref_month}-{ref_day}, ..."
+{_competitive_evidence_contract(reference_date)}
 
 ## 뉴스 분류 및 분석
 
@@ -113,15 +138,12 @@ def create_us_news_analysis_agent(
 - 도구 사용 언급 금지
 
 ## 주의사항
-- firecrawl_scrape는 대상 종목 뉴스 페이지 1회만 사용 (개별 기사, 리더 뉴스 추가 스크랩 금지 - 토큰 절약)
-- 섹터 리더 및 동향은 Perplexity 답변만으로 분석 (firecrawl 추가 호출 불필요)
 - perplexity 환각 주의, 항상 날짜 확인
 - 당일 가격 원인 분석 우선
 - 정확한 뉴스 식별을 위해 티커 심볼 사용
-- 섹터 리더 움직임은 Perplexity 답변 기반으로 신뢰도 평가
 - 깊이 있는 분석과 인사이트 제공
 - 명확한 출처 표기: [YahooFinance:TICKER] / [Perplexity:Number, Date]
-- 최근 정보만 사용 (분석일 기준 1개월 이내)
+- 뉴스는 분석일 이전 1개월을 우선하되, 구조적 경쟁력 통계는 위 규칙에 따라 기준 기간을 명시합니다
 
 {social_context}
 
@@ -147,49 +169,10 @@ def create_us_news_analysis_agent(
    - formats: ["markdown"], onlyMainContent: true, maxAge: 7200000 (2-hour cache)
    - If no news from target date ({reference_date}), collect news from past week
 
-2. Analyze using news list page titles and summaries only (do NOT scrape individual article URLs - token optimization)
+2. Start with news list page titles and summaries; material competitive claims follow the bounded source verification contract below.
 
-### STEP 2: Identify Sector Leaders and Analyze Trends (Mandatory - Use Perplexity)
 
-**CRITICAL: Always specify the reference date ({ref_year}-{ref_month}-{ref_day}) when asking Perplexity**
-
-**2-1. Ask Perplexity to find sector leaders**
-- **perplexity_ask** with this query structure:
-  "As of {ref_year}-{ref_month}-{ref_day}, what are the 2-3 leading stocks in the same sector as {company_name} ({ticker})?
-   Please provide ticker symbols and brief reason why they are sector leaders.
-   Focus on information from {ref_year}-{ref_month}-{ref_day} or the most recent available."
-
-- Perplexity will return leaders with tickers (e.g., Apple AAPL, Microsoft MSFT)
-- **IMPORTANT**: Always verify the dates in Perplexity's response match {ref_year}-{ref_month}-{ref_day} or are recent
-
-**2-2. Ask Perplexity for sector trend analysis**
-- **perplexity_ask**: "As of {ref_year}-{ref_month}-{ref_day}, what is the recent trend for the sector containing {company_name}?
-   Are the leading stocks showing positive momentum? Provide recent news from {ref_year}-{ref_month}-{ref_day} or close to it."
-- Compare: Rising with leaders → High reliability / This stock alone → Possibly temporary
-
-## Tool Usage Principles
-
-1. **firecrawl 1 call only**: Target stock Yahoo Finance news page only (do NOT scrape individual articles or leader stocks)
-2. **perplexity for leaders & trends**: Find sector leaders and analyze trends (ALWAYS specify date: {ref_year}-{ref_month}-{ref_day})
-3. **Date verification critical**: Always check dates in Perplexity responses match analysis date or are recent
-4. **Source notation**: [YahooFinance:TickerSymbol] / [Perplexity:Number, verified date]
-5. **Token optimization**: Minimize firecrawl calls - use Perplexity responses for sector leader analysis instead of scraping
-
-## Tool Guide
-
-**firecrawl_scrape**: Page scraping (PRIMARY for individual stock news)
-- url: Yahoo Finance news page (https://finance.yahoo.com/quote/TICKER/news)
-- formats: ["markdown"]
-- onlyMainContent: true
-- maxAge: 7200000 (2-hour cache - 500% performance boost, mandatory)
-
-**perplexity_ask**: AI search (PRIMARY for sector leaders and trends)
-- Use for: Finding sector leaders, analyzing sector trends, recent earnings news
-- ALWAYS include reference date in query: "As of {ref_year}-{ref_month}-{ref_day}, ..."
-- Always verify dates in responses
-- Example queries:
-  * "As of {ref_year}-{ref_month}-{ref_day}, what are the leading stocks in the technology sector?"
-  * "As of {ref_year}-{ref_month}-{ref_day}, what is the recent trend for semiconductor stocks?"
+{_competitive_evidence_contract(reference_date)}
 
 ## News Classification and Analysis
 
@@ -217,15 +200,12 @@ def create_us_news_analysis_agent(
 - No tool usage mentions
 
 ## Precautions
-- firecrawl_scrape only 1 call for target stock news page (do NOT scrape individual articles or leader news - token optimization)
-- Sector leader trends analyzed via Perplexity responses only (no additional firecrawl calls needed)
 - Beware perplexity hallucinations, always verify dates
 - Prioritize same-day price cause analysis
 - Use ticker symbols for accurate news identification
-- Assess reliability via sector leader movements (using Perplexity data only)
 - Provide deep analysis and insights
 - Clear source notation: [YahooFinance:TICKER] / [Perplexity:Number, Date]
-- Use only recent info (within 1 month of analysis date)
+- For news, prioritize the month up to the analysis date; dated structural competitive statistics follow the contract above
 
 {social_context}
 

--- a/prism-us/cores/us_analysis.py
+++ b/prism-us/cores/us_analysis.py
@@ -8,6 +8,7 @@ import os
 import asyncio
 from datetime import datetime
 from pathlib import Path
+from prism_core.competitive_evidence import attach_competitive_evidence
 
 from dotenv import load_dotenv
 load_dotenv()
@@ -300,6 +301,16 @@ async def analyze_us_stock(
         for result in all_results[1:]:
             if result and result[1] is not None:
                 section_reports[result[0]] = result[1]
+
+        # Both hybrid branches are complete: reuse news without another model call.
+        section_reports, evidence_receipt = attach_competitive_evidence(
+            section_reports, "US", ticker, reference_date, language
+        )
+        logger.info(
+            f"[COMPETITIVE_EVIDENCE] market=US symbol={ticker} date={reference_date} "
+            f"status={evidence_receipt['status']} evidence_id={evidence_receipt['evidence_id']} "
+            f"record_chars={evidence_receipt['record_chars']}"
+        )
 
         # 6. Integrate content from other reports
         combined_reports = ""

--- a/prism_core/competitive_evidence.py
+++ b/prism_core/competitive_evidence.py
@@ -1,0 +1,97 @@
+"""Reuse a report's evidence prose without inventing or validating source facts.
+
+The content hash identifies a report record, not an independently verified fact.
+No network, model, account, or persistence operations belong in this module.
+"""
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+
+
+_HEADING = re.compile(r"^####[ \t]+Competitive Evidence[ \t]*$", re.MULTILINE)
+_NEXT_SECTION = re.compile(r"^#{1,4}(?:[ \t]|$)", re.MULTILINE)
+_MAX_RECORD_CHARS = 12000
+
+
+def _mask_fences(text: str) -> tuple[str, bool]:
+    """Keep offsets while excluding fenced code from Markdown heading parsing."""
+    masked = []
+    fence = None
+    for line in text.splitlines(keepends=True):
+        match = re.match(r"^ {0,3}(`{3,}|~{3,})(.*?)(?:\r?\n)?$", line)
+        was_open = fence is not None
+        if match:
+            marker, suffix = match.groups()
+            if fence is None:
+                fence = marker
+            elif marker[0] == fence[0] and len(marker) >= len(fence) and not suffix.strip():
+                fence = None
+        masked.append("".join("\n" if c == "\n" else " " for c in line) if was_open or fence else line)
+    return "".join(masked), fence is not None
+
+
+def attach_competitive_evidence(
+    section_reports: Mapping[str, str],
+    market: str,
+    symbol: str,
+    reference_date: str,
+    language: str = "ko",
+) -> tuple[dict[str, str], dict]:
+    """Copy the news record into overview before downstream synthesis.
+
+    Failures leave original news untouched and expose a handoff gap. Even a
+    successfully copied SOURCE_CHECKED statement is only a source-agent claim.
+    """
+    reports = dict(section_reports)
+    news = reports.get("news_analysis", "")
+    visible, _ = _mask_fences(news)
+    matches = list(_HEADING.finditer(visible))
+    record = ""
+    if not matches:
+        status = "RECORD_ABSENT"
+    elif len(matches) != 1:
+        status = "RECORD_AMBIGUOUS"
+    else:
+        match = matches[0]
+        next_section = _NEXT_SECTION.search(visible, match.end())
+        end = next_section.start() if next_section else len(news)
+        body = news[match.end():end].strip()
+        record = news[match.start():end].strip()
+        status = "COPIED_NOT_VALIDATED" if body else "RECORD_EMPTY"
+        if len(record) > _MAX_RECORD_CHARS:
+            status = "RECORD_OVERSIZE"
+        elif _mask_fences(record)[1]:
+            status = "RECORD_MALFORMED"
+
+    evidence_id = None
+    if status == "COPIED_NOT_VALIDATED":
+        identity = json.dumps(
+            [market, symbol, reference_date, record], ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        evidence_id = "CE-" + hashlib.sha256(identity.encode()).hexdigest()[:20]
+        note = (
+            "뉴스 섹션의 근거 기록을 그대로 재사용합니다. 근거 ID는 내용 식별자이며 "
+            "독립적인 사실 검증이나 리더 판정을 뜻하지 않습니다. 원문의 상태·출처·기간을 따르세요."
+            if language == "ko" else
+            "Reused verbatim from news. The evidence ID identifies content, not independent "
+            "fact verification or leadership. Preserve the record's status, source and period."
+        )
+        block = f"\n\n#### Competitive Evidence Handoff\nEvidence ID: {evidence_id}\n{note}\n\n{record}\n"
+        offset = matches[0].end()
+        reports["news_analysis"] = news[:offset] + f"\nEvidence ID: {evidence_id}" + news[offset:]
+    else:
+        note = (
+            "뉴스 경쟁근거 기록을 전달하지 못했습니다. 이는 기업 경쟁력의 부재를 뜻하지 않습니다."
+            if language == "ko" else
+            "News competitive evidence could not be handed off. This does not imply a lack of business competitiveness."
+        )
+        block = f"\n\n#### Competitive Evidence Handoff\nHandoff status: {status}\n{note}\n"
+    reports["company_overview"] = reports.get("company_overview", "") + block
+    return reports, {
+        "status": status,
+        "evidence_id": evidence_id,
+        "record_chars": len(record),
+    }

--- a/tests/test_competitive_evidence_handoff.py
+++ b/tests/test_competitive_evidence_handoff.py
@@ -1,0 +1,160 @@
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from prism_core.competitive_evidence import attach_competitive_evidence
+
+
+NEWS = """### News
+Ordinary news.
+#### Competitive Evidence
+type: business_competitive_position
+entity: EXAMPLE
+peers: Peer A; Peer B
+metric: operating_margin
+value: 12%
+period: FY2025
+geography: global
+source: https://example.com/annual-report
+status: SEARCH_ONLY
+#### Risks
+Other risks.
+"""
+
+
+@pytest.mark.parametrize("market,symbol", [("KR", "012630"), ("US", "EXAMPLE")])
+@pytest.mark.parametrize("language", ["ko", "en"])
+def test_reuse_preserves_record_without_claiming_verification(market, symbol, language):
+    original = {"news_analysis": NEWS, "company_overview": "Original overview"}
+    reports, receipt = attach_competitive_evidence(original, market, symbol, "20260911", language)
+    assert original["news_analysis"] == NEWS
+    assert original["company_overview"] == "Original overview"
+    assert receipt["status"] == "COPIED_NOT_VALIDATED"
+    assert receipt["evidence_id"].startswith("CE-")
+    for key in ("news_analysis", "company_overview"):
+        assert receipt["evidence_id"] in reports[key]
+        assert "status: SEARCH_ONLY" in reports[key]
+        assert "source: https://example.com/annual-report" in reports[key]
+    assert "Other risks." not in reports["company_overview"]
+    assert attach_competitive_evidence(original, market, symbol, "20260911", language) == (reports, receipt)
+
+
+@pytest.mark.parametrize("news,status", [("no record", "RECORD_ABSENT"), ("#### Competitive Evidence\n", "RECORD_EMPTY"), (NEWS + NEWS, "RECORD_AMBIGUOUS")])
+def test_missing_or_ambiguous_never_becomes_positive(news, status):
+    reports, receipt = attach_competitive_evidence({"news_analysis": news}, "US", "EXAMPLE", "20260911")
+    assert receipt["status"] == status
+    assert receipt["evidence_id"] is None
+    assert status in reports["company_overview"]
+    assert reports["news_analysis"] == news
+
+
+def test_oversize_is_not_silently_truncated_or_copied():
+    news = "#### Competitive Evidence\n" + "x" * 12001
+    reports, receipt = attach_competitive_evidence({"news_analysis": news}, "KR", "012630", "20260911")
+    assert receipt["status"] == "RECORD_OVERSIZE"
+    assert reports["news_analysis"] == news
+    assert len(reports["company_overview"]) < 500
+
+
+@pytest.mark.parametrize("fence", ["```", "~~~"])
+def test_heading_inside_fenced_example_is_not_a_record(fence):
+    _, receipt = attach_competitive_evidence({"news_analysis": f"{fence}markdown\n{NEWS}{fence}\n"}, "US", "EXAMPLE", "20260911")
+    assert receipt["status"] == "RECORD_ABSENT"
+
+
+def test_unclosed_fence_in_record_cannot_corrupt_report():
+    _, receipt = attach_competitive_evidence({"news_analysis": "#### Competitive Evidence\n```\nnot closed"}, "US", "EXAMPLE", "20260911")
+    assert receipt["status"] == "RECORD_MALFORMED"
+
+
+def test_real_record_after_fenced_example_gets_id_at_correct_offset():
+    prefix = "```markdown\n#### Competitive Evidence\nfake\n```\n"
+    reports, receipt = attach_competitive_evidence({"news_analysis": prefix + NEWS}, "US", "EXAMPLE", "20260911")
+    assert reports["news_analysis"].startswith(prefix)
+    assert receipt["status"] == "COPIED_NOT_VALIDATED"
+    assert reports["news_analysis"].count(receipt["evidence_id"]) == 1
+
+
+def test_clean_markdown_preserves_exact_evidence_headings():
+    from cores.utils import clean_markdown
+    reports, receipt = attach_competitive_evidence({"news_analysis": NEWS}, "US", "EXAMPLE", "20260911", "en")
+    cleaned = clean_markdown(reports["company_overview"])
+    assert "#### Competitive Evidence Handoff" in cleaned
+    assert "#### Competitive Evidence\n" in cleaned
+    assert receipt["evidence_id"] in cleaned
+
+
+def test_context_and_content_are_bound_to_id():
+    def ident(market="US", symbol="EXAMPLE", date="20260911", news=NEWS):
+        return attach_competitive_evidence({"news_analysis": news}, market, symbol, date)[1]["evidence_id"]
+    assert len({ident(), ident(market="KR"), ident(symbol="OTHER"), ident(date="20260910"), ident(news=NEWS.replace("12%", "13%"))}) == 5
+
+
+@pytest.mark.parametrize("file", ["cores/analysis.py", "prism-us/cores/us_analysis.py"])
+def test_both_pipelines_handoff_before_strategy_and_summary(file):
+    source = (Path(__file__).resolve().parents[1] / file).read_text()
+    calls = [n for n in ast.walk(ast.parse(source)) if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)]
+    handoff = [n.lineno for n in calls if n.func.id == "attach_competitive_evidence"]
+    assert len(handoff) == 1
+    downstream = [n.lineno for n in calls if n.func.id in {"generate_investment_strategy", "generate_summary"}]
+    assert downstream and all(handoff[0] < line for line in downstream)
+    assert re.search(r"section_reports(?:\.get\(|\[)['\"]company_overview['\"]", source)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("market,symbol", [("KR", "012630"), ("US", "EXAMPLE")])
+async def test_downstream_real_prompt_builders_receive_identical_evidence(monkeypatch, market, symbol):
+    from unittest.mock import Mock
+    import cores.report_generation as generation
+    from cores.llm.ports import LLMResult
+
+    seen = []
+
+    class Backend:
+        async def run(self, spec, user_input):
+            seen.append(user_input)
+            return LLMResult(text="test synthesis")
+
+    monkeypatch.setattr(generation, "_report_backend", Backend())
+    reports, receipt = attach_competitive_evidence({"news_analysis": NEWS}, market, symbol, "20260911", "en")
+    await generation.generate_investment_strategy(reports, "\n".join(reports.values()), "Example", symbol, "20260911", Mock(), "en")
+    await generation.generate_summary(reports, "Example", symbol, "20260911", Mock(), "en")
+    assert len(seen) == 2
+    for user_input in seen:
+        assert receipt["evidence_id"] in user_input
+        assert "status: SEARCH_ONLY" in user_input
+        assert "https://example.com/annual-report" in user_input
+
+
+def test_id_and_source_survive_actual_pdf_text_input(tmp_path):
+    from reportlab.pdfgen import canvas
+    from pdf_converter import pdf_to_markdown_text
+
+    reports, receipt = attach_competitive_evidence({"news_analysis": NEWS}, "US", "EXAMPLE", "20260911", "en")
+    path = tmp_path / "evidence.pdf"
+    pdf = canvas.Canvas(str(path))
+    text = pdf.beginText(36, 800)
+    text.setFont("Helvetica", 8)
+    for line in reports["company_overview"].splitlines():
+        text.textLine(line)
+    pdf.drawText(text)
+    pdf.save()
+    extracted = pdf_to_markdown_text(str(path))
+    assert receipt["evidence_id"] in extracted
+    assert "https://example.com/annual-report" in extracted
+    assert "SEARCH_ONLY" in extracted
+
+
+@pytest.mark.parametrize("file", ["cores/analysis.py", "prism-us/cores/us_analysis.py"])
+def test_handoff_logger_is_compatible_with_mcp_logger_signature(file):
+    import inspect
+    from mcp_agent.logging.logger import Logger
+
+    source = (Path(__file__).resolve().parents[1] / file).read_text()
+    calls = [n for n in ast.walk(ast.parse(source)) if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute) and n.func.attr == "info"]
+    calls = [n for n in calls if "[COMPETITIVE_EVIDENCE]" in ast.get_source_segment(source, n)]
+    assert len(calls) == 1
+    assert len(calls[0].args) == 1
+    inspect.signature(Logger.info).bind(None, "safe metadata")

--- a/tests/test_news_competitive_evidence_contract.py
+++ b/tests/test_news_competitive_evidence_contract.py
@@ -1,0 +1,56 @@
+"""Offline prompt contracts; these do not prove source collection or model compliance."""
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture(params=["kr", "us"])
+def market_factory(request):
+    root = Path(__file__).resolve().parents[1]
+    path = root / ("prism-us/" if request.param == "us" else "") / "cores/agents/news_strategy_agents.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    tree.body = [node for node in tree.body if not isinstance(node, (ast.Import, ast.ImportFrom))]
+    namespace = {"Agent": SimpleNamespace}
+    exec(compile(tree, str(path), "exec"), namespace)
+    name = "create_us_news_analysis_agent" if request.param == "us" else "create_news_analysis_agent"
+    return request.param, namespace[name]
+
+
+@pytest.mark.parametrize("language", ["ko", "en"])
+def test_news_preserves_listing_cache_shape_and_bounded_source_reuse(market_factory, language):
+    market, factory = market_factory
+    agent = factory("Example", "TEST", "20260910", language=language)
+    prompt = agent.instruction
+    assert agent.server_names == ["perplexity", "firecrawl"]
+    assert "maxAge: 7200000" in prompt
+    assert ("finance.yahoo.com/quote/TEST/news" if market == "us" else "finance.naver.com/item/news.naver?code=TEST") in prompt
+    assert "### 3." in prompt and "#### " in prompt
+    for required in ("at most 2 consolidated", "at most 2 additional", "Reuse", "public primary", "never invent URLs", "only if", "publication_date"):
+        assert required in prompt
+
+
+@pytest.mark.parametrize("language", ["ko", "en"])
+def test_competitive_records_separate_claims_and_missingness(market_factory, language):
+    _, factory = market_factory
+    prompt = factory("Example", "TEST", "20260910", language=language).instruction
+    for required in ("#### Competitive Evidence", "sector_tailwind", "price_leadership", "business_competitive_position", "field", "type", "entity", "peer_universe", "metric", "value", "period", "geography", "unit", "source", "status", "excerpt", "SOURCE_CHECKED", "SEARCH_ONLY", "NOT_FOUND", "INCOMPARABLE", "not a guarantee", "subsidiary", "decision timestamp"):
+        assert required in prompt
+
+
+@pytest.mark.parametrize("language", ["ko", "en"])
+def test_no_old_verification_prohibitions_remain(market_factory, language):
+    _, factory = market_factory
+    prompt = factory("Example", "TEST", "20260910", language=language).instruction
+    for forbidden in ("firecrawl 1회만", "firecrawl 1 call only", "firecrawl_scrape only 1 call", "뉴스 페이지 1회만", "추가 스크랩 금지", "Perplexity 답변만으로", "Perplexity 답변으로 충분", "Perplexity data only", "Perplexity responses only", "do NOT scrape individual", "do NOT scrape leader", "no firecrawl for leaders", "no additional firecrawl calls needed", "Mandatory - Use Perplexity", "필수 - Perplexity 사용"):
+        assert forbidden not in prompt
+
+
+def test_us_social_prefetch_still_does_not_trigger_duplicate_calls(market_factory):
+    market, factory = market_factory
+    if market == "us":
+        prompt = factory("Example", "TEST", "20260910", language="en", prefetched_social_sentiment="sentiment snapshot").instruction
+        assert "sentiment snapshot" in prompt
+        assert "do not make extra tool calls for social sentiment" in prompt

--- a/tests/test_us_overview_evidence_boundary.py
+++ b/tests/test_us_overview_evidence_boundary.py
@@ -1,0 +1,70 @@
+"""US overview input contracts; no SDK, network, or model execution."""
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def factories():
+    source = Path(__file__).resolve().parents[1] / "prism-us/cores/agents/company_info_agents.py"
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    tree.body = [node for node in tree.body if not isinstance(node, ast.ImportFrom)]
+    namespace = {"Agent": SimpleNamespace, "Dict": dict}
+    exec(compile(tree, str(source), "exec"), namespace)
+    return namespace
+
+
+URLS = {key: f"https://example.test/{key}" for key in (
+    "profile", "holders", "key_statistics", "financials", "analysis"
+)}
+
+
+@pytest.mark.parametrize("language", ["ko", "en"])
+@pytest.mark.parametrize("prefetched", [False, True])
+def test_competitive_evidence_is_owned_by_news_not_profile(factories, language, prefetched):
+    data = {"company_profile": "PROFILE_SENTINEL"} if prefetched else None
+    agent = factories["create_us_company_overview_agent"](
+        "Example Corp", "EXAM", "20260911", URLS, language, data
+    )
+    prompt = agent.instruction
+    for term in ("COMPETITIVE_EVIDENCE_OWNER: news", "UNKNOWN", "industry_leadership", "price_RS", "sector_tailwind"):
+        assert term in prompt
+    assert ("경쟁우위의 증거가 아닙니다" if language == "ko" else "not evidence of competitive advantage") in prompt
+    assert ("같은 경쟁사를 다시 조사하지" if language == "ko" else "Do not research the same peers again") in prompt
+    assert ("부정적인 투자 판정이 아닙니다" if language == "ko" else "not a negative investment verdict") in prompt
+    assert ("경쟁사나 점유율을 만들어" if language == "ko" else "invent competitors or market shares") in prompt
+    assert agent.server_names == ([] if prefetched else ["firecrawl", "yahoo_finance"])
+    assert agent.name == "us_company_overview_agent"
+    assert "### 2-2." in prompt
+
+
+@pytest.mark.parametrize("language", ["ko", "en"])
+def test_prefetch_keeps_profile_holders_segments_without_new_tools(factories, language):
+    data = {
+        "company_profile": "PROFILE_SENTINEL",
+        "holder_info": "HOLDERS_SENTINEL",
+        "segment_revenue": "SEGMENTS_SENTINEL",
+    }
+    agent = factories["create_us_company_overview_agent"](
+        "Example Corp", "EXAM", "20260911", URLS, language, data
+    )
+    assert agent.server_names == []
+    for value in data.values():
+        assert agent.instruction.count(value) == 1
+    assert ("MCP 도구 호출 금지" if language == "ko" else "DO NOT call any MCP tools") in agent.instruction
+    assert ("기본정보·주주·사업부 자료" if language == "ko" else "profile, holders, and segment data") in agent.instruction
+
+
+@pytest.mark.parametrize("language", ["ko", "en"])
+def test_status_fundamentals_contract_is_not_changed(factories, language):
+    agent = factories["create_us_company_status_agent"](
+        "Example Corp", "EXAM", "20260911", URLS, language,
+        {"stock_info": "STOCK_SENTINEL", "analysis_estimates": "ESTIMATES_SENTINEL"},
+    )
+    assert agent.server_names == []
+    assert "STOCK_SENTINEL" in agent.instruction
+    assert "ESTIMATES_SENTINEL" in agent.instruction
+    assert "COMPETITIVE_EVIDENCE_OWNER" not in agent.instruction


### PR DESCRIPTION
## Scope
Repair existing Perplexity discovery / Firecrawl source-verification contracts, not trading filters.
- Both news agents: reuse first, bounded optional discovery and two material cited primary-source lookups; typed competitive evidence record with source/date/entity/peer/status.
- US profile prefetch no longer claims competitive coverage; news owns peer research to avoid duplicated calls.
- Deterministic post-base handoff copies news record to company overview before summary/strategy/PDF, with content-bound ID and COPIED_NOT_VALIDATED telemetry. No new model call or section concurrency change.
- Missing/empty/ambiguous/oversize/malformed evidence remains visible. Fenced-code headings ignored; canonical headings preserved by Markdown cleaner.

## Verification
Root 76 tests passed before one additional offset regression; helper now 21 pass. Independent reviewer final 54 pass, Ruff/compile/diff checks pass. Actual PDF extraction fixture and real downstream prompt builders exercised without model calls. US MCP logger compatibility regression added. Tests overlap; not additive.

## Limits
Prompt tool caps are not hard quotas. Source-agent SOURCE_CHECKED remains a claim; hash identifies content, not factual truth. No HDC leadership proof or zero-missing-data guarantee. Trading criteria/models/order paths unchanged. Postdeployment bounded news-only source probes planned; no BUY/SELL reruns or old UNKNOWN diagnostic changes.