### PR TITLE
fix: prevent missing competitive evidence from bypassing discovery

### DIFF
--- a/cores/agents/news_strategy_agents.py
+++ b/cores/agents/news_strategy_agents.py
@@ -6,12 +6,19 @@ def _competitive_evidence_contract(reference_date):
     return f"""## Competitive evidence collection and reporting contract
 - Reuse already obtained input facts and source excerpts before any new search. Do not
   repeat a query or re-read a URL whose relevant evidence is already available.
-- Use perplexity_ask only if leader/trend context or material competitive evidence is
-  missing: at most 2 consolidated queries total, not two queries per company or field.
-  Query 1 combines sector leaders (2-3 peers), their trends and cited primary sources;
-  query 2 is optional and covers only unresolved material competitive-position gaps.
+- Query 1 is REQUIRED using perplexity_ask unless complete, comparable, cited competitive
+  evidence records were already supplied at invocation. Only those explicit input records
+  can waive discovery; a news listing fetched later, basic company profile, or social sentiment
+  does not waive it. Reuse qualifying input records without duplicate searches or source reads.
+  Make at most 2 consolidated queries total, not two queries per company or field.
+  Query 1 MUST cover the target business scope, appropriate peer_universe, and
+  business_competitive_position together with sector/price leaders (2-3 peers), trends,
+  metrics, and cited public primary source URLs. Merely asking which stocks are rising
+  is insufficient. For holding companies, seek comparable holding-company peers or
+  explicitly scoped subsidiary business comparisons; do not stop at an inappropriate
+  holding-company versus operating-company comparison or infer parent dominance.
+  Query 2 is optional and covers only unresolved material competitive-position gaps.
   Specify entity/ticker, market, and reference date {reference_date} in every query.
-  No blanket mandatory search if the necessary cited evidence is already supplied.
 - In addition to the cached target-news listing, use firecrawl_scrape for at most 2 additional
   cited public primary URLs, only if material competitive claims remain unverified.
   Prefer company filings/IR, regulators, exchanges, or industry statistics over marketing
@@ -40,11 +47,17 @@ def _competitive_evidence_contract(reference_date):
   field names the question being assessed; type is one of sector_tailwind,
   price_leadership, business_competitive_position. Missing values remain UNKNOWN.
 - status must be SOURCE_CHECKED, SEARCH_ONLY, NOT_FOUND, or INCOMPARABLE.
-  SOURCE_CHECKED means the relevant original source was actually read (or its original
-  excerpt supplied), not a guarantee that the claim is true, comparable, or leadership proven.
+  SOURCE_CHECKED requires the exact cited page to have been actually opened and its relevant
+  original content read, or that original excerpt with its source was supplied at invocation.
+  A Perplexity answer, citation alone, unrelated listing, or mere HTTP success never qualifies.
+  This status is a model-reported assessment, not a runtime proof and not a guarantee
+  that the claim is true, comparable, or leadership proven.
   SEARCH_ONLY means only discovery/search material supports it. NOT_FOUND means evidence
   was not found in the inspected scope, not that no public data exists; state whether
-  unqueried, access failed, parsing failed, or searched without a result. INCOMPARABLE
+  attempted searches/source reads versus unqueried, access failed, parsing failed,
+  or searched without a result. Never describe all sources as exhausted when only a
+  listing was read. If required discovery was unavailable, record NOT_FOUND and the
+  attempted/unqueried reason instead of implying successful investigation. INCOMPARABLE
   means entity/period/scope/metric mismatches prevent comparison despite available data.
   Do not fabricate quotations, peers, values, dates, URLs, or positive leadership. Preserve
   source qualifiers and unknowns in conclusions; absence of evidence is not negative proof.

--- a/cores/agents/news_strategy_agents.py
+++ b/cores/agents/news_strategy_agents.py
@@ -28,12 +28,17 @@ def _competitive_evidence_contract(reference_date):
   source verification. On access/parsing failure preserve that reason without retry loops.
 - Separate sector_tailwind, price_leadership, and business_competitive_position. Price
   momentum, sector membership, company size, or positive news alone proves no market dominance.
+  price_leadership means share-price relative return or RS with an explicit window and peer_universe,
+  not product pricing or cost leadership; those belong to business_competitive_position.
   Separate the listed parent entity from each subsidiary or separately listed affiliate;
   a subsidiary's advantage is not automatically the parent's leadership. Identify the
   parent's ownership/contribution if available, otherwise keep that linkage unknown.
 - Compare the same period, geography, business scope, metric definition, and unit across
   an explicit peer_universe. Disclose partial peer coverage; do not infer an industry rank
-  from a screened subset. Separate actual and forecast values. Check publication_date and
+  from a screened subset. Separate actual and forecast values.
+  Support any rank or strongest claim with a comparable metric across the covered peers;
+  partial coverage or different fiscal periods may describe company strength but cannot
+  prove a competitive ranking: mark that comparison INCOMPARABLE. Check publication_date and
   information availability against the decision timestamp, not just today's access date:
   a currently available source does not prove it was available at a historical decision.
   Older official competitive statistics may be used with their period and staleness stated;

--- a/cores/utils.py
+++ b/cores/utils.py
@@ -80,7 +80,7 @@ def clean_markdown(text: str) -> str:
     def is_valid_section_header(header_text):
         """Check if this is a valid section header"""
         header_text = header_text.strip()
-        if header_text in {"Competitive Evidence", "Competitive Evidence Handoff"}:
+        if header_text.strip("*").casefold() in {"competitive evidence", "competitive evidence handoff"}:
             return True
         # Consider it a valid header if <= 50 chars and contains keywords
         if len(header_text) <= 50:

--- a/prism-us/cores/agents/news_strategy_agents.py
+++ b/prism-us/cores/agents/news_strategy_agents.py
@@ -13,12 +13,19 @@ def _competitive_evidence_contract(reference_date):
     return f"""## Competitive evidence collection and reporting contract
 - Reuse already obtained input facts and source excerpts before any new search. Do not
   repeat a query or re-read a URL whose relevant evidence is already available.
-- Use perplexity_ask only if leader/trend context or material competitive evidence is
-  missing: at most 2 consolidated queries total, not two queries per company or field.
-  Query 1 combines sector leaders (2-3 peers), their trends and cited primary sources;
-  query 2 is optional and covers only unresolved material competitive-position gaps.
+- Query 1 is REQUIRED using perplexity_ask unless complete, comparable, cited competitive
+  evidence records were already supplied at invocation. Only those explicit input records
+  can waive discovery; a news listing fetched later, basic company profile, or social sentiment
+  does not waive it. Reuse qualifying input records without duplicate searches or source reads.
+  Make at most 2 consolidated queries total, not two queries per company or field.
+  Query 1 MUST cover the target business scope, appropriate peer_universe, and
+  business_competitive_position together with sector/price leaders (2-3 peers), trends,
+  metrics, and cited public primary source URLs. Merely asking which stocks are rising
+  is insufficient. For holding companies, seek comparable holding-company peers or
+  explicitly scoped subsidiary business comparisons; do not stop at an inappropriate
+  holding-company versus operating-company comparison or infer parent dominance.
+  Query 2 is optional and covers only unresolved material competitive-position gaps.
   Specify entity/ticker, market, and reference date {reference_date} in every query.
-  No blanket mandatory search if the necessary cited evidence is already supplied.
 - In addition to the cached target-news listing, use firecrawl_scrape for at most 2 additional
   cited public primary URLs, only if material competitive claims remain unverified.
   Prefer company filings/IR, regulators, exchanges, or industry statistics over marketing
@@ -47,11 +54,17 @@ def _competitive_evidence_contract(reference_date):
   field names the question being assessed; type is one of sector_tailwind,
   price_leadership, business_competitive_position. Missing values remain UNKNOWN.
 - status must be SOURCE_CHECKED, SEARCH_ONLY, NOT_FOUND, or INCOMPARABLE.
-  SOURCE_CHECKED means the relevant original source was actually read (or its original
-  excerpt supplied), not a guarantee that the claim is true, comparable, or leadership proven.
+  SOURCE_CHECKED requires the exact cited page to have been actually opened and its relevant
+  original content read, or that original excerpt with its source was supplied at invocation.
+  A Perplexity answer, citation alone, unrelated listing, or mere HTTP success never qualifies.
+  This status is a model-reported assessment, not a runtime proof and not a guarantee
+  that the claim is true, comparable, or leadership proven.
   SEARCH_ONLY means only discovery/search material supports it. NOT_FOUND means evidence
   was not found in the inspected scope, not that no public data exists; state whether
-  unqueried, access failed, parsing failed, or searched without a result. INCOMPARABLE
+  attempted searches/source reads versus unqueried, access failed, parsing failed,
+  or searched without a result. Never describe all sources as exhausted when only a
+  listing was read. If required discovery was unavailable, record NOT_FOUND and the
+  attempted/unqueried reason instead of implying successful investigation. INCOMPARABLE
   means entity/period/scope/metric mismatches prevent comparison despite available data.
   Do not fabricate quotations, peers, values, dates, URLs, or positive leadership. Preserve
   source qualifiers and unknowns in conclusions; absence of evidence is not negative proof.

--- a/prism-us/cores/agents/news_strategy_agents.py
+++ b/prism-us/cores/agents/news_strategy_agents.py
@@ -35,12 +35,17 @@ def _competitive_evidence_contract(reference_date):
   source verification. On access/parsing failure preserve that reason without retry loops.
 - Separate sector_tailwind, price_leadership, and business_competitive_position. Price
   momentum, sector membership, company size, or positive news alone proves no market dominance.
+  price_leadership means share-price relative return or RS with an explicit window and peer_universe,
+  not product pricing or cost leadership; those belong to business_competitive_position.
   Separate the listed parent entity from each subsidiary or separately listed affiliate;
   a subsidiary's advantage is not automatically the parent's leadership. Identify the
   parent's ownership/contribution if available, otherwise keep that linkage unknown.
 - Compare the same period, geography, business scope, metric definition, and unit across
   an explicit peer_universe. Disclose partial peer coverage; do not infer an industry rank
-  from a screened subset. Separate actual and forecast values. Check publication_date and
+  from a screened subset. Separate actual and forecast values.
+  Support any rank or strongest claim with a comparable metric across the covered peers;
+  partial coverage or different fiscal periods may describe company strength but cannot
+  prove a competitive ranking: mark that comparison INCOMPARABLE. Check publication_date and
   information availability against the decision timestamp, not just today's access date:
   a currently available source does not prove it was available at a historical decision.
   Older official competitive statistics may be used with their period and staleness stated;

--- a/prism_core/competitive_evidence.py
+++ b/prism_core/competitive_evidence.py
@@ -10,8 +10,11 @@ import re
 from collections.abc import Mapping
 
 
-_HEADING = re.compile(r"^####[ \t]+Competitive Evidence[ \t]*$", re.MULTILINE)
-_NEXT_SECTION = re.compile(r"^#{1,4}(?:[ \t]|$)", re.MULTILINE)
+_HEADING = re.compile(
+    r"^(#{3,4})[ \t]+(?:Competitive Evidence|\*\*Competitive Evidence\*\*)[ \t]*$",
+    re.MULTILINE | re.IGNORECASE,
+)
+_NEXT_SECTION = re.compile(r"^(#{1,4})(?:[ \t]|$)", re.MULTILINE)
 _MAX_RECORD_CHARS = 12000
 
 
@@ -55,7 +58,11 @@ def attach_competitive_evidence(
         status = "RECORD_AMBIGUOUS"
     else:
         match = matches[0]
-        next_section = _NEXT_SECTION.search(visible, match.end())
+        next_section = next(
+            (heading for heading in _NEXT_SECTION.finditer(visible, match.end())
+             if len(heading.group(1)) <= len(match.group(1))),
+            None,
+        )
         end = next_section.start() if next_section else len(news)
         body = news[match.end():end].strip()
         record = news[match.start():end].strip()

--- a/tests/test_competitive_evidence_handoff.py
+++ b/tests/test_competitive_evidence_handoff.py
@@ -77,6 +77,21 @@ def test_real_record_after_fenced_example_gets_id_at_correct_offset():
     assert reports["news_analysis"].count(receipt["evidence_id"]) == 1
 
 
+def test_generic_report_h3_variant_keeps_nested_h4_records():
+    news = "### Competitive Evidence\n#### First claim\nstatus: SEARCH_ONLY\n### News Analysis\nnot evidence"
+    reports, receipt = attach_competitive_evidence({"news_analysis": news}, "US", "EXAMPLE", "20260911")
+    assert receipt["status"] == "COPIED_NOT_VALIDATED"
+    assert "#### First claim" in reports["company_overview"]
+    assert "not evidence" not in reports["company_overview"]
+
+
+@pytest.mark.parametrize("heading", ["### competitive evidence", "#### COMPETITIVE EVIDENCE", "### **Competitive Evidence**"])
+def test_exact_title_format_variants_not_arbitrary_fuzzy_matches(heading):
+    reports, receipt = attach_competitive_evidence({"news_analysis": heading + "\nstatus: SEARCH_ONLY"}, "US", "EXAMPLE", "20260911")
+    assert receipt["status"] == "COPIED_NOT_VALIDATED"
+    assert "SEARCH_ONLY" in reports["company_overview"]
+
+
 def test_clean_markdown_preserves_exact_evidence_headings():
     from cores.utils import clean_markdown
     reports, receipt = attach_competitive_evidence({"news_analysis": NEWS}, "US", "EXAMPLE", "20260911", "en")

--- a/tests/test_competitive_evidence_handoff.py
+++ b/tests/test_competitive_evidence_handoff.py
@@ -87,9 +87,11 @@ def test_generic_report_h3_variant_keeps_nested_h4_records():
 
 @pytest.mark.parametrize("heading", ["### competitive evidence", "#### COMPETITIVE EVIDENCE", "### **Competitive Evidence**"])
 def test_exact_title_format_variants_not_arbitrary_fuzzy_matches(heading):
+    from cores.utils import clean_markdown
     reports, receipt = attach_competitive_evidence({"news_analysis": heading + "\nstatus: SEARCH_ONLY"}, "US", "EXAMPLE", "20260911")
     assert receipt["status"] == "COPIED_NOT_VALIDATED"
     assert "SEARCH_ONLY" in reports["company_overview"]
+    assert heading in clean_markdown(reports["news_analysis"])
 
 
 def test_clean_markdown_preserves_exact_evidence_headings():

--- a/tests/test_news_competitive_evidence_contract.py
+++ b/tests/test_news_competitive_evidence_contract.py
@@ -54,3 +54,21 @@ def test_us_social_prefetch_still_does_not_trigger_duplicate_calls(market_factor
         prompt = factory("Example", "TEST", "20260910", language="en", prefetched_social_sentiment="sentiment snapshot").instruction
         assert "sentiment snapshot" in prompt
         assert "do not make extra tool calls for social sentiment" in prompt
+
+
+@pytest.mark.parametrize("language", ["ko", "en"])
+def test_required_discovery_is_not_waived_by_listing_profile_or_social(market_factory, language):
+    market, factory = market_factory
+    kwargs = {"prefetched_social_sentiment": "positive social snapshot"} if market == "us" else {}
+    prompt = factory("Holding Example", "TEST", "20260910", language=language, **kwargs).instruction
+    for required in ("Query 1 is REQUIRED", "at invocation", "complete, comparable", "news listing", "basic company profile", "social sentiment", "does not waive", "target business scope", "appropriate peer_universe", "business_competitive_position", "holding-company peers", "subsidiary business"):
+        assert required in prompt
+    assert "No blanket mandatory search" not in prompt
+
+
+@pytest.mark.parametrize("language", ["ko", "en"])
+def test_source_status_requires_relevant_original_content_and_audit_reason(market_factory, language):
+    _, factory = market_factory
+    prompt = factory("Example", "TEST", "20260910", language=language).instruction
+    for required in ("exact cited page", "actually opened", "Perplexity answer", "unrelated listing", "NOT_FOUND", "attempted", "unqueried", "not a runtime proof", "unresolved material"):
+        assert required in prompt

--- a/tests/test_news_competitive_evidence_contract.py
+++ b/tests/test_news_competitive_evidence_contract.py
@@ -72,3 +72,11 @@ def test_source_status_requires_relevant_original_content_and_audit_reason(marke
     prompt = factory("Example", "TEST", "20260910", language=language).instruction
     for required in ("exact cited page", "actually opened", "Perplexity answer", "unrelated listing", "NOT_FOUND", "attempted", "unqueried", "not a runtime proof", "unresolved material"):
         assert required in prompt
+
+
+@pytest.mark.parametrize("language", ["ko", "en"])
+def test_price_leadership_is_stock_rs_and_peer_rank_requires_comparability(market_factory, language):
+    _, factory = market_factory
+    prompt = factory("Example", "TEST", "20260910", language=language).instruction
+    for required in ("share-price relative return or RS", "window and peer_universe", "not product pricing or cost leadership", "business_competitive_position", "rank or strongest", "comparable metric", "covered peers", "different fiscal periods", "company strength", "comparison INCOMPARABLE"):
+        assert required in prompt


### PR DESCRIPTION
## Actual validation finding
After PR715, production-model news-only HDC validation produced a record but Perplexity0 and unconfirmed/incomparable competitive evidence. NVDA usedPerplexity1 but still lacked business comparison. Handoff success was NOT source-coverage success.

## Repair
Require first consolidated discovery unless complete comparable cited evidence was already supplied at invocation; listing/profile/social cannot waive. Query1 covers target business scope and suitable peers, not only price/sector leaders. Tighten SOURCE_CHECKED to exact source read or actual original excerpt supplied, not a search citation. Keep caps, unknowns, models, trading gates unchanged.

## Verification
85 targeted root tests pass; staged news-only candidate validation running before merge/deploy with exact module hashes. No BUY/SELL reruns or order actions. This fixes skipped investigation, not a promise all companies have public market-share data.