### PR TITLE
fix: prevent KRX authentication stalls from blocking KR batches

### DIFF
--- a/cores/data_prefetch.py
+++ b/cores/data_prefetch.py
@@ -1,11 +1,11 @@
 """
 Data Prefetch Module for Korean Stock Analysis
 
-Pre-fetches stock data by calling kospi_kosdaq MCP server's library functions directly
+Pre-fetches stock data through the repository-owned provider-chain adapter
 (not via MCP protocol), eliminating MCP tool call round-trips during analysis.
 
 Architecture:
-- Direct call: import kospi_kosdaq_stock_server module → call functions → Dict → markdown
+- Direct call: repository market_data adapter → provider chain → Dict → markdown
 - MCP fallback: if import fails, agents use MCP tool calls as before (no prefetch)
 
 This mirrors the US module's pattern (us_data_client.py direct import).
@@ -68,17 +68,28 @@ def _dict_to_markdown(data: dict, title: str = "") -> str:
 
 
 def _get_mcp_server_module():
-    """Import kospi_kosdaq_stock_server module for direct library calls.
+    """Reuse the same provider chain as tools, without legacy eager KRX login.
 
     Returns:
         The kospi_kosdaq_stock_server module, or None if import fails
     """
     try:
-        import kospi_kosdaq_stock_server as server
+        from cores.market_data import mcp_server as server
         return server
     except ImportError:
-        logger.warning("kospi_kosdaq_stock_server module not available, prefetch disabled")
+        logger.warning("Repository market-data adapter unavailable, prefetch disabled")
         return None
+
+
+def _prefetch_sector_info(reference_date: str, market: str) -> dict:
+    """Optional KRX-only field; missing auth must not remove index/price data."""
+    try:
+        from krx_data_client import _get_client
+        data = _get_client().get_market_sector_info(reference_date, market=market)
+        return data if isinstance(data, dict) and "error" not in data else {}
+    except Exception as exc:
+        logger.warning("Sector classification unavailable: %s", type(exc).__name__)
+        return {}
 
 
 def prefetch_stock_ohlcv(company_code: str, start_date: str, end_date: str) -> str:
@@ -247,8 +258,8 @@ def prefetch_macro_intelligence_data(reference_date: str) -> dict:
     try:
         import json as _json
         # Fetch KOSPI + KOSDAQ sector classifications
-        kospi_sectors = server.get_sector_info("KOSPI")
-        kosdaq_sectors = server.get_sector_info("KOSDAQ")
+        kospi_sectors = _prefetch_sector_info(reference_date, "KOSPI")
+        kosdaq_sectors = _prefetch_sector_info(reference_date, "KOSDAQ")
         sector_data = {}
         for raw in [kospi_sectors, kosdaq_sectors]:
             parsed = _json.loads(raw) if isinstance(raw, str) else raw

--- a/cores/market_data/mcp_server.py
+++ b/cores/market_data/mcp_server.py
@@ -87,6 +87,9 @@ def _load_repo_env() -> None:
 
 
 _load_repo_env()
+# MCP stdio may receive a filtered environment rather than the parent's guard.
+# Tool requests are noninteractive; reuse cached auth but never launch 2FA here.
+os.environ.setdefault("KRX_ALLOW_BROWSER_LOGIN", "0")
 
 from cores.market_data import (  # noqa: E402
     get_index_ohlcv_by_date,

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ holidays~=0.68
 
 python-telegram-bot[job-queue]>=20.0
 
-kospi_kosdaq_stock_server>=0.4.2  # 0.4.2: KRX IP 제한을 재시도 대상에서 제외 + 24h 서킷 브레이커
+kospi_kosdaq_stock_server @ git+https://github.com/dragon1086/kospi-kosdaq-stock-server.git@0e6446f7e3d61e152f165f28daca4d79193bd8dc  # 0.4.3: noninteractive auth guard and failure cooldown
 DateTime~=5.5
 matplotlib~=3.10.1
 seaborn~=0.13.2

--- a/stock_analysis_orchestrator.py
+++ b/stock_analysis_orchestrator.py
@@ -356,7 +356,7 @@ class StockAnalysisOrchestrator:
         try:
             # Step 1: Prefetch index data and compute regime programmatically
             from cores.data_prefetch import prefetch_macro_intelligence_data
-            prefetched = prefetch_macro_intelligence_data(reference_date)
+            prefetched = await asyncio.to_thread(prefetch_macro_intelligence_data, reference_date)
             logger.info(f"Macro prefetch complete: {list(prefetched.keys())}")
 
             if prefetched.get("computed_regime"):
@@ -1219,6 +1219,9 @@ class StockAnalysisOrchestrator:
             mode (str): 'morning' or 'afternoon'
             language (str): Analysis language ("ko" or "en")
         """
+        # Scheduled runs can reuse a valid KRX session, but must never wait for
+        # an interactive browser/2FA login. Manual recovery can explicitly opt in.
+        os.environ.setdefault("KRX_ALLOW_BROWSER_LOGIN", "0")
         logger.info(f"Starting full pipeline - mode: {mode}")
         campaign_trade_date = datetime.now().strftime("%Y%m%d")
 

--- a/tests/test_prefetch_auth_outage.py
+++ b/tests/test_prefetch_auth_outage.py
@@ -1,0 +1,53 @@
+import ast
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+from cores import data_prefetch
+
+
+def test_prefetch_uses_repository_provider_chain_not_eager_legacy_server(monkeypatch):
+    monkeypatch.setitem(sys.modules, "kospi_kosdaq_stock_server", SimpleNamespace(__name__="legacy_sentinel"))
+    server = data_prefetch._get_mcp_server_module()
+    assert server.__name__ == "cores.market_data.mcp_server"
+
+
+def test_sector_auth_failure_is_optional_and_does_not_invent_data(monkeypatch):
+    def unavailable():
+        raise RuntimeError("authentication unavailable")
+    monkeypatch.setitem(sys.modules, "krx_data_client", SimpleNamespace(_get_client=unavailable))
+    assert data_prefetch._prefetch_sector_info("20260911", "KOSPI") == {}
+
+
+def test_sector_lookup_keeps_original_provider_and_reference_date(monkeypatch):
+    seen = []
+    def query(day, market):
+        seen.append((day, market))
+        return {"005930": "전기전자"}
+    monkeypatch.setitem(sys.modules, "krx_data_client", SimpleNamespace(_get_client=lambda: SimpleNamespace(get_market_sector_info=query)))
+    assert data_prefetch._prefetch_sector_info("20260911", "KOSDAQ") == {"005930": "전기전자"}
+    assert seen == [("20260911", "KOSDAQ")]
+
+
+def test_macro_uses_sector_helper_not_legacy_server_attribute():
+    source = (Path(__file__).resolve().parents[1] / "cores/data_prefetch.py").read_text()
+    node = next(n for n in ast.parse(source).body if isinstance(n, ast.FunctionDef) and n.name == "prefetch_macro_intelligence_data")
+    text = ast.get_source_segment(source, node)
+    assert "_prefetch_sector_info(reference_date" in text
+    assert "server.get_sector_info" not in text
+
+
+def test_noninteractive_batch_guard_precedes_macro_and_preserves_override():
+    source = (Path(__file__).resolve().parents[1] / "stock_analysis_orchestrator.py").read_text()
+    tree = ast.parse(source)
+    function = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef) and n.name == "run_full_pipeline")
+    text = ast.get_source_segment(source, function)
+    assert text.index('setdefault("KRX_ALLOW_BROWSER_LOGIN", "0")') < text.index("self.run_macro_intelligence")
+    macro = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef) and n.name == "run_macro_intelligence")
+    assert "await asyncio.to_thread(prefetch_macro_intelligence_data" in ast.get_source_segment(source, macro)
+
+
+def test_filtered_stdio_child_has_its_own_noninteractive_guard():
+    source = (Path(__file__).resolve().parents[1] / "cores/market_data/mcp_server.py").read_text()
+    assert 'os.environ.setdefault("KRX_ALLOW_BROWSER_LOGIN", "0")' in source
+    assert source.index('os.environ.setdefault("KRX_ALLOW_BROWSER_LOGIN", "0")') < source.index("from cores.market_data import (")

--- a/tests/test_trigger_provider_outage.py
+++ b/tests/test_trigger_provider_outage.py
@@ -1,0 +1,71 @@
+"""Screening must honor the configured data chain without inventing evidence."""
+import pandas as pd
+import pytest
+
+import cores.market_data as market_data
+import krx_data_client
+import trigger_batch as trigger
+
+
+@pytest.mark.parametrize("missing", [None, "history", "fundamentals", "unprofitable", "invalid_pbr", "shallow"])
+def test_contrarian_uses_chain_and_preserves_required_evidence(monkeypatch, missing):
+    direct_calls = []
+
+    def forbidden(*args, **kwargs):
+        direct_calls.append(args)
+        raise RuntimeError("direct KRX authentication unavailable")
+
+    monkeypatch.setattr(krx_data_client, "get_market_ohlcv_by_date", forbidden, raising=False)
+    monkeypatch.setattr(krx_data_client, "get_market_fundamental_by_date", forbidden, raising=False)
+    history = pd.DataFrame({"High": [100.0]})
+    fundamentals = pd.DataFrame({"PER": [10.0], "PBR": [0.8]})
+    if missing == "unprofitable":
+        fundamentals["PER"] = -1.0
+    elif missing == "invalid_pbr":
+        fundamentals["PBR"] = 0.0
+    elif missing == "shallow":
+        history["High"] = 85.0
+    calls = []
+
+    def fetch_history(start, end, ticker):
+        calls.append(("history", start, end, ticker))
+        return pd.DataFrame() if missing == "history" else history
+
+    def fetch_fundamentals(start, end, ticker):
+        calls.append(("fundamentals", start, end, ticker))
+        return pd.DataFrame() if missing == "fundamentals" else fundamentals
+
+    monkeypatch.setattr(market_data, "get_market_ohlcv_by_date", fetch_history)
+    monkeypatch.setattr(market_data, "get_market_fundamental_by_date", fetch_fundamentals)
+    monkeypatch.setattr(trigger, "enhance_dataframe", lambda frame: frame)
+    snapshot = pd.DataFrame({"Open": [75.0], "Close": [80.0], "Volume": [1_000_000],
+                             "Amount": [20_000_000_000]}, index=["005930"])
+    previous = snapshot.copy()
+    previous["Close"] = 76.0
+    result = trigger.trigger_contrarian_value("20260911", snapshot, previous)
+    assert direct_calls == []
+    assert calls[0] == ("history", "20250911", "20260911", "005930")
+    if missing:
+        assert result.empty
+    else:
+        assert result.index.tolist() == ["005930"]
+        assert result.loc["005930", "Drawdown"] == -20.0
+        assert result.loc["005930", "TrailingPE"] == 10.0
+        assert result.loc["005930", "PriceToBook"] == 0.8
+
+
+@pytest.mark.parametrize("column", ["stock_name", "Company Name", "종목명"])
+def test_supplied_names_do_not_require_krx_authentication(monkeypatch, column):
+    calls = []
+
+    def forbidden():
+        calls.append(True)
+        raise RuntimeError("KRX authentication unavailable")
+
+    monkeypatch.setattr(trigger, "_get_client", forbidden)
+    monkeypatch.setattr(trigger, "_TICKER_NAME_CACHE", None)
+    monkeypatch.setattr(market_data, "get_market_ticker_name", lambda ticker: ticker)
+    snapshot = pd.DataFrame({column: ["삼성전자"], "Close": [80.0]}, index=["005930"])
+    result = trigger.enhance_dataframe(snapshot)
+    assert calls == []
+    assert result.loc["005930", "stock_name"] == "삼성전자"

--- a/trigger_batch.py
+++ b/trigger_batch.py
@@ -382,7 +382,17 @@ def enhance_dataframe(df: pd.DataFrame) -> pd.DataFrame:
     """
     if not df.empty:
         df = df.copy()  # Explicitly create copy to prevent SettingWithCopyWarning
-        name_map = _get_ticker_name_map()
+        # A snapshot may already carry names. Do not authenticate to KRX just
+        # to replace those labels; resolve only missing labels via the chain.
+        name_map = {}
+        for column in ("stock_name", "Company Name", "종목명"):
+            if column not in df.columns:
+                continue
+            for ticker, value in df[column].items():
+                if isinstance(value, str) and value.strip():
+                    name_map.setdefault(_normalize_ticker_code(ticker), value.strip())
+        if not name_map:
+            name_map = _get_ticker_name_map()
         df["stock_name"] = df.index.map(lambda ticker: _get_display_ticker_name(ticker, name_map))
     return df
 
@@ -1383,9 +1393,9 @@ def trigger_contrarian_value(trade_date: str, snapshot: pd.DataFrame,
     - Identifies quality stocks in a deep drawdown (15%-40% below 52-week high)
     - Requires positive recovery signal today (Close > Open)
     - Scores on drawdown magnitude, liquidity, low P/B ratio, and daily recovery
-    - Uses krx_data_client for 52-week high and fundamental data
+    - Uses the configured source chain for 52-week high and fundamental data
     """
-    from krx_data_client import get_market_ohlcv_by_date, get_market_fundamental_by_date
+    from cores.market_data import get_market_ohlcv_by_date, get_market_fundamental_by_date
 
     logger.debug("trigger_contrarian_value started")
 


### PR DESCRIPTION
## Incident evidence
KR Sep11 morning cron started09:30, repeatedly attemptedKakao login acrosscandidates and hit120minhardexit11:30. Afternoonstarted14:46 andstalledinsidelegacyMCPimport/browser2FA at0seconds for47min. crondactive; notcronabsence. Stalledafternoonjobtree wasterminated beforeanyBUY/SELLstage topreventlateexecution.

## Fix
- Pin reviewedupstream0.4.3 exactmerge0e6446f7 (PR12; no upstreamCI configured,12tests+15legacychecks). Noninteractiveflagdeniesbrowser BEFORElock; validcachedsessionsallowed; authfailurecooldown15min.
- KRscheduledpipeline andfilteredstdioMCPserver setdefault noninteractiveflag; explicitmanualoverridepreserved.
- PrefetchusesexistingKIS/FDR/KRXsourcechain notlegacymoduleeagerauth; optionalKRXsectorfailuredoesnotdiscardindices; syncmacrofetchrunsoffasyncmainthread.
- Contrariancandidateperstockdatausesproviderchain; suppliednamesreused; criteriaunchanged, missingfundamentalsnotfabricated.

## Verification
Root62testsPASS, upstream12PASS independentlyreviewed; finalCIrequired. Actualread-onlyserverproviderprobesplanned, noafter-closeBUY/SELLrerun. Authitself/2FAstillrequiresoperatorrepair; thischangeboundsbatchimpact, notsecuritybypass. ExistingstandaloneUSflatcandletestfailsindependentlyunchangedKRcode; seeCIforregressionstatus.