### PR TITLE
fix: resolve KIS names through master and internal product IDs

### DIFF
--- a/cores/market_data/kis_source.py
+++ b/cores/market_data/kis_source.py
@@ -487,7 +487,21 @@ class KisSource:
         return {"sector": sector.strip(), "source": "kis",
                 "as_of": observed_at.isoformat(), "latest_only": True}
 
+    @staticmethod
+    def _master_names() -> dict[str, str]:
+        # This loader shares the official KIS master's daily cache with market
+        # screening. Do not download the universe or issue a quote per ticker.
+        from cores.kis_market_snapshot import fetch_kis_master_universe
+
+        return fetch_kis_master_universe()
+
     def ticker_name(self, ticker: str) -> str:
+        try:
+            name = self._master_names().get(ticker)
+            if isinstance(name, str) and name.strip():
+                return name.strip()
+        except Exception as exc:
+            logger.warning("KIS master name unavailable (%s); trying KIS stock-info", type(exc).__name__)
         # inquire-price has a market name, not a company name. Use the official
         # stock-info endpoint (v1_국내주식-067), never get_current_price.stock_name.
         body = self._fetch(
@@ -499,7 +513,10 @@ class KisSource:
             output = output[0]
         if not isinstance(output, dict):
             raise Unavailable("KIS stock-info has no company name object")
-        if output.get("pdno") and str(output["pdno"]).strip() != ticker:
+        # CTPF1002R was observed returning internal product ID 00000A005930
+        # for request 005930. Accept only that exact prefix form, not suffix
+        # matches that could silently resolve another product class or ticker.
+        if output.get("pdno") and str(output["pdno"]).strip() not in {ticker, f"00000A{ticker}"}:
             raise Unavailable("KIS stock-info returned a different ticker")
         for field in ("prdt_abrv_name", "prdt_name", "prdt_name120"):
             value = output.get(field)

--- a/tests/test_kis_current_capabilities.py
+++ b/tests/test_kis_current_capabilities.py
@@ -30,6 +30,7 @@ def source(monkeypatch):
         return SimpleNamespace(output=obj.output)
 
     monkeypatch.setattr(obj, "_fetch", fetch)
+    monkeypatch.setattr(obj, "_master_names", lambda: {}, raising=False)
     return obj
 
 
@@ -141,6 +142,36 @@ def test_company_name_uses_official_stock_info(source):
     assert source.calls[0][1:] == ("CTPF1002R", {"PRDT_TYPE_CD": "300", "PDNO": "012630"})
 
 
+def test_company_name_prefers_official_master_without_quote_rpc(source, monkeypatch):
+    monkeypatch.setattr(source, "_master_names", lambda: {"005930": "삼성전자", "012630": "HDC"})
+    assert source.ticker_name("005930") == "삼성전자"
+    assert source.ticker_name("012630") == "HDC"
+    assert source.calls == []
+
+
+def test_master_download_failure_falls_back_to_kis_stock_info(source, monkeypatch):
+    def unavailable():
+        raise RuntimeError("master unavailable")
+
+    monkeypatch.setattr(source, "_master_names", unavailable)
+    source.output = {"pdno": "005930", "prdt_name": "삼성전자"}
+    assert source.ticker_name("005930") == "삼성전자"
+    assert len(source.calls) == 1
+
+
+def test_master_helper_reuses_shared_daily_loader(monkeypatch):
+    import cores.kis_market_snapshot as master
+
+    monkeypatch.setattr(master, "fetch_kis_master_universe", lambda: {"005930": "삼성전자"})
+    obj = KisSource()
+
+    def forbidden(*args):
+        pytest.fail("master hit must not authenticate or request stock-info")
+
+    monkeypatch.setattr(obj, "_fetch", forbidden)
+    assert obj.ticker_name("005930") == "삼성전자"
+
+
 def test_company_name_rejects_market_and_wrong_ticker(source):
     source.output = {"rprs_mrkt_kor_name": "KOSPI200"}
     with pytest.raises(Unavailable, match="company name"):
@@ -148,3 +179,15 @@ def test_company_name_rejects_market_and_wrong_ticker(source):
     source.output = {"pdno": "005930", "prdt_name": "삼성전자"}
     with pytest.raises(Unavailable, match="different ticker"):
         source.ticker_name("012630")
+
+
+def test_company_name_accepts_observed_kis_internal_product_identifier(source):
+    source.output = {"pdno": "00000A005930", "prdt_abrv_name": "삼성전자"}
+    assert source.ticker_name("005930") == "삼성전자"
+
+
+@pytest.mark.parametrize("identifier", ["00000A000660", "00000B005930", "other005930"])
+def test_company_name_rejects_wrong_internal_identifier(source, identifier):
+    source.output = {"pdno": identifier, "prdt_name": "삼성전자"}
+    with pytest.raises(Unavailable, match="different ticker"):
+        source.ticker_name("005930")

--- a/tests/test_kis_source.py
+++ b/tests/test_kis_source.py
@@ -78,6 +78,7 @@ def _price_row(date, close=1000):
 def _source(client):
     source = KisSource()
     source._client = client
+    source._master_names = lambda: {}
     return source
 
 


### PR DESCRIPTION
Completes KIS-only live MCP validation: reuse official daily master for names, accept only exact verified internal product ID prefix in stock-info fallback, and reject mismatched products. Targeted source/current-capabilities/architecture regression suite: 65 passed. No trading rule or order changes.